### PR TITLE
Fix out-by-one errors in tests

### DIFF
--- a/cargo-rmc-tests/simple-lib/expected.test_one_plus_two
+++ b/cargo-rmc-tests/simple-lib/expected.test_one_plus_two
@@ -1,1 +1,1 @@
-[test_one_plus_two.assertion.1] line 30 assertion failed: p.sum() == 3: SUCCESS
+[test_one_plus_two.assertion.1] line 31 assertion failed: p.sum() == 3: SUCCESS

--- a/cargo-rmc-tests/simple-lib/expected.test_sum
+++ b/cargo-rmc-tests/simple-lib/expected.test_sum
@@ -1,1 +1,1 @@
-[test_sum.assertion.1] line 26 assertion failed: p.sum() == a.wrapping_add(b): SUCCESS
+[test_sum.assertion.1] line 27 assertion failed: p.sum() == a.wrapping_add(b): SUCCESS

--- a/src/test/run-make/gotoc-allocation/expected
+++ b/src/test/run-make/gotoc-allocation/expected
@@ -1,2 +1,2 @@
-line 7 assertion failed: foo() == None: SUCCESS
-line 10 assertion failed: foo() == y: SUCCESS
+line 8 assertion failed: foo() == None: SUCCESS
+line 11 assertion failed: foo() == y: SUCCESS

--- a/src/test/run-make/gotoc-array/expected
+++ b/src/test/run-make/gotoc-array/expected
@@ -3,7 +3,7 @@ array 'y'.0 upper bound in y.0[var_12]: SUCCESS
 array 'y'.0 upper bound in y.0[var_16]: FAILURE
 array 'x'.0 upper bound in x.0[var_3]: SUCCESS
 array 'x'.0 upper bound in x.0[var_5]: SUCCESS
-line 10 assertion failed: y[0] == 1: SUCCESS
-line 11 assertion failed: y[1] == 2: SUCCESS
-line 12 index out of bounds: the length is move _17 but the index is _16: FAILURE
-line 12 assertion failed: y[z] == 3: FAILURE
+line 11 assertion failed: y[0] == 1: SUCCESS
+line 12 assertion failed: y[1] == 2: SUCCESS
+line 13 index out of bounds: the length is move _17 but the index is _16: FAILURE
+line 13 assertion failed: y[z] == 3: FAILURE

