### PR TITLE
Override assert_eq and assert_ne macros

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -46,6 +46,17 @@ macro_rules! assert {
     };
 }
 
+// Override the assert_eq and assert_ne macros to
+// 1. Bypass the formatting-related code in the standard library implementation,
+//    which is not relevant for verification (see
+//    https://github.com/model-checking/kani/issues/14)
+// 2. Generate a suitable message for the assert of the form:
+//        assertion failed: $left == $right
+//    instead of the uninformative:
+//        a panicking function core::panicking::assert_failed is invoked
+//    (see https://github.com/model-checking/kani/issues/13)
+// 3. Call kani::assert so that any instrumentation that it does (e.g. injecting
+//    reachability checks) is done for assert_eq and assert_ne
 #[macro_export]
 macro_rules! assert_eq {
     ($left:expr, $right:expr $(,)?) => ({

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -45,3 +45,23 @@ macro_rules! assert {
         kani::assert($cond, concat!(stringify!($($arg)+)));
     };
 }
+
+#[macro_export]
+macro_rules! assert_eq {
+    ($left:expr, $right:expr $(,)?) => ({
+        assert!($left == $right);
+    });
+    ($left:expr, $right:expr, $($arg:tt)+) => ({
+        assert!($left == $right, $($arg)+);
+    });
+}
+
+#[macro_export]
+macro_rules! assert_ne {
+    ($left:expr, $right:expr $(,)?) => ({
+        assert!($left != $right);
+    });
+    ($left:expr, $right:expr, $($arg:tt)+) => ({
+        assert!($left != $right, $($arg)+);
+    });
+}

--- a/tests/expected/assert-eq/expected
+++ b/tests/expected/assert-eq/expected
@@ -1,3 +1,3 @@
-a panicking function core::panicking::assert_failed is invoked: SUCCESS
-a panicking function core::panicking::assert_failed is invoked: FAILURE
-a panicking function core::panicking::assert_failed is invoked: SUCCESS
+line 15 assertion failed: x + 1 == y: SUCCESS
+line 16 assertion failed: x == y: FAILURE
+line 17 assertion failed: x != y: SUCCESS


### PR DESCRIPTION
### Description of changes: 

For `assert_eq` and `assert_ne` macros, Kani currently displays a confusing message:
```
a panicking function core::panicking::assert_failed is invoked: SUCCESS
```
and generates many checks (see #13 for an example).

With the changes in this PR, a more intuitive message is displayed. For example:
```
$ cat test.rs 
fn main() {
    let x = 1;
    let y = 2;
    assert_eq!(x + 1, y);
    assert_eq!(x, y); //Expected failure
    assert_ne!(x, y);
}
$ kani test.rs 
<snip>
** Results:
[assertion.1] Code generation sanity check: Correct CBMC vtable size for StructTag("tag-_4317141983261250885") (MIR type Closure(DefId(2:9147 ~ std[2f3c]::rt::lang_start::{closure#0}), [(), i8, extern "rust-call" fn(()) -> i32, (fn(),)])). Please report failures:
https://github.com/model-checking/kani/issues/new?template=bug_report.md: SUCCESS
[pointer_primitives.1] dead object in OBJECT_SIZE(&temp_0): SUCCESS
/home/ubuntu/git/kani/tests/expected/assert-eq/test.rs function main
[main.assertion.1] line 4 assertion failed: x + 1 == y: SUCCESS
[main.assertion.2] line 5 assertion failed: x == y: FAILURE
[main.assertion.3] line 6 assertion failed: x != y: SUCCESS

** 1 of 5 failed (2 iterations)
VERIFICATION FAILED
```


### Resolved issues:

Resolves #13 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing test (`tests/expected/assert-eq`)

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
