### PR TITLE
Fix "Delete Regression Test Caches" Documentation

### DIFF
--- a/docs/src/dev-documentation.md
+++ b/docs/src/dev-documentation.md
@@ -13,7 +13,7 @@ cargo build
 ```
 ```bash
 # Delete regression test caches
-rm -r build/x86_64-unknown-linux-gnu/test/
+rm -r build/x86_64-unknown-linux-gnu/tests/
 ```
 ```bash
 # Test suite run (to run a specific suite from src/test/, just remove the others)


### PR DESCRIPTION
Change "Delete Regression Test Caches" Documentation from `/test` to `/tests`, the new directory

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