--- a/src/test/run-make/gotoc-binop/expected
+++ b/src/test/run-make/gotoc-binop/expected
@@ -1,42 +1,42 @@
-line 3 attempt to compute `move _8 + move _9`, which would overflow: SUCCESS
-line 3 assertion failed: a + b == correct: SUCCESS
-line 4 attempt to compute `move _15 + move _16`, which would overflow: SUCCESS
-line 4 assertion failed: a + b == wrong: FAILURE
-line 8 attempt to compute `move _8 - move _9`, which would overflow: SUCCESS
-line 8 assertion failed: a - b == correct: SUCCESS
-line 9 attempt to compute `move _15 - move _16`, which would overflow: SUCCESS
-line 9 assertion failed: a - b == wrong: FAILURE
-line 13 attempt to compute `move _8 * move _9`, which would overflow: SUCCESS
-line 13 assertion failed: a * b == correct: SUCCESS
-line 14 attempt to compute `move _15 * move _16`, which would overflow: SUCCESS
-line 14 assertion failed: a * b == wrong: FAILURE
-line 18 attempt to divide `_8` by zero: SUCCESS
-line 18 attempt to compute `_8 / _9`, which would overflow: SUCCESS
-line 18 assertion failed: a / b == correct: SUCCESS
-line 19 attempt to divide `_18` by zero: SUCCESS
-line 19 attempt to compute `_18 / _19`, which would overflow: SUCCESS
-line 19 assertion failed: a / b == wrong: FAILURE
-line 23 attempt to calculate the remainder of `_8` with a divisor of zero: SUCCESS
-line 23 attempt to compute the remainder of `_8 % _9`, which would overflow: SUCCESS
-line 23 assertion failed: a % b == correct: SUCCESS
-line 24 attempt to calculate the remainder of `_18` with a divisor of zero: SUCCESS
-line 24 attempt to compute the remainder of `_18 % _19`, which would overflow: SUCCESS
-line 24 assertion failed: a % b == wrong: FAILURE
-line 28 attempt to shift left by `move _9`, which would overflow: SUCCESS
-line 28 assertion failed: a << b == correct: SUCCESS
-line 29 attempt to shift left by `move _16`, which would overflow: SUCCESS
-line 29 assertion failed: a << b == wrong: FAILURE
-line 33 attempt to shift right by `move _9`, which would overflow: SUCCESS
-line 33 assertion failed: a >> b == correct: SUCCESS
-line 34 attempt to shift right by `move _16`, which would overflow: SUCCESS
-line 34 assertion failed: a >> b == wrong: FAILURE
-line 38 attempt to shift right by `move _9`, which would overflow: SUCCESS
-line 38 assertion failed: a >> b == correct: SUCCESS
-line 39 attempt to shift right by `move _16`, which would overflow: SUCCESS
-line 39 assertion failed: a >> b == wrong: FAILURE
-line 43 assertion failed: a & b == correct: SUCCESS
-line 44 assertion failed: a & b == wrong: FAILURE
-line 48 assertion failed: a | b == correct: SUCCESS
-line 49 assertion failed: a | b == wrong: FAILURE
-line 53 assertion failed: a ^ b == correct: SUCCESS
-line 54 assertion failed: a ^ b == wrong: FAILURE
+line 4 attempt to compute `move _8 + move _9`, which would overflow: SUCCESS
+line 4 assertion failed: a + b == correct: SUCCESS
+line 5 attempt to compute `move _15 + move _16`, which would overflow: SUCCESS
+line 5 assertion failed: a + b == wrong: FAILURE
+line 9 attempt to compute `move _8 - move _9`, which would overflow: SUCCESS
+line 9 assertion failed: a - b == correct: SUCCESS
+line 10 attempt to compute `move _15 - move _16`, which would overflow: SUCCESS
+line 10 assertion failed: a - b == wrong: FAILURE
+line 14 attempt to compute `move _8 * move _9`, which would overflow: SUCCESS
+line 14 assertion failed: a * b == correct: SUCCESS
+line 15 attempt to compute `move _15 * move _16`, which would overflow: SUCCESS
+line 15 assertion failed: a * b == wrong: FAILURE
+line 19 attempt to divide `_8` by zero: SUCCESS
+line 19 attempt to compute `_8 / _9`, which would overflow: SUCCESS
+line 19 assertion failed: a / b == correct: SUCCESS
+line 20 attempt to divide `_18` by zero: SUCCESS
+line 20 attempt to compute `_18 / _19`, which would overflow: SUCCESS
+line 20 assertion failed: a / b == wrong: FAILURE
+line 24 attempt to calculate the remainder of `_8` with a divisor of zero: SUCCESS
+line 24 attempt to compute the remainder of `_8 % _9`, which would overflow: SUCCESS
+line 24 assertion failed: a % b == correct: SUCCESS
+line 25 attempt to calculate the remainder of `_18` with a divisor of zero: SUCCESS
+line 25 attempt to compute the remainder of `_18 % _19`, which would overflow: SUCCESS
+line 25 assertion failed: a % b == wrong: FAILURE
+line 29 attempt to shift left by `move _9`, which would overflow: SUCCESS
+line 29 assertion failed: a << b == correct: SUCCESS
+line 30 attempt to shift left by `move _16`, which would overflow: SUCCESS
+line 30 assertion failed: a << b == wrong: FAILURE
+line 34 attempt to shift right by `move _9`, which would overflow: SUCCESS
+line 34 assertion failed: a >> b == correct: SUCCESS
+line 35 attempt to shift right by `move _16`, which would overflow: SUCCESS
+line 35 assertion failed: a >> b == wrong: FAILURE
+line 39 attempt to shift right by `move _9`, which would overflow: SUCCESS
+line 39 assertion failed: a >> b == correct: SUCCESS
+line 40 attempt to shift right by `move _16`, which would overflow: SUCCESS
+line 40 assertion failed: a >> b == wrong: FAILURE
+line 44 assertion failed: a & b == correct: SUCCESS
+line 45 assertion failed: a & b == wrong: FAILURE
+line 49 assertion failed: a | b == correct: SUCCESS
+line 50 assertion failed: a | b == wrong: FAILURE
+line 54 assertion failed: a ^ b == correct: SUCCESS
+line 55 assertion failed: a ^ b == wrong: FAILURE

