### PR TITLE
Redirect build output to temporary files

### DIFF
--- a/scripts/codegen-firecracker.sh
+++ b/scripts/codegen-firecracker.sh
@@ -21,9 +21,14 @@ echo
 echo "Starting Firecracker codegen regression..."
 echo
 
+TEMP_FOLD="/tmp/FcCodegenTest"
+mkdir -p $TEMP_FOLD
+
+FC_CODEGEN_LOG=$TEMP_FOLD/"log.txt"
+
 # At the moment, we only test codegen for the virtio module
 cd $RMC_DIR/firecracker/src/devices/src/virtio/
-RUST_BACKTRACE=1 RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build --target x86_64-unknown-linux-gnu
+RUST_BACKTRACE=1 RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build --target x86_64-unknown-linux-gnu > $FC_CODEGEN_LOG 2>&1
 
 echo
 echo "Finished Firecracker codegen regression successfully..."

--- a/scripts/std-lib-regression.sh
+++ b/scripts/std-lib-regression.sh
@@ -37,12 +37,14 @@ if ! rustup toolchain list | grep -q nightly; then
   rustup toolchain install nightly
 fi
 
-STD_LIB_LOG="/tmp/StdLibTest/log.txt"
+TEMP_FOLD="/tmp/StdLibTest"
+mkdir -p $TEMP_FOLD
+
+STD_LIB_LOG=$TEMP_FOLD/"log.txt"
 
 echo "Starting cargo build with RMC"
 RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" \
-  RUSTC=rmc-rustc cargo +nightly build -Z build-std --target $TARGET 2>&1 \
-  | tee $STD_LIB_LOG
+  RUSTC=rmc-rustc cargo +nightly build -Z build-std --target $TARGET > $STD_LIB_LOG 2>&1
 
 # For now, we expect a linker error, but no modules should fail with a compiler
 # panic. 

--- a/src/test/rmc-dependency-test/diamond-dependency/run-dependency-test.sh
+++ b/src/test/rmc-dependency-test/diamond-dependency/run-dependency-test.sh
@@ -9,18 +9,23 @@ echo
 echo "Starting Diamond Dependency Test..."
 echo
 
+TEMP_FOLD="/tmp/DependencyTest"
+mkdir -p $TEMP_FOLD
+
+DEP_LOG=$TEMP_FOLD/"log.txt"
+
 # Compile crates with RMC backend
 cd $(dirname $0)
 rm -rf build
-CARGO_TARGET_DIR=build RUST_BACKTRACE=1 RUSTFLAGS="-Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build
+CARGO_TARGET_DIR=build RUST_BACKTRACE=1 RUSTFLAGS="-Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build > $DEP_LOG 2>&1
 
 # Convert from JSON to Gotoc 
 cd build/debug/deps/
-ls *.json | xargs symtab2gb
+ls *.json | xargs symtab2gb >> $DEP_LOG 2>&1
 
 # Add the entry point and remove unused functions
-goto-cc --function harness *.out -o a.out 
-goto-instrument --drop-unused-functions a.out b.out 
+goto-cc --function harness *.out -o a.out >> $DEP_LOG 2>&1
+goto-instrument --drop-unused-functions a.out b.out >> $DEP_LOG 2>&1
 
 # Run the solver
 RESULT="/tmp/dependency_test_result.txt"

--- a/src/test/rmc-multicrate/type-mismatch/run-mismatch-test.sh
+++ b/src/test/rmc-multicrate/type-mismatch/run-mismatch-test.sh
@@ -9,19 +9,24 @@ echo
 echo "Starting type mismatch test..."
 echo
 
+TEMP_FOLD="/tmp/MismatchTest"
+mkdir -p $TEMP_FOLD
+
+MISMATCH_LOG=$TEMP_FOLD/"log.txt"
+
 # Compile crates with RMC backend
 cd $(dirname $0)
 rm -rf /tmp/type_mismatch_test_build
 cd mismatch
-CARGO_TARGET_DIR=/tmp/type_mismatch_test_build RUST_BACKTRACE=1 RUSTFLAGS="-Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build
+CARGO_TARGET_DIR=/tmp/type_mismatch_test_build RUST_BACKTRACE=1 RUSTFLAGS="-Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build > $MISMATCH_LOG 2>&1
 
 # Convert from JSON to Gotoc 
 cd /tmp/type_mismatch_test_build/debug/deps/
-ls *.json | xargs symtab2gb
+ls *.json | xargs symtab2gb >> $MISMATCH_LOG 2>&1
 
 # Add the entry point and remove unused functions
-goto-cc --function main *.out -o a.out 
-goto-instrument --drop-unused-functions a.out b.out 
+goto-cc --function main *.out -o a.out >> $MISMATCH_LOG 2>&1
+goto-instrument --drop-unused-functions a.out b.out >> $MISMATCH_LOG 2>&1
 
 # Run the solver
 RESULT="/tmp/dependency_test_result.txt"


### PR DESCRIPTION
### Description of changes: 

Create log files for each script test in our regression and redirect build output to them. This the output with this change:

```
Starting RMC codegen for the Rust standard library...

     Created binary (application) `StdLibTest` package
Starting cargo build with RMC

Finished RMC codegen for the Rust standard library successfully...


real    1m45.669s
user    2m27.281s
sys     0m31.683s

Starting Firecracker codegen regression...


Finished Firecracker codegen regression successfully...


real    0m37.639s
user    1m7.565s
sys     0m17.985s

Starting Diamond Dependency Test...


Finished Diamond Dependency Test successfully...


real    0m0.565s
user    0m0.615s
sys     0m0.186s

Starting type mismatch test...


Finished type mismatch test successfully...


real    0m0.541s
user    0m0.495s
sys     0m0.171s

All RMC regression tests completed successfully.
```
### Resolved issues:

Resolves #573 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regression. See CI run.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
