### PR TITLE
Introduce an std wrapper crate to allow overriding standard library definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
+name = "std"
+version = "0.1.0"
+
+[[package]]
 name = "string-interner"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "library/kani",
   "library/kani_restrictions",
+  "library/std",
   "tools/bookrunner",
   "tools/compiletest",
   "tools/kani-link-restrictions",
@@ -19,4 +20,3 @@ exclude = [
   # cargo kani tests should also have their own workspace
   "tests/cargo-kani"
 ]
-

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -1,0 +1,12 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+[package]
+# Note: this package is intentionally named std to make sure the names of
+# standard library symbols are preserved
+name = "std"
+version = "0.1.0"
+edition = "2018"
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! The purpose of this crate is to allow kani to selectively override
+//! definitions from the standard library.  Definitions provided below would
+//! override the standard library versions.
+
+// See discussion in
+// https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20Globally.20override.20an.20std.20macro/near/268873354
+// for more details.
+
+// re-export all std symbols
+pub use std::*;

--- a/src/kani-compiler/build.rs
+++ b/src/kani-compiler/build.rs
@@ -52,5 +52,6 @@ pub fn main() {
     let lib_out = path_str!([&out_dir, "lib"]);
     setup_lib(&out_dir, &lib_out, "kani");
     setup_lib(&out_dir, &lib_out, "kani_macros");
+    setup_lib(&out_dir, &lib_out, "std");
     println!("cargo:rustc-env=KANI_LIB_PATH={}", lib_out);
 }

--- a/src/kani-compiler/src/main.rs
+++ b/src/kani-compiler/src/main.rs
@@ -29,7 +29,9 @@ fn rustc_gotoc_flags(lib_path: &str) -> Vec<String> {
     // standard library can be overriden. See
     // https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20Globally.20override.20an.20std.20macro/near/268873354
     // for more details.
-    let kani_std_wrapper = format!("noprelude:std={}/libstd.rlib", lib_path);
+    let mut kani_std_rlib = PathBuf::from(lib_path);
+    kani_std_rlib.push("libstd.rlib");
+    let kani_std_wrapper = format!("noprelude:std={}", kani_std_rlib.to_str().unwrap());
     let args = vec![
         "-C",
         "overflow-checks=on",

--- a/src/kani-compiler/src/main.rs
+++ b/src/kani-compiler/src/main.rs
@@ -25,11 +25,18 @@ use std::rc::Rc;
 /// This function generates all rustc configurations required by our goto-c codegen.
 fn rustc_gotoc_flags(lib_path: &str) -> Vec<String> {
     let kani_deps = lib_path.clone().to_owned() + "/deps";
+    // The option below provides a mechanism by which definitions in the
+    // standard library can be overriden. See
+    // https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20Globally.20override.20an.20std.20macro/near/268873354
+    // for more details.
+    let kani_std_wrapper = format!("noprelude:std={}/libstd.rlib", lib_path);
     let args = vec![
         "-C",
         "overflow-checks=on",
         "-C",
         "panic=abort",
+        "-Z",
+        "unstable-options",
         "-Z",
         "panic_abort_tests=yes",
         "-Z",
@@ -45,6 +52,8 @@ fn rustc_gotoc_flags(lib_path: &str) -> Vec<String> {
         lib_path,
         "--extern",
         "kani",
+        "--extern",
+        kani_std_wrapper.as_str(),
         "-L",
         kani_deps.as_str(),
     ];


### PR DESCRIPTION
### Description of changes: 

Introduce a mechanism that allows us to override definitions from the standard library (e.g. macros). This is achieved via a new kani crate, `std`, that is brought in through specifying `--extern noprelude:std=/path/to/libstd.rlib` when compiling each crate.  See discussion in [zulip](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20Globally.20override.20an.20std.20macro) for more information.

### Resolved issues:


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->
The new crate is intentionally named `std` to make sure all symbol names are maintained (e.g. `std::mem::swap` as opposed to `kani_std_wrapper::mem::swap`).

### Testing:

* How is this change tested? Testing is done in follow-up PRs.

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
