### PR TITLE
Print the output from CBMC when it crashes

### DIFF
--- a/scripts/cbmc_json_parser.py
+++ b/scripts/cbmc_json_parser.py
@@ -115,9 +115,9 @@ def transform_cbmc_output(cbmc_response_string, output_style):
         print(messages)
 
     else:
-        # DynTrait tests generate a non json output due to "Invariant check failed" error
-        # For these cases, we just produce the cbmc output unparsed
-        # TODO: Parse these non json outputs from CBMC
+        # When CBMC crashes or does not produce json output, print the response
+        # string to allow us to debug
+        print(cbmc_response_string)
         raise Exception("CBMC Crashed - Unable to present Result")
 
     return num_failed > 0


### PR DESCRIPTION
### Description of changes: 

Currently, when CBMC crashes, Kani's CBMC parser script crashes without showing the error from CBMC:
```
$ kani --unwind 2 test.rs 
Traceback (most recent call last):
  File "/home/ubuntu/git/kani/scripts/kani.py", line 198, in run_cmd
    returncode = cbmc_json_parser.transform_cbmc_output(stdout, output_style)
  File "/home/ubuntu/git/kani/scripts/cbmc_json_parser.py", line 121, in transform_cbmc_output
    raise Exception("CBMC Crashed - Unable to present Result")
Exception: CBMC Crashed - Unable to present Result

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/git/kani/scripts/kani", line 201, in <module>
    sys.exit(main())
  File "/home/ubuntu/git/kani/scripts/kani", line 141, in main
    retcode = kani.run_cbmc(
  File "/home/ubuntu/git/kani/scripts/kani.py", line 346, in run_cbmc
    return run_cmd(
  File "/home/ubuntu/git/kani/scripts/kani.py", line 200, in run_cmd
    raise Exception("JSON Parsing Error")
Exception: JSON Parsing Error
```
 This PR prints the output from CBMC to stdout to allow us to debug the issue.

### Resolved issues:

Part of #861 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
