### PR TITLE
Clean build firecracker in the regression suite

### DIFF
--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -28,6 +28,14 @@ check-cbmc-viewer-version.py --major 2 --minor 5
 # Check codegen for the standard library
 time "$SCRIPT_DIR"/std-lib-regression.sh
 
+# We rarely benefit from re-using build artifacts in the firecracker test,
+# and we often end up with incompatible leftover artifacts:
+# "error[E0514]: found crate `serde_derive` compiled by an incompatible version of rustc"
+# So if we're calling the full regression suite, wipe out old artifacts.
+if [ -d "$RMC_DIR/firecracker/build" ]; then
+  rm -rf "$RMC_DIR/firecracker/build"
+fi
+
 # Check codegen of firecracker
 time "$SCRIPT_DIR"/codegen-firecracker.sh
 


### PR DESCRIPTION
### Description of changes: 

People often end up with errors like

```
error[E0514]: found crate `serde_derive` compiled by an incompatible version of rustc
```

when re-running the rmc regression suite locally.

This PR removes the old generated artifacts for firecracker.

Re-using these artifacts means builds take about 23s for me locally. A clean build is 42s. So this adds 19s to the rmc regressions time (locally, CI is unaffected). I'm not happy about that, but considering how often this problem arises, seems worth it.

### Call-outs:

* I put it in the main rmc-regression script, so that people can still manually run the firecracker test script without blowing away the build artifacts.
* I was previously going to document the fix for these failures, merging this means we don't have to document it at all, things just work.

### Testing:

* How is this change tested? manually

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [na] Methods or procedures are documented
- [na] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
