### PR TITLE
fix rmc debug after crate refactoring

### DIFF
--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -89,7 +89,7 @@ def add_selected_default_cbmc_flags(args):
 
 # Updates environment to use gotoc backend debugging
 def add_rmc_rustc_debug_to_env(env):
-    env["RUSTC_LOG"] = env.get("RUSTC_LOG", "rustc_codegen_llvm::gotoc")
+    env["RUSTC_LOG"] = env.get("RUSTC_LOG", "rustc_codegen_rmc")
 
 # Prints info about the RMC process
 def print_rmc_step_status(step_name, completed_process, verbose=False):


### PR DESCRIPTION
### Description of changes: 

`--debug` did nothing anymore. We moved crates in #510, so that's the fix for the flag.




### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Manually. Possibly we should add a test, but eh

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
