### PR TITLE
Restore `apt` updates in ubuntu CI

### DIFF
--- a/scripts/setup/ubuntu/install_deps.sh
+++ b/scripts/setup/ubuntu/install_deps.sh
@@ -39,10 +39,11 @@ OTHER_DEPS="${VERSION_DEPS[${UBUNTU_VERSION}]:-""}"
 
 set -x
 
-# Github promises weekly build image updates, so we can skip the update step and
-# worst case we should only be 1-2 weeks behind upstream repos.
-# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
-#sudo apt-get --yes update
+# Github promises weekly build image updates, but recommends running
+# `sudo apt-get update` before installing packages in case the `apt`
+# index is stale. This prevents package installation failures.
+# https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners
+sudo apt-get --yes update
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes "${DEPS[@]}" "${OTHER_DEPS[@]}"
 


### PR DESCRIPTION
### Description of changes: 

We had a CI failure while pushing to `main` just a few hours ago due a package installation failure in [this run](https://github.com/model-checking/rmc/runs/3897859082).

What I understand after reading [this part of the Github-hosted runners documentation](https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners) is that even if they provide weekly updates to their images, `sudo apt-get update` should be run before installing any packages.

### Testing:

* How is this change tested? Cannot test since behavior appears in CI push events.

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
