### PR TITLE
Fix kani-compiler logs + add json option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,10 +394,13 @@ dependencies = [
 name = "kani-compiler"
 version = "0.1.0"
 dependencies = [
+ "atty",
  "clap",
  "kani_queries",
  "rustc_codegen_kani",
  "tracing",
+ "tracing-subscriber",
+ "tracing-tree",
 ]
 
 [[package]]
@@ -1049,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -1090,11 +1093,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -1109,21 +1113,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.6"
+name = "tracing-serde"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77be66445c4eeebb934a7340f227bfe7b338173d3f8c00a60a5a58005c9faecf"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74786ce43333fcf51efe947aed9718fbe46d5c7328ec3f1029e818083966d9aa"
 dependencies = [
  "ansi_term",
  "lazy_static",
  "matchers",
  "parking_lot",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1168,6 +1186,12 @@ checksum = "496a3d395ed0c30f411ceace4a91f7d93b148fb5a9b383d5d4cff7850f048d5f"
 dependencies = [
  "diff",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vec_map"

--- a/src/kani-compiler/Cargo.toml
+++ b/src/kani-compiler/Cargo.toml
@@ -8,10 +8,13 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+atty = "0.2.14"
 clap = "2.33.0"
 kani_queries = {path = "kani_queries"}
 rustc_codegen_kani = {path = "rustc_codegen_kani"}
-tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_info"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}
+tracing-subscriber = {version = "0.3.8", features = ["env-filter", "json", "fmt"]}
+tracing-tree = "0.2.0"
 
 [package.metadata.rust-analyzer]
 # This package uses rustc crates.

--- a/src/kani-compiler/src/main.rs
+++ b/src/kani-compiler/src/main.rs
@@ -12,12 +12,13 @@ extern crate rustc_codegen_ssa;
 extern crate rustc_driver;
 extern crate rustc_session;
 
-use clap::{
-    app_from_crate, crate_authors, crate_description, crate_name, crate_version, App, AppSettings,
-    Arg, ArgMatches,
-};
+mod parser;
+mod session;
+
+use crate::session::init_session;
+use clap::ArgMatches;
 use kani_queries::{QueryDb, UserInput};
-use rustc_driver::{init_env_logger, install_ice_hook, Callbacks, RunCompiler};
+use rustc_driver::{Callbacks, RunCompiler};
 use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -62,81 +63,23 @@ fn rustc_gotoc_flags(lib_path: &str) -> Vec<String> {
     args.iter().map(|s| s.to_string()).collect()
 }
 
-fn parser<'a, 'b>() -> App<'a, 'b> {
-    app_from_crate!()
-        .setting(AppSettings::TrailingVarArg) // This allow us to fwd commands to rustc.
-        .setting(clap::AppSettings::AllowLeadingHyphen)
-        .version_short("?")
-        .arg(
-            Arg::with_name("kani-lib")
-                .long("--kani-lib")
-                .value_name("FOLDER_PATH")
-                .help("Sets the path to locate the kani library.")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("goto-c")
-                .long("--goto-c")
-                .help("Enables compilation to goto-c intermediate representation."),
-        )
-        .arg(
-            Arg::with_name("symbol-table-passes")
-                .long("--symbol-table-passes")
-                .value_name("PASS")
-                .help("Transformations to perform to the symbol table after it has been generated.")
-                .takes_value(true)
-                .use_delimiter(true)
-                .multiple(true),
-        )
-        .arg(
-            Arg::with_name("restrict-vtable-fn-ptrs")
-                .long("--restrict-vtable-fn-ptrs")
-                .help("Restrict the targets of virtual table function pointer calls."),
-        )
-        .arg(
-            Arg::with_name("sysroot")
-                .long("--sysroot")
-                .help("Override the system root.")
-                .long_help(
-                    "The \"sysroot\" is the location where Kani will look for the Rust \
-                distribution.",
-                ),
-        )
-        .arg(
-            // TODO: Move this to a cargo wrapper. This should return kani version.
-            Arg::with_name("rustc-version")
-                .short("V")
-                .long("--version")
-                .help("Gets underlying rustc version."),
-        )
-        .arg(
-            Arg::with_name("rustc-options")
-                .help("Arguments to be passed down to rustc.")
-                .multiple(true)
-                .takes_value(true),
-        )
-}
-
 /// Main function. Configure arguments and run the compiler.
 fn main() -> Result<(), &'static str> {
-    let matches = parser().get_matches();
+    let matches = parser::parser().get_matches();
+    init_session(&matches);
 
-    // Initialize the logger.
-    init_env_logger("KANI_LOG");
+    // Configure queries.
+    let mut queries = QueryDb::default();
+    if let Some(symbol_table_passes) = matches.values_of_os(parser::SYM_TABLE_PASSES) {
+        queries.set_symbol_table_passes(symbol_table_passes.map(convert_arg).collect::<Vec<_>>());
+    }
+    queries.set_emit_vtable_restrictions(matches.is_present(parser::RESTRICT_FN_PTRS));
 
     // Generate rustc args.
     let rustc_args = generate_rustc_args(&matches);
 
-    // Configure queries.
-    let mut queries = QueryDb::default();
-    if let Some(symbol_table_passes) = matches.values_of_os("symbol-table-passes") {
-        queries.set_symbol_table_passes(symbol_table_passes.map(convert_arg).collect::<Vec<_>>());
-    }
-    queries.set_emit_vtable_restrictions(matches.is_present("restrict-vtable-fn-ptrs"));
-
     // Configure and run compiler.
     let mut callbacks = KaniCallbacks {};
-    install_ice_hook();
     let mut compiler = RunCompiler::new(&rustc_args, &mut callbacks);
     if matches.is_present("goto-c") {
         compiler.set_make_codegen_backend(Some(Box::new(move |_cfg| {
@@ -155,23 +98,29 @@ impl Callbacks for KaniCallbacks {}
 /// Generate the arguments to pass to rustc_driver.
 fn generate_rustc_args(args: &ArgMatches) -> Vec<String> {
     let mut gotoc_args =
-        rustc_gotoc_flags(&args.value_of("kani-lib").unwrap_or(std::env!("KANI_LIB_PATH")));
+        rustc_gotoc_flags(&args.value_of(parser::KANI_LIB).unwrap_or(std::env!("KANI_LIB_PATH")));
     let mut rustc_args = vec![String::from("rustc")];
-    if args.is_present("goto-c") {
+    if args.is_present(parser::GOTO_C) {
         rustc_args.append(&mut gotoc_args);
     }
 
-    if args.is_present("rustc-version") {
+    if args.is_present(parser::RUSTC_VERSION) {
         rustc_args.push(String::from("--version"))
     }
 
-    if let Some(extra_flags) = args.values_of_os("rustc-options") {
+    if args.is_present(parser::JSON_OUTPUT) {
+        rustc_args.push(String::from("--error-format=json"));
+    }
+
+    if let Some(extra_flags) = args.values_of_os(parser::RUSTC_OPTIONS) {
         extra_flags.for_each(|arg| rustc_args.push(convert_arg(arg)));
     }
-    let sysroot = sysroot_path(args.value_of("sysroot")).expect("[Error] Invalid sysroot. Rebuild Kani or provide the path to rust sysroot using --sysroot option");
+    let sysroot = sysroot_path(args.value_of(parser::SYSROOT)).expect(
+        "[Error] Invalid sysroot. Rebuild Kani or provide the path to rust sysroot using --sysroot option",
+    );
     rustc_args.push(String::from("--sysroot"));
     rustc_args.push(convert_arg(sysroot.as_os_str()));
-    tracing::info!(?rustc_args, "Compile");
+    tracing::debug!(?rustc_args, "Compile");
     rustc_args
 }
 
@@ -215,25 +164,26 @@ fn sysroot_path(sysroot_arg: Option<&str>) -> Option<PathBuf> {
             let toolchain = std::option_env!("RUSTUP_TOOLCHAIN");
             toolchain_path(home.map(String::from), toolchain.map(String::from))
         });
-    tracing::debug!(?path, "Sysroot path.");
+    tracing::debug!(?path, ?sysroot_arg, "Sysroot path.");
     path
 }
 
 #[cfg(test)]
 mod parser_test {
     use super::*;
+    use crate::parser;
 
     #[test]
     fn test_rustc_version() {
         let args = vec!["kani-compiler", "-V"];
-        let matches = parser().get_matches_from(args);
+        let matches = parser::parser().get_matches_from(args);
         assert!(matches.is_present("rustc-version"));
     }
 
     #[test]
     fn test_kani_flags() {
         let args = vec!["kani-compiler", "--goto-c", "--kani-lib", "some/path"];
-        let matches = parser().get_matches_from(args);
+        let matches = parser::parser().get_matches_from(args);
         assert!(matches.is_present("goto-c"));
         assert_eq!(matches.value_of("kani-lib"), Some("some/path"));
     }
@@ -250,7 +200,7 @@ mod parser_test {
         let os_str = OsStr::from_bytes(&source[..]);
         assert_eq!(os_str.to_str(), None);
 
-        let matches = parser().get_matches_from(vec![
+        let matches = parser::parser().get_matches_from(vec![
             OsString::from("--sysroot").as_os_str(),
             OsString::from("any").as_os_str(),
             os_str,

--- a/src/kani-compiler/src/parser.rs
+++ b/src/kani-compiler/src/parser.rs
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use clap::{
+    app_from_crate, crate_authors, crate_description, crate_name, crate_version, App, AppSettings,
+    Arg,
+};
+
+/// Option name used to set log level.
+pub const LOG_LEVEL: &'static str = "log-level";
+
+/// Option name used to enable goto-c compilation.
+pub const GOTO_C: &'static str = "goto-c";
+
+/// Option name used to override Kani library path.
+pub const KANI_LIB: &'static str = "kani-lib";
+
+/// Option name used to select symbol table passes.
+pub const SYM_TABLE_PASSES: &'static str = "symbol-table-passes";
+
+/// Option name used to set the log output to a json file.
+pub const JSON_OUTPUT: &'static str = "json-output";
+
+/// Option name used to dump function pointer restrictions.
+pub const RESTRICT_FN_PTRS: &'static str = "restrict-vtable-fn-ptrs";
+
+/// Option name used to override the sysroot.
+pub const SYSROOT: &'static str = "sysroot";
+
+/// Option name used to pass extra rustc-options.
+pub const RUSTC_OPTIONS: &'static str = "rustc-options";
+
+pub const RUSTC_VERSION: &'static str = "rustc-version";
+
+/// Configure command options for the Kani compiler.
+pub fn parser<'a, 'b>() -> App<'a, 'b> {
+    app_from_crate!()
+        .setting(AppSettings::TrailingVarArg) // This allow us to fwd commands to rustc.
+        .setting(clap::AppSettings::AllowLeadingHyphen)
+        .version_short("?")
+        .arg(
+            Arg::with_name(KANI_LIB)
+                .long("--kani-lib")
+                .value_name("FOLDER_PATH")
+                .help("Sets the path to locate the kani library.")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(GOTO_C)
+                .long("--goto-c")
+                .help("Enables compilation to goto-c intermediate representation."),
+        )
+        .arg(
+            Arg::with_name(SYM_TABLE_PASSES)
+                .long("--symbol-table-passes")
+                .value_name("PASS")
+                .help("Transformations to perform to the symbol table after it has been generated.")
+                .takes_value(true)
+                .use_delimiter(true)
+                .multiple(true),
+        )
+        .arg(
+            Arg::with_name(LOG_LEVEL)
+                .long("--log-level")
+                .takes_value(true)
+                .possible_values(["error", "warn", "info", "debug", "trace"].as_slice())
+                .value_name("LOG_LEVEL")
+                .help(
+                    "Sets the maximum log level to the value given. Use KANI_LOG for more granular \
+            control.",
+                ),
+        )
+        .arg(
+            Arg::with_name(JSON_OUTPUT)
+                .long("--json-output")
+                .help("Print output including logs in json format."),
+        )
+        .arg(
+            Arg::with_name(RESTRICT_FN_PTRS)
+                .long("--restrict-vtable-fn-ptrs")
+                .help("Restrict the targets of virtual table function pointer calls."),
+        )
+        .arg(Arg::with_name(SYSROOT).long("--sysroot").help("Override the system root.").long_help(
+            "The \"sysroot\" is the location where Kani will look for the Rust \
+                distribution.",
+        ))
+        .arg(
+            // TODO: Move this to a cargo wrapper. This should return kani version.
+            Arg::with_name(RUSTC_VERSION)
+                .short("V")
+                .long("--version")
+                .help("Gets underlying rustc version."),
+        )
+        .arg(
+            Arg::with_name(RUSTC_OPTIONS)
+                .help("Arguments to be passed down to rustc.")
+                .multiple(true)
+                .takes_value(true),
+        )
+}

--- a/src/kani-compiler/src/session.rs
+++ b/src/kani-compiler/src/session.rs
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Module used to configure a compiler session.
+
+use crate::parser;
+use clap::ArgMatches;
+use rustc_driver;
+use std::str::FromStr;
+use tracing_subscriber::{filter::Directive, layer::SubscriberExt, EnvFilter, Registry};
+use tracing_tree::HierarchicalLayer;
+
+/// Environment variable used to control this session log tracing.
+const LOG_ENV_VAR: &'static str = "KANI_LOG";
+
+/// Initialize compiler session.
+pub fn init_session(args: &ArgMatches) {
+    // Initialize the rustc logger using value from RUSTC_LOG. We keep the log control separate
+    // because we cannot control the RUSTC log format unless if we match the exact tracing
+    // version used by RUSTC.
+    rustc_driver::init_rustc_env_logger();
+    // Use rustc internal compiler error (ICE) hook for now.
+    rustc_driver::install_ice_hook();
+
+    // Kani logger initialization.
+    init_logger(args);
+}
+
+/// Initialize the logger using the KANI_LOG environment variable and the --log-level argument.
+pub fn init_logger(args: &ArgMatches) {
+    let filter = EnvFilter::from_env(LOG_ENV_VAR);
+    let filter = if let Some(log_level) = args.value_of(parser::LOG_LEVEL) {
+        filter.add_directive(Directive::from_str(log_level).unwrap())
+    } else {
+        filter
+    };
+
+    if args.is_present(parser::JSON_OUTPUT) {
+        json_logs(filter);
+    } else {
+        hier_logs(filter);
+    };
+}
+
+/// Configure global logger to use a json logger.
+fn json_logs(filter: EnvFilter) {
+    use tracing_subscriber::fmt::layer;
+    let subscriber = Registry::default().with(filter).with(layer().json());
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+}
+
+/// Configure global logger to use a hierarchical view.
+fn hier_logs(filter: EnvFilter) {
+    let use_colors = atty::is(atty::Stream::Stdout);
+    let subscriber = Registry::default().with(filter);
+    let subscriber = subscriber.with(
+        HierarchicalLayer::default()
+            .with_writer(std::io::stdout)
+            .with_indent_lines(true)
+            .with_ansi(use_colors)
+            .with_targets(true)
+            .with_verbose_exit(true)
+            .with_indent_amount(2),
+    );
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+}


### PR DESCRIPTION
### Description of changes: 

This change fixes https://github.com/model-checking/kani/issues/785. It allow users to configure the Kani logs via KANI_LOG environment variable as well as via --log-level argument. Note that the former allows finer grain control on a per crate configuration.

We also support the RUSTC_LOG variable to control the underlying rustc packages. In order to control the rustc logging, we would need to match the exact version of the tracing crate used by rustc. To avoid that, we're keeping them separate.

### Resolved issues:

Resolves #785  and it's related to #759.

### Call-outs:

I moved the parser to a separate file because it is evolving rather fast and we don't have a clear timeline to join this with the main Kani application.

### Testing:

* How is this change tested? I don't think we have a reliable mechanism to test this today.

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
