### PR TITLE
[PR 795 must be merged before this one] Add an option to turn on reachability checks for assertions

### DIFF
--- a/scripts/kani_flags.py
+++ b/scripts/kani_flags.py
@@ -193,6 +193,8 @@ def add_artifact_flags(make_group, add_flag, config):
 # Add flags to turn off default checks.
 def add_check_flags(make_group, add_flag, config):
     group = make_group("Check flags", "Disable some or all default checks.")
+    add_flag(group, "--assertion-reach-checks", default=False, action=BooleanOptionalAction,
+             help="Turn on assertion reachability checks")
     add_flag(group, "--default-checks", default=True, action=BooleanOptionalAction,
              help="Turn on all default checks")
     add_flag(group, "--memory-safety-checks", default=True, action=BooleanOptionalAction,

--- a/src/kani-compiler/kani_queries/src/lib.rs
+++ b/src/kani-compiler/kani_queries/src/lib.rs
@@ -9,10 +9,14 @@ pub trait UserInput {
 
     fn set_emit_vtable_restrictions(&mut self, restrictions: bool);
     fn get_emit_vtable_restrictions(&self) -> bool;
+
+    fn set_check_assertion_reachability(&mut self, reachability: bool);
+    fn get_check_assertion_reachability(&self) -> bool;
 }
 
 #[derive(Debug, Default)]
 pub struct QueryDb {
+    check_assertion_reachability: AtomicBool,
     emit_vtable_restrictions: AtomicBool,
     symbol_table_passes: Vec<String>,
 }
@@ -32,5 +36,13 @@ impl UserInput for QueryDb {
 
     fn get_emit_vtable_restrictions(&self) -> bool {
         self.emit_vtable_restrictions.load(Ordering::Relaxed)
+    }
+
+    fn set_check_assertion_reachability(&mut self, reachability: bool) {
+        self.check_assertion_reachability.store(reachability, Ordering::Relaxed);
+    }
+
+    fn get_check_assertion_reachability(&self) -> bool {
+        self.check_assertion_reachability.load(Ordering::Relaxed)
     }
 }

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/statement.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/statement.rs
@@ -486,6 +486,21 @@ impl<'tcx> GotocCtx<'tcx> {
         )
     }
 
+    /// Generate code to cover the given condition
+    pub fn codegen_cover(&self, cond: Expr, msg: &str, span: Option<Span>) -> Stmt {
+        let loc = self.codegen_caller_span(&span);
+        // Should use Stmt::cover, but currently this doesn't work with CBMC
+        // unless it is run with '--cover cover' (see
+        // https://github.com/diffblue/cbmc/issues/6613). So for now use
+        // assert(!cond).
+        Stmt::assert(cond.not(), msg, loc)
+    }
+
+    /// Generate code to cover the current location
+    pub fn codegen_cover_loc(&self, msg: &str, span: Option<Span>) -> Stmt {
+        self.codegen_cover(Expr::bool_true(), msg, span)
+    }
+
     pub fn codegen_statement(&mut self, stmt: &Statement<'tcx>) -> Stmt {
         debug!("handling statement {:?}", stmt);
         match &stmt.kind {

--- a/src/kani-compiler/src/main.rs
+++ b/src/kani-compiler/src/main.rs
@@ -92,6 +92,11 @@ fn parser<'a, 'b>() -> App<'a, 'b> {
                 .help("Restrict the targets of virtual table function pointer calls."),
         )
         .arg(
+            Arg::with_name("assertion-reach-checks")
+                .long("--assertion-reach-checks")
+                .help("Check the reachability of every assertion."),
+        )
+        .arg(
             Arg::with_name("sysroot")
                 .long("--sysroot")
                 .help("Override the system root.")
@@ -131,6 +136,7 @@ fn main() -> Result<(), &'static str> {
         queries.set_symbol_table_passes(symbol_table_passes.map(convert_arg).collect::<Vec<_>>());
     }
     queries.set_emit_vtable_restrictions(matches.is_present("restrict-vtable-fn-ptrs"));
+    queries.set_check_assertion_reachability(matches.is_present("assertion-reach-checks"));
 
     // Configure and run compiler.
     let mut callbacks = KaniCallbacks {};

--- a/tests/expected/reach/expected
+++ b/tests/expected/reach/expected
@@ -1,0 +1,9 @@
+line 8 kani_reachability_check for assertion: x < 4: FAILURE
+line 8 assertion: x < 4: FAILURE
+line 10 kani_reachability_check for assertion: x == 2: SUCCESS
+line 10 assertion: x == 2: SUCCESS
+line 13 kani_reachability_check for assertion: x <= 5: FAILURE
+line 13 assertion: x <= 5: SUCCESS
+
+** 3 of 8 failed (3 iterations)
+VERIFICATION FAILED

--- a/tests/expected/reach/test.rs
+++ b/tests/expected/reach/test.rs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: --function foo --assertion-reach-checks
+
+#[kani::proof]
+fn foo(x: i32) {
+    if x > 5 {
+        assert!(x < 4);
+        if x < 3 {
+            assert!(x == 2);
+        }
+    } else {
+        assert!(x <= 5);
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
### Description of changes: 

A new option, `--assertion-reach-checks`, turns on reachability checks for assertions specified via the `assert!` macro. The results of reachability checks can aid in identifying vacuously passing properties that are reported as "SUCCESS" due to their unreachability (see #637).

### Resolved issues:


### Call-outs:

1. The option currently turns on reachability checks for assertions specified via the `assert!` macro only. 
2. The post-processing of results to pair a reachability check to its assert will be done in a later PR.
3. Reachability checks are implemented via `__CPROVER_assert(false)` as opposed to the cleaner `__CPROVER_cover`. But using `__CPROVER_cover` is currently blocked by https://github.com/diffblue/cbmc/issues/6613. Because of using `__CPROVER_assert(false)`, the way to interpret the results of reachability checks is:
  - "SUCCESS": Assert is unreachable
  - "FAILURE": Assert is reachable
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? A new test is added 

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
