### PR TITLE
Simplify how we invoke compiletest

### DIFF
--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -8,16 +8,6 @@ fi
 set -o pipefail
 set -o nounset
 
-# Test for platform
-PLATFORM=$(uname -sp)
-if [[ $PLATFORM == "Linux x86_64" ]]
-then
-  TARGET="x86_64-unknown-linux-gnu"
-elif [[ $PLATFORM == "Darwin i386" ]]
-then
-  TARGET="x86_64-apple-darwin"
-fi
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export PATH=$SCRIPT_DIR:$PATH
 EXTRA_X_PY_BUILD_ARGS="${EXTRA_X_PY_BUILD_ARGS:-}"

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -55,15 +55,10 @@ for testp in "${TESTS[@]}"; do
   testl=($testp)
   suite=${testl[0]}
   mode=${testl[1]}
-  echo "Check compiletest suite=$suite mode=$mode ($TARGET -> $TARGET)"
+  echo "Check compiletest suite=$suite mode=$mode"
   # Note: `cargo-kani` tests fail if we do not add `$(pwd)` to `--build-base`
   # Tracking issue: https://github.com/model-checking/kani/issues/755
-  cargo run -p compiletest --  --kani-dir-path scripts --src-base tests/$suite \
-                               --build-base $(pwd)/build/$TARGET/tests/$suite \
-                               --stage-id stage1-$TARGET \
-                               --suite $suite --mode $mode \
-                               --target $TARGET --host $TARGET \
-                               --quiet --channel dev
+  cargo run -p compiletest --quiet -- --suite $suite --mode $mode --quiet
 done
 
 # Check codegen for the standard library

--- a/tools/compiletest/src/common.rs
+++ b/tools/compiletest/src/common.rs
@@ -88,9 +88,6 @@ pub struct Config {
     /// The directory where programs should be built
     pub build_base: PathBuf,
 
-    /// The name of the stage being built (stage1, etc)
-    pub stage_id: String,
-
     /// The test mode, e.g. ui or debuginfo.
     pub mode: Mode,
 
@@ -134,9 +131,6 @@ pub struct Config {
 
     /// Whether to use colors in test.
     pub color: ColorConfig,
-
-    /// The current Rust channel
-    pub channel: String,
 
     /// The default Rust edition
     pub edition: Option<String>,

--- a/tools/compiletest/src/header.rs
+++ b/tools/compiletest/src/header.rs
@@ -6,7 +6,7 @@
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use tracing::*;
 
@@ -174,22 +174,6 @@ impl Config {
         } else {
             None
         }
-    }
-
-    /// This function finds the root source of the repository by starting at the source base for
-    /// compiletest. It will then visit its parent folder and check if we found the root by
-    /// checking if it can find the compiletest `Cargo.toml` file in the path relative to the root.
-    pub fn find_rust_src_root(&self) -> Option<PathBuf> {
-        let mut path = self.src_base.clone();
-        let path_postfix = Path::new("tools/compiletest/Cargo.toml");
-
-        while path.pop() {
-            if path.join(&path_postfix).is_file() {
-                return Some(path);
-            }
-        }
-
-        None
     }
 
     fn parse_edition(&self, line: &str) -> Option<String> {

--- a/tools/compiletest/src/runtest.rs
+++ b/tools/compiletest/src/runtest.rs
@@ -15,10 +15,8 @@ use crate::read2::read2_abbreviated;
 use crate::util::logv;
 use regex::Regex;
 
-use std::collections::hash_map::DefaultHasher;
 use std::env;
 use std::fs::{self, create_dir_all};
-use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus, Output, Stdio};
 use std::str;
@@ -47,13 +45,6 @@ pub fn run(config: Config, testpaths: &TestPaths, revision: Option<&str>) {
     create_dir_all(&cx.output_base_dir()).unwrap();
     cx.run_revision();
     cx.create_stamp();
-}
-
-pub fn compute_stamp_hash(config: &Config) -> String {
-    let mut hash = DefaultHasher::new();
-    config.stage_id.hash(&mut hash);
-
-    format!("{:x}", hash.finish())
 }
 
 #[derive(Copy, Clone)]
@@ -411,7 +402,7 @@ impl<'test> TestCx<'test> {
 
     fn create_stamp(&self) {
         let stamp = crate::stamp(&self.config, self.testpaths, self.revision);
-        fs::write(&stamp, compute_stamp_hash(&self.config)).unwrap();
+        fs::write(&stamp, "we only support one configuration").unwrap();
     }
 }
 

--- a/tools/compiletest/src/util.rs
+++ b/tools/compiletest/src/util.rs
@@ -7,6 +7,7 @@ use crate::common::Config;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
+use std::process::Command;
 use tracing::*;
 
 pub fn logv(config: &Config, s: String) {
@@ -33,5 +34,14 @@ impl PathBufExt for PathBuf {
             fname.push(extension);
             self.with_file_name(fname)
         }
+    }
+}
+
+pub(crate) fn top_level() -> Option<PathBuf> {
+    match Command::new("git").arg("rev-parse").arg("--show-toplevel").output() {
+        Ok(out) if out.status.success() => {
+            Some(PathBuf::from(String::from_utf8(out.stdout).unwrap().trim()))
+        }
+        _ => None,
     }
 }


### PR DESCRIPTION
### Description of changes: 

I removed stuff that wasn't needed and I have also added default values for stuff that doesn't really change for Kani. Now only --suite and --mode is requied.

This will make it easier for us to manually invoke a single test suite.

### Resolved issues:

N/A

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
