### PR TITLE
Allow cast of fat pointers to thin pointers

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/place.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/place.rs
@@ -267,7 +267,12 @@ impl<'tcx> GotocCtx<'tcx> {
                         // should be the ADT itself. So we need the `.dereference()` here.
                         // Note that this causes problems in `codegen_rvalue_ref()`.
                         // See the comment there for more details.
-                        inner_goto_expr.member("data", &self.symbol_table).dereference()
+                        inner_goto_expr
+                            .member("data", &self.symbol_table)
+                            // In the case of a vtable fat pointer, this data member is a void pointer,
+                            // so ensure the pointer has the correct type before dereferencing it.
+                            .cast_to(self.codegen_ty(inner_mir_typ).to_pointer())
+                            .dereference()
                     }
                     _ => inner_goto_expr.dereference(),
                 };

--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -4,7 +4,7 @@ use super::cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, Symbol, Type};
 use super::cbmc::utils::aggr_name;
 use super::cbmc::MachineModel;
 use super::metadata::*;
-use super::typ::pointee_type;
+use super::typ::{is_pointer, pointee_type};
 use super::utils::{dynamic_fat_ptr, slice_fat_ptr};
 use crate::btree_string_map;
 use rustc_middle::mir::{AggregateKind, BinOp, CastKind, NullOp, Operand, Place, Rvalue, UnOp};
@@ -530,6 +530,19 @@ impl<'tcx> GotocCtx<'tcx> {
         )
     }
 
+    pub fn codegen_fat_ptr_to_thin_ptr_cast(
+        &mut self,
+        src: &Operand<'tcx>,
+        dst_t: Ty<'tcx>,
+    ) -> Expr {
+        debug!("codegen_fat_ptr_to_thin_ptr_cast |{:?}| |{:?}|", src, dst_t);
+        let src_goto_expr = self.codegen_operand(src);
+        let dst_goto_typ = self.codegen_ty(dst_t);
+        // In a vtable fat pointer, the data member is a void pointer,
+        // so ensure the pointer has the correct type before dereferencing it.
+        src_goto_expr.member("data", &self.symbol_table).cast_to(dst_goto_typ)
+    }
+
     fn codegen_misc_cast(&mut self, src: &Operand<'tcx>, dst_t: Ty<'tcx>) -> Expr {
         let src_t = self.operand_ty(src);
         debug!(
@@ -556,6 +569,10 @@ impl<'tcx> GotocCtx<'tcx> {
         // Cast between fat pointers
         if self.is_ref_of_unsized(src_t) && self.is_ref_of_unsized(dst_t) {
             return self.codegen_fat_ptr_to_fat_ptr_cast(src, dst_t);
+        }
+
+        if self.is_ref_of_unsized(src_t) && self.is_ref_of_sized(dst_t) {
+            return self.codegen_fat_ptr_to_thin_ptr_cast(src, dst_t);
         }
 
         // pointer casting. from a pointer / reference to another pointer / reference
@@ -949,8 +966,8 @@ impl<'tcx> GotocCtx<'tcx> {
         if let Some((concrete_type, trait_type)) =
             self.nested_pair_of_concrete_and_trait_types(src_pointee_type, dst_pointee_type)
         {
-            let dst_goto_type = self.codegen_ty(dst_mir_type);
             let dst_goto_expr = src_goto_expr.cast_to(Type::void_pointer());
+            let dst_goto_type = self.codegen_ty(dst_mir_type);
             let vtable = self.codegen_vtable(concrete_type, trait_type);
             let vtable_expr = vtable.address_of();
             Some(dynamic_fat_ptr(dst_goto_type, dst_goto_expr, vtable_expr, &self.symbol_table))
@@ -1020,11 +1037,18 @@ impl<'tcx> GotocCtx<'tcx> {
     /// position a concrete type. This function returns the pair (concrete type,
     /// trait type) that we can use to build the vtable for the concrete type
     /// implementation of the trait type.
-    fn nested_pair_of_concrete_and_trait_types(
+    pub fn nested_pair_of_concrete_and_trait_types(
         &self,
         src_mir_type: Ty<'tcx>,
         dst_mir_type: Ty<'tcx>,
     ) -> Option<(Ty<'tcx>, Ty<'tcx>)> {
+        // We are walking an ADT searching for a trait type in this ADT.  We can
+        // terminate a walk down a path when we hit a primitive type or which we hit
+        // a pointer type (that would take us out of this ADT and into another type).
+        if dst_mir_type.is_primitive() || is_pointer(dst_mir_type) {
+            return None;
+        }
+
         match (src_mir_type.kind(), dst_mir_type.kind()) {
             (_, ty::Dynamic(..)) => Some((src_mir_type.clone(), dst_mir_type.clone())),
             (ty::Adt(..), ty::Adt(..)) => {
@@ -1067,7 +1091,7 @@ impl<'tcx> GotocCtx<'tcx> {
             //     Some((src_mir_type.clone(), dst_mir_type.clone()))
             // }
             _ => panic!(
-                "Searching for pairs of concrete and trait types found unexpected types in {:?} and {:?}",
+                "Found unexpected types while searching for pairs of concrete and trait types in {:?} and {:?}",
                 src_mir_type, dst_mir_type
             ),
         }

--- a/rust-tests/cbmc-reg/SizeAndAlignOfDst/main_fail.rs
+++ b/rust-tests/cbmc-reg/SizeAndAlignOfDst/main_fail.rs
@@ -6,7 +6,6 @@
 // This test still fails with a final coercion error for
 // DummySubscriber to dyn Subscriber.
 
-#![feature(layout_for_ptr)]
 use std::mem;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -30,13 +29,5 @@ impl Subscriber for DummySubscriber {
 }
 
 fn main() {
-    let v = unsafe { mem::size_of_val_raw(&5i32) };
-    assert!(v == 4);
-
-    let x: [u8; 13] = [0; 13];
-    let y: &[u8] = &x;
-    let v = unsafe { mem::size_of_val_raw(y) };
-    assert!(v == 13);
-
     let s: Arc<Mutex<dyn Subscriber>> = Arc::new(Mutex::new(DummySubscriber::new()));
 }


### PR DESCRIPTION
### Resolved issues:

 resolves #ISSUE-NUMBER

### Description of changes: 

Allow cast of fat pointers to thin pointers

Also:
* Correctly cast before dereferencing a thin pointer to a flexible struct
* Correct search for trait type in adt (ignore primitive types and pointers)
* Correct the choice between thin and fat pointers in `codegen_fat_ptr` and `codegen_ty_ref` (and rewrite to use mir pointer metadata)

Note: The first commit of this pull request is #98 and that should be reviewed and merged first.

### Call-outs:

<!-- Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->
### Testing:

 How is this change tested?

 Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
