### PR TITLE
Adding Property Class and Comment Fields to Source Location for Expect_Fail asserts

### DIFF
--- a/src/kani-compiler/cbmc/src/goto_program/builtin.rs
+++ b/src/kani-compiler/cbmc/src/goto_program/builtin.rs
@@ -7,6 +7,7 @@ use super::{Expr, Location, Symbol, Type};
 #[derive(Debug, Clone, Copy)]
 pub enum BuiltinFn {
     Abort,
+    Assert,
     CProverAssert,
     CProverAssume,
     CProverCover,
@@ -66,6 +67,7 @@ impl ToString for BuiltinFn {
     fn to_string(&self) -> String {
         match self {
             Abort => "abort",
+            Assert => "assert",
             CProverAssert => "__CPROVER_assert",
             CProverAssume => "__CPROVER_assume",
             CProverCover => "__CPROVER_cover",
@@ -129,6 +131,7 @@ impl BuiltinFn {
     pub fn param_types(&self) -> Vec<Type> {
         match self {
             Abort => vec![],
+            Assert => vec![Type::bool()],
             CProverAssert => vec![Type::bool(), Type::c_char().to_pointer()],
             CProverAssume => vec![Type::bool()],
             CProverCover => vec![Type::bool()],
@@ -185,6 +188,7 @@ impl BuiltinFn {
     pub fn return_type(&self) -> Type {
         match self {
             Abort => Type::empty(),
+            Assert => Type::empty(),
             CProverAssert => Type::empty(),
             CProverAssume => Type::empty(),
             CProverCover => Type::empty(),
@@ -244,6 +248,7 @@ impl BuiltinFn {
     pub fn list_all() -> Vec<BuiltinFn> {
         vec![
             Abort,
+            Assert,
             CProverAssert,
             CProverAssume,
             CProverCover,

--- a/src/kani-compiler/cbmc/src/goto_program/stmt.rs
+++ b/src/kani-compiler/cbmc/src/goto_program/stmt.rs
@@ -40,6 +40,10 @@ pub enum StmtBody {
         lhs: Expr,
         rhs: Expr,
     },
+    /// `assert(cond)`
+    Assert {
+        cond: Expr,
+    },
     /// `__CPROVER_assume(cond);`
     Assume {
         cond: Expr,
@@ -174,6 +178,22 @@ impl Stmt {
             return Stmt::block(vec![assert_stmt, nondet_assign_stmt], loc);
         }
         stmt!(Assign { lhs, rhs }, loc)
+    }
+
+    /// `assert(cond);`
+    pub fn assert_stmt(cond: Expr, prop_class: &str, msg: &str, loc: Location) -> Self {
+        assert!(cond.typ().is_bool());
+
+        let file = loc.filename().unwrap();
+        let line = loc.line().unwrap();
+        let function = loc.function_name();
+        let col = loc.get_column_number().unwrap();
+        let comment = msg.to_string();
+        let property_class = prop_class.to_string();
+
+        let loc = Location::new(file, function, line, Some(col), comment, property_class);
+
+        stmt!(Assert { cond }, loc)
     }
 
     /// `__CPROVER_assert(cond, msg);`

--- a/src/kani-compiler/cbmc/src/goto_program/stmt.rs
+++ b/src/kani-compiler/cbmc/src/goto_program/stmt.rs
@@ -184,6 +184,7 @@ impl Stmt {
     pub fn assert_stmt(cond: Expr, prop_class: &str, msg: &str, loc: Location) -> Self {
         assert!(cond.typ().is_bool());
 
+        // TODO: Extract location metadata in a safer manner
         let file = loc.filename().unwrap();
         let line = loc.line().unwrap();
         let function = loc.function_name();

--- a/src/kani-compiler/cbmc/src/goto_program/symtab_transformer/transformer.rs
+++ b/src/kani-compiler/cbmc/src/goto_program/symtab_transformer/transformer.rs
@@ -496,6 +496,7 @@ pub trait Transformer: Sized {
     fn transform_stmt(&mut self, stmt: &Stmt) -> Stmt {
         match stmt.body() {
             StmtBody::Assign { lhs, rhs } => self.transform_stmt_assign(lhs, rhs),
+            StmtBody::Assert { cond } => self.transform_stmt_assert(cond),
             StmtBody::Assume { cond } => self.transform_stmt_assume(cond),
             StmtBody::AtomicBlock(block) => self.transform_stmt_atomic_block(block),
             StmtBody::Block(block) => self.transform_stmt_block(block),
@@ -527,6 +528,14 @@ pub trait Transformer: Sized {
         let transformed_lhs = self.transform_expr(lhs);
         let transformed_rhs = self.transform_expr(rhs);
         transformed_lhs.assign(transformed_rhs, Location::none())
+    }
+
+    /// Transforms a CPROVER assume stmt (`__CPROVER_assert(cond);`)
+    fn transform_stmt_assert(&mut self, cond: &Expr) -> Stmt {
+        let transformed_cond = self.transform_expr(cond);
+        let msg = "test_message";
+        let property_class = "test_property_class";
+        Stmt::assert_stmt(transformed_cond, property_class, msg, Location::none())
     }
 
     /// Transforms a CPROVER assume stmt (`__CPROVER_assume(cond);`)

--- a/src/kani-compiler/cbmc/src/irep/to_irep.rs
+++ b/src/kani-compiler/cbmc/src/irep/to_irep.rs
@@ -321,12 +321,19 @@ impl ToIrep for Location {
                 (IrepId::Function, Irep::just_string_id(function_name.to_string())),
             ])
             .with_named_sub_option(IrepId::Line, line.map(Irep::just_int_id)),
-            Location::Loc { file, function, line, col } => Irep::just_named_sub(vector_map![
-                (IrepId::File, Irep::just_string_id(file.to_string())),
-                (IrepId::Line, Irep::just_int_id(*line)),
-            ])
-            .with_named_sub_option(IrepId::Column, col.map(Irep::just_int_id))
-            .with_named_sub_option(IrepId::Function, function.map(Irep::just_string_id)),
+            Location::Loc { file, function, line, col, comment, property_class } => {
+                Irep::just_named_sub(vector_map![
+                    (IrepId::File, Irep::just_string_id(file.to_string())),
+                    (IrepId::Line, Irep::just_int_id(*line)),
+                ])
+                .with_named_sub_option(IrepId::Column, col.map(Irep::just_int_id))
+                .with_named_sub_option(IrepId::Function, function.map(Irep::just_string_id))
+                .with_named_sub(IrepId::Comment, Irep::just_string_id(comment.to_string()))
+                .with_named_sub(
+                    IrepId::PropertyClass,
+                    Irep::just_string_id(property_class.to_string()),
+                )
+            }
         }
     }
 }
@@ -355,6 +362,7 @@ impl ToIrep for StmtBody {
             StmtBody::Assign { lhs, rhs } => {
                 code_irep(IrepId::Assign, vec![lhs.to_irep(mm), rhs.to_irep(mm)])
             }
+            StmtBody::Assert { cond } => code_irep(IrepId::Assert, vec![cond.to_irep(mm)]),
             StmtBody::Assume { cond } => code_irep(IrepId::Assume, vec![cond.to_irep(mm)]),
             StmtBody::AtomicBlock(stmts) => {
                 let mut irep_stmts = vec![code_irep(IrepId::AtomicBegin, vec![])];

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/span.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/span.rs
@@ -19,11 +19,17 @@ impl<'tcx> GotocCtx<'tcx> {
             Ok(pathbuf) => pathbuf.to_str().unwrap().to_string(),
             Err(_) => filename0,
         };
+
+        // Default to empty strings for both Comment and Property_class
+        let comment = "".to_string();
+        let property_class = "".to_string();
         Location::new(
             filename1,
             self.current_fn.as_ref().map(|x| x.readable_name().to_string()),
             line,
             Some(col),
+            comment,
+            property_class,
         )
     }
 

--- a/src/kani-compiler/rustc_codegen_kani/src/overrides/hooks.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/overrides/hooks.rs
@@ -102,13 +102,13 @@ impl<'tcx> GotocHook<'tcx> for ExpectFail {
         // msg is the comment field that's set on source location
         let msg = "EXPECTED FAIL";
 
-        // property class is used as a unique identifier for this assert
-        let property_class = "expect_fail";
+        // property_class is used as a unique identifier for this assert
+        let _property_class = "expect_fail";
 
         let loc = tcx.codegen_span_option(span);
         Stmt::block(
             vec![
-                Stmt::assert_stmt(cond, property_class, msg, loc.clone()),
+                Stmt::assert(cond, msg, loc.clone()),
                 Stmt::goto(tcx.current_fn().find_label(&target), loc.clone()),
             ],
             loc,

--- a/src/kani-compiler/rustc_codegen_kani/src/overrides/hooks.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/overrides/hooks.rs
@@ -98,11 +98,17 @@ impl<'tcx> GotocHook<'tcx> for ExpectFail {
         let target = target.unwrap();
         let cond = fargs.remove(0).cast_to(Type::bool());
         //TODO: actually use the error message passed by the user.
+
+        // msg is the comment field that's set on source location
         let msg = "EXPECTED FAIL";
+
+        // property class is used as a unique identifier for this assert
+        let property_class = "expect_fail";
+
         let loc = tcx.codegen_span_option(span);
         Stmt::block(
             vec![
-                Stmt::assert(cond, msg, loc.clone()),
+                Stmt::assert_stmt(cond, property_class, msg, loc.clone()),
                 Stmt::goto(tcx.current_fn().find_label(&target), loc.clone()),
             ],
             loc,


### PR DESCRIPTION
### Description of changes: 

Adds Property_classes and Comment Fields to the Source Location Metadata for Expect_fail asserts only (for now). With this change, the output for the rust line - 

` kani::expect_fail(i > 20, "Blocked by assumption above.");` changes from

Before the change -
`[main.assertion.1] line 7 EXPECTED FAIL: FAILURE` 

After the change -
`[main.expect_fail.1] line 7 EXPECTED FAIL: FAILURE`

It's now possible to customize the assertion ID strings as well as control descriptions for various types of assertions (which currently default to `assertion`.

### Resolved issues:

Resolves #793

### Call-outs:

Wherever needed, `Stmt::assert` should be replaced by `Stmt:assert_stmt` which takes in additional arguments for `property_class` and `comment`.

As of now, both of these fields default to "" or empty strings so they don't interfere with the current flow but that could cause potential problems and so the new symtab structure must be verified against existing symtabs.

### Testing:

* How is this change tested?

* Is this a refactor change? Yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
