### PR TITLE
Warnings to errors

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
@@ -156,7 +156,7 @@ impl Stmt {
         //assert_eq!(lhs.typ(), rhs.typ());
         if lhs.typ() != rhs.typ() {
             rmc_warn!(
-                WarningType::Other,
+                WarningType::TypeMismatch,
                 "Assign statement with unequal types lhs {:?} rhs {:?}",
                 lhs.typ(),
                 rhs.typ()

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use self::StmtBody::*;
+use super::super::super::logging::{rmc_warn, WarningType};
 use super::{BuiltinFn, Expr, Location};
 use std::fmt::Debug;
-use tracing::debug;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 /// Datatypes
@@ -155,8 +155,9 @@ impl Stmt {
         //by disabling the assert and soundly assigning nondet
         //assert_eq!(lhs.typ(), rhs.typ());
         if lhs.typ() != rhs.typ() {
-            debug!(
-                "WARNING: assign statement with unequal types lhs {:?} rhs {:?}",
+            rmc_warn!(
+                WarningType::Other,
+                "Assign statement with unequal types lhs {:?} rhs {:?}",
                 lhs.typ(),
                 rhs.typ()
             );

--- a/compiler/rustc_codegen_llvm/src/gotoc/logging.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/logging.rs
@@ -61,8 +61,10 @@ impl ToJson for LogType {
 #[derive(Debug)]
 pub enum WarningType {
     Concurrency,
+    GlobalAsm,
+    MissingSymbol,
+    TypeMismatch,
     Unsupported,
-    Other,
 }
 
 impl ToJson for WarningType {

--- a/compiler/rustc_codegen_llvm/src/gotoc/logging.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/logging.rs
@@ -1,0 +1,127 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Logging for RMC to write structured logs to a log file.
+use crate::btree_string_map;
+use rustc_serialize::json::*;
+use std::env;
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+use tracing::{debug, warn};
+
+pub use crate::{rmc_debug, rmc_log, rmc_warn};
+
+/// A line in the log file.
+struct LogLine {
+    log_type: LogType,
+    message: String,
+}
+
+impl ToJson for LogLine {
+    fn to_json(&self) -> Json {
+        let output = btree_string_map![
+            ("log_type", self.log_type.to_json()),
+            ("message", self.message.to_json())
+        ];
+
+        Json::Object(output)
+    }
+}
+
+/// The kind of log message.
+#[derive(Debug)]
+enum LogType {
+    Debug,
+    Log,
+    Warning(WarningType),
+}
+
+impl ToJson for LogType {
+    fn to_json(&self) -> Json {
+        match self {
+            LogType::Debug => {
+                let output = btree_string_map![("type", "DEBUG".to_json())];
+                Json::Object(output)
+            }
+            LogType::Log => {
+                let output = btree_string_map![("type", "LOG".to_json())];
+                Json::Object(output)
+            }
+            LogType::Warning(warning_type) => {
+                let output = btree_string_map![
+                    ("type", "WARNING".to_json()),
+                    ("warning_kind", warning_type.to_json())
+                ];
+                Json::Object(output)
+            }
+        }
+    }
+}
+
+/// The kind of warning message.
+#[derive(Debug)]
+pub enum WarningType {
+    Concurrency,
+    Unsupported,
+    Other,
+}
+
+impl ToJson for WarningType {
+    fn to_json(&self) -> Json {
+        format!("{:?}", self).to_json()
+    }
+}
+
+/// Writes a given log line to the log file specified through
+/// the the environment variable RMC_LOG_FILE.
+/// If this is not set, continues without failing.
+fn write_to_log_file(log_line: LogLine) {
+    let line = format!("{}\n", log_line.to_json().to_string());
+    match env::var("RMC_LOG_FILE") {
+        Err(_) => (),
+        Ok(path) => {
+            OpenOptions::new().append(true).create(true).open(&path)
+                .expect(&format!("Internal error: Unable to open log file at location {}; try specifying a different location for the log file using the `--save-logs` flag. If this issue persists, file a ticket at https://github.com/model-checking/rmc/issues/new?assignees=&labels=bug&template=bug_report.md", &path))
+                .write_all(line.as_bytes())
+                .expect(&format!("Internal error: Error writing to log file."))
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! rmc_debug {
+    ($( $parts:expr ),*) => {
+        let message = rustc_middle::ty::print::with_no_trimmed_paths(|| format!($( $parts, )*));
+        crate::gotoc::logging::write_debug(message);
+    }
+}
+
+pub fn write_debug(message: String) {
+    debug!("RMC [DEBUG]: {}", message);
+    write_to_log_file(LogLine { log_type: LogType::Debug, message: message })
+}
+
+#[macro_export]
+macro_rules! rmc_log {
+    ($( $parts:expr ),*) => {
+        let message = rustc_middle::ty::print::with_no_trimmed_paths(|| format!($( $parts, )*));
+        crate::gotoc::logging::write_log(message);
+    }
+}
+
+pub fn write_log(message: String) {
+    debug!("RMC [LOG]: {}", message);
+    write_to_log_file(LogLine { log_type: LogType::Log, message: message })
+}
+
+#[macro_export]
+macro_rules! rmc_warn {
+    ($warning_type:expr, $( $rest:expr ),*) => {
+        let rest_string = rustc_middle::ty::print::with_no_trimmed_paths(|| format!($( $rest, )*));
+        crate::gotoc::logging::write_warning($warning_type, rest_string);
+    }
+}
+
+pub fn write_warning(warning_type: WarningType, message: String) {
+    warn!("RMC [WARNING] <{:?}>: {}", warning_type, message);
+    write_to_log_file(LogLine { log_type: LogType::Warning(warning_type), message: message })
+}

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/intrinsic.rs
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! this module handles intrinsics
-use tracing::{debug, warn};
 
 use crate::gotoc::cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, Type};
+use crate::gotoc::logging::{rmc_debug, rmc_warn, WarningType};
 use crate::gotoc::mir_to_goto::GotocCtx;
 use rustc_middle::mir::Place;
 use rustc_middle::ty::Instance;
@@ -42,9 +42,12 @@ impl<'tcx> GotocCtx<'tcx> {
         let intrinsic = self.symbol_name(instance);
         let intrinsic = intrinsic.as_str();
         let loc = self.codegen_span_option(span);
-        debug!(
+        rmc_debug!(
             "codegen_intrinsic:\n\tinstance {:?}\n\tfargs {:?}\n\tp {:?}\n\tspan {:?}",
-            instance, fargs, p, span
+            instance,
+            fargs,
+            p,
+            span
         );
         let sig = instance.ty(self.tcx, ty::ParamEnv::reveal_all()).fn_sig(self.tcx);
         let sig = self.tcx.normalize_erasing_late_bound_regions(ty::ParamEnv::reveal_all(), sig);
@@ -203,7 +206,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // -------------------------
         macro_rules! codegen_atomic_binop {
             ($op: ident) => {{
-                warn!("RMC does not support concurrency for now. {} treated as a sequential operation.", intrinsic);
+                rmc_warn!(WarningType::Concurrency, "RMC does not support concurrency for now. {} treated as a sequential operation.", intrinsic);
                 let loc = self.codegen_span_option(span);
                 let var1_ref = fargs.remove(0);
                 let var1 = var1_ref.dereference();
@@ -531,7 +534,8 @@ impl<'tcx> GotocCtx<'tcx> {
         p: &Place<'tcx>,
         loc: Location,
     ) -> Stmt {
-        warn!(
+        rmc_warn!(
+            WarningType::Concurrency,
             "RMC does not support concurrency for now. {} treated as a sequential operation.",
             intrinsic
         );
@@ -562,7 +566,8 @@ impl<'tcx> GotocCtx<'tcx> {
         p: &Place<'tcx>,
         loc: Location,
     ) -> Stmt {
-        warn!(
+        rmc_warn!(
+            WarningType::Concurrency,
             "RMC does not support concurrency for now. {} treated as a sequential operation.",
             intrinsic
         );
@@ -601,7 +606,8 @@ impl<'tcx> GotocCtx<'tcx> {
         p: &Place<'tcx>,
         loc: Location,
     ) -> Stmt {
-        warn!(
+        rmc_warn!(
+            WarningType::Concurrency,
             "RMC does not support concurrency for now. {} treated as a sequential operation.",
             intrinsic
         );
@@ -617,7 +623,8 @@ impl<'tcx> GotocCtx<'tcx> {
 
     /// Atomic no-ops (e.g., atomic_fence) are transformed into SKIP statements
     fn codegen_atomic_noop(&mut self, intrinsic: &str, loc: Location) -> Stmt {
-        warn!(
+        rmc_warn!(
+            WarningType::Concurrency,
             "RMC does not support concurrency for now. {} treated as a sequential operation.",
             intrinsic
         );

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/place.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/place.rs
@@ -6,13 +6,13 @@
 //! in [codegen_place] below.
 
 use crate::gotoc::cbmc::goto_program::{Expr, Type};
+use crate::gotoc::logging::{rmc_debug, rmc_warn, WarningType};
 use crate::gotoc::mir_to_goto::GotocCtx;
 use rustc_middle::{
     mir::{Field, Local, Place, ProjectionElem},
     ty::{self, Ty, TyS, VariantDef},
 };
 use rustc_target::abi::{LayoutOf, TagEncoding, Variants};
-use tracing::{debug, warn};
 
 /// A projection in RMC can either be to a type (the normal case),
 /// or a variant in the case of a downcast.
@@ -106,9 +106,11 @@ impl<'tcx> ProjectedPlace<'tcx> {
         // I think it may have to do with boxed fat pointers.
         // https://github.com/model-checking/rmc/issues/277
         if !Self::check_expr_typ(&goto_expr, &mir_typ_or_variant, ctx) {
-            warn!(
+            rmc_warn!(
+                WarningType::Other,
                 "Unexpected type mismatch in projection: \n{:?}\n{:?}",
-                &goto_expr, &mir_typ_or_variant
+                &goto_expr,
+                &mir_typ_or_variant
             );
         };
 
@@ -399,7 +401,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// If it passes through a fat pointer along the way, it stores info about it,
     /// which can be useful in reconstructing fat pointer operations.
     pub fn codegen_place(&mut self, p: &Place<'tcx>) -> ProjectedPlace<'tcx> {
-        debug!("codegen_place: {:?}", p);
+        rmc_debug!("codegen_place: {:?}", p);
         let initial_expr = self.codegen_local(p.local);
         let initial_typ = TypeOrVariant::Type(self.local_ty(p.local));
         let initial_projection = ProjectedPlace::new(initial_expr, initial_typ, None, None, self);

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/place.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/place.rs
@@ -107,7 +107,7 @@ impl<'tcx> ProjectedPlace<'tcx> {
         // https://github.com/model-checking/rmc/issues/277
         if !Self::check_expr_typ(&goto_expr, &mir_typ_or_variant, ctx) {
             rmc_warn!(
-                WarningType::Other,
+                WarningType::TypeMismatch,
                 "Unexpected type mismatch in projection: \n{:?}\n{:?}",
                 &goto_expr,
                 &mir_typ_or_variant

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/rvalue.rs
@@ -704,7 +704,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 .cast_to(field_type)
         } else {
             rmc_warn!(
-                WarningType::Other,
+                WarningType::MissingSymbol,
                 "Unable to find vtable symbol for virtual function {}, attempted lookup for symbol name: {}",
                 self.readable_instance_name(instance),
                 fn_name
@@ -735,7 +735,7 @@ impl<'tcx> GotocCtx<'tcx> {
         } else {
             // TODO: check why in https://github.com/model-checking/rmc/issues/66
             rmc_warn!(
-                WarningType::Other,
+                WarningType::MissingSymbol,
                 "drop_in_place not found for {:?}",
                 self.readable_instance_name(drop_instance)
             );

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/statement.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/statement.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use super::typ::FN_RETURN_VOID_VAR_NAME;
 use crate::gotoc::cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, Type};
+use crate::gotoc::logging::rmc_debug;
 use crate::gotoc::mir_to_goto::GotocCtx;
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir;
@@ -14,7 +15,6 @@ use rustc_span::Span;
 use rustc_target::abi::{FieldsShape, LayoutOf, Primitive, TagEncoding, Variants};
 use smallvec::SmallVec;
 use std::convert::TryInto;
-use tracing::debug;
 
 impl<'tcx> GotocCtx<'tcx> {
     fn codegen_ret_unit(&mut self) -> Stmt {
@@ -27,7 +27,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
     pub fn codegen_terminator(&mut self, term: &Terminator<'tcx>) -> Stmt {
         let loc = self.codegen_span(&term.source_info.span);
-        debug!("handling terminator {:?}", term);
+        rmc_debug!("handling terminator {:?}", term);
         //TODO: Instead of doing location::none(), and updating, just putit in when we make the stmt.
         match &term.kind {
             TerminatorKind::Goto { target } => {
@@ -201,7 +201,7 @@ impl<'tcx> GotocCtx<'tcx> {
         fargs: &mut Vec<Expr>,
         last_mir_arg: Option<&Operand<'tcx>>,
     ) {
-        debug!(
+        rmc_debug!(
             "codegen_untuple_closure_args instance: {:?}, fargs {:?}",
             self.readable_instance_name(instance),
             fargs
@@ -460,7 +460,7 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     pub fn codegen_statement(&mut self, stmt: &Statement<'tcx>) -> Stmt {
-        debug!("handling statement {:?}", stmt);
+        rmc_debug!("handling statement {:?}", stmt);
         match &stmt.kind {
             StatementKind::Assign(box (l, r)) => {
                 let lty = self.place_ty(l);

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/compiler_interface.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/compiler_interface.rs
@@ -5,6 +5,7 @@
 
 use crate::gotoc::cbmc::goto_program::symtab_transformer;
 use crate::gotoc::cbmc::goto_program::SymbolTable;
+use crate::gotoc::logging::{rmc_debug, rmc_log, rmc_warn, WarningType};
 use crate::gotoc::mir_to_goto::monomorphize;
 use crate::gotoc::mir_to_goto::GotocCtx;
 use bitflags::_core::any::Any;
@@ -19,7 +20,6 @@ use rustc_middle::ty::{self, TyCtxt};
 use rustc_serialize::json::ToJson;
 use rustc_session::config::{OutputFilenames, OutputType};
 use rustc_session::Session;
-use tracing::{debug, warn};
 
 // #[derive(RustcEncodable, RustcDecodable)]
 pub struct GotocCodegenResult {
@@ -55,6 +55,8 @@ impl CodegenBackend for GotocCodegenBackend {
     ) -> Box<dyn Any> {
         use rustc_hir::def_id::LOCAL_CRATE;
 
+        rmc_log!("Beginning codegen_crate.");
+
         super::utils::init();
 
         let codegen_units: &'tcx [CodegenUnit<'_>] = tcx.collect_and_partition_mono_items(()).1;
@@ -78,7 +80,8 @@ impl CodegenBackend for GotocCodegenBackend {
                         );
                     }
                     MonoItem::GlobalAsm(_) => {
-                        warn!(
+                        rmc_warn!(
+                            WarningType::GlobalAsm,
                             "Crate {} contains global ASM, which is not handled by RMC",
                             c.crate_name()
                         );
@@ -146,7 +149,7 @@ impl CodegenBackend for GotocCodegenBackend {
         let pretty_json = json.pretty();
 
         let output_name = outputs.path(OutputType::Object).with_extension("json");
-        debug!("output to {:?}", output_name);
+        rmc_debug!("output to {:?}", output_name);
         let mut out_file = ::std::fs::File::create(output_name).unwrap();
         write!(out_file, "{}", pretty_json.to_string()).unwrap();
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/monomorphize/partitioning.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/monomorphize/partitioning.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-use tracing::debug;
+use crate::rmc_debug;
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::sync;
@@ -402,7 +402,7 @@ fn merge_codegen_units<'tcx>(
         let mut consumed_cgu_names = cgu_contents.remove(&smallest.name()).unwrap();
         cgu_contents.get_mut(&second_smallest.name()).unwrap().extend(consumed_cgu_names.drain(..));
 
-        debug!(
+        rmc_debug!(
             "CodegenUnit {} merged into CodegenUnit {}",
             smallest.name(),
             second_smallest.name()
@@ -725,9 +725,9 @@ where
     'tcx: 'a,
 {
     if cfg!(debug_assertions) {
-        debug!("{}", label);
+        rmc_debug!("{}", label);
         for cgu in cgus {
-            debug!("CodegenUnit {} estimated size {} :", cgu.name(), cgu.size_estimate());
+            rmc_debug!("CodegenUnit {} estimated size {} :", cgu.name(), cgu.size_estimate());
 
             for (mono_item, linkage) in cgu.items() {
                 let symbol_name = mono_item.symbol_name(tcx).name;
@@ -735,7 +735,7 @@ where
                 let symbol_hash =
                     symbol_hash_start.map(|i| &symbol_name[i..]).unwrap_or("<no hash>");
 
-                debug!(
+                rmc_debug!(
                     " - {} [{:?}] [{}] estimated size {}",
                     mono_item.to_string(),
                     linkage,
@@ -744,7 +744,7 @@ where
                 );
             }
 
-            debug!("");
+            rmc_debug!("");
         }
     }
 }

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/monomorphize/partitioning.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/monomorphize/partitioning.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-use crate::rmc_debug;
 
+use crate::gotoc::logging::rmc_debug;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::sync;
 use rustc_hir::def::DefKind;
@@ -898,7 +898,7 @@ fn collect_and_partition_mono_items(
         item_keys.sort();
 
         for item in item_keys {
-            println!("MONO_ITEM {}", item);
+            rmc_debug!("MONO_ITEM {}", item);
         }
     }
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/overrides/stubs/hash_map_stub.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/overrides/stubs/hash_map_stub.rs
@@ -11,6 +11,7 @@ use std::cell::{Cell, RefCell, RefMut};
 
 use super::super::hooks::GotocHook;
 use crate::gotoc::cbmc::goto_program::{Expr, Location, Stmt};
+use crate::gotoc::logging::rmc_debug;
 use crate::gotoc::mir_to_goto::GotocCtx;
 
 pub struct HashMapStub<'tcx> {
@@ -47,7 +48,7 @@ impl<'tcx> GotocHook<'tcx> for HashMapStub<'tcx> {
 
         let is_destructor = self.is_target_destructor(instance);
         let unmangled = with_no_trimmed_paths(|| tcx.def_path_str(instance.def_id()));
-        println!("*** Unmangled was {} {} ", unmangled, is_destructor);
+        rmc_debug!("*** Unmangled was {} {} ", unmangled, is_destructor);
         let matched = match &unmangled[..] {
             "std::collections::HashMap::<K, V>::new" => true,
             "std::collections::HashMap::<K, V, S>::insert" => true,
@@ -68,7 +69,7 @@ impl<'tcx> GotocHook<'tcx> for HashMapStub<'tcx> {
         _span: Option<Span>,
     ) -> Stmt {
         let old_unmangled = with_no_trimmed_paths(|| tcx.tcx.def_path_str(instance.def_id()));
-        println!("Handeling {}", old_unmangled);
+        rmc_debug!("Handeling {}", old_unmangled);
         match &old_unmangled[..] {
             "std::collections::HashMap::<K, V>::new" => {
                 self.translate_to_stub(tcx, instance, fargs, assign_to, target, "new")

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/overrides/stubs/rust_stubber.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/overrides/stubs/rust_stubber.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use super::super::hooks::GotocTypeHook;
 use crate::gotoc::cbmc::goto_program::{Expr, Location, Stmt, Type};
+use crate::gotoc::logging::rmc_debug;
 use crate::gotoc::mir_to_goto::GotocCtx;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::definitions::{DefPathData, DisambiguatedDefPathData};
@@ -115,7 +116,7 @@ pub trait RustStubber<'tcx> {
                 .unwrap();
 
         let new_name = tcx.symbol_name(new_fn_instance);
-        println!("translate_function: {} {:?}", new_name, new_fn_instance);
+        rmc_debug!("translate_function: {} {:?}", new_name, new_fn_instance);
         let fctn = tcx.find_function(&new_name).unwrap();
         let p = assign_to.unwrap();
         let fn_call = fctn.call(fargs);
@@ -132,13 +133,13 @@ pub trait RustStubber<'tcx> {
     fn find_cbmc_fn(&self, tcx: TyCtxt<'tcx>, stubbed_ty: Ty<'tcx>, name: &str) -> Option<DefId> {
         for def_id in tcx.mir_keys(()).iter().map(|def_id| def_id.to_def_id()) {
             let defpath = tcx.def_path(def_id);
-            println!("defpath is {:?}, name is {}", defpath, name);
+            rmc_debug!("defpath is {:?}, name is {}", defpath, name);
             match &defpath.data[..] {
                 [.., DisambiguatedDefPathData { data: DefPathData::Impl, .. }, dpdata] => {
                     let key = tcx.def_key(def_id);
                     let impl_def_id = DefId { index: key.parent.unwrap(), ..def_id };
                     let self_ty = tcx.type_of(impl_def_id);
-                    println!("self_ty is {:?}", self_ty);
+                    rmc_debug!("self_ty is {:?}", self_ty);
                     let subst = match self_ty.kind() {
                         ty::Adt(_, substs) => substs,
                         _ => unreachable!(),

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/overrides/stubs/vec_stub.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/overrides/stubs/vec_stub.rs
@@ -11,6 +11,7 @@ use std::cell::{Cell, RefCell, RefMut};
 
 use super::super::hooks::GotocHook;
 use crate::gotoc::cbmc::goto_program::{Expr, Location, Stmt};
+use crate::gotoc::logging::rmc_debug;
 use crate::gotoc::mir_to_goto::GotocCtx;
 
 pub struct VecStub<'tcx> {
@@ -68,7 +69,7 @@ impl<'tcx> GotocHook<'tcx> for VecStub<'tcx> {
         _span: Option<Span>,
     ) -> Stmt {
         let old_unmangled = with_no_trimmed_paths(|| tcx.tcx.def_path_str(instance.def_id()));
-        println!("Handeling {}", old_unmangled);
+        rmc_debug!("Handeling {}", old_unmangled);
 
         match &old_unmangled[..] {
             "std::vec::Vec::<T, A>::pop" => {

--- a/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
@@ -2,5 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 pub mod cbmc;
+mod logging;
+pub use logging::{rmc_debug, rmc_log, rmc_warn, WarningType};
 mod mir_to_goto;
 pub use mir_to_goto::GotocCodegenBackend;

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -253,7 +253,7 @@ def extract_flags_from_toml(path):
     for flag in flags:
         add_flag(flag, flags[flag])
     
-    rmc.ensure(success)
+    rmc.ensure(success, None)
     return flag_list
 
 if __name__ == "__main__":

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -20,7 +20,7 @@ CBMC_VERIFICATION_FAILURE_EXIT_CODE = 10
 def main():
     args = parse_args()
 
-    rmc.ensure_dependencies_in_path()
+    rmc.ensure_dependencies_in_path(args.quiet)
 
     if args.gen_c_runnable:
         rmc.cargo_build(args.crate, args.target_dir,
@@ -49,7 +49,7 @@ def main():
 
     pattern = os.path.join(args.target_dir, "debug", "deps", "*.json")
     jsons = glob.glob(pattern)
-    rmc.ensure(len(jsons) == 1, f"Unexpected number of json outputs: {len(jsons)}")
+    rmc.ensure(len(jsons) == 1, f"Unexpected number of json outputs: {len(jsons)}", args.quiet)
 
     cbmc_filename = os.path.join(args.target_dir, "cbmc.out")
     c_filename = os.path.join(args.target_dir, "cbmc.c")

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -23,7 +23,7 @@ def main():
     rmc.ensure_dependencies_in_path(args.quiet)
 
     if args.gen_c_runnable:
-        rmc.cargo_build(args.crate, args.target_dir, False, [],
+        rmc.cargo_build(args.crate, args.target_dir,
                         args.verbose, args.debug, args.mangler, args.dry_run, ["gen-c"])
 
         pattern = os.path.join(args.target_dir, "debug", "deps", "*.json")
@@ -44,7 +44,7 @@ def main():
         
         rmc.gen_c_postprocess(c_runnable_filename, args.dry_run)
 
-    rmc.cargo_build(args.crate, args.target_dir, args.error_on_warning, args.suppress_rmc_warnings,
+    rmc.cargo_build(args.crate, args.target_dir,
                     args.verbose, args.debug, args.save_logs, args.mangler, args.dry_run, [])
 
     pattern = os.path.join(args.target_dir, "debug", "deps", "*.json")
@@ -56,6 +56,9 @@ def main():
     symbols_filename = os.path.join(args.target_dir, "cbmc.symbols")
     if EXIT_CODE_SUCCESS != rmc.symbol_table_to_gotoc(jsons[0], cbmc_filename, args.verbose, args.keep_temps, args.dry_run):
         return 1
+
+    if args.error_on_warning:
+        rmc.check_rmc_logs_for_warnings(args.save_logs, args.suppress_rmc_warnings)
 
     args.c_lib.append(str(RMC_C_LIB))
 

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -58,7 +58,7 @@ def main():
         return 1
 
     if args.error_on_warning:
-        rmc.check_rmc_logs_for_warnings(args.save_logs, args.suppress_rmc_warnings)
+        rmc.check_rmc_logs_for_warnings(args.save_logs, args.suppress_rmc_warnings, args.quiet)
 
     args.c_lib.append(str(RMC_C_LIB))
 

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -73,6 +73,9 @@ def main():
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])
 
+    if args.error_on_warnings_except is not None:
+        rmc.get_warnings(cbmc_filename, args.cbmc_args, args.error_on_warnings_except, args.verbose, args.quiet, args.keep_temps, args.target_dir, args.dry_run)
+
     if args.visualize:
         # Use a separate set of flags for coverage checking (empty for now)
         cover_args = []

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -23,7 +23,7 @@ def main():
     rmc.ensure_dependencies_in_path(args.quiet)
 
     if args.gen_c_runnable:
-        rmc.cargo_build(args.crate, args.target_dir,
+        rmc.cargo_build(args.crate, args.target_dir, False, [],
                         args.verbose, args.debug, args.mangler, args.dry_run, ["gen-c"])
 
         pattern = os.path.join(args.target_dir, "debug", "deps", "*.json")
@@ -44,7 +44,7 @@ def main():
         
         rmc.gen_c_postprocess(c_runnable_filename, args.dry_run)
 
-    rmc.cargo_build(args.crate, args.target_dir,
+    rmc.cargo_build(args.crate, args.target_dir, args.error_on_warning, args.suppress_rmc_warnings,
                     args.verbose, args.debug, args.save_logs, args.mangler, args.dry_run, [])
 
     pattern = os.path.join(args.target_dir, "debug", "deps", "*.json")
@@ -73,8 +73,8 @@ def main():
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])
 
-    if args.error_on_warnings_except is not None:
-        rmc.get_warnings(cbmc_filename, args.cbmc_args, args.error_on_warnings_except, args.verbose, args.quiet, args.keep_temps, args.target_dir, args.dry_run)
+    if args.error_on_warning:
+        rmc.get_warnings(cbmc_filename, args.cbmc_args, args.suppress_cbmc_warnings, args.verbose, args.quiet, args.keep_temps, args.target_dir, args.dry_run)
 
     if args.visualize:
         # Use a separate set of flags for coverage checking (empty for now)

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 import argparse
+import atexit
 import glob
 import sys
 import rmc
@@ -44,7 +45,7 @@ def main():
         rmc.gen_c_postprocess(c_runnable_filename, args.dry_run)
 
     rmc.cargo_build(args.crate, args.target_dir,
-                    args.verbose, args.debug, args.mangler, args.dry_run, [])
+                    args.verbose, args.debug, args.save_logs, args.mangler, args.dry_run, [])
 
     pattern = os.path.join(args.target_dir, "debug", "deps", "*.json")
     jsons = glob.glob(pattern)
@@ -165,6 +166,12 @@ def parse_args():
         # --quiet overrides --verbose
         if args.quiet:
             args.verbose = False
+
+        # If --save-logs not present, use default and delete after done
+        if args.save_logs is None:
+            args.save_logs = pathlib.Path(args.target_dir) / rmc.RMC_LOG_FILE
+            if not args.keep_temps:
+                atexit.register(rmc.delete_file, args.save_logs)
 
         # Add some CBMC flags by default unless `--no-default-checks` is being used
         if args.default_checks:

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -51,7 +51,7 @@ def main():
         return 1
 
     if args.error_on_warning:
-        rmc.check_rmc_logs_for_warnings(args.save_logs, args.suppress_rmc_warnings)
+        rmc.check_rmc_logs_for_warnings(args.save_logs, args.suppress_rmc_warnings, args.quiet)
 
     if EXIT_CODE_SUCCESS != rmc.symbol_table_to_gotoc(json_filename, goto_filename, args.verbose, args.keep_temps, args.dry_run):
         return 1

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -67,6 +67,9 @@ def main():
 
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])
+
+    if args.error_on_warnings_except is not None:
+        rmc.get_warnings(goto_filename, args.cbmc_args, args.error_on_warnings_except, args.verbose, args.quiet, args.keep_temps, args.target_dir, args.dry_run)
     
     if args.visualize:
         # Use a separate set of flags for coverage checking (empty for now)

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -46,7 +46,8 @@ def main():
     c_filename = base + ".c"
     symbols_filename = base + ".symbols"
 
-    if EXIT_CODE_SUCCESS != rmc.compile_single_rust_file(args.input, json_filename, args.verbose, args.debug, args.keep_temps, args.save_logs, args.mangler, args.dry_run, []):
+    if EXIT_CODE_SUCCESS != rmc.compile_single_rust_file(args.input, json_filename, args.error_on_warning, args.suppress_rmc_warnings, 
+                                                         args.verbose, args.debug, args.quiet, args.keep_temps, args.save_logs, args.mangler, args.dry_run, []):
         return 1
 
     if EXIT_CODE_SUCCESS != rmc.symbol_table_to_gotoc(json_filename, goto_filename, args.verbose, args.keep_temps, args.dry_run):
@@ -68,8 +69,8 @@ def main():
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])
 
-    if args.error_on_warnings_except is not None:
-        rmc.get_warnings(goto_filename, args.cbmc_args, args.error_on_warnings_except, args.verbose, args.quiet, args.keep_temps, args.target_dir, args.dry_run)
+    if args.error_on_warning:
+        rmc.get_warnings(goto_filename, args.cbmc_args, args.suppress_cbmc_warnings, args.verbose, args.quiet, args.keep_temps, args.target_dir, args.dry_run)
     
     if args.visualize:
         # Use a separate set of flags for coverage checking (empty for now)

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -46,9 +46,12 @@ def main():
     c_filename = base + ".c"
     symbols_filename = base + ".symbols"
 
-    if EXIT_CODE_SUCCESS != rmc.compile_single_rust_file(args.input, json_filename, args.error_on_warning, args.suppress_rmc_warnings, 
+    if EXIT_CODE_SUCCESS != rmc.compile_single_rust_file(args.input, json_filename,
                                                          args.verbose, args.debug, args.quiet, args.keep_temps, args.save_logs, args.mangler, args.dry_run, []):
         return 1
+
+    if args.error_on_warning:
+        rmc.check_rmc_logs_for_warnings(args.save_logs, args.suppress_rmc_warnings)
 
     if EXIT_CODE_SUCCESS != rmc.symbol_table_to_gotoc(json_filename, goto_filename, args.verbose, args.keep_temps, args.dry_run):
         return 1

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -21,7 +21,7 @@ def main():
     rmc.ensure_dependencies_in_path()
 
     base, ext = os.path.splitext(args.input)
-    rmc.ensure(ext == ".rs", "Expecting .rs input file.")
+    rmc.ensure(ext == ".rs", "Expecting .rs input file.", args.quiet)
 
     if args.gen_c_runnable:
         json_runnable_filename = base + "_runnable.json"

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 import argparse
+import atexit
 import os
 import sys
 import rmc
@@ -45,7 +46,7 @@ def main():
     c_filename = base + ".c"
     symbols_filename = base + ".symbols"
 
-    if EXIT_CODE_SUCCESS != rmc.compile_single_rust_file(args.input, json_filename, args.verbose, args.debug, args.keep_temps, args.mangler, args.dry_run, []):
+    if EXIT_CODE_SUCCESS != rmc.compile_single_rust_file(args.input, json_filename, args.verbose, args.debug, args.keep_temps, args.save_logs, args.mangler, args.dry_run, []):
         return 1
 
     if EXIT_CODE_SUCCESS != rmc.symbol_table_to_gotoc(json_filename, goto_filename, args.verbose, args.keep_temps, args.dry_run):
@@ -114,6 +115,12 @@ def parse_args():
         if args.quiet:
             args.verbose = False
 
+        # If --save-logs not present, use default and delete after done
+        if args.save_logs is None:
+            args.save_logs = pathlib.Path(args.target_dir) / rmc.RMC_LOG_FILE
+            if not args.keep_temps:
+                atexit.register(rmc.delete_file, args.save_logs)
+            
         # In the future we hope to make this configurable in the command line.
         # For now, however, changing this from "main" breaks rmc.
         # Issue: https://github.com/model-checking/rmc/issues/169

--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -34,6 +34,12 @@ UNWINDING_CHECKS = ["--unwinding-assertions"]
 
 RMC_LOG_FILE = "rmc.log"
 
+RMC_WARNING_TYPES = ["Concurrency",
+                     "GlobalAsm",
+                     "MissingSymbol",
+                     "TypeMismatch",
+                     "Unsupported"]
+
 # A Scanner is intended to match a pattern with an output
 # and edit the output based on an edit function
 class Scanner:
@@ -276,7 +282,7 @@ def get_warnings(cbmc_filename, cbmc_args, ignore_patterns, verbose=False, quiet
         if message.attrib["type"] == "WARNING"
     ]
 
-    def ignore(warning, ignore_patterns):
+    def ignore(warning):
         return any([re.match(pattern, warning) is not None
             for pattern in ignore_patterns])
 

--- a/scripts/rmc_flags.py
+++ b/scripts/rmc_flags.py
@@ -67,7 +67,7 @@ def add_warning_flags(make_group, add_flag, config):
              help="Raise an error when an unsuppressed warning is present")
     add_flag(group, "--suppress-cbmc-warnings", nargs="*", default=[], action="extend",
              help="Ignore warnings produced by cbmc by regex pattern match on the message")
-    add_flag(group, "--suppress-rmc-warnings", nargs="*", default=[], action="extend", choices=[],
+    add_flag(group, "--suppress-rmc-warnings", nargs="*", default=[], action="extend", choices=rmc.RMC_WARNING_TYPES,
              help="Ignore warnings produced by RMC by type")
 
 # Add flags which specify configurations for the proof.

--- a/scripts/rmc_flags.py
+++ b/scripts/rmc_flags.py
@@ -4,6 +4,7 @@
 
 import argparse
 import pathlib as pl
+import rmc
 
 # Taken from https://github.com/python/cpython/blob/3.9/Lib/argparse.py#L858
 # Cannot use `BooleanOptionalAction` with Python 3.8
@@ -86,6 +87,12 @@ def add_artifact_flags(make_group, add_flag, config):
              help="Generate a goto symbol table")
     add_flag(group, "--keep-temps", default=False, action=BooleanOptionalAction,
              help="Keep temporary files generated throughout RMC process")
+    add_flag(group, "--save-logs", nargs="?", type=pl.Path, const=rmc.RMC_LOG_FILE,
+             help="""
+                  If flag is not provided, uses a temporary log file at <target>/rmc.log;
+                  if flag is provided without argument, logs are saved to <target>/rmc.log;
+                  if flag is provided with argument, logs are saved to <target>/<argument>
+                  """)
     add_flag(group, "--target-dir", type=pl.Path, default=default_target, metavar="DIR",
              help=f"Directory for all generated artifacts; defaults to \"{default_target}\"")
 

--- a/scripts/rmc_flags.py
+++ b/scripts/rmc_flags.py
@@ -129,7 +129,7 @@ def add_other_flags(make_group, add_flag, config):
              help="Do not produce error return code on CBMC verification failure")
     add_flag(group, "--dry-run", default=False, action=BooleanOptionalAction,
              help="Print commands instead of running them")
-    add_flag(group, "--error-on-warnings-except", default=False, action="extend",
+    add_flag(group, "--error-on-warnings-except", default=None, action="extend",
              help="If this flag is provided, then anything that would normally be a warning "
                   "will instead be converted to an error, unless the warning message matches "
                   "one of the provided arguments; matches with regex on partial strings")

--- a/scripts/rmc_flags.py
+++ b/scripts/rmc_flags.py
@@ -129,6 +129,10 @@ def add_other_flags(make_group, add_flag, config):
              help="Do not produce error return code on CBMC verification failure")
     add_flag(group, "--dry-run", default=False, action=BooleanOptionalAction,
              help="Print commands instead of running them")
+    add_flag(group, "--error-on-warnings-except", default=False, action="extend",
+             help="If this flag is provided, then anything that would normally be a warning "
+                  "will instead be converted to an error, unless the warning message matches "
+                  "one of the provided arguments; matches with regex on partial strings")
 
 # Add flags we don't expect end-users to use.
 def add_developer_flags(make_group, add_flag, config):

--- a/scripts/rmc_flags.py
+++ b/scripts/rmc_flags.py
@@ -129,7 +129,7 @@ def add_other_flags(make_group, add_flag, config):
              help="Do not produce error return code on CBMC verification failure")
     add_flag(group, "--dry-run", default=False, action=BooleanOptionalAction,
              help="Print commands instead of running them")
-    add_flag(group, "--error-on-warnings-except", default=None, action="extend",
+    add_flag(group, "--error-on-warnings-except", nargs="*", default=None, action="extend",
              help="If this flag is provided, then anything that would normally be a warning "
                   "will instead be converted to an error, unless the warning message matches "
                   "one of the provided arguments; matches with regex on partial strings")

--- a/scripts/rmc_flags.py
+++ b/scripts/rmc_flags.py
@@ -55,9 +55,20 @@ def add_loudness_flags(make_group, add_flag, config):
     add_flag(group, "--debug", default=False, action=BooleanOptionalAction,
              help="Produce full debug information")
     add_flag(group, "--quiet", "-q", default=False, action=BooleanOptionalAction,
-             help="Produces no output, just an exit code and requested artifacts; overrides --verbose")
+             help="Produce no output, just an exit code and requested artifacts; overrides --verbose")
     add_flag(group, "--verbose", "-v", default=False, action=BooleanOptionalAction,
              help="Output processing stages and commands, along with minor debug information")
+
+# Add flags that suppress or raise seriousness of warnings
+def add_warning_flags(make_group, add_flag, config):
+    group = make_group(
+        "Warning flags", "Suppress warnings, or promote them to errors.")
+    add_flag(group, "--error-on-warning", action="store_true",
+             help="Raise an error when an unsuppressed warning is present")
+    add_flag(group, "--suppress-cbmc-warnings", nargs="*", default=[], action="extend",
+             help="Ignore warnings produced by cbmc by regex pattern match on the message")
+    add_flag(group, "--suppress-rmc-warnings", nargs="*", default=[], action="extend", choices=[],
+             help="Ignore warnings produced by RMC by type")
 
 # Add flags which specify configurations for the proof.
 def add_linking_flags(make_group, add_flag, config):
@@ -129,10 +140,6 @@ def add_other_flags(make_group, add_flag, config):
              help="Do not produce error return code on CBMC verification failure")
     add_flag(group, "--dry-run", default=False, action=BooleanOptionalAction,
              help="Print commands instead of running them")
-    add_flag(group, "--error-on-warnings-except", nargs="*", default=None, action="extend",
-             help="If this flag is provided, then anything that would normally be a warning "
-                  "will instead be converted to an error, unless the warning message matches "
-                  "one of the provided arguments; matches with regex on partial strings")
 
 # Add flags we don't expect end-users to use.
 def add_developer_flags(make_group, add_flag, config):
@@ -172,6 +179,7 @@ def add_flags(parser, config, exclude_flags=[], exclude_groups=[]):
 
     add_groups = [
         add_loudness_flags,
+        add_warning_flags,
         add_linking_flags,
         add_artifact_flags,
         add_check_flags,


### PR DESCRIPTION
### Description of changes: 

Introduces a flag `--error-on-warnings-except`, which converts all warnings from CBMC into RMC errors. It allows you to provide arguments to ignore certain warnings using regex pattern matching. 

### Resolved issues:

Resolves #350 

### Call-outs:

Using this flag currently requires running `cbmc` twice due to the fact that textual output and xml output cannot both be produced on a single run.

### Testing:

* How is this change tested? Existing regression suite.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
