### PR TITLE
Conform with latest changes to `Binder` (used in closures)

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/monomorphize/collector.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/monomorphize/collector.rs
@@ -35,10 +35,10 @@ pub fn custom_coerce_unsize_info<'tcx>(
 ) -> CustomCoerceUnsized {
     let def_id = tcx.require_lang_item(LangItem::CoerceUnsized, None);
 
-    let trait_ref = ty::Binder::bind(ty::TraitRef {
-        def_id,
-        substs: tcx.mk_substs_trait(source_ty, &[target_ty.into()]),
-    });
+    let trait_ref = ty::Binder::bind(
+        ty::TraitRef { def_id, substs: tcx.mk_substs_trait(source_ty, &[target_ty.into()]) },
+        tcx,
+    );
 
     match tcx.codegen_fulfill_obligation((ty::ParamEnv::reveal_all(), trait_ref)) {
         Ok(traits::ImplSource::UserDefined(traits::ImplSourceUserDefinedData {

--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -682,7 +682,7 @@ impl<'tcx> GotocCtx<'tcx> {
         &mut self,
         def_id: DefId,
         _substs: ty::subst::SubstsRef<'tcx>,
-        trait_ref_t: Binder<TraitRef<'tcx>>,
+        trait_ref_t: Binder<'_, TraitRef<'tcx>>,
         t: Ty<'tcx>,
     ) -> Expr {
         let function_name = self.tcx.item_name(def_id).to_string();
@@ -745,7 +745,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
     fn codegen_vtable_methods(
         &mut self,
-        trait_ref_t: Binder<TraitRef<'tcx>>,
+        trait_ref_t: Binder<'tcx, TraitRef<'tcx>>,
         t: Ty<'tcx>,
     ) -> Vec<Expr> {
         //DSN This assumes that we always get the methods back in the same order.

--- a/compiler/rustc_codegen_llvm/src/gotoc/statement.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/statement.rs
@@ -205,7 +205,9 @@ impl<'tcx> GotocCtx<'tcx> {
                 let tupe = fargs.remove(1);
                 for (i, t) in self.closure_params(substs).iter().enumerate() {
                     if !t.is_unit() {
-                        fargs.push(tupe.clone().member(&i.to_string(), &self.symbol_table));
+                        // Access the tupled parameters through the `member` operation
+                        let index_param = tupe.clone().member(&i.to_string(), &self.symbol_table);
+                        fargs.push(index_param);
                     }
                 }
             }
@@ -470,7 +472,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 let e = BuiltinFn::Memcpy.call(vec![dst, src, n], Location::none());
                 e.as_stmt()
             }
-            StatementKind::FakeRead(_, _)
+            StatementKind::FakeRead(_)
             | StatementKind::Retag(_, _)
             | StatementKind::AscribeUserType(_, _)
             | StatementKind::Nop

--- a/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
@@ -201,7 +201,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// We solve this by normalizeing and removing the "&">::vol", but the inner type would be <&Rectangle as Vol>
     pub fn normalized_name_of_dynamic_object_type(
         &self,
-        trait_ref_t: Binder<TraitRef<'tcx>>,
+        trait_ref_t: Binder<'_, TraitRef<'tcx>>,
     ) -> String {
         with_no_trimmed_paths(|| trait_ref_t.skip_binder().to_string().replace("&", ""))
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Rebase (2021-04-08) - Conform with latest changes to Binder (used in closures).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
