### PR TITLE
Update CODEOWNERS to kani-devs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-*   @model-checking/rmc-devs
+*   @model-checking/kani-devs


### PR DESCRIPTION
### Description of changes: 

Change to match rename of GitHub team from rmc-devs to kani-devs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
