### PR TITLE
Update rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2022-02-09"
+channel = "nightly-2022-02-22"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/function.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/function.rs
@@ -9,7 +9,7 @@ use cbmc::goto_program::{Expr, Stmt, Symbol};
 use cbmc::InternString;
 use rustc_ast::ast;
 use rustc_middle::mir::{HasLocalDecls, Local};
-use rustc_middle::ty::{self, Instance, TyS};
+use rustc_middle::ty::{self, Instance};
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
 use tracing::{debug, warn};
@@ -184,8 +184,8 @@ impl<'tcx> GotocCtx<'tcx> {
         // ```
 
         let tupe = sig.inputs().last().unwrap();
-        let args: Vec<&TyS<'tcx>> = match tupe.kind() {
-            ty::Tuple(substs) => substs.iter().map(|s| s.expect_ty()).collect(),
+        let args = match tupe.kind() {
+            ty::Tuple(substs) => *substs,
             _ => unreachable!("a function's spread argument must be a tuple"),
         };
         let starting_idx = sig.inputs().len();

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/operand.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/operand.rs
@@ -51,11 +51,11 @@ impl<'tcx> GotocCtx<'tcx> {
         self.codegen_const(const_, Some(&c.span))
     }
 
-    pub fn codegen_const(&mut self, lit: &'tcx Const<'tcx>, span: Option<&Span>) -> Expr {
+    pub fn codegen_const(&mut self, lit: Const<'tcx>, span: Option<&Span>) -> Expr {
         debug!("found literal: {:?}", lit);
         let lit = self.monomorphize(lit);
 
-        match lit.val {
+        match lit.val() {
             // evaluate constant if it has no been evaluated yet
             ConstKind::Unevaluated(unevaluated) => {
                 debug!("The literal was a Unevaluated");
@@ -63,15 +63,18 @@ impl<'tcx> GotocCtx<'tcx> {
                     .tcx
                     .const_eval_resolve(ty::ParamEnv::reveal_all(), unevaluated, None)
                     .unwrap();
-                self.codegen_const_value(const_val, lit.ty, span)
+                self.codegen_const_value(const_val, lit.ty(), span)
             }
 
             ConstKind::Value(v) => {
                 debug!("The literal was a ConstValue {:?}", v);
-                self.codegen_const_value(v, lit.ty, span)
+                self.codegen_const_value(v, lit.ty(), span)
             }
             _ => {
-                unreachable!("monomorphized item shouldn't have this constant value: {:?}", lit.val)
+                unreachable!(
+                    "monomorphized item shouldn't have this constant value: {:?}",
+                    lit.val()
+                )
             }
         }
     }
@@ -199,7 +202,7 @@ impl<'tcx> GotocCtx<'tcx> {
             // We need a regression for this case.
             (Scalar::Int(int), ty::Ref(_, ty, _)) => {
                 if int.is_null() {
-                    self.codegen_ty(ty).to_pointer().null()
+                    self.codegen_ty(*ty).to_pointer().null()
                 } else {
                     unreachable!()
                 }
@@ -280,7 +283,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 // here we have tuples of at most one length
                 if substs.len() == 1 {
                     let overall_t = self.codegen_ty(ty);
-                    let t = substs[0].expect_ty();
+                    let t = substs[0];
                     self.codegen_single_variant_single_field(s, span, overall_t, t)
                 } else {
                     unreachable!()

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/rvalue.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/rvalue.rs
@@ -158,7 +158,7 @@ impl<'tcx> GotocCtx<'tcx> {
     fn codegen_rvalue_repeat(
         &mut self,
         op: &Operand<'tcx>,
-        sz: &&'tcx ty::Const<'tcx>,
+        sz: &ty::Const<'tcx>,
         res_ty: Ty<'tcx>,
     ) -> Expr {
         let func_name = format!("gen-repeat<{}>", self.ty_mangled_name(res_ty));
@@ -182,7 +182,7 @@ impl<'tcx> GotocCtx<'tcx> {
             );
             body.push(Stmt::for_loop(
                 Stmt::skip(Location::none()),
-                idx.clone().lt(tcx.codegen_const(sz, None)),
+                idx.clone().lt(tcx.codegen_const(*sz, None)),
                 idx.postincr().as_stmt(Location::none()),
                 lbody,
                 Location::none(),
@@ -202,7 +202,7 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn codegen_rvalue_len(&mut self, p: &Place<'tcx>) -> Expr {
         let pt = self.place_ty(p);
         match pt.kind() {
-            ty::Array(_, sz) => self.codegen_const(sz, None),
+            ty::Array(_, sz) => self.codegen_const(*sz, None),
             ty::Slice(_) => {
                 self.codegen_place(p).fat_ptr_goto_expr.unwrap().member("len", &self.symbol_table)
             }
@@ -737,11 +737,7 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     /// Generate a function pointer to drop_in_place for entry into the vtable
-    fn codegen_vtable_drop_in_place(
-        &mut self,
-        ty: Ty<'tcx>,
-        trait_ty: &'tcx ty::TyS<'tcx>,
-    ) -> Expr {
+    fn codegen_vtable_drop_in_place(&mut self, ty: Ty<'tcx>, trait_ty: ty::Ty<'tcx>) -> Expr {
         let drop_instance = Instance::resolve_drop_in_place(self.tcx, ty).polymorphize(self.tcx);
         let drop_sym_name: InternedString = self.symbol_name(drop_instance).into();
 
@@ -854,7 +850,7 @@ impl<'tcx> GotocCtx<'tcx> {
     fn codegen_vtable(&mut self, src_mir_type: Ty<'tcx>, dst_mir_type: Ty<'tcx>) -> Expr {
         let trait_type = match dst_mir_type.kind() {
             // DST is pointer type
-            ty::Ref(_, pointee_type, ..) => pointee_type,
+            ty::Ref(_, pointee_type, ..) => *pointee_type,
             // DST is box type
             ty::Adt(adt_def, adt_subst) if adt_def.is_box() => {
                 adt_subst.first().unwrap().expect_ty()
@@ -890,15 +886,15 @@ impl<'tcx> GotocCtx<'tcx> {
                     COMMON_VTABLE_ENTRIES
                 };
 
-                let (vt_size, vt_align) = ctx.codegen_vtable_size_and_align(&src_mir_type);
-                let size_assert = ctx.check_vtable_size(&src_mir_type, vt_size.clone());
+                let (vt_size, vt_align) = ctx.codegen_vtable_size_and_align(*&src_mir_type);
+                let size_assert = ctx.check_vtable_size(src_mir_type, vt_size.clone());
 
                 let vtable_fields: Vec<Expr> = vtable_entries
                     .iter()
                     .enumerate()
                     .filter_map(|(idx, entry)| match entry {
                         VtblEntry::MetadataDropInPlace => {
-                            Some(ctx.codegen_vtable_drop_in_place(&src_mir_type, trait_type))
+                            Some(ctx.codegen_vtable_drop_in_place(src_mir_type, trait_type))
                         }
                         VtblEntry::MetadataSize => Some(vt_size.clone()),
                         VtblEntry::MetadataAlign => Some(vt_align.clone()),
@@ -1077,8 +1073,8 @@ impl<'tcx> GotocCtx<'tcx> {
                 assert_eq!(src_elt_type, dst_elt_type);
                 let dst_goto_type = self.codegen_ty(dst_mir_type);
                 let dst_goto_expr = // cast from an array type to a pointer type
-                    src_goto_expr.cast_to(self.codegen_ty(src_elt_type).to_pointer());
-                let dst_goto_len = self.codegen_const(src_elt_count, None);
+                    src_goto_expr.cast_to(self.codegen_ty(*src_elt_type).to_pointer());
+                let dst_goto_len = self.codegen_const(*src_elt_count, None);
                 Some(slice_fat_ptr(dst_goto_type, dst_goto_expr, dst_goto_len, &self.symbol_table))
             }
             (src_kind, dst_kind) => panic!(
@@ -1135,8 +1131,8 @@ impl<'tcx> GotocCtx<'tcx> {
         for field in src_goto_field_values.keys() {
             if let Some(expr) = self.cast_to_unsized_expr(
                 src_goto_field_values.get(field).unwrap().clone(),
-                src_mir_field_types.get(field).unwrap(),
-                dst_mir_field_types.get(field).unwrap(),
+                *src_mir_field_types.get(field).unwrap(),
+                *dst_mir_field_types.get(field).unwrap(),
             ) {
                 cast_required.push((*field, expr));
             }
@@ -1195,8 +1191,8 @@ impl<'tcx> GotocCtx<'tcx> {
                 let mut matching_types: Option<(Ty<'tcx>, Ty<'tcx>)> = None;
                 for field in src_fields.keys() {
                     let pair = self.nested_pair_of_concrete_and_trait_types(
-                        src_fields.get(field).unwrap(),
-                        dst_fields.get(field).unwrap(),
+                        *src_fields.get(field).unwrap(),
+                        *dst_fields.get(field).unwrap(),
                     );
                     if pair.is_some() {
                         assert!(

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/rvalue.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/rvalue.rs
@@ -886,7 +886,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     COMMON_VTABLE_ENTRIES
                 };
 
-                let (vt_size, vt_align) = ctx.codegen_vtable_size_and_align(*&src_mir_type);
+                let (vt_size, vt_align) = ctx.codegen_vtable_size_and_align(src_mir_type);
                 let size_assert = ctx.check_vtable_size(src_mir_type, vt_size.clone());
 
                 let vtable_fields: Vec<Expr> = vtable_entries

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/statement.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/statement.rs
@@ -40,7 +40,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 Stmt::goto(self.current_fn().find_label(target), loc)
             }
             TerminatorKind::SwitchInt { discr, switch_ty, targets } => {
-                self.codegen_switch_int(discr, switch_ty, targets)
+                self.codegen_switch_int(discr, *switch_ty, targets)
             }
             TerminatorKind::Resume => Stmt::assert_false("resume instruction", loc),
             TerminatorKind::Abort => Stmt::assert_false("abort instruction", loc),
@@ -273,9 +273,7 @@ impl<'tcx> GotocCtx<'tcx> {
         if fargs.len() > 0 {
             let tupe = fargs.remove(fargs.len() - 1);
             let tupled_args: Vec<Type> = match self.operand_ty(last_mir_arg.unwrap()).kind() {
-                ty::Tuple(tupled_args) => {
-                    tupled_args.iter().map(|s| self.codegen_ty(s.expect_ty())).collect()
-                }
+                ty::Tuple(tupled_args) => tupled_args.iter().map(|s| self.codegen_ty(s)).collect(),
                 _ => unreachable!("Argument to function with Abi::RustCall is not a tuple"),
             };
 

--- a/src/kani-compiler/rustc_codegen_kani/src/context/vtable_ctx.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/context/vtable_ctx.rs
@@ -137,7 +137,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // We only have the Gotoc type, we need to normalize to match the MIR type.
         assert!(trait_ty.is_struct_tag());
         let mir_name =
-            self.normalized_trait_name(self.type_map.get(&trait_ty.tag().unwrap()).unwrap());
+            self.normalized_trait_name(*self.type_map.get(&trait_ty.tag().unwrap()).unwrap());
         self.vtable_ctx.add_call_site(mir_name.into(), vtable_idx, wrapper_name);
 
         // Declare the wrapper's parameters

--- a/src/kani-compiler/rustc_codegen_kani/src/overrides/hooks.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/overrides/hooks.rs
@@ -280,7 +280,7 @@ impl<'tcx> GotocHook<'tcx> for Nevers {
     ) -> Stmt {
         let msg = format!(
             "a panicking function {} is invoked",
-            with_no_trimmed_paths(|| tcx.tcx.def_path_str(instance.def_id()))
+            with_no_trimmed_paths!(tcx.tcx.def_path_str(instance.def_id()))
         );
         tcx.codegen_fatal_error(&msg, span)
     }
@@ -326,7 +326,7 @@ struct MemReplace;
 
 impl<'tcx> GotocHook<'tcx> for MemReplace {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
-        let name = with_no_trimmed_paths(|| tcx.def_path_str(instance.def_id()));
+        let name = with_no_trimmed_paths!(tcx.def_path_str(instance.def_id()));
         name == "core::mem::replace" || name == "std::mem::replace"
     }
 
@@ -371,7 +371,7 @@ struct MemSwap;
 impl<'tcx> GotocHook<'tcx> for MemSwap {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
         // We need to keep the old std / core functions here because we don't compile std yet.
-        let name = with_no_trimmed_paths(|| tcx.def_path_str(instance.def_id()));
+        let name = with_no_trimmed_paths!(tcx.def_path_str(instance.def_id()));
         name == "core::mem::swap"
             || name == "std::mem::swap"
             || name == "core::ptr::swap"
@@ -433,7 +433,7 @@ struct PtrRead;
 
 impl<'tcx> GotocHook<'tcx> for PtrRead {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
-        let name = with_no_trimmed_paths(|| tcx.def_path_str(instance.def_id()));
+        let name = with_no_trimmed_paths!(tcx.def_path_str(instance.def_id()));
         name == "core::ptr::read"
             || name == "core::ptr::read_unaligned"
             || name == "core::ptr::read_volatile"
@@ -471,7 +471,7 @@ struct PtrWrite;
 
 impl<'tcx> GotocHook<'tcx> for PtrWrite {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
-        let name = with_no_trimmed_paths(|| tcx.def_path_str(instance.def_id()));
+        let name = with_no_trimmed_paths!(tcx.def_path_str(instance.def_id()));
         name == "core::ptr::write"
             || name == "core::ptr::write_unaligned"
             || name == "std::ptr::write"
@@ -506,7 +506,7 @@ struct RustAlloc;
 impl<'tcx> GotocHook<'tcx> for RustAlloc {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
         let name = tcx.symbol_name(instance).name.to_string();
-        let full_name = with_no_trimmed_paths(|| tcx.def_path_str(instance.def_id()));
+        let full_name = with_no_trimmed_paths!(tcx.def_path_str(instance.def_id()));
         name == "__rust_alloc" || full_name == "alloc::alloc::exchange_malloc"
     }
 
@@ -657,7 +657,7 @@ struct SliceFromRawPart;
 
 impl<'tcx> GotocHook<'tcx> for SliceFromRawPart {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
-        let name = with_no_trimmed_paths(|| tcx.def_path_str(instance.def_id()));
+        let name = with_no_trimmed_paths!(tcx.def_path_str(instance.def_id()));
         name == "core::ptr::slice_from_raw_parts"
             || name == "std::ptr::slice_from_raw_parts"
             || name == "core::ptr::slice_from_raw_parts_mut"

--- a/src/kani-compiler/rustc_codegen_kani/src/utils/debug.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/utils/debug.rs
@@ -94,7 +94,7 @@ impl<'tcx> GotocCtx<'tcx> {
             debug!(
                 "handling {}, {}",
                 instance,
-                with_no_trimmed_paths(|| self.tcx.def_path_str(instance.def_id()))
+                with_no_trimmed_paths!(self.tcx.def_path_str(instance.def_id()))
             );
             debug!("variables: ");
             for l in mir.args_iter().chain(mir.vars_and_temps_iter()) {

--- a/src/kani-compiler/rustc_codegen_kani/src/utils/names.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/utils/names.rs
@@ -56,7 +56,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
     /// A human readable name in Rust for reference, should not be used as a key.
     pub fn readable_instance_name(&self, instance: Instance<'tcx>) -> String {
-        with_no_trimmed_paths(|| self.tcx.def_path_str(instance.def_id()))
+        with_no_trimmed_paths!(self.tcx.def_path_str(instance.def_id()))
     }
 
     /// The actual function name used in the symbol table
@@ -105,7 +105,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// the vtable struct, but we add the method name for debugging readability.
     ///     Example: 3_vol
     pub fn vtable_field_name(&self, _def_id: DefId, idx: usize) -> InternedString {
-        // format!("{}_{}", idx, with_no_trimmed_paths(|| self.tcx.item_name(def_id)))
+        // format!("{}_{}", idx, with_no_trimmed_paths!(|| self.tcx.item_name(def_id)))
         // TODO: use def_id https://github.com/model-checking/kani/issues/364
         idx.to_string().into()
     }

--- a/src/kani-compiler/rustc_codegen_kani/src/utils/utils.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/utils/utils.rs
@@ -5,7 +5,7 @@ use crate::GotocCtx;
 use cbmc::btree_string_map;
 use cbmc::goto_program::{Expr, ExprValue, Location, Stmt, SymbolTable, Type};
 use rustc_middle::ty::layout::LayoutOf;
-use rustc_middle::ty::TyS;
+use rustc_middle::ty::Ty;
 use tracing::debug;
 
 // Should move into rvalue
@@ -71,7 +71,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
     /// Generates an expression `((dst as usize) % align_of(T) == 0`
     /// to determine if `dst` is aligned.
-    pub fn is_aligned(&mut self, typ: &'tcx TyS<'_>, dst: Expr) -> Expr {
+    pub fn is_aligned(&mut self, typ: Ty<'tcx>, dst: Expr) -> Expr {
         let layout = self.layout_of(typ);
         let align = Expr::int_constant(layout.align.abi.bytes(), Type::size_t());
         let cast_dst = dst.cast_to(Type::size_t());

--- a/tests/firecracker/virtio-block-parse/main.rs
+++ b/tests/firecracker/virtio-block-parse/main.rs
@@ -262,8 +262,7 @@ unsafe impl kani::Invariant for Error {
                 | Error::GuestMemory
                 | Error::InvalidOffset
                 | Error::UnexpectedReadOnlyDescriptor
-                | Error::UnexpectedWriteOnlyDescriptor
-        )
+        ) || matches!(*self, Error::UnexpectedWriteOnlyDescriptor)
     }
 }
 

--- a/tests/kani/Invariants/enum.rs
+++ b/tests/kani/Invariants/enum.rs
@@ -28,7 +28,8 @@ macro_rules! check_enum {
     ( $fn_name:ident, $repr:ty, $enum_type:ident, $v1:literal, $v2:literal, $v3:literal ) => {
         unsafe impl kani::Invariant for $enum_type {
             fn is_valid(&self) -> bool {
-                matches!(*self, $enum_type::Variant1 | $enum_type::Variant2 | $enum_type::Variant3)
+                matches!(*self, $enum_type::Variant1 | $enum_type::Variant2)
+                    || matches!(*self, $enum_type::Variant3)
             }
         }
 

--- a/tests/kani/Invariants/enum_raw_fail.rs
+++ b/tests/kani/Invariants/enum_raw_fail.rs
@@ -15,8 +15,11 @@ enum Basic {
 fn main() {
     let e = unsafe { kani::any_raw::<Basic>() };
     // This enum can be invalid and this code may actually not match any of the options below.
+    // We had to split this into two matches because the compiler was statically pruning the
+    // default branch of matches. When that happens, the failure is due to unreachable code being
+    // executed.
     kani::expect_fail(
-        matches!(e, Basic::Variant1 | Basic::Variant2 | Basic::Variant3),
+        matches!(e, Basic::Variant1 | Basic::Variant2) || matches!(e, Basic::Variant3),
         "Invalid enum variant",
     );
     match e {

--- a/tests/kani/Invariants/result.rs
+++ b/tests/kani/Invariants/result.rs
@@ -26,7 +26,7 @@ unsafe impl kani::Invariant for MyType {
 
 unsafe impl kani::Invariant for Error {
     fn is_valid(&self) -> bool {
-        matches!(*self, Error::Error1 | Error::Error2)
+        *self == Error::Error1 || *self == Error::Error2
     }
 }
 

--- a/tools/bookrunner/librustdoc/clean/auto_trait.rs
+++ b/tools/bookrunner/librustdoc/clean/auto_trait.rs
@@ -297,7 +297,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                     .get(name)
                     .unwrap_or(&empty)
                     .iter()
-                    .map(|region| GenericBound::Outlives(Self::get_lifetime(region, names_map)))
+                    .map(|region| GenericBound::Outlives(Self::get_lifetime(*region, names_map)))
                     .collect();
 
                 if bounds.is_empty() {

--- a/tools/bookrunner/librustdoc/clean/inline.rs
+++ b/tools/bookrunner/librustdoc/clean/inline.rs
@@ -564,7 +564,7 @@ crate fn print_inlined_const(tcx: TyCtxt<'_>, did: DefId) -> String {
         let hir_id = tcx.hir().local_def_id_to_hir_id(did);
         rustc_hir_pretty::id_to_string(&tcx.hir(), hir_id)
     } else {
-        tcx.rendered_const(did)
+        tcx.rendered_const(did).clone()
     }
 }
 

--- a/tools/bookrunner/librustdoc/clean/types.rs
+++ b/tools/bookrunner/librustdoc/clean/types.rs
@@ -1874,7 +1874,7 @@ impl Path {
     /// Checks if this is a `T::Name` path for an associated type.
     crate fn is_assoc_ty(&self) -> bool {
         match self.res {
-            Res::SelfTy(..) if self.segments.len() != 1 => true,
+            Res::SelfTy { .. } if self.segments.len() != 1 => true,
             Res::Def(DefKind::TyParam, _) if self.segments.len() != 1 => true,
             Res::Def(DefKind::AssocTy, _) => true,
             _ => false,


### PR DESCRIPTION
### Description of changes: 

There were a few fixes required due to the following changes:

1. TyS is no longer public. Instead we have to use Ty directly. This also caused a bunch of little updates since TyS is used as a reference and Ty is by value.
2. TyKind::Tuple now uses List<Ty>. We no longer need to convert subst to Ty.
3. Const fields are no longer public. Use methods instead.
4. with_no_trimmed_paths is now a macro and it takes an object instead of closure.
5. Res::SelfTy is now a struct. Update match branches.
6. `rustc` can now prune matches!() statements when all possible enum values are provided. Updated our testcases to use 2 matches instead. Need to figure out a more robust solution but this unblocks the update.

### Resolved issues:

Resolves #857 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Regression

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
