### PR TITLE
Only call the CBMC json parser on the output of a CBMC command

### DIFF
--- a/scripts/kani.py
+++ b/scripts/kani.py
@@ -192,7 +192,7 @@ def run_cmd(
     # Write to stdout if specified, or if failure, or verbose or debug
     if (output_to == "stdout" or process.returncode != EXIT_CODE_SUCCESS or verbose or debug) and not quiet:
         # By Default, the flag passed is the old output style
-        if (output_style != kani_flags.OutputStyle.OLD and not dry_run):
+        if (label == "cbmc" and output_style != kani_flags.OutputStyle.OLD and not dry_run):
             try:
                 returncode = cbmc_json_parser.transform_cbmc_output(stdout, output_style)
             except BaseException:


### PR DESCRIPTION
### Description of changes: 

The `kani.py` script (which is going away very soon) currently calls the CBMC json parser to process the output of every command (compilation, `goto-cc`, `goto-instrument`, etc.), while it is meant to be used for processing the output of the CBMC command only.

### Resolved issues:

Resolves #830 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
