### PR TITLE
Correct surprising argparse abbreviation behavior

### DIFF
--- a/scripts/cargo-kani
+++ b/scripts/cargo-kani
@@ -174,7 +174,8 @@ def parse_args():
     def create_parser():
         parser = argparse.ArgumentParser(
             prog="cargo kani",
-            description="Verify a Rust crate. For more information, see https://github.com/model-checking/kani.")
+            description="Verify a Rust crate. For more information, see https://github.com/model-checking/kani.",
+            allow_abbrev=False)
 
         crate_group = parser.add_argument_group(
             "Crate", "You can pass in the rust crate positionally or with the --crate flag.")

--- a/scripts/codegen-firecracker.sh
+++ b/scripts/codegen-firecracker.sh
@@ -27,7 +27,7 @@ cd $KANI_DIR/firecracker/src/devices/src/virtio/
 export RUSTC_LOG=error
 export RUST_BACKTRACE=1
 # Kani cannot locate Cargo.toml correctly: https://github.com/model-checking/kani/issues/717
-cargo kani --only-codegen --target x86_64-unknown-linux-gnu --no-config-toml
+cargo kani --only-codegen --no-config-toml
 
 echo
 echo "Finished Firecracker codegen regression successfully..."

--- a/scripts/kani
+++ b/scripts/kani
@@ -156,7 +156,8 @@ def parse_args():
     # Create parser
     def create_parser():
         parser = argparse.ArgumentParser(
-            description="Verify a single Rust file. For more information, see https://github.com/model-checking/kani.")
+            description="Verify a single Rust file. For more information, see https://github.com/model-checking/kani.",
+            allow_abbrev=False)
 
         input_group = parser.add_argument_group(
             "Input", "You can pass in the rust file positionally or with the --input flag.")

--- a/tests/kani-dependency-test/diamond-dependency/run-dependency-test.sh
+++ b/tests/kani-dependency-test/diamond-dependency/run-dependency-test.sh
@@ -27,7 +27,7 @@ fi
 # Compile crates with Kani backend
 cd $(dirname $0)
 rm -rf build
-RUST_BACKTRACE=1 cargo kani --target-dir build --only-codegen --keep-temp --verbose
+RUST_BACKTRACE=1 cargo kani --target-dir build --only-codegen --keep-temps --verbose
 
 # Convert from JSON to Gotoc
 cd build/${TARGET}/debug/deps/

--- a/tools/compiletest/src/runtest.rs
+++ b/tools/compiletest/src/runtest.rs
@@ -327,7 +327,7 @@ impl<'test> TestCx<'test> {
         cargo
             .arg("kani")
             .args(["--function", function_name])
-            .arg("--target")
+            .arg("--target-dir")
             .arg(self.output_base_dir().join("target"))
             .arg("--crate")
             .arg(&parent_dir);


### PR DESCRIPTION
### Description of changes: 

Fix confusion with `--target` and `--target-dir` among other things.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