--- a/src/test/run-make/gotoc-closure/expected
+++ b/src/test/run-make/gotoc-closure/expected
@@ -1,7 +1,7 @@
 resume instruction: SUCCESS
-line 20 attempt to compute `move _8 + move _9`, which would overflow: SUCCESS
-line 20 attempt to compute `move _5 + move _6`, which would overflow: SUCCESS
-line 20 attempt to compute `(*((*_1).0: &mut i32)) + move _4`, which would overflow: SUCCESS
-line 25 attempt to compute `move _18 + const 12_i32`, which would overflow: SUCCESS
-line 25 assertion failed: original_num + 12 == num: SUCCESS
-line 25 arithmetic overflow on signed + in var_18 + 12: SUCCESS
+line 21 attempt to compute `move _8 + move _9`, which would overflow: SUCCESS
+line 21 attempt to compute `move _5 + move _6`, which would overflow: SUCCESS
+line 21 attempt to compute `(*((*_1).0: &mut i32)) + move _4`, which would overflow: SUCCESS
+line 26 attempt to compute `move _18 + const 12_i32`, which would overflow: SUCCESS
+line 26 assertion failed: original_num + 12 == num: SUCCESS
+line 26 arithmetic overflow on signed + in var_18 + 12: SUCCESS

--- a/src/test/run-make/gotoc-closure2/expected
+++ b/src/test/run-make/gotoc-closure2/expected
@@ -1,4 +1,4 @@
-line 4 attempt to compute `move _3 + move _4`, which would overflow: SUCCESS
-line 6 attempt to compute `move _3 + move _4`, which would overflow: SUCCESS
-line 7 assertion failed: z == 102: SUCCESS
-line 8 assertion failed: g(z) == 206: SUCCESS
+line 5 attempt to compute `move _3 + move _4`, which would overflow: SUCCESS
+line 7 attempt to compute `move _3 + move _4`, which would overflow: SUCCESS
+line 8 assertion failed: z == 102: SUCCESS
+line 9 assertion failed: g(z) == 206: SUCCESS

--- a/src/test/run-make/gotoc-closure3/expected
+++ b/src/test/run-make/gotoc-closure3/expected
@@ -1,3 +1,3 @@
-line 17 attempt to compute `move _3 + move _4`, which would overflow: SUCCESS
-line 18 attempt to compute `move _11 + const 10_i64`, which would overflow: SUCCESS
-line 18 assertion failed: num + 10 == y: SUCCESS
+line 18 attempt to compute `move _3 + move _4`, which would overflow: SUCCESS
+line 19 attempt to compute `move _11 + const 10_i64`, which would overflow: SUCCESS
+line 19 assertion failed: num + 10 == y: SUCCESS

--- a/src/test/run-make/gotoc-comp/expected
+++ b/src/test/run-make/gotoc-comp/expected
@@ -1,11 +1,11 @@
-line 4 attempt to compute `move _6 + move _7`, which would overflow: SUCCESS
-line 4 attempt to compute `move _10 + move _11`, which would overflow: SUCCESS
-line 4 assertion failed: a + b == b + a: SUCCESS
-line 5 attempt to compute `move _16 + move _17`, which would overflow: SUCCESS
-line 5 attempt to compute `move _21 + move _22`, which would overflow: SUCCESS
-line 5 attempt to compute `move _20 + const 1_i32`, which would overflow: SUCCESS
-line 5 assertion failed: a + b != a + b + 1: SUCCESS
-line 10 attempt to compute `move _6 + move _7`, which would overflow: SUCCESS
-line 10 assertion failed: a + b > a: SUCCESS
-line 11 attempt to compute `move _13 - move _14`, which would overflow: SUCCESS
-line 11 assertion failed: a - b < a: SUCCESS
+line 5 attempt to compute `move _6 + move _7`, which would overflow: SUCCESS
+line 5 attempt to compute `move _10 + move _11`, which would overflow: SUCCESS
+line 5 assertion failed: a + b == b + a: SUCCESS
+line 6 attempt to compute `move _16 + move _17`, which would overflow: SUCCESS
+line 6 attempt to compute `move _21 + move _22`, which would overflow: SUCCESS
+line 6 attempt to compute `move _20 + const 1_i32`, which would overflow: SUCCESS
+line 6 assertion failed: a + b != a + b + 1: SUCCESS
+line 11 attempt to compute `move _6 + move _7`, which would overflow: SUCCESS
+line 11 assertion failed: a + b > a: SUCCESS
+line 12 attempt to compute `move _13 - move _14`, which would overflow: SUCCESS
+line 12 assertion failed: a - b < a: SUCCESS

