### PR TITLE
Rename links to github project after repository rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Kani Rust Verifier
 The Kani Rust Verifier aims to be a bit-precise model-checker for Rust.
 
-Check out the [Documentation](https://model-checking.github.io/rmc) for
+Check out the [Documentation](https://model-checking.github.io/kani) for
 instructions on installing and running Kani.
 
 ## Security
-See [SECURITY](https://github.com/model-checking/rmc/security/policy) for more information.
+See [SECURITY](https://github.com/model-checking/kani/security/policy) for more information.
 
 ## Developer guide
-See [Kani developer documentation](https://model-checking.github.io/rmc/dev-documentation.html).
+See [Kani developer documentation](https://model-checking.github.io/kani/dev-documentation.html).
 
 ## License
 ### Rust compiler

--- a/kani-docs/book.toml
+++ b/kani-docs/book.toml
@@ -10,5 +10,5 @@ multilingual = false
 
 [output.html]
 site-url = "/kani/"
-git-repository-url = "https://github.com/model-checking/rmc"
-edit-url-template = "https://github.com/model-checking/rmc/edit/main/kani-docs/{path}"
+git-repository-url = "https://github.com/model-checking/kani"
+edit-url-template = "https://github.com/model-checking/kani/edit/main/kani-docs/{path}"

--- a/kani-docs/src/bookrunner.md
+++ b/kani-docs/src/bookrunner.md
@@ -50,7 +50,7 @@ To kick off the book runner process use
 ```
 
 The main function of the bookrunner is `generate_run()` in
-[`src/tools/bookrunner/src/books.rs`](https://github.com/model-checking/rmc/blob/main/src/tools/bookrunner/src/books.rs),
+[`src/tools/bookrunner/src/books.rs`](https://github.com/model-checking/kani/blob/main/src/tools/bookrunner/src/books.rs),
 which follows these steps:
  * First, it calls the different `parse_..._hierarchy()` functions which parse
    the summary files for each book.

--- a/kani-docs/src/cargo-kani.md
+++ b/kani-docs/src/cargo-kani.md
@@ -1,6 +1,6 @@
 # Kani on a package
 
-Kani currently ships with a `cargo-kani` script, but this support is limited. If you find any issue, please [filed a bug report](https://github.com/model-checking/rmc/issues/new?assignees=&labels=bug&template=bug_report.md).
+Kani currently ships with a `cargo-kani` script, but this support is limited. If you find any issue, please [filed a bug report](https://github.com/model-checking/kani/issues/new?assignees=&labels=bug&template=bug_report.md).
 
 To run `cargo-kani` in your crate, execute from the crate directory:
 

--- a/kani-docs/src/dev-documentation.md
+++ b/kani-docs/src/dev-documentation.md
@@ -49,7 +49,7 @@ So you don't have to worry about a series of "oops typo fix" messages while fixi
 
 ```bash
 # Set up your git fork
-git remote add fork git@github.com:${USER}/rmc.git
+git remote add fork git@github.com:${USER}/kani.git
 ```
 ```bash
 # Reset everything. Don't have any uncommitted changes!

--- a/kani-docs/src/getting-started.md
+++ b/kani-docs/src/getting-started.md
@@ -10,7 +10,7 @@ But Kani is also useful for finding panics in safe Rust, and it can check user-d
 Kani is currently in the initial development phase, and has not yet made an official release.
 It is under active development, but it does not yet support all Rust language features.
 (The [Book runner](./bookrunner.md) can help you understand our current progress.)
-If you encounter issues when using Kani we encourage you to [report them to us](https://github.com/model-checking/rmc/issues/new/choose).
+If you encounter issues when using Kani we encourage you to [report them to us](https://github.com/model-checking/kani/issues/new/choose).
 
 Kani usually syncs with the main branch of Rust every week, and so is generally up-to-date with the latest Rust language features.
 

--- a/kani-docs/src/install-guide.md
+++ b/kani-docs/src/install-guide.md
@@ -13,8 +13,8 @@ In general, the following dependencies are required. Note: These dependencies ma
 The simplest way to install (especially if you're using a fresh VM) is following our CI scripts:
 
 ```
-# git clone git@github.com:model-checking/rmc.git
-git clone https://github.com/model-checking/rmc.git
+# git clone git@github.com:model-checking/kani.git
+git clone https://github.com/model-checking/kani.git
 cd kani
 git submodule update --init
 ./scripts/setup/ubuntu-20.04/install_deps.sh
@@ -29,8 +29,8 @@ source $HOME/.cargo/env
 You need to have [Homebrew](https://brew.sh/) installed already.
 
 ```
-# git clone git@github.com:model-checking/rmc.git
-git clone https://github.com/model-checking/rmc.git
+# git clone git@github.com:model-checking/kani.git
+git clone https://github.com/model-checking/kani.git
 cd kani
 git submodule update --init
 ./scripts/setup/macos-10.15/install_deps.sh

--- a/kani-docs/src/kani-testing.md
+++ b/kani-docs/src/kani-testing.md
@@ -171,9 +171,9 @@ These tests follow the
 style.
 
 At present, Kani only uses unit tests in the
-[cbmc crate](https://github.com/model-checking/rmc/tree/main/compiler/cbmc)
+[cbmc crate](https://github.com/model-checking/kani/tree/main/compiler/cbmc)
 to test the
-[identity symbol table transformer](https://github.com/model-checking/rmc/blob/main/compiler/cbmc/src/goto_program/symtab_transformer/identity_transformer.rs).
+[identity symbol table transformer](https://github.com/model-checking/kani/blob/main/compiler/cbmc/src/goto_program/symtab_transformer/identity_transformer.rs).
 
 ## Script-based tests
 

--- a/kani-docs/src/limitations.md
+++ b/kani-docs/src/limitations.md
@@ -11,7 +11,7 @@ We use the following values to indicate the level of support:
  * **No**: The feature is not supported. Some support may be available but analyses should not be trusted.
 
 As with all software, bugs may be found anywhere regardless of the level of support. In such cases, we
-would greatly appreciate that you [filed a bug report](https://github.com/model-checking/rmc/issues/new?assignees=&labels=bug&template=bug_report.md).
+would greatly appreciate that you [filed a bug report](https://github.com/model-checking/kani/issues/new?assignees=&labels=bug&template=bug_report.md).
 
 Reference | Feature | Support | Notes |
 --- | --- | --- | --- |
@@ -129,8 +129,8 @@ Kani does not support assembly code for now. We may add it in the future but at
 present there are no plans to do so.
 
 Check out the tracking issues for [inline assembly (`asm!`
-macro)](https://github.com/model-checking/rmc/issues/2) and [global assembly
-(`asm_global!` macro)](https://github.com/model-checking/rmc/issues/316) to know
+macro)](https://github.com/model-checking/kani/issues/2) and [global assembly
+(`asm_global!` macro)](https://github.com/model-checking/kani/issues/316) to know
 more about the current status.
 
 ### Concurrency
@@ -153,7 +153,7 @@ example, includes a reachable `println!` statement.
 We have done some experiments to embed the standard library into the generated
 code, but this causes verification times to increase significantly. As of now,
 we have not been able to find a simple solution for [this
-issue](https://github.com/model-checking/rmc/issues/581), but we have some ideas
+issue](https://github.com/model-checking/kani/issues/581), but we have some ideas
 for future work in this direction.
 
 ### Advanced features
@@ -164,19 +164,19 @@ all their use cases.
 
 In particular, there are some outstanding issues to note here:
  * Unimplemented `PointerCast::ClosureFnPointer` in
-   [#274](https://github.com/model-checking/rmc/issues/274) and `Variant` case
+   [#274](https://github.com/model-checking/kani/issues/274) and `Variant` case
    in projections type in
-   [#448](https://github.com/model-checking/rmc/issues/448).
+   [#448](https://github.com/model-checking/kani/issues/448).
  * Unexpected fat pointer results in
-   [#82](https://github.com/model-checking/rmc/issues/82),
-   [#277](https://github.com/model-checking/rmc/issues/277),
-   [#327](https://github.com/model-checking/rmc/issues/327),
-   [#378](https://github.com/model-checking/rmc/issues/378) and
-   [#676](https://github.com/model-checking/rmc/issues/676).
+   [#82](https://github.com/model-checking/kani/issues/82),
+   [#277](https://github.com/model-checking/kani/issues/277),
+   [#327](https://github.com/model-checking/kani/issues/327),
+   [#378](https://github.com/model-checking/kani/issues/378) and
+   [#676](https://github.com/model-checking/kani/issues/676).
 
 We are particularly interested in bug reports concerning
 these features, so please [file a bug
-report](https://github.com/model-checking/rmc/issues/new?assignees=&labels=bug&template=bug_report.md)
+report](https://github.com/model-checking/kani/issues/new?assignees=&labels=bug&template=bug_report.md)
 if you are aware of one.
 
 ### Panic strategies
@@ -189,7 +189,7 @@ Rust has two different strategies when a panic occurs:
 Currently, Kani does not support stack unwinding. This has some implications
 regarding memory safety since programs sometimes rely on the unwinding logic to
 ensure there is no resource leak or persistent data inconsistency. Check out
-[this issue](https://github.com/model-checking/rmc/issues/692) for updates on
+[this issue](https://github.com/model-checking/kani/issues/692) for updates on
 stack unwinding support.
 
 ### Destructors

--- a/kani-docs/src/tutorial-first-steps.md
+++ b/kani-docs/src/tutorial-first-steps.md
@@ -6,7 +6,7 @@ Kani is unlike the testing tools you may already be familiar with.
 Much of testing is concerned with thinking of new corner cases that need to be covered.
 With Kani, all the corner cases are covered from the start, and the new concern is narrowing down the scope to something manageable for the checker.
 
-Consider this first program (which can be found under [`kani-docs/src/tutorial/kani-first-steps`](https://github.com/model-checking/rmc/tree/main/kani-docs/src/tutorial/kani-first-steps/)):
+Consider this first program (which can be found under [`kani-docs/src/tutorial/kani-first-steps`](https://github.com/model-checking/kani/tree/main/kani-docs/src/tutorial/kani-first-steps/)):
 
 ```rust
 {{#include tutorial/kani-first-steps/src/lib.rs:code}}

--- a/kani-docs/src/tutorial-kinds-of-failure.md
+++ b/kani-docs/src/tutorial-kinds-of-failure.md
@@ -8,7 +8,7 @@ In this section, we're going to expand on these additional checks, to give you a
 ## Bounds checking and pointers
 
 Rust is safe by default, and so includes dynamic (run-time) bounds checking where needed.
-Consider this Rust code (which can be found under [`kani-docs/src/tutorial/kinds-of-failure`](https://github.com/model-checking/rmc/tree/main/kani-docs/src/tutorial/kinds-of-failure/)):
+Consider this Rust code (which can be found under [`kani-docs/src/tutorial/kinds-of-failure`](https://github.com/model-checking/kani/tree/main/kani-docs/src/tutorial/kinds-of-failure/)):
 
 ```rust
 {{#include tutorial/kinds-of-failure/src/bounds_check.rs:code}}
@@ -179,7 +179,7 @@ Notice the two failures: the Rust-inserted overflow check (`simple_addition.asse
 > **NOTE:** You could attempt to fix this issue by using Rust's alternative mathematical functions with explicit overflow behavior.
 For instance, instead of `a + b` write `a.wrapping_add(b)`.
 >
-> However, [at the present time](https://github.com/model-checking/rmc/issues/480), while this disables the dynamic assertion that Rust inserts, it does not disable the additional Kani overflow check.
+> However, [at the present time](https://github.com/model-checking/kani/issues/480), while this disables the dynamic assertion that Rust inserts, it does not disable the additional Kani overflow check.
 > As a result, this currently still fails in Kani.
 
 ### Exercise: Classic overflow failure

--- a/kani-docs/src/tutorial-loops-unwinding.md
+++ b/kani-docs/src/tutorial-loops-unwinding.md
@@ -16,7 +16,7 @@ We can try to find this bug with a proof harness like this:
 When we run Kani on this, we run into an unfortunate result: non-termination.
 This non-termination is caused by the model checker trying to unroll the loop an unbounded number of times.
 
-> **NOTE:** Presently, [due to a bug](https://github.com/model-checking/rmc/issues/493), this is especially bad: we don't see any output at all.
+> **NOTE:** Presently, [due to a bug](https://github.com/model-checking/kani/issues/493), this is especially bad: we don't see any output at all.
 > You are supposed to see some log lines that might give some clue that an infinite loop is occurring.
 > If Kani doesn't terminate, it's almost always the problem that this section is covering, however.
 

--- a/kani-docs/src/tutorial-nondeterministic-variables.md
+++ b/kani-docs/src/tutorial-nondeterministic-variables.md
@@ -29,7 +29,7 @@ In this harness, we use`kani::any()` to generate `ProductId` and the new quantit
 If we run this example, Kani verification will succeed, including the assertion that shows that the underlying `u32` variable  used to represent `NonZeroU32` cannot be zero, per its type invariant:
 
 You can try it out by running the example under
-[arbitrary-variables directory](https://github.com/model-checking/rmc/tree/main/kani-docs/src/tutorial/arbitrary-variables/):
+[arbitrary-variables directory](https://github.com/model-checking/kani/tree/main/kani-docs/src/tutorial/arbitrary-variables/):
 
 ```
 cargo kani --function safe_update
@@ -54,7 +54,7 @@ The Kani verification will now fail showing that `inventory.get(&id).unwrap()` m
 This is an interesting issue that emerges from how `rustc` optimizes the memory layout of `Option<NonZeroU32>`.
 The compiler is able to represent `Option<NonZeroU32>` using `32` bits by using the value `0` to represent `None`.
 
-You can try it out by running the example under [arbitrary-variables directory](https://github.com/model-checking/rmc/tree/main/kani-docs/src/tutorial/arbitrary-variables/):
+You can try it out by running the example under [arbitrary-variables directory](https://github.com/model-checking/kani/tree/main/kani-docs/src/tutorial/arbitrary-variables/):
 
 ```
 cargo kani --function unsafe_update
@@ -85,7 +85,7 @@ Now you can use `kani::any()` to create valid nondeterministic variables of the 
 ```
 
 You can try it out by running the example under
-[`kani-docs/src/tutorial/arbitrary-variables`](https://github.com/model-checking/rmc/tree/main/kani-docs/src/tutorial/arbitrary-variables/):
+[`kani-docs/src/tutorial/arbitrary-variables`](https://github.com/model-checking/kani/tree/main/kani-docs/src/tutorial/arbitrary-variables/):
 
 ```
 cargo kani --function check_rating

--- a/library/kani/gen_c_lib.c
+++ b/library/kani/gen_c_lib.c
@@ -31,7 +31,7 @@ typedef bool __CPROVER_bool;
 // POINTER_OBJECT is used by Rust's offset_from to ensure
 // the two pointers are from the same object.
 // We can't do this in C.
-// Tracking issue: https://github.com/model-checking/rmc/issues/440
+// Tracking issue: https://github.com/model-checking/kani/issues/440
 #define POINTER_OBJECT(value) 0
 
 // Use built-in overflow operators

--- a/library/kani/stubs/Rust/hashset/c_hashset.rs
+++ b/library/kani/stubs/Rust/hashset/c_hashset.rs
@@ -40,7 +40,7 @@
 //
 // But it important to note here that Kani currently does not support unbounded
 // structures and arrays;
-// Tracking issue: https://github.com/model-checking/rmc/issues/311
+// Tracking issue: https://github.com/model-checking/kani/issues/311
 #[repr(C)]
 pub struct c_hashset {
     domain: *mut int16_t,

--- a/scripts/cargo-kani
+++ b/scripts/cargo-kani
@@ -162,7 +162,7 @@ def parse_args():
     def create_parser():
         parser = argparse.ArgumentParser(
             prog="cargo kani",
-            description="Verify a Rust crate. For more information, see https://github.com/model-checking/rmc.")
+            description="Verify a Rust crate. For more information, see https://github.com/model-checking/kani.")
 
         crate_group = parser.add_argument_group(
             "Crate", "You can pass in the rust crate positionally or with the --crate flag.")

--- a/scripts/cbmc_json_parser.py
+++ b/scripts/cbmc_json_parser.py
@@ -181,7 +181,7 @@ def postprocess_results(properties):
     may hide failures
     2. TODO: Change results from "SUCCESS" to "UNDETERMINED" if an unwinding
     assertion failed, since the insufficient unwinding may cause some execution
-    paths to be left unexplored (https://github.com/model-checking/rmc/issues/746)
+    paths to be left unexplored (https://github.com/model-checking/kani/issues/746)
 
     Additionally, print a message at the end of the output that indicates if any
     of the special cases above was hit.

--- a/scripts/codegen-firecracker.sh
+++ b/scripts/codegen-firecracker.sh
@@ -23,10 +23,10 @@ echo
 
 # At the moment, we only test codegen for the virtio module
 cd $KANI_DIR/firecracker/src/devices/src/virtio/
-# Disable warnings until https://github.com/model-checking/rmc/issues/573 is fixed
+# Disable warnings until https://github.com/model-checking/kani/issues/573 is fixed
 export RUSTC_LOG=error
 export RUST_BACKTRACE=1
-# Kani cannot locate Cargo.toml correctly: https://github.com/model-checking/rmc/issues/717
+# Kani cannot locate Cargo.toml correctly: https://github.com/model-checking/kani/issues/717
 cargo kani --only-codegen --target x86_64-unknown-linux-gnu --no-config-toml
 
 echo

--- a/scripts/kani
+++ b/scripts/kani
@@ -156,7 +156,7 @@ def parse_args():
     # Create parser
     def create_parser():
         parser = argparse.ArgumentParser(
-            description="Verify a single Rust file. For more information, see https://github.com/model-checking/rmc.")
+            description="Verify a single Rust file. For more information, see https://github.com/model-checking/kani.")
 
         input_group = parser.add_argument_group(
             "Input", "You can pass in the rust file positionally or with the --input flag.")

--- a/scripts/kani-fmt.sh
+++ b/scripts/kani-fmt.sh
@@ -14,7 +14,7 @@ cd ${ROOT_FOLDER}
 
 # Verify crates.
 # TODO: We should be able to use workspace once we unfork from rustc.
-# https://github.com/model-checking/rmc/issues/719
+# https://github.com/model-checking/kani/issues/719
 CRATES=(
     "bookrunner"
     "cbmc"

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -62,7 +62,7 @@ for testp in "${TESTS[@]}"; do
   mode=${testl[1]}
   echo "Check compiletest suite=$suite mode=$mode ($TARGET -> $TARGET)"
   # Note: `cargo-kani` tests fail if we do not add `$(pwd)` to `--build-base`
-  # Tracking issue: https://github.com/model-checking/rmc/issues/755
+  # Tracking issue: https://github.com/model-checking/kani/issues/755
   ./target/release/compiletest --kani-dir-path scripts --src-base src/test/$suite \
                                --build-base $(pwd)/build/$TARGET/test/$suite \
                                --stage-id stage1-$TARGET \

--- a/scripts/kani_flags.py
+++ b/scripts/kani_flags.py
@@ -173,7 +173,7 @@ def add_artifact_flags(make_group, add_flag, config):
     default_target = config["default-target"]
     assert default_target is not None, \
         f"Missing item in parser config: \"default-target\".\n" \
-        "This is a bug; please report this to https://github.com/model-checking/rmc/issues."
+        "This is a bug; please report this to https://github.com/model-checking/kani/issues."
 
     group = make_group(
         "Artifact flags", "Produce artifacts in addition to a basic Kani report.")
@@ -317,4 +317,4 @@ def add_flags(parser, config, exclude_flags=[], exclude_groups=[]):
     extra_groups = set(exclude_groups) - excluded_groups
     assert len(extra_flags.union(extra_groups)) == 0, \
         f"Attempt to exclude parser options which don't exist: {extra_groups.union(extra_flags)}\n" \
-        "This is a bug; please report this to https://github.com/model-checking/rmc/issues."
+        "This is a bug; please report this to https://github.com/model-checking/kani/issues."

--- a/src/kani-compiler/cbmc/src/goto_program/stmt.rs
+++ b/src/kani-compiler/cbmc/src/goto_program/stmt.rs
@@ -152,7 +152,7 @@ macro_rules! stmt {
 impl Stmt {
     /// `lhs = rhs;`
     pub fn assign(lhs: Expr, rhs: Expr, loc: Location) -> Self {
-        //Temporarily work around https://github.com/model-checking/rmc/issues/95
+        //Temporarily work around https://github.com/model-checking/kani/issues/95
         //by disabling the assert and soundly assigning nondet
         //assert_eq!(lhs.typ(), rhs.typ());
         if lhs.typ() != rhs.typ() {

--- a/src/kani-compiler/cbmc/src/goto_program/symbol.rs
+++ b/src/kani-compiler/cbmc/src/goto_program/symbol.rs
@@ -45,7 +45,7 @@ pub struct Symbol {
 }
 
 /// Currently, only C is understood by CBMC.
-// TODO: https://github.com/model-checking/rmc/issues/1
+// TODO: https://github.com/model-checking/kani/issues/1
 #[derive(Clone, Debug)]
 pub enum SymbolModes {
     C,

--- a/src/kani-compiler/cbmc/src/goto_program/symtab_transformer/gen_c_transformer/expr_transformer.rs
+++ b/src/kani-compiler/cbmc/src/goto_program/symtab_transformer/gen_c_transformer/expr_transformer.rs
@@ -142,7 +142,7 @@ impl Transformer for ExprTransformer {
     /// When indexing into a SIMD vector, cast to a pointer first to make legal indexing in C.
     /// `typ __attribute__((vector_size (size * sizeof(typ)))) var;`
     /// `((typ*) &var)[index]`
-    /// Tracking issue: https://github.com/model-checking/rmc/issues/444
+    /// Tracking issue: https://github.com/model-checking/kani/issues/444
     fn transform_expr_index(&mut self, _typ: &Type, array: &Expr, index: &Expr) -> Expr {
         let transformed_array = self.transform_expr(array);
         let transformed_index = self.transform_expr(index);

--- a/src/kani-compiler/cbmc/src/goto_program/symtab_transformer/gen_c_transformer/name_transformer.rs
+++ b/src/kani-compiler/cbmc/src/goto_program/symtab_transformer/gen_c_transformer/name_transformer.rs
@@ -88,7 +88,7 @@ impl NameTransformer {
 
             // Replace reserved names with alternatives
             // This should really handle *all* reserved C names.
-            // Tracking issue: https://github.com/model-checking/rmc/issues/439
+            // Tracking issue: https://github.com/model-checking/kani/issues/439
             let illegal_names = [("case", "case_"), ("default", "default_")];
             for (illegal, replacement) in illegal_names {
                 if new_name.ends_with(illegal) {

--- a/src/kani-compiler/cbmc/src/irep/symbol.rs
+++ b/src/kani-compiler/cbmc/src/irep/symbol.rs
@@ -19,7 +19,7 @@ pub struct Symbol {
     /// Almost always the same as base_name, but with name mangling can be relevant
     pub pretty_name: InternedString,
     /// Currently set to C. Consider creating a "rust" mode and using it in cbmc
-    /// https://github.com/model-checking/rmc/issues/1
+    /// https://github.com/model-checking/kani/issues/1
     pub mode: InternedString,
 
     // global properties

--- a/src/kani-compiler/cbmc/src/irep/to_irep.rs
+++ b/src/kani-compiler/cbmc/src/irep/to_irep.rs
@@ -446,7 +446,7 @@ impl goto_program::Symbol {
             /// Almost always the same as base_name, but with name mangling can be relevant
             pretty_name: self.pretty_name.unwrap_or("".into()),
             /// Currently set to C. Consider creating a "rust" mode and using it in cbmc
-            /// https://github.com/model-checking/rmc/issues/1
+            /// https://github.com/model-checking/kani/issues/1
             mode: self.mode.to_string().into(),
 
             // global properties

--- a/src/kani-compiler/cbmc/src/utils.rs
+++ b/src/kani-compiler/cbmc/src/utils.rs
@@ -7,7 +7,7 @@ use num::bigint::BigInt;
 
 /// Kani bug report URL, for asserts/errors
 pub const BUG_REPORT_URL: &str =
-    "https://github.com/model-checking/rmc/issues/new?template=bug_report.md";
+    "https://github.com/model-checking/kani/issues/new?template=bug_report.md";
 
 /// The aggregate name used in CBMC for aggregates of type `n`.
 pub fn aggr_tag<T: Into<InternedString>>(n: T) -> InternedString {

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/function.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/function.rs
@@ -18,13 +18,13 @@ use tracing::{debug, warn};
 impl<'tcx> GotocCtx<'tcx> {
     fn should_skip_current_fn(&self) -> bool {
         match self.current_fn().readable_name() {
-            // https://github.com/model-checking/rmc/issues/202
+            // https://github.com/model-checking/kani/issues/202
             "fmt::ArgumentV1::<'a>::as_usize" => true,
-            // https://github.com/model-checking/rmc/issues/204
+            // https://github.com/model-checking/kani/issues/204
             name if name.ends_with("__getit") => true,
-            // https://github.com/model-checking/rmc/issues/281
+            // https://github.com/model-checking/kani/issues/281
             name if name.starts_with("bridge::client") => true,
-            // https://github.com/model-checking/rmc/issues/282
+            // https://github.com/model-checking/kani/issues/282
             "bridge::closure::Closure::<'a, A, R>::call" => true,
             // Generators
             name if name.starts_with("<std::future::from_generator::GenFuture<T>") => true,
@@ -198,7 +198,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 // The spread arguments are additional function paramaters that are patched in
                 // They are to the function signature added in the `fn_typ` function.
                 // But they were never added to the symbol table, which we currently do here.
-                // https://github.com/model-checking/rmc/issues/686 to track a better solution.
+                // https://github.com/model-checking/kani/issues/686 to track a better solution.
                 self.symbol_table.insert(sym.clone());
                 // As discussed above, fields are named like `0: t1`.
                 // Follow that pattern for the marshalled data.

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/intrinsic.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/intrinsic.rs
@@ -361,7 +361,9 @@ impl<'tcx> GotocCtx<'tcx> {
             "breakpoint" => Stmt::skip(loc),
             "bswap" => self.codegen_expr_to_place(p, fargs.remove(0).bswap()),
             "caller_location" => {
-                codegen_unimplemented_intrinsic!("https://github.com/model-checking/kani/issues/374")
+                codegen_unimplemented_intrinsic!(
+                    "https://github.com/model-checking/kani/issues/374"
+                )
             }
             "ceilf32" => codegen_simple_intrinsic!(Ceilf),
             "ceilf64" => codegen_simple_intrinsic!(Ceil),
@@ -469,7 +471,9 @@ impl<'tcx> GotocCtx<'tcx> {
             "truncf32" => codegen_simple_intrinsic!(Truncf),
             "truncf64" => codegen_simple_intrinsic!(Trunc),
             "try" => {
-                codegen_unimplemented_intrinsic!("https://github.com/model-checking/kani/issues/267")
+                codegen_unimplemented_intrinsic!(
+                    "https://github.com/model-checking/kani/issues/267"
+                )
             }
             "type_id" => codegen_intrinsic_const!(),
             "type_name" => codegen_intrinsic_const!(),

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/intrinsic.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/intrinsic.rs
@@ -117,7 +117,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
         //  To solve this, we need to store the `self.get_sqrt()` into a temporary variable.
         //  Using the macro form allows us to keep the call as a oneliner, while still making rust happy.
-        //  TODO: https://github.com/model-checking/rmc/issues/5
+        //  TODO: https://github.com/model-checking/kani/issues/5
         macro_rules! codegen_simple_intrinsic {
             ($f:ident) => {{
                 let mm = self.symbol_table.machine_model();
@@ -361,7 +361,7 @@ impl<'tcx> GotocCtx<'tcx> {
             "breakpoint" => Stmt::skip(loc),
             "bswap" => self.codegen_expr_to_place(p, fargs.remove(0).bswap()),
             "caller_location" => {
-                codegen_unimplemented_intrinsic!("https://github.com/model-checking/rmc/issues/374")
+                codegen_unimplemented_intrinsic!("https://github.com/model-checking/kani/issues/374")
             }
             "ceilf32" => codegen_simple_intrinsic!(Ceilf),
             "ceilf64" => codegen_simple_intrinsic!(Ceil),
@@ -469,7 +469,7 @@ impl<'tcx> GotocCtx<'tcx> {
             "truncf32" => codegen_simple_intrinsic!(Truncf),
             "truncf64" => codegen_simple_intrinsic!(Trunc),
             "try" => {
-                codegen_unimplemented_intrinsic!("https://github.com/model-checking/rmc/issues/267")
+                codegen_unimplemented_intrinsic!("https://github.com/model-checking/kani/issues/267")
             }
             "type_id" => codegen_intrinsic_const!(),
             "type_name" => codegen_intrinsic_const!(),
@@ -510,7 +510,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
             // Unimplemented
             _ => codegen_unimplemented_intrinsic!(
-                "https://github.com/model-checking/rmc/issues/new/choose"
+                "https://github.com/model-checking/kani/issues/new/choose"
             ),
         }
     }

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/operand.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/operand.rs
@@ -32,7 +32,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 // we need to pull off the fat pointer. In that case, the rustc kind() on
                 // both the operand and the inner type are Dynamic.
                 // Consider moving this check elsewhere in:
-                // https://github.com/model-checking/rmc/issues/277
+                // https://github.com/model-checking/kani/issues/277
                 match self.operand_ty(o).kind() {
                     ty::Dynamic(..) => projection.fat_ptr_goto_expr.unwrap(),
                     _ => projection.goto_expr,
@@ -362,11 +362,11 @@ impl<'tcx> GotocCtx<'tcx> {
 
                     // we believe rlinkage being `Some` means the static not extern
                     // based on compiler/rustc_codegen_cranelift/src/linkage.rs#L21
-                    // see https://github.com/model-checking/rmc/issues/388
+                    // see https://github.com/model-checking/kani/issues/388
                     //
                     // Update: The assertion below may fail in similar environments.
                     // We are disabling it until we find out the root cause, see
-                    // https://github.com/model-checking/rmc/issues/400
+                    // https://github.com/model-checking/kani/issues/400
                     //
                     // assert!(rlinkage.is_none());
 

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/place.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/place.rs
@@ -80,7 +80,7 @@ impl<'tcx> ProjectedPlace<'tcx> {
                 let type_from_mir = ctx.codegen_ty(t);
                 if expr_ty != type_from_mir { Some((expr_ty, type_from_mir)) } else { None }
             }
-            // TODO: handle Variant https://github.com/model-checking/rmc/issues/448
+            // TODO: handle Variant https://github.com/model-checking/kani/issues/448
             TypeOrVariant::Variant(_) => None,
         }
     }
@@ -117,7 +117,7 @@ impl<'tcx> ProjectedPlace<'tcx> {
         }
         // TODO: these assertions fail on a few regressions. Figure out why.
         // I think it may have to do with boxed fat pointers.
-        // https://github.com/model-checking/rmc/issues/277
+        // https://github.com/model-checking/kani/issues/277
         if let Some((expr_ty, ty_from_mir)) =
             Self::check_expr_typ_mismatch(&goto_expr, &mir_typ_or_variant, ctx)
         {
@@ -212,7 +212,7 @@ impl<'tcx> GotocCtx<'tcx> {
                         "ty::Generator",
                         Type::code(vec![], Type::empty()),
                         res.location().clone(),
-                        "https://github.com/model-checking/rmc/issues/416",
+                        "https://github.com/model-checking/kani/issues/416",
                     ),
                     _ => unimplemented!(),
                 }
@@ -383,7 +383,7 @@ impl<'tcx> GotocCtx<'tcx> {
             // Best effort to codegen subslice projection.
             // This is known to fail with a CBMC invariant violation
             // in some cases. Full support to be added in
-            // https://github.com/model-checking/rmc/issues/357
+            // https://github.com/model-checking/kani/issues/357
             ProjectionElem::Subslice { from, to, from_end } => {
                 // https://rust-lang.github.io/rfcs/2359-subslice-pattern-syntax.html
                 match before.mir_typ().kind() {

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/rvalue.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/rvalue.rs
@@ -424,7 +424,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     "Rvalue::ThreadLocalRef",
                     typ,
                     Location::none(),
-                    "https://github.com/model-checking/rmc/issues/541",
+                    "https://github.com/model-checking/kani/issues/541",
                 )
             }
         }
@@ -630,7 +630,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     "PointerCast::ClosureFnPointer",
                     dest_typ,
                     Location::none(),
-                    "https://github.com/model-checking/rmc/issues/274",
+                    "https://github.com/model-checking/kani/issues/274",
                 )
             }
             PointerCast::MutToConstPointer => self.codegen_operand(o),
@@ -774,7 +774,7 @@ impl<'tcx> GotocCtx<'tcx> {
                         format!("drop_in_place for {}", drop_sym_name).as_str(),
                         Type::empty(),
                         Location::none(),
-                        "https://github.com/model-checking/rmc/issues/281",
+                        "https://github.com/model-checking/kani/issues/281",
                     )
                     .as_stmt(Location::none());
 
@@ -904,7 +904,7 @@ impl<'tcx> GotocCtx<'tcx> {
                         VtblEntry::MetadataAlign => Some(vt_align.clone()),
                         VtblEntry::Vacant => None,
                         // TODO: trait upcasting
-                        // https://github.com/model-checking/rmc/issues/358
+                        // https://github.com/model-checking/kani/issues/358
                         VtblEntry::TraitVPtr(_trait_ref) => None,
                         VtblEntry::Method(instance) => {
                             Some(ctx.codegen_vtable_method_field(*instance, trait_type, idx))

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/statement.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/statement.rs
@@ -99,14 +99,14 @@ impl<'tcx> GotocCtx<'tcx> {
                     "InlineAsm",
                     Type::empty(),
                     loc.clone(),
-                    "https://github.com/model-checking/rmc/issues/2",
+                    "https://github.com/model-checking/kani/issues/2",
                 )
                 .as_stmt(loc),
         }
     }
 
     // TODO: this function doesn't handle unwinding which begins if the destructor panics
-    // https://github.com/model-checking/rmc/issues/221
+    // https://github.com/model-checking/kani/issues/221
     fn codegen_drop(&mut self, location: &Place<'tcx>, target: &BasicBlock) -> Stmt {
         let loc_ty = self.place_ty(location);
         let drop_instance = Instance::resolve_drop_in_place(self.tcx, loc_ty);
@@ -170,8 +170,8 @@ impl<'tcx> GotocCtx<'tcx> {
                             // drop entirely causes unsound verification results in common cases
                             // like vector extend, so for now, add a sound special case workaround
                             // for calls that fail the typecheck.
-                            // https://github.com/model-checking/rmc/issues/426
-                            // Unblocks: https://github.com/model-checking/rmc/issues/435
+                            // https://github.com/model-checking/kani/issues/426
+                            // Unblocks: https://github.com/model-checking/kani/issues/435
                             if Expr::typecheck_call(&func, &args) {
                                 func.call(args)
                             } else {
@@ -179,7 +179,7 @@ impl<'tcx> GotocCtx<'tcx> {
                                     format!("drop_in_place call for {:?}", func).as_str(),
                                     func.typ().return_type().unwrap().clone(),
                                     Location::none(),
-                                    "https://github.com/model-checking/rmc/issues/426",
+                                    "https://github.com/model-checking/kani/issues/426",
                                 )
                             }
                             .as_stmt(Location::none())
@@ -521,7 +521,7 @@ impl<'tcx> GotocCtx<'tcx> {
                                 "ty::Generator",
                                 Type::code(vec![], Type::empty()),
                                 Location::none(),
-                                "https://github.com/model-checking/rmc/issues/416",
+                                "https://github.com/model-checking/kani/issues/416",
                             )
                             .as_stmt(Location::none());
                     }

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/typ.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/typ.rs
@@ -372,7 +372,7 @@ impl<'tcx> GotocCtx<'tcx> {
                             Some(self.trait_method_vtable_field_type(instance, idx))
                         }
                         // TODO: trait upcasting
-                        // https://github.com/model-checking/rmc/issues/358
+                        // https://github.com/model-checking/kani/issues/358
                         VtblEntry::TraitVPtr(..) => None,
                         VtblEntry::MetadataDropInPlace
                         | VtblEntry::MetadataSize
@@ -402,7 +402,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// TODO: to handle trait upcasting, this will need to use a
     /// poly existential trait type as a part of the key as well.
     /// See compiler/rustc_middle/src/ty/vtable.rs
-    /// https://github.com/model-checking/rmc/issues/358
+    /// https://github.com/model-checking/kani/issues/358
     pub fn vtable_name(&self, t: Ty<'tcx>) -> String {
         format!("{}::vtable", self.normalized_trait_name(t))
     }
@@ -429,7 +429,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // as the C name, so don't mangle in that case.
         // TODO: this is likely insufficient if a dependent crate has two versions of
         // linked C libraries
-        // https://github.com/model-checking/rmc/issues/450
+        // https://github.com/model-checking/kani/issues/450
         if is_repr_c_adt(t) {
             self.ty_pretty_name(t)
         } else {
@@ -815,12 +815,12 @@ impl<'tcx> GotocCtx<'tcx> {
             | ty::Uint(_) => self.codegen_ty(pointee_type).to_pointer(),
 
             // These types were blocking firecracker. Doing the default thing to unblock.
-            // https://github.com/model-checking/rmc/issues/215
-            // https://github.com/model-checking/rmc/issues/216
+            // https://github.com/model-checking/kani/issues/215
+            // https://github.com/model-checking/kani/issues/216
             ty::FnDef(_, _) | ty::Never => self.codegen_ty(pointee_type).to_pointer(),
 
             // These types were blocking stdlib. Doing the default thing to unblock.
-            // https://github.com/model-checking/rmc/issues/214
+            // https://github.com/model-checking/kani/issues/214
             ty::FnPtr(_) => self.codegen_ty(pointee_type).to_pointer(),
 
             // These types have no regression tests for them.
@@ -1294,7 +1294,7 @@ pub fn is_repr_c_adt(mir_type: Ty<'tcx>) -> bool {
 /// This is a place holder function that should normalize the given type.
 ///
 /// TODO: We should normalize the type projection here. For more details, see
-/// https://github.com/model-checking/rmc/issues/752
+/// https://github.com/model-checking/kani/issues/752
 fn normalize_type(ty: Ty<'tcx>) -> Ty<'tcx> {
     ty
 }

--- a/src/kani-compiler/rustc_codegen_kani/src/compiler_interface.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/compiler_interface.rs
@@ -191,7 +191,7 @@ fn check_options(session: &Session, need_metadata_module: bool) {
     if session.panic_strategy() != PanicStrategy::Abort {
         session.err(
             "Kani can only handle abort panic strategy (-C panic=abort). See for more details \
-        https://github.com/model-checking/rmc/issues/692",
+        https://github.com/model-checking/kani/issues/692",
         );
     }
 

--- a/src/kani-compiler/rustc_codegen_kani/src/context/vtable_ctx.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/context/vtable_ctx.rs
@@ -114,7 +114,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// the naming unambiguous.
     ///
     /// This can be simplified if CBMC implemented label-based restrictions.
-    /// Kani tracking: https://github.com/model-checking/rmc/issues/651
+    /// Kani tracking: https://github.com/model-checking/kani/issues/651
     /// CBMC tracking: https://github.com/diffblue/cbmc/issues/6464
     pub fn virtual_call_with_restricted_fn_ptr(
         &mut self,

--- a/src/kani-compiler/rustc_codegen_kani/src/overrides/hooks.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/overrides/hooks.rs
@@ -75,7 +75,7 @@ struct ExpectFail;
 impl<'tcx> GotocHook<'tcx> for ExpectFail {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
         // Deprecate old __VERIFIER notation that doesn't respect rust naming conventions.
-        // Complete removal is tracked here: https://github.com/model-checking/rmc/issues/599
+        // Complete removal is tracked here: https://github.com/model-checking/kani/issues/599
         if instance_name_starts_with(tcx, instance, "__VERIFIER_expect_fail") {
             warn!(
                 "The function __VERIFIER_expect_fail is deprecated. Use kani::expect_fail instead"
@@ -114,7 +114,7 @@ struct Assume;
 impl<'tcx> GotocHook<'tcx> for Assume {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
         // Deprecate old __VERIFIER notation that doesn't respect rust naming conventions.
-        // Complete removal is tracked here: https://github.com/model-checking/rmc/issues/599
+        // Complete removal is tracked here: https://github.com/model-checking/kani/issues/599
         if instance_name_starts_with(tcx, instance, "__VERIFIER_assume") {
             warn!("The function __VERIFIER_assume is deprecated. Use kani::assume instead");
             return true;
@@ -151,7 +151,7 @@ struct Nondet;
 impl<'tcx> GotocHook<'tcx> for Nondet {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
         // Deprecate old __nondet since it doesn't match rust naming conventions.
-        // Complete removal is tracked here: https://github.com/model-checking/rmc/issues/599
+        // Complete removal is tracked here: https://github.com/model-checking/kani/issues/599
         if instance_name_starts_with(tcx, instance, "__nondet") {
             warn!("The function __nondet is deprecated. Use kani::any instead");
             return true;

--- a/src/kani-compiler/rustc_codegen_kani/src/utils/debug.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/utils/debug.rs
@@ -21,7 +21,7 @@ thread_local!(static CURRENT_CODEGEN_ITEM: RefCell<(Option<String>, Option<Locat
 
 // Include Kani's bug reporting URL in our panics.
 const BUG_REPORT_URL: &str =
-    "https://github.com/model-checking/rmc/issues/new?labels=bug&template=bug_report.md";
+    "https://github.com/model-checking/kani/issues/new?labels=bug&template=bug_report.md";
 
 pub fn init() {
     // Install panic hook

--- a/src/kani-compiler/rustc_codegen_kani/src/utils/names.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/utils/names.rs
@@ -74,7 +74,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let pretty = self.readable_instance_name(instance);
 
         // Make main function a special case for easy CBMC entry
-        // TODO: probably need to edit for https://github.com/model-checking/rmc/issues/169
+        // TODO: probably need to edit for https://github.com/model-checking/kani/issues/169
         if pretty == "main" {
             "main".to_string()
         } else {
@@ -106,7 +106,7 @@ impl<'tcx> GotocCtx<'tcx> {
     ///     Example: 3_vol
     pub fn vtable_field_name(&self, _def_id: DefId, idx: usize) -> InternedString {
         // format!("{}_{}", idx, with_no_trimmed_paths(|| self.tcx.item_name(def_id)))
-        // TODO: use def_id https://github.com/model-checking/rmc/issues/364
+        // TODO: use def_id https://github.com/model-checking/kani/issues/364
         idx.to_string().into()
     }
 }
@@ -129,7 +129,7 @@ pub fn full_crate_name(tcx: TyCtxt<'tcx>) -> String {
 //TODO: These were moved from hooks.rs, where they didn't have a goto context. Normalize them.
 
 /// Helper function to determine if the function name starts with `expected`
-// TODO: rationalize how we match the hooks https://github.com/model-checking/rmc/issues/130
+// TODO: rationalize how we match the hooks https://github.com/model-checking/kani/issues/130
 pub fn instance_name_starts_with(
     tcx: TyCtxt<'tcx>,
     instance: Instance<'tcx>,

--- a/src/kani-compiler/rustc_codegen_kani/src/utils/utils.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/utils/utils.rs
@@ -25,8 +25,8 @@ impl<'tcx> GotocCtx<'tcx> {
     /// If it is not used, we the assertion will pass.
     /// This allows us to continue to make progress parsing rust code, while remaining sound (thanks to the `assert(false)`)
     ///
-    /// TODO: https://github.com/model-checking/rmc/issues/8 assume the required validity constraints for the nondet return
-    /// TODO: https://github.com/model-checking/rmc/issues/9 Have a parameter that decides whether to `assume(0)` to block further traces or not
+    /// TODO: https://github.com/model-checking/kani/issues/8 assume the required validity constraints for the nondet return
+    /// TODO: https://github.com/model-checking/kani/issues/9 Have a parameter that decides whether to `assume(0)` to block further traces or not
     pub fn codegen_unimplemented(
         &mut self,
         operation_name: &str,

--- a/src/test/expected/assert-eq/main.rs
+++ b/src/test/expected/assert-eq/main.rs
@@ -4,10 +4,10 @@
 /// if(x != y) { String msg = format_error_message(<x as debug>::fmt(x), <y as debug>::fmt(y)); panic!(msg)} else {}
 /// This leads us to the land of foreign types, ReifyFnPointer, and transmute.
 /// The "C" output from Kani is about 1KLOC, vs 80LOC for the same version with straight `assert!`.
-///     https://github.com/model-checking/rmc/issues/14
+///     https://github.com/model-checking/kani/issues/14
 /// The assertion message printed to the user on success is uninformative:
 ///     "library/std/src/macros.rs line 17 a panicking function core::panicking::panic_fmt is invoked: SUCCESS"
-///     https://github.com/model-checking/rmc/issues/13
+///     https://github.com/model-checking/kani/issues/13
 
 fn main() {
     let x = 1;

--- a/src/test/expected/copy/main.rs
+++ b/src/test/expected/copy/main.rs
@@ -4,7 +4,7 @@ use std::ptr;
 
 fn main() {
     // TODO: make an overlapping set of locations, and check that it does the right thing for the overlapping region too.
-    // https://github.com/model-checking/rmc/issues/12
+    // https://github.com/model-checking/kani/issues/12
     let expected_val = 42;
     let src: *const i32 = &expected_val as *const i32;
     let mut old_val = 99;

--- a/src/test/expected/report/unsupported/failure/expected
+++ b/src/test/expected/report/unsupported/failure/expected
@@ -1,4 +1,4 @@
 assertion failed: x == 0
 Failed Checks: assertion failed: x == 0
-Failed Checks: InlineAsm is not currently supported by Kani. Please post your example at https://github.com/model-checking/rmc/issues/2
+Failed Checks: InlineAsm is not currently supported by Kani. Please post your example at https://github.com/model-checking/kani/issues/2
 ** WARNING: A Rust construct that is not currently supported by Kani was found to be reachable. Check the results for more details.

--- a/src/test/expected/report/unsupported/reachable/expected
+++ b/src/test/expected/report/unsupported/reachable/expected
@@ -1,4 +1,4 @@
 UNDETERMINED
 assertion failed: x == 0
-Failed Checks: InlineAsm is not currently supported by Kani. Please post your example at https://github.com/model-checking/rmc/issues/2
+Failed Checks: InlineAsm is not currently supported by Kani. Please post your example at https://github.com/model-checking/kani/issues/2
 ** WARNING: A Rust construct that is not currently supported by Kani was found to be reachable. Check the results for more details.

--- a/src/test/kani-multicrate/type-mismatch/run-mismatch-test.sh
+++ b/src/test/kani-multicrate/type-mismatch/run-mismatch-test.sh
@@ -15,7 +15,7 @@ rm -rf /tmp/type_mismatch_test_build
 cd mismatch
 RESULT="/tmp/dependency_test_result.txt"
 
-# Disable warnings until https://github.com/model-checking/rmc/issues/573 is fixed
+# Disable warnings until https://github.com/model-checking/kani/issues/573 is fixed
 export RUSTC_LOG=error
 export CARGO_TARGET_DIR=/tmp/type_mismatch_test_build
 export RUST_BACKTRACE=1

--- a/src/test/kani/BitManipulation/Stable/fixme_main.rs
+++ b/src/test/kani/BitManipulation/Stable/fixme_main.rs
@@ -12,7 +12,7 @@ fn main() {
     let num_leading = x.leading_zeros();
     let rotated_num = x.rotate_left(3);
 
-    assert!(num_trailing == 3); // fails because of https://github.com/model-checking/rmc/issues/26
+    assert!(num_trailing == 3); // fails because of https://github.com/model-checking/kani/issues/26
     assert!(num_leading == 2);
     assert!(rotated_num == 0b1100_0001_u8);
 }

--- a/src/test/kani/BitManipulation/Unstable/fixme_main.rs
+++ b/src/test/kani/BitManipulation/Unstable/fixme_main.rs
@@ -16,7 +16,7 @@ fn main() {
     let num_leading = ctlz(v8);
     let num_trailing_nz = unsafe { cttz_nonzero(v8) };
 
-    // fail because of https://github.com/model-checking/rmc/issues/26
+    // fail because of https://github.com/model-checking/kani/issues/26
     assert!(nttz8 == 3);
     assert!(nttz16 == 11);
     assert!(nttz32 == 27);

--- a/src/test/kani/Cast/cast_abstract_args_to_concrete.rs
+++ b/src/test/kani/Cast/cast_abstract_args_to_concrete.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// https://github.com/model-checking/rmc/issues/555
+// https://github.com/model-checking/kani/issues/555
 // kani-flags: --no-undefined-function-checks
 
 // This regression test is in response to issue #135.

--- a/src/test/kani/Cleanup/unwind_fixme.rs
+++ b/src/test/kani/Cleanup/unwind_fixme.rs
@@ -3,7 +3,7 @@
 //
 // We currently do not support stack unwinding panic strategy. Once we do, this testcase should
 // fail during the verification with both the panic and the assertion failing.
-// https://github.com/model-checking/rmc/issues/692
+// https://github.com/model-checking/kani/issues/692
 //
 // To run manually, execute:
 // ```

--- a/src/test/kani/Closure/tupled_closure.rs
+++ b/src/test/kani/Closure/tupled_closure.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! When a closure is put inside a `Fn` trait, the Rustc backend injects a shim that converts
 //! between calling conventions.  This test ensures that the shim works correctly.
-//! https://github.com/model-checking/rmc/issues/678
+//! https://github.com/model-checking/kani/issues/678
 
 fn h(x: u8, y: usize, o: Option<std::num::NonZeroUsize>) -> usize {
     x as usize + y

--- a/src/test/kani/CodegenConstValue/main.rs
+++ b/src/test/kani/CodegenConstValue/main.rs
@@ -6,7 +6,7 @@
 // We use `--no-memory-safety-checks` in this test to avoid getting
 // a verification failure:
 // [main.pointer_dereference.5] line 16 dereference failure: pointer outside object bounds in *lut_ptr: FAILURE
-// Tracking issue: https://github.com/model-checking/rmc/issues/307
+// Tracking issue: https://github.com/model-checking/kani/issues/307
 const DEC_DIGITS_LUT: &'static [u8] = b"ab";
 fn main() {
     // The next two assertions don't go through to CBMC

--- a/src/test/kani/CopyIntrinsics/main.rs
+++ b/src/test/kani/CopyIntrinsics/main.rs
@@ -7,7 +7,7 @@ use std::ptr;
 
 fn test_copy() {
     // TODO: make an overlapping set of locations, and check that it does the right thing for the overlapping region too.
-    // https://github.com/model-checking/rmc/issues/12
+    // https://github.com/model-checking/kani/issues/12
     let mut expected_val = 42;
     let src: *mut i32 = &mut expected_val as *mut i32;
     let mut old_val = 99;

--- a/src/test/kani/Enum/discriminant.rs
+++ b/src/test/kani/Enum/discriminant.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Testcase for https://github.com/model-checking/rmc/issues/558.
+// Testcase for https://github.com/model-checking/kani/issues/558.
 // See https://rust-lang.github.io/unsafe-code-guidelines/layout/enums.html for information on the
 // layout.
 pub enum MyEnum {

--- a/src/test/kani/Enum/niche.rs
+++ b/src/test/kani/Enum/niche.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Testcase for https://github.com/model-checking/rmc/issues/558.
+// Testcase for https://github.com/model-checking/kani/issues/558.
 
 enum MyError {
     Val1,

--- a/src/test/kani/FatPointers/boxmuttrait.rs
+++ b/src/test/kani/FatPointers/boxmuttrait.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// https://github.com/model-checking/rmc/issues/555
+// https://github.com/model-checking/kani/issues/555
 // kani-flags: --no-undefined-function-checks
 
 #![feature(core_intrinsics)]

--- a/src/test/kani/FatPointers/boxslice1.rs
+++ b/src/test/kani/FatPointers/boxslice1.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// https://github.com/model-checking/rmc/issues/555
+// https://github.com/model-checking/kani/issues/555
 // kani-flags: --no-undefined-function-checks
 
 // Casts boxed array to boxed slice (example taken from rust documentation)

--- a/src/test/kani/ForeignItems/fixme_main.rs
+++ b/src/test/kani/ForeignItems/fixme_main.rs
@@ -37,7 +37,7 @@ extern "C" {
     // Some(&x) => &x;
     // None => NULL;
     // FIXME: we need to notice when this happens and do a bitcast, or C is unhappy
-    // https://github.com/model-checking/rmc/issues/3
+    // https://github.com/model-checking/kani/issues/3
     fn takes_ptr_option(p: Option<&u32>) -> u32;
     fn mutates_ptr(p: &mut u32);
     #[link_name = "name_in_c"]

--- a/src/test/kani/FunctionCall/Variadic/main.rs
+++ b/src/test/kani/FunctionCall/Variadic/main.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// https://github.com/model-checking/rmc/issues/555
+// https://github.com/model-checking/kani/issues/555
 // kani-flags: --no-undefined-function-checks
 
 // Minimized from vmm-sys-util/src/linux/aio.rs new()

--- a/src/test/kani/Generator/main.rs
+++ b/src/test/kani/Generator/main.rs
@@ -3,7 +3,7 @@
 
 // Check that we can codegen code that has a Generator type present,
 // as long as the path is not dynamically used. Full Generator support
-// tracked in: https://github.com/model-checking/rmc/issues/416
+// tracked in: https://github.com/model-checking/kani/issues/416
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/kani/Intrinsics/Assert/inhabited_panic.rs
+++ b/src/test/kani/Intrinsics/Assert/inhabited_panic.rs
@@ -8,7 +8,7 @@ use std::mem::MaybeUninit;
 // The code below attempts to instantiate uninhabited type `!`.
 // This should cause the intrinsic `assert_inhabited` to generate a panic during
 // compilation, but at present it triggers the `Nevers` hook instead.
-// See https://github.com/model-checking/rmc/issues/751
+// See https://github.com/model-checking/kani/issues/751
 fn main() {
     let _uninit_never: () = unsafe {
         MaybeUninit::<!>::uninit().assume_init();

--- a/src/test/kani/Intrinsics/fixme_try.rs
+++ b/src/test/kani/Intrinsics/fixme_try.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// See discussion on https://github.com/model-checking/rmc/issues/267
+// See discussion on https://github.com/model-checking/kani/issues/267
 #![feature(core_intrinsics)]
 use std::intrinsics::r#try;
 

--- a/src/test/kani/Invariants/fixme_niche_opt.rs
+++ b/src/test/kani/Invariants/fixme_niche_opt.rs
@@ -12,7 +12,7 @@
 /// ```
 /// This test will succeed.
 ///
-/// Issue: https://github.com/model-checking/rmc/issues/729
+/// Issue: https://github.com/model-checking/kani/issues/729
 
 enum Error {
     Error1,

--- a/src/test/kani/Pointers_OtherTypes/main.rs
+++ b/src/test/kani/Pointers_OtherTypes/main.rs
@@ -6,7 +6,7 @@
 // We use `--no-overflow-checks` in this test to avoid getting
 // a verification failure:
 // [main.NaN.1] line 25 NaN on * in var_30 * 0.0f: FAILURE
-// Tracking issue: https://github.com/model-checking/rmc/issues/307
+// Tracking issue: https://github.com/model-checking/kani/issues/307
 
 fn main() {
     let mut x = 1;

--- a/src/test/kani/SizeAndAlignOfDst/main_assert_fixme.rs
+++ b/src/test/kani/SizeAndAlignOfDst/main_assert_fixme.rs
@@ -4,7 +4,7 @@
 // size and alignment of a dynamically-sized type like
 // Arc<Mutex<dyn Subscriber>>.
 
-// https://github.com/model-checking/rmc/issues/426
+// https://github.com/model-checking/kani/issues/426
 // Current Kani-time compiler panic in implementing drop_in_place:
 
 // thread 'rustc' panicked at 'Function call does not type check:

--- a/src/test/kani/SizeAndAlignOfDst/main_fixme.rs
+++ b/src/test/kani/SizeAndAlignOfDst/main_fixme.rs
@@ -4,7 +4,7 @@
 // size and alignment of a dynamically-sized type like
 // Arc<Mutex<dyn Subscriber>>.
 
-// https://github.com/model-checking/rmc/issues/426
+// https://github.com/model-checking/kani/issues/426
 // Current Kani-time compiler panic in implementing drop_in_place:
 
 // thread 'rustc' panicked at 'Function call does not type check:

--- a/src/test/kani/Strings/copy_empty_string_by_intrinsic_fixme.rs
+++ b/src/test/kani/Strings/copy_empty_string_by_intrinsic_fixme.rs
@@ -3,7 +3,7 @@
 
 // Make sure we can handle explicit copy_nonoverlapping on empty string
 
-// TODO: https://github.com/model-checking/rmc/issues/241
+// TODO: https://github.com/model-checking/kani/issues/241
 // The copy_nonoverlapping succeeds, but the final copy back to a slice
 // fails:
 // [...copy_empty_string_by_intrinsic.assertion.2] line 1035 unreachable code: FAILURE

--- a/src/test/kani/SubSlice/subslice2_fixme.rs
+++ b/src/test/kani/SubSlice/subslice2_fixme.rs
@@ -28,7 +28,7 @@
 //       * value: 1
 //
 // This issue is captured in:
-// https://github.com/model-checking/rmc/issues/708
+// https://github.com/model-checking/kani/issues/708
 
 fn main() {
     let arr = [1, 2, 3];

--- a/src/test/kani/VolatileIntrinsics/main.rs
+++ b/src/test/kani/VolatileIntrinsics/main.rs
@@ -19,7 +19,7 @@ fn test_volatile_store() {
 // https://doc.redox-os.org/std/std/intrinsics/fn.volatile_copy_memory.html
 fn test_copy_volatile() {
     // TODO: make an overlapping set of locations, and check that it does the right thing for the overlapping region too.
-    // https://github.com/model-checking/rmc/issues/12
+    // https://github.com/model-checking/kani/issues/12
     let mut expected_val = 42;
     let src: *mut i32 = &mut expected_val as *mut i32;
     let mut old_val = 99;
@@ -103,7 +103,7 @@ fn test_swap() {
 /// https://doc.redox-os.org/std/std/intrinsics/fn.volatile_copy_nonoverlapping_memory.html
 fn test_copy_volatile_nonoverlapping() {
     // TODO: make an overlapping set of locations, and check that it does the right thing for the overlapping region too.
-    // https://github.com/model-checking/rmc/issues/12
+    // https://github.com/model-checking/kani/issues/12
     let mut expected_val = 42;
     let src: *mut i32 = &mut expected_val as *mut i32;
     let mut old_val = 99;

--- a/src/tools/bookrunner/src/util.rs
+++ b/src/tools/bookrunner/src/util.rs
@@ -4,7 +4,7 @@
 //!
 //! TODO: The types and procedures in this modules are similar to the ones in
 //! `compiletest`. Consider using `Litani` to run the test suites (see
-//! [issue #390](https://github.com/model-checking/rmc/issues/390)).
+//! [issue #390](https://github.com/model-checking/kani/issues/390)).
 
 use crate::litani::Litani;
 use std::{


### PR DESCRIPTION
### Description of changes: 

Renamed the following:
- https://github.com/model-checking/rmc - > https://github.com/model-checking/kani
- https://model-checking.github.io/rmc -> https://model-checking.github.io/kani

### Resolved issues:

N/A

### Call-outs:

N/A

### Testing:

* How is this change tested? Regression

* Is this a refactor change? Maybe

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
