### PR TITLE
Don't use the broken overflow builtins for pointers

### DIFF
--- a/src/kani-compiler/cbmc/src/goto_program/expr.rs
+++ b/src/kani-compiler/cbmc/src/goto_program/expr.rs
@@ -855,7 +855,7 @@ impl Expr {
             // While one can technically use these on pointers, the result is treated as an integer.
             // This is almost never what you actually want.
             OverflowMinus | OverflowMult | OverflowPlus => {
-                lhs.typ.is_integer() && rhs.typ.is_integer()
+                lhs.typ == rhs.typ && lhs.typ.is_integer()
             }
         }
     }
@@ -1206,7 +1206,7 @@ impl Expr {
         // FIXME: https://github.com/model-checking/kani/issues/786
         // Overflow checking on pointers is hard to do at the IREP level.
         // Instead, we rely on `--pointer-overflow-check` in CBMC.
-        let overflowed = if self.typ.is_pointer() {
+        let overflowed = if self.typ.is_pointer() || e.typ.is_pointer() {
             warn!(
                 "Overflow operations are not properly supported on pointer types {:?} {:?}",
                 self, e


### PR DESCRIPTION
### Description of changes: 

Currently, we emit `__builtin_overflow_p` operations for pointer arithmetic.  This is basically broken, since CBMC converts to integers and does integer arithmetic under the hood, which is not what we want. 

### Resolved issues:

Initial step towards addressing https://github.com/model-checking/kani/issues/786

### Call-outs:

1. This relies on `--pointer-overflow-check` being used on CBMC for soundness.  We currently do so, but it would be better to have a `__pointer_overflow` builtin we could use when we need this behaviour. https://github.com/diffblue/cbmc/issues/6627

2. Also fixed some confusing missing brackets in the typechecking code for binops.

### Testing: 

* How is this change tested? Existing regression tests. 

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