--- a/src/test/run-make/gotoc-dynamic-trait-static-dispatch/expected
+++ b/src/test/run-make/gotoc-dynamic-trait-static-dispatch/expected
@@ -1,2 +1,2 @@
-line 24 assertion failed: bar.a() == 3: SUCCESS
-line 25 assertion failed: bar.b() == 5: SUCCESS
+line 25 assertion failed: bar.a() == 3: SUCCESS
+line 26 assertion failed: bar.b() == 5: SUCCESS

--- a/src/test/run-make/gotoc-dynamic-trait/expected
+++ b/src/test/run-make/gotoc-dynamic-trait/expected
@@ -1,16 +1,16 @@
-line 22 attempt to compute `move _2 * move _3`, which would overflow: SUCCESS
-line 25 attempt to compute `move _4 * move _5`, which would overflow: SUCCESS
-line 25 attempt to compute `move _3 * move _7`, which would overflow: SUCCESS
-line 31 attempt to compute `move _2 * move _3`, which would overflow: SUCCESS
-line 34 attempt to compute `move _4 * move _5`, which would overflow: SUCCESS
-line 34 attempt to compute `move _3 * move _7`, which would overflow: SUCCESS
-line 51 assertion failed: rec.vol(3) == 150: SUCCESS
-line 52 assertion failed: impl_area(rec.clone()) == 50: SUCCESS
-line 55 assertion failed: vol == 100: SUCCESS
-line 58 assertion failed: square.vol(3) == 27: SUCCESS
-line 59 assertion failed: do_vol(&square, 2) == 18: SUCCESS
-line 60 assertion failed: impl_area(square.clone()) == 9: SUCCESS
-line 62 assertion failed: !square.compare_area(&square): SUCCESS
-line 63 assertion failed: !square.compare_area(&rec): SUCCESS
-line 64 assertion failed: rec.compare_area(&square): SUCCESS
-line 65 assertion failed: !rec.compare_area(&rec): SUCCESS
+line 23 attempt to compute `move _2 * move _3`, which would overflow: SUCCESS
+line 26 attempt to compute `move _4 * move _5`, which would overflow: SUCCESS
+line 26 attempt to compute `move _3 * move _7`, which would overflow: SUCCESS
+line 32 attempt to compute `move _2 * move _3`, which would overflow: SUCCESS
+line 35 attempt to compute `move _4 * move _5`, which would overflow: SUCCESS
+line 35 attempt to compute `move _3 * move _7`, which would overflow: SUCCESS
+line 52 assertion failed: rec.vol(3) == 150: SUCCESS
+line 53 assertion failed: impl_area(rec.clone()) == 50: SUCCESS
+line 56 assertion failed: vol == 100: SUCCESS
+line 59 assertion failed: square.vol(3) == 27: SUCCESS
+line 60 assertion failed: do_vol(&square, 2) == 18: SUCCESS
+line 61 assertion failed: impl_area(square.clone()) == 9: SUCCESS
+line 63 assertion failed: !square.compare_area(&square): SUCCESS
+line 64 assertion failed: !square.compare_area(&rec): SUCCESS
+line 65 assertion failed: rec.compare_area(&square): SUCCESS
+line 66 assertion failed: !rec.compare_area(&rec): SUCCESS

--- a/src/test/run-make/gotoc-enum/expected
+++ b/src/test/run-make/gotoc-enum/expected
@@ -1,7 +1,7 @@
-line 17 unreachable code: SUCCESS
-line 18 assertion failed: false: SUCCESS
-line 18 assertion failed: x == 10: SUCCESS
-line 21 unreachable code: SUCCESS
-line 22 assertion failed: false: SUCCESS
-line 24 assertion failed: x == 30 && y == 60.0: SUCCESS
-line 25 assertion failed: x == 31: FAILURE
+line 18 unreachable code: SUCCESS
+line 19 assertion failed: false: SUCCESS
+line 19 assertion failed: x == 10: SUCCESS
+line 22 unreachable code: SUCCESS
+line 23 assertion failed: false: SUCCESS
+line 25 assertion failed: x == 30 && y == 60.0: SUCCESS
+line 26 assertion failed: x == 31: FAILURE

