### PR TITLE
Add basic test for --visualize

### DIFF
--- a/tests/cargo-kani/simple-visualize/Cargo.toml
+++ b/tests/cargo-kani/simple-visualize/Cargo.toml
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+[package]
+name = "simple-visualize"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+
+[workspace]
+
+[package.metadata.kani]
+flags = {visualize = true}

--- a/tests/cargo-kani/simple-visualize/main.expected
+++ b/tests/cargo-kani/simple-visualize/main.expected
@@ -1,0 +1,1 @@
+report/html/index.html

--- a/tests/cargo-kani/simple-visualize/src/main.rs
+++ b/tests/cargo-kani/simple-visualize/src/main.rs
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+fn main() {
+    assert!(1 == 2);
+}


### PR DESCRIPTION
### Description of changes: 

Bare bones test that runs `--visualize` in CI. Checks that we print out the path to the report (which the new cargo-kani does).

### Resolved issues:


### Call-outs:

Doesn't test that the report directory actually exists, but the cargo-kani prints the report location only after it successfully calls cbmc-viewer, so this should be somewhat robust unless that particular fact changes.

### Testing:

* How is this change tested? new test only

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
