### PR TITLE
Add test for `likely` and `unlikely` intrinsics.

### DIFF
--- a/tests/kani/Intrinsics/Likely/main.rs
+++ b/tests/kani/Intrinsics/Likely/main.rs
@@ -30,6 +30,6 @@ fn check_unlikely(x: i32, y: i32) {
 fn main() {
     let x = kani::any();
     let y = kani::any();
-    let _ = check_likely(x, y);
-    let _ = check_unlikely(x, y);
+    check_likely(x, y);
+    check_unlikely(x, y);
 }

--- a/tests/kani/Intrinsics/Likely/main.rs
+++ b/tests/kani/Intrinsics/Likely/main.rs
@@ -27,7 +27,7 @@ fn check_unlikely(x: i32, y: i32) {
     }
 }
 
-fn main () {
+fn main() {
     let x = kani::any();
     let y = kani::any();
     let _ = check_likely(x, y);

--- a/tests/kani/Intrinsics/Likely/main.rs
+++ b/tests/kani/Intrinsics/Likely/main.rs
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `likely` and `unlikely` return the value of the condition passed
+// as an argument. These intrinsics hint the Rust compiler what branch in an
+// `if`-`else` statement is more probable to be executed, allowing it to
+// optimize code for the execution of one of the two branches:
+// https://rust-lang.github.io/rfcs/1131-likely-intrinsic.html
+// This aspect is not relevant for verification, which is why it is not modeled.
+
+#![feature(core_intrinsics)]
+use std::intrinsics::{likely, unlikely};
+
+fn check_likely(x: i32, y: i32) {
+    if likely(x != y) {
+        assert!(x != y);
+    } else {
+        assert!(x == y);
+    }
+}
+
+fn check_unlikely(x: i32, y: i32) {
+    if unlikely(x == y) {
+        assert!(x == y);
+    } else {
+        assert!(x != y);
+    }
+}
+
+fn main () {
+    let x = kani::any();
+    let y = kani::any();
+    let _ = check_likely(x, y);
+    let _ = check_unlikely(x, y);
+}


### PR DESCRIPTION
### Description of changes: 

Adds a missing test for the `likely` and `unlikely` intrinsics.

### Resolved issues:

Part of #727 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? One more test.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
