### PR TITLE
Move bookrunner and doc to its own job

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+name: Build Kani
+description: Install dependencies and build kani binaries
+inputs:
+  os:
+    description: In which Operating System is this running
+    required: true
+    default: ubuntu-20.04
+runs:
+  using: composite
+  steps:
+      - name: Install dependencies
+        run: ./scripts/setup/${{ inputs.os }}/install_deps.sh
+        shell: bash
+
+      - name: Install CBMC
+        run: ./scripts/setup/${{ inputs.os }}/install_cbmc.sh
+        shell: bash
+
+      - name: Install cbmc-viewer
+        run: ./scripts/setup/install_viewer.sh 2.6
+        shell: bash
+
+      - name: Install Rust toolchain
+        run: ./scripts/setup/install_rustup.sh
+        shell: bash
+
+      - name: Update submodules
+        run: |
+          git submodule update --init --depth 1
+        shell: bash
+
+      - name: Build Kani and Kani Library
+        run: |
+          export RUST_BACKTRACE=1
+          cargo build -p kani-compiler
+        shell: bash
+

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-name: Kani CI
+name: Kani Format Check
 on: pull_request
 
 jobs:

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -9,8 +9,6 @@ jobs:
     strategy:
       matrix:
         os: [macos-10.15, ubuntu-18.04, ubuntu-20.04]
-    permissions:
-      contents: write
     steps:
       - name: Checkout Kani
         uses: actions/checkout@v2

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -15,52 +15,45 @@ jobs:
       - name: Checkout Kani
         uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: ./scripts/setup/${{ matrix.os }}/install_deps.sh
-
-      - name: Install CBMC
-        run: ./scripts/setup/${{ matrix.os }}/install_cbmc.sh
-
-      - name: Install cbmc-viewer
-        run: ./scripts/setup/install_viewer.sh 2.6
-
-      - name: Install Rust toolchain
-        run: ./scripts/setup/install_rustup.sh
-
-      - name: Update submodules
-        run: |
-          git submodule update --init --depth 1
-
-      - name: Build Kani and Kani Library
-        run: |
-          export RUST_BACKTRACE=1
-          cargo build -p kani-compiler
+      - name: Build Kani
+        uses: ./.github/actions/build
+        with:
+            os: ${{ matrix.os }}
 
       - name: Execute Kani regression
         run: ./scripts/kani-regression.sh
 
+  bookrunner:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Kani
+        uses: actions/checkout@v2
+
+      - name: Build Kani
+        uses: ./.github/actions/build
+        with:
+            os: ubuntu-20.04
+
       - name: Install book runner dependencies
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: ./scripts/setup/install_bookrunner_deps.sh
 
       - name: Generate book runner report
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: cargo run -p bookrunner
         env:
             DOC_RUST_LANG_ORG_CHANNEL: nightly
 
       - name: Print book runner text results
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: cat build/output/latest/html/bookrunner.txt
 
       # On one OS only, build the documentation, too.
       - name: Build Documentation
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: ./docs/build-docs.sh
 
       # When we're pushed to main branch, only then actually publish the docs.
       - name: Publish Documentation
-        if: ${{ matrix.os == 'ubuntu-20.04' && github.event_name == 'push' && startsWith('refs/heads/main', github.ref) }}
+        if: ${{ github.event_name == 'push' && startsWith('refs/heads/main', github.ref) }}
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages


### PR DESCRIPTION
### Description of changes: 

I created a Build Kani action and split the usual regression job into 2 separate jobs. One that builds kani and run the regression tests and a second one that builds kani, run bookrunner and build the docs.

### Resolved issues:

N/A

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