--- a/src/test/run-make/gotoc-float-nan/expected
+++ b/src/test/run-make/gotoc-float-nan/expected
@@ -1,5 +1,5 @@
-line 10 assertion failed: 1.0 / f != 0.0 / f: SUCCESS
-line 12 assertion failed: !(1.0 / f == 0.0 / f): SUCCESS
-line 14 assertion failed: 1.0 / f == 0.0 / f: FAILURE
-line 16 assertion failed: 0.0 / f == 0.0 / f: FAILURE
-line 18 assertion failed: 0.0 / f != 0.0 / f: SUCCESS
+line 11 assertion failed: 1.0 / f != 0.0 / f: SUCCESS
+line 13 assertion failed: !(1.0 / f == 0.0 / f): SUCCESS
+line 15 assertion failed: 1.0 / f == 0.0 / f: FAILURE
+line 17 assertion failed: 0.0 / f == 0.0 / f: FAILURE
+line 19 assertion failed: 0.0 / f != 0.0 / f: SUCCESS

--- a/src/test/run-make/gotoc-generics/expected
+++ b/src/test/run-make/gotoc-generics/expected
@@ -1,2 +1,2 @@
-line 23 assertion failed: x == y.data: SUCCESS
-line 24 assertion failed: z == w.data: SUCCESS
+line 24 assertion failed: x == y.data: SUCCESS
+line 25 assertion failed: z == w.data: SUCCESS

--- a/src/test/run-make/gotoc-iterator/expected
+++ b/src/test/run-make/gotoc-iterator/expected
@@ -1,3 +1,3 @@
-line 4 unreachable code: SUCCESS
-line 5 attempt to compute `_1 * move _13`, which would overflow: SUCCESS
-line 7 assertion failed: z == 6: SUCCESS
+line 5 unreachable code: SUCCESS
+line 6 attempt to compute `_1 * move _13`, which would overflow: SUCCESS
+line 8 assertion failed: z == 6: SUCCESS

--- a/src/test/run-make/gotoc-niche/expected
+++ b/src/test/run-make/gotoc-niche/expected
@@ -1,5 +1,5 @@
-line 19 unreachable code: SUCCESS
-line 20 assertion failed: false: SUCCESS
-line 24 unreachable code: SUCCESS
-line 25 assertion failed: false: SUCCESS
-line 26 assertion failed: a == *b: SUCCESS
+line 20 unreachable code: SUCCESS
+line 21 assertion failed: false: SUCCESS
+line 25 unreachable code: SUCCESS
+line 26 assertion failed: false: SUCCESS
+line 27 assertion failed: a == *b: SUCCESS

--- a/src/test/run-make/gotoc-niche2/expected
+++ b/src/test/run-make/gotoc-niche2/expected
@@ -1,5 +1,5 @@
 assertion failed: false: SUCCESS
 assertion failed: false: SUCCESS
-line 20 unreachable code: SUCCESS
-line 21 assertion failed: false: SUCCESS
-line 26 assertion failed: x == 10: SUCCESS
+line 21 unreachable code: SUCCESS
+line 22 assertion failed: false: SUCCESS
+line 27 assertion failed: x == 10: SUCCESS

--- a/src/test/run-make/gotoc-nondet/expected
+++ b/src/test/run-make/gotoc-nondet/expected
@@ -1,5 +1,5 @@
-line 10 attempt to compute `move _12 * move _13`, which would overflow: SUCCESS
-line 10 attempt to compute `const 2_i32 * move _16`, which would overflow: SUCCESS
-line 10 attempt to compute `move _11 - move _15`, which would overflow: SUCCESS
-line 10 attempt to compute `move _10 + const 1_i32`, which would overflow: SUCCESS
-line 10 assertion failed: x * x - 2 * x + 1 != 4 || (x == -1 || x == 3): SUCCESS
+line 11 attempt to compute `move _12 * move _13`, which would overflow: SUCCESS
+line 11 attempt to compute `const 2_i32 * move _16`, which would overflow: SUCCESS
+line 11 attempt to compute `move _11 - move _15`, which would overflow: SUCCESS
+line 11 attempt to compute `move _10 + const 1_i32`, which would overflow: SUCCESS
+line 11 assertion failed: x * x - 2 * x + 1 != 4 || (x == -1 || x == 3): SUCCESS

