### PR TITLE
Enable copyright checks in CI

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+name: RMC CI
+on: pull_request
+
+jobs:
+  copyright-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout RMC
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get paths for files added
+        id: git-diff
+        run: |
+          files=$(git diff --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | xargs)
+          echo "::set-output name=paths::$files"
+
+      - name: Execute copyright check
+        if: ${{ steps.git-diff.outputs.paths }}
+        run: ./scripts/ci/copyright_check.py ${{ steps.git-diff.outputs.paths }}

--- a/scripts/ci/copyright_check.py
+++ b/scripts/ci/copyright_check.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+import re
+import sys
+
+def copyright_check(filename):
+    fo = open(filename)
+    lines = fo.readlines()
+
+    # The check is failed if the file is empty
+    if len(lines) == 0:
+        return False
+
+    # Scripts may include in their first line a character sequence starting with
+    # '#!' (also know as shebang) to indicate an interpreter for execution.
+    # The values for the minimum number of lines and the indices of copyright
+    # lines depend on whether the file has a shebang or not.
+    shb_re = re.compile('#!\S+')
+    has_shebang = shb_re.search(lines[0])
+    min_lines = 3 if has_shebang else 2
+    
+    # The check is failed if the file does not contain enough lines
+    if len(lines) < min_lines:
+        return False
+
+    # Compile the regexes for copyright lines
+    fst_re = re.compile('(//|#) Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.')
+    snd_re = re.compile('(//|#) SPDX-License-Identifier: Apache-2.0 OR MIT')
+
+    fst_idx = min_lines - 2
+    snd_idx = min_lines - 1
+
+    # The copyright check succeeds if the regexes can be found
+    if fst_re.search(lines[fst_idx]) and snd_re.search(lines[snd_idx]):
+        return True
+    else:
+        return False
+
+if __name__ == "__main__":
+    filenames = sys.argv[1:]
+    checks = [copyright_check(fname) for fname in filenames]
+    
+    for i in range(len(filenames)):
+        print(f'Copyright check - {filenames[i]}: ', end='')
+        print('PASS') if checks[i] else print('FAIL')
+
+    if all(checks):
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
### Resolved issues:

Resolves #70 

### Description of changes: 

This enables a copyright check in CI for all files added in a PR.

This check is performed using:
 * A workflow file that triggers on `pull_request` events.
 * A python script that runs on a variable number of arguments

The workflow gets the paths of the files added (using `git diff` on the base/head refs), which are then passed to the copyright script. If there are no files added, the workflow finishes.

Note that accepting multiple arguments in the copyright script (instead of just one) allows printing the result of the `copyright_check` for all files in one execution. This will avoid having contributors fix the copyright issue for one file only to realize the issue is also present in other files.

### Testing:

The python script has been tested using [these examples](https://gist.github.com/adpaco-aws/7c1193abcce7cf045692f5ed92d73ab4). This is the corresponding output:
```
accorell@rmc $ ./copyright_check.py `echo tests/*`                 
Copyright check - tests/rust.rs: PASS
Copyright check - tests/rust.rs.bad: FAIL
Copyright check - tests/script.py: PASS
Copyright check - tests/script.py.bad: FAIL
Copyright check - tests/script.sh: PASS
Copyright check - tests/script.sh.bad: FAIL
```

The workflow is being tested in this PR. Just click on "Details" for the "copyright-check" action that you can now find on the list of checks.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
