### PR TITLE
Add tests for pointer overflow checking

### DIFF
--- a/tests/kani/Overflow/pointer_overflow_fail.rs
+++ b/tests/kani/Overflow/pointer_overflow_fail.rs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+pub fn main() {
+    let a = [0; 5];
+    let i: i32 = 0;
+    let ptr1: *const i32 = &a[0];
+    let ptr_overflow1 = unsafe { ptr1.offset(isize::MAX) };
+}

--- a/tests/kani/Overflow/pointer_overflow_fixme.rs
+++ b/tests/kani/Overflow/pointer_overflow_fixme.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+// This should fail, but doesn't due to https://github.com/diffblue/cbmc/issues/6631
+
+pub fn main() {
+    let a = [0; 5];
+    let i: i32 = 0;
+    let ptr1: *const i32 = &a[1];
+    let ptr2: *const i32 = &i;
+    let ptr2 = unsafe { ptr2.offset(1) };
+    let ptr_overflow1 = unsafe { ptr1.offset(isize::MAX) };
+    let ptr_overflow2 = unsafe { ptr2.offset(isize::MAX) };
+}


### PR DESCRIPTION
### Description of changes: 

We currently don't have tests that ensure that we catch pointer overflows. Fix that.

### Resolved issues:



### Call-outs:

1. These tests discovered an underlying corner case in CBMC https://github.com/diffblue/cbmc/issues/6631
2. It would be nice to check that its specifically pointer failures, and not just any failure. But I don't believe we have that capability.
3. 
### Testing:

* How is this change tested? This PR only adds tests.

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