--- a/src/test/run-make/gotoc-references/expected
+++ b/src/test/run-make/gotoc-references/expected
@@ -1,1 +1,1 @@
-line 16 assertion failed: z == 2: SUCCESS
+line 17 assertion failed: z == 2: SUCCESS

--- a/src/test/run-make/gotoc-replace-hashmap/expected
+++ b/src/test/run-make/gotoc-replace-hashmap/expected
@@ -1,6 +1,6 @@
-line 26 attempt to compute `((*_1).0: usize) + const 1_usize`, which would overflow: SUCCESS
-line 26 arithmetic overflow on unsigned + in self->len + 1: SUCCESS
-line 56 assertion failed: a.is_some(): FAILURE
-line 57 assertion failed: a.is_none(): FAILURE
-line 59 assertion failed: b.is_some(): SUCCESS
-line 60 assertion failed: b.is_none(): FAILURE
+line 27 attempt to compute `((*_1).0: usize) + const 1_usize`, which would overflow: SUCCESS
+line 27 arithmetic overflow on unsigned + in self->len + 1: SUCCESS
+line 57 assertion failed: a.is_some(): FAILURE
+line 58 assertion failed: a.is_none(): FAILURE
+line 60 assertion failed: b.is_some(): SUCCESS
+line 61 assertion failed: b.is_none(): FAILURE

--- a/src/test/run-make/gotoc-replace-vec/expected
+++ b/src/test/run-make/gotoc-replace-vec/expected
@@ -1,8 +1,8 @@
-line 23 attempt to compute `((*_1).0: usize) + const 1_usize`, which would overflow: SUCCESS
-line 33 attempt to compute `((*_1).0: usize) - const 1_usize`, which would overflow: SUCCESS
-line 52 assertion failed: v.len() == 1: SUCCESS
-line 53 assertion failed: v.len() == 11: FAILURE
-line 55 assertion failed: p != None: SUCCESS
-line 56 assertion failed: p == None: FAILURE
-line 57 assertion failed: p == Some(to_push): SUCCESS
-line 58 assertion failed: p == Some(not_pushed): FAILURE
+line 24 attempt to compute `((*_1).0: usize) + const 1_usize`, which would overflow: SUCCESS
+line 34 attempt to compute `((*_1).0: usize) - const 1_usize`, which would overflow: SUCCESS
+line 53 assertion failed: v.len() == 1: SUCCESS
+line 54 assertion failed: v.len() == 11: FAILURE
+line 56 assertion failed: p != None: SUCCESS
+line 57 assertion failed: p == None: FAILURE
+line 58 assertion failed: p == Some(to_push): SUCCESS
+line 59 assertion failed: p == Some(not_pushed): FAILURE

--- a/src/test/run-make/gotoc-slice/expected
+++ b/src/test/run-make/gotoc-slice/expected
@@ -1,4 +1,4 @@
-line 14 assertion failed: y.len() == 5: SUCCESS
-line 15 index out of bounds: the length is move _16 but the index is _15: SUCCESS
-line 15 assertion failed: y[1] == 2: SUCCESS
-line 16 assertion failed: z.len() == 3: SUCCESS
+line 15 assertion failed: y.len() == 5: SUCCESS
+line 16 index out of bounds: the length is move _16 but the index is _15: SUCCESS
+line 16 assertion failed: y[1] == 2: SUCCESS
+line 17 assertion failed: z.len() == 3: SUCCESS

--- a/src/test/run-make/gotoc-static-mutable-struct/expected
+++ b/src/test/run-make/gotoc-static-mutable-struct/expected
@@ -1,12 +1,12 @@
-line 24 assertion failed: foo().x == 12: SUCCESS
-line 25 assertion failed: foo().y == 12: FAILURE
-line 26 assertion failed: foo().x == 14: FAILURE
-line 27 assertion failed: foo().y == 14: SUCCESS
-line 30 assertion failed: foo().x == 1: SUCCESS
-line 31 assertion failed: foo().y == 1: FAILURE
-line 32 assertion failed: foo().x == 2: FAILURE
-line 33 assertion failed: foo().y == 2: SUCCESS
-line 36 assertion failed: foo().x == 1 << 62: SUCCESS
-line 37 assertion failed: foo().x == 1 << 31: FAILURE
-line 38 assertion failed: foo().y == 1 << 31: SUCCESS
+line 25 assertion failed: foo().x == 12: SUCCESS
+line 26 assertion failed: foo().y == 12: FAILURE
+line 27 assertion failed: foo().x == 14: FAILURE
+line 28 assertion failed: foo().y == 14: SUCCESS
+line 31 assertion failed: foo().x == 1: SUCCESS
+line 32 assertion failed: foo().y == 1: FAILURE
+line 33 assertion failed: foo().x == 2: FAILURE
+line 34 assertion failed: foo().y == 2: SUCCESS
+line 37 assertion failed: foo().x == 1 << 62: SUCCESS
+line 38 assertion failed: foo().x == 1 << 31: FAILURE
+line 39 assertion failed: foo().y == 1 << 31: SUCCESS
 

