### PR TITLE
[Not ready for review] Inject reachability checks for assertions

### DIFF
--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -100,3 +100,54 @@ pub fn expect_fail(_cond: bool, _message: &str) {}
 
 /// Kani proc macros must be in a separate crate
 pub use kani_macros::*;
+
+pub use std::*;
+
+#[rustc_diagnostic_item = "KaniOptionalCover"]
+#[inline(never)]
+#[doc(hidden)]
+pub fn __optional_cover() {
+    unimplemented!("Kani optional_cover")
+}
+
+#[macro_export]
+macro_rules! assert {
+    ($cond:expr $(,)?) => {
+        //core::assert!($crate::any::<bool>());
+        //$crate::__optional_cover(concat!("reachability check for assert in file ", file!(), " line ", line!()));
+        $crate::__optional_cover();
+        core::assert!($cond);
+    };
+}
+
+#[macro_export]
+macro_rules! assert_eq {
+    ($left:expr, $right:expr $(,)?) => {{
+        assert!($left == $right);
+    }};
+    ($left:expr, $right:expr, $($arg:tt)+) => {{
+        assert!($left == $right);
+    }};
+}
+
+#[macro_export]
+macro_rules! assert_ne {
+    ($left:expr, $right:expr $(,)?) => {{
+        assert!(!($left == $right));
+    }};
+    ($left:expr, $right:expr, $($arg:tt)+) => {{
+        assert!(!($left == $right));
+    }};
+}
+
+#[macro_export]
+macro_rules! format_args {
+    ($fmt:expr) => {};
+    ($fmt:expr, $($args:tt)*) => {};
+}
+
+//#[macro_export]
+//macro_rules! println {
+//    () => ();
+//    ($($arg:tt)*) => ()
+//}

--- a/scripts/kani_flags.py
+++ b/scripts/kani_flags.py
@@ -193,6 +193,8 @@ def add_artifact_flags(make_group, add_flag, config):
 # Add flags to turn off default checks.
 def add_check_flags(make_group, add_flag, config):
     group = make_group("Check flags", "Disable some or all default checks.")
+    add_flag(group, "--assertion-reach-checks", default=False, action=BooleanOptionalAction,
+             help="Turn on assertion reachability checks")
     add_flag(group, "--default-checks", default=True, action=BooleanOptionalAction,
              help="Turn on all default checks")
     add_flag(group, "--memory-safety-checks", default=True, action=BooleanOptionalAction,

--- a/src/kani-compiler/kani_queries/src/lib.rs
+++ b/src/kani-compiler/kani_queries/src/lib.rs
@@ -9,10 +9,14 @@ pub trait UserInput {
 
     fn set_emit_vtable_restrictions(&mut self, restrictions: bool);
     fn get_emit_vtable_restrictions(&self) -> bool;
+
+    fn set_check_assertion_reachability(&mut self, reachability: bool);
+    fn get_check_assertion_reachability(&self) -> bool;
 }
 
 #[derive(Debug, Default)]
 pub struct QueryDb {
+    check_assertion_reachability: AtomicBool,
     emit_vtable_restrictions: AtomicBool,
     symbol_table_passes: Vec<String>,
 }
@@ -32,5 +36,13 @@ impl UserInput for QueryDb {
 
     fn get_emit_vtable_restrictions(&self) -> bool {
         self.emit_vtable_restrictions.load(Ordering::Relaxed)
+    }
+
+    fn set_check_assertion_reachability(&mut self, reachability: bool) {
+        self.check_assertion_reachability.store(reachability, Ordering::Relaxed);
+    }
+
+    fn get_check_assertion_reachability(&self) -> bool {
+        self.check_assertion_reachability.load(Ordering::Relaxed)
     }
 }


### PR DESCRIPTION
### Description of changes: 

Inject a reachability check for every assertion so that unreachable checks are reported as "UNREACHABLE" as opposed to "SUCCESS". The reachability checks are currently enabled by a new option, `--assertion-reach-checks` that is default off.

### Resolved issues:

Resolves #637 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
