### PR TITLE
Replace rmc by kani in the bookrunner *props files

### DIFF
--- a/tools/bookrunner/configs/books/Rust by Example/Custom Types/Enums/Testcase: linked-list/5.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Custom Types/Enums/Testcase: linked-list/5.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 3
+// kani-flags: --cbmc-args --unwind 3

--- a/tools/bookrunner/configs/books/Rust by Example/Error handling/Iterating over Results/22.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Error handling/Iterating over Results/22.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 4 --object-bits 9
+// kani-flags: --cbmc-args --unwind 4 --object-bits 9

--- a/tools/bookrunner/configs/books/Rust by Example/Error handling/Iterating over Results/39.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Error handling/Iterating over Results/39.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 4 --object-bits 9
+// kani-flags: --cbmc-args --unwind 4 --object-bits 9

--- a/tools/bookrunner/configs/books/Rust by Example/Error handling/Iterating over Results/5.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Error handling/Iterating over Results/5.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 4
+// kani-flags: --cbmc-args --unwind 4

--- a/tools/bookrunner/configs/books/Rust by Example/Error handling/Iterating over Results/54.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Error handling/Iterating over Results/54.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/Rust by Example/Error handling/Iterating over Results/69.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Error handling/Iterating over Results/69.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/Rust by Example/Flow of Control/for and range/102.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Flow of Control/for and range/102.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 7
+// kani-flags: --cbmc-args --unwind 7

--- a/tools/bookrunner/configs/books/Rust by Example/Flow of Control/for and range/63.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Flow of Control/for and range/63.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 7
+// kani-flags: --cbmc-args --unwind 7

--- a/tools/bookrunner/configs/books/Rust by Example/Functions/Closures/Capturing/89.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Functions/Closures/Capturing/89.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 4
+// kani-flags: --cbmc-args --unwind 4

--- a/tools/bookrunner/configs/books/Rust by Example/Functions/Closures/Examples in std/Iterator::any/22.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Functions/Closures/Examples in std/Iterator::any/22.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 4
+// kani-flags: --cbmc-args --unwind 4

--- a/tools/bookrunner/configs/books/Rust by Example/Functions/Closures/Examples in std/Searching through iterators/22.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Functions/Closures/Examples in std/Searching through iterators/22.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 4
+// kani-flags: --cbmc-args --unwind 4

--- a/tools/bookrunner/configs/books/Rust by Example/Functions/Closures/Examples in std/Searching through iterators/52.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Functions/Closures/Examples in std/Searching through iterators/52.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 7
+// kani-flags: --cbmc-args --unwind 7

--- a/tools/bookrunner/configs/books/Rust by Example/Hello World/Formatted print/Formatting/17.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Hello World/Formatted print/Formatting/17.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 4
+// kani-flags: --cbmc-args --unwind 4

--- a/tools/bookrunner/configs/books/Rust by Example/Std library types/HashMap/14.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Std library types/HashMap/14.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/Rust by Example/Std library types/HashMap/Alternate_custom key types/29.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Std library types/HashMap/Alternate_custom key types/29.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/Rust by Example/Std library types/Strings/12.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Std library types/Strings/12.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/Rust by Example/Std misc/Channels/7.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Std misc/Channels/7.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/Rust by Example/Std misc/File I_O/read lines/9.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Std misc/File I_O/read lines/9.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/Rust by Example/Std misc/Program arguments/8.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Std misc/Program arguments/8.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/Rust by Example/Std misc/Program arguments/Argument parsing/5.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Std misc/Program arguments/Argument parsing/5.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/Rust by Example/Std misc/Threads/6.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Std misc/Threads/6.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/Rust by Example/Std misc/Threads/Testcase: map-reduce/24.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Std misc/Threads/Testcase: map-reduce/24.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/Rust by Example/Traits/Disambiguating overlapping traits/11.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Traits/Disambiguating overlapping traits/11.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 10
+// kani-flags: --cbmc-args --unwind 10

--- a/tools/bookrunner/configs/books/Rust by Example/Traits/Iterators/12.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Traits/Iterators/12.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 5
+// kani-flags: --cbmc-args --unwind 5

--- a/tools/bookrunner/configs/books/Rust by Example/Traits/impl Trait/115.props
+++ b/tools/bookrunner/configs/books/Rust by Example/Traits/impl Trait/115.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/The Rust Reference/Appendices/Glossary/263.props
+++ b/tools/bookrunner/configs/books/The Rust Reference/Appendices/Glossary/263.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 4
+// kani-flags: --cbmc-args --unwind 4

--- a/tools/bookrunner/configs/books/The Rust Reference/Attributes/Limits/45.props
+++ b/tools/bookrunner/configs/books/The Rust Reference/Attributes/Limits/45.props
@@ -1,1 +1,1 @@
-// rmc-codegen-fail
+// kani-codegen-fail

--- a/tools/bookrunner/configs/books/The Rust Reference/Linkage/190.props
+++ b/tools/bookrunner/configs/books/The Rust Reference/Linkage/190.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/The Rust Reference/Patterns/367.props
+++ b/tools/bookrunner/configs/books/The Rust Reference/Patterns/367.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/The Rust Reference/Statements and expressions/Expressions/Loop expressions/133.props
+++ b/tools/bookrunner/configs/books/The Rust Reference/Statements and expressions/Expressions/Loop expressions/133.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 4
+// kani-flags: --cbmc-args --unwind 4

--- a/tools/bookrunner/configs/books/The Rust Reference/Statements and expressions/Expressions/Method call expressions/10.props
+++ b/tools/bookrunner/configs/books/The Rust Reference/Statements and expressions/Expressions/Method call expressions/10.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0

--- a/tools/bookrunner/configs/books/The Rust Reference/Type system/Types/113.props
+++ b/tools/bookrunner/configs/books/The Rust Reference/Type system/Types/113.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 0
+// kani-flags: --cbmc-args --unwind 0


### PR DESCRIPTION
### Description of changes: 

I guess this somehow got ignored before. Sorry about that!

### Resolved issues:

N/A


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? This actually speeds up the regression by about 10min. Comparing the [regression that ran on HEAD of main](https://github.com/model-checking/kani/runs/4970211719) and [this one from my repo](https://github.com/celinval/kani-dev/runs/4970512102).

* Is this a refactor change??

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