--- a/src/test/run-make/gotoc-static-mutable/expected
+++ b/src/test/run-make/gotoc-static-mutable/expected
@@ -1,4 +1,4 @@
-line 17 assertion failed: 10 == foo(): FAILURE
-line 18 assertion failed: 12 == foo(): SUCCESS
-line 20 assertion failed: 10 == foo(): SUCCESS
-line 21 assertion failed: 12 == foo(): FAILURE
+line 18 assertion failed: 10 == foo(): FAILURE
+line 19 assertion failed: 12 == foo(): SUCCESS
+line 21 assertion failed: 10 == foo(): SUCCESS
+line 22 assertion failed: 12 == foo(): FAILURE

--- a/src/test/run-make/gotoc-static/expected
+++ b/src/test/run-make/gotoc-static/expected
@@ -1,2 +1,2 @@
-line 9 assertion failed: 10 == foo(): FAILURE
-line 10 assertion failed: 12 == foo(): SUCCESS
+line 10 assertion failed: 10 == foo(): FAILURE
+line 11 assertion failed: 12 == foo(): SUCCESS

--- a/src/test/run-make/gotoc-test1/expected
+++ b/src/test/run-make/gotoc-test1/expected
@@ -1,5 +1,5 @@
-line 6 attempt to compute `_1 + move _4`, which would overflow: SUCCESS
-line 7 attempt to compute `_2 - const 1_i32`, which would overflow: SUCCESS
-line 11 assertion failed: a == 54: FAILURE
-line 13 assertion failed: a == 55: SUCCESS
-line 15 assertion failed: a >= 55: SUCCESS
+line 7 attempt to compute `_1 + move _4`, which would overflow: SUCCESS
+line 8 attempt to compute `_2 - const 1_i32`, which would overflow: SUCCESS
+line 12 assertion failed: a == 54: FAILURE
+line 14 assertion failed: a == 55: SUCCESS
+line 16 assertion failed: a >= 55: SUCCESS

--- a/src/test/run-make/gotoc-test2/expected
+++ b/src/test/run-make/gotoc-test2/expected
@@ -1,5 +1,5 @@
-line 6 attempt to shift right by `const 1_i32`, which would overflow: SUCCESS
-line 7 attempt to compute `_2 + const 1_i32`, which would overflow: SUCCESS
-line 12 assertion failed: i == 3: FAILURE
-line 14 assertion failed: i == 2: SUCCESS
-line 16 assertion failed: i == 2 || i == 3: SUCCESS
+line 7 attempt to shift right by `const 1_i32`, which would overflow: SUCCESS
+line 8 attempt to compute `_2 + const 1_i32`, which would overflow: SUCCESS
+line 13 assertion failed: i == 3: FAILURE
+line 15 assertion failed: i == 2: SUCCESS
+line 17 assertion failed: i == 2 || i == 3: SUCCESS

--- a/src/test/run-make/gotoc-test3/expected
+++ b/src/test/run-make/gotoc-test3/expected
@@ -1,9 +1,9 @@
-line 8 attempt to compute `_2 - const 1_i32`, which would overflow: SUCCESS
-line 13 assertion failed: a == 10.0 && i == 1: FAILURE
-line 15 assertion failed: a == 9.0 && i == 0: FAILURE
-line 17 assertion failed: a == 9.0 && i == 1: FAILURE
-line 19 assertion failed: a == 10.0 && i == 0: SUCCESS
-line 22 assertion failed: a == 9.0 || i == 0: SUCCESS
-line 24 assertion failed: a == 10.0 || i == 1: SUCCESS
-line 26 assertion failed: a == 9.0 || i == 1: FAILURE
-line 28 assertion failed: a == 10.0 || i == 0: SUCCESS
+line 9 attempt to compute `_2 - const 1_i32`, which would overflow: SUCCESS
+line 14 assertion failed: a == 10.0 && i == 1: FAILURE
+line 16 assertion failed: a == 9.0 && i == 0: FAILURE
+line 18 assertion failed: a == 9.0 && i == 1: FAILURE
+line 20 assertion failed: a == 10.0 && i == 0: SUCCESS
+line 23 assertion failed: a == 9.0 || i == 0: SUCCESS
+line 25 assertion failed: a == 10.0 || i == 1: SUCCESS
+line 27 assertion failed: a == 9.0 || i == 1: FAILURE
+line 29 assertion failed: a == 10.0 || i == 0: SUCCESS

--- a/src/test/run-make/gotoc-test4/expected
+++ b/src/test/run-make/gotoc-test4/expected
@@ -1,6 +1,6 @@
-line 7 attempt to compute `_2 + const 1_i32`, which would overflow: SUCCESS
-line 12 assertion failed: i == 3: FAILURE
-line 14 assertion failed: i == 2: SUCCESS
-line 16 assertion failed: i == 2 || i == 3: SUCCESS
-line 20 attempt to divide `_3` by zero: SUCCESS
-line 20 attempt to compute `_3 / _4`, which would overflow: SUCCESS
+line 8 attempt to compute `_2 + const 1_i32`, which would overflow: SUCCESS
+line 13 assertion failed: i == 3: FAILURE
+line 15 assertion failed: i == 2: SUCCESS
+line 17 assertion failed: i == 2 || i == 3: SUCCESS
+line 21 attempt to divide `_3` by zero: SUCCESS
+line 21 attempt to compute `_3 / _4`, which would overflow: SUCCESS

--- a/src/test/run-make/gotoc-test5/expected
+++ b/src/test/run-make/gotoc-test5/expected
@@ -1,4 +1,4 @@
-line 4 assertion failed: div(4, 2) == 2: SUCCESS
-line 6 assertion failed: div(6, 2) == 2: FAILURE
-line 10 attempt to divide `_3` by zero: SUCCESS
-line 10 attempt to compute `_3 / _4`, which would overflow: SUCCESS
+line 5 assertion failed: div(4, 2) == 2: SUCCESS
+line 7 assertion failed: div(6, 2) == 2: FAILURE
+line 11 attempt to divide `_3` by zero: SUCCESS
+line 11 attempt to compute `_3 / _4`, which would overflow: SUCCESS

--- a/src/test/run-make/gotoc-test6/expected
+++ b/src/test/run-make/gotoc-test6/expected
@@ -1,2 +1,2 @@
-line 8 assertion failed: add2(1, 1) == 2.0: SUCCESS
-line 10 assertion failed: add2(2, 1) == 2.0: FAILURE
+line 9 assertion failed: add2(1, 1) == 2.0: SUCCESS
+line 11 assertion failed: add2(2, 1) == 2.0: FAILURE

--- a/src/test/run-make/gotoc-transmute/expected
+++ b/src/test/run-make/gotoc-transmute/expected
@@ -1,2 +1,2 @@
-line 6 assertion failed: bitpattern == 0x3F800000: SUCCESS
-line 12 assertion failed: f == 1.0: SUCCESS
+line 7 assertion failed: bitpattern == 0x3F800000: SUCCESS
+line 13 assertion failed: f == 1.0: SUCCESS

--- a/src/test/run-make/gotoc-vec/expected
+++ b/src/test/run-make/gotoc-vec/expected
@@ -12,6 +12,6 @@
 [realloc.precondition_instance.10] line 30 double free: SUCCESS
 [realloc.precondition_instance.11] line 30 free called for new[] object: SUCCESS
 [realloc.precondition_instance.12] line 30 free called for stack-allocated object: SUCCESS
-line 5 assertion failed: x[0] == 10: SUCCESS
-line 7 assertion failed: y == 10: SUCCESS
-line 8 assertion failed: y != 10: FAILURE
+line 6 assertion failed: x[0] == 10: SUCCESS
+line 8 assertion failed: y == 10: SUCCESS
+line 9 assertion failed: y != 10: FAILURE


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes out-by-one errors in `cargo-rmc-tests` and `run-make` tests due to copyright text being updated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
