### PR TITLE
Refactor: Move the lookup_components code from `SymbolTable` to `Type`

### DIFF
--- a/cprover_bindings/src/goto_program/symbol_table.rs
+++ b/cprover_bindings/src/goto_program/symbol_table.rs
@@ -96,44 +96,6 @@ impl SymbolTable {
         self.symbol_table.get(&name)
     }
 
-    pub fn lookup_components(&self, aggr_name: InternedString) -> Option<&Vec<DatatypeComponent>> {
-        self.lookup(aggr_name).and_then(|x| x.typ.components())
-    }
-
-    pub fn lookup_components_in_type(&self, base_type: &Type) -> Option<&Vec<DatatypeComponent>> {
-        base_type.type_name().and_then(|aggr_name| self.lookup_components(aggr_name))
-    }
-
-    /// If aggr_name.field_name exists in the symbol table, return Some(field_type),
-    /// otherwise, return none.
-    pub fn lookup_field_type(
-        &self,
-        aggr_name: InternedString,
-        field_name: InternedString,
-    ) -> Option<&Type> {
-        self.lookup_components(aggr_name)
-            .and_then(|fields| fields.iter().find(|&field| field.name() == field_name))
-            .and_then(|field| field.field_typ())
-    }
-
-    /// If aggr_name.field_name exists in the symbol table, return Some(field_type),
-    /// otherwise, return none.
-    pub fn lookup_field_type_in_type<T: Into<InternedString>>(
-        &self,
-        base_type: &Type,
-        field_name: T,
-    ) -> Option<&Type> {
-        let field_name = field_name.into();
-        base_type.type_name().and_then(|aggr_name| self.lookup_field_type(aggr_name, field_name))
-    }
-
-    pub fn lookup_fields_in_type(&self, base_type: &Type) -> Option<&Vec<DatatypeComponent>> {
-        base_type
-            .type_name()
-            .and_then(|aggr_name| self.lookup(aggr_name))
-            .and_then(|x| x.typ.components())
-    }
-
     pub fn machine_model(&self) -> &MachineModel {
         &self.machine_model
     }

--- a/cprover_bindings/src/goto_program/symtab_transformer/gen_c_transformer/nondet_transformer.rs
+++ b/cprover_bindings/src/goto_program/symtab_transformer/gen_c_transformer/nondet_transformer.rs
@@ -84,7 +84,7 @@ impl Transformer for NondetTransformer {
 
         // Instead of just mapping `self.transform_expr` over the values,
         // only transform those which are true fields, not padding
-        let fields = self.symbol_table().lookup_fields_in_type(&transformed_typ).unwrap().clone();
+        let fields = transformed_typ.lookup_components(self.symbol_table()).unwrap().clone();
         let transformed_values: Vec<_> = fields
             .into_iter()
             .zip(values.into_iter())

--- a/src/kani-compiler/rustc_codegen_kani/src/utils/utils.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/utils/utils.rs
@@ -133,12 +133,10 @@ impl<'tcx> GotocCtx<'tcx> {
     /// `boxed_type` is the type of the resulting expression
     pub fn box_value(&self, boxed_value: Expr, boxed_type: Type) -> Expr {
         self.assert_is_rust_box_like(&boxed_type);
-        let get_field_type = |struct_typ, field| {
-            self.symbol_table.lookup_field_type_in_type(struct_typ, field).unwrap().clone()
-        };
-        let unique_ptr_typ = get_field_type(&boxed_type, "0");
+        let unique_ptr_typ = boxed_type.lookup_field_type("0", &self.symbol_table).unwrap();
         self.assert_is_rust_unique_pointer_like(&unique_ptr_typ);
-        let unique_ptr_pointer_typ = get_field_type(&unique_ptr_typ, "pointer");
+        let unique_ptr_pointer_typ =
+            unique_ptr_typ.lookup_field_type("pointer", &self.symbol_table).unwrap();
         assert_eq!(&unique_ptr_pointer_typ, boxed_value.typ());
         let unique_ptr_val = Expr::struct_expr_with_nondet_fields(
             unique_ptr_typ,
@@ -158,7 +156,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // TODO: A std::alloc::Global appears to be an empty struct, in the cases we've seen.
         // Is there something smarter we can do here?
         assert!(t.is_struct_like());
-        let components = self.symbol_table.lookup_components_in_type(t).unwrap();
+        let components = t.lookup_components(&self.symbol_table).unwrap();
         assert_eq!(components.len(), 0);
     }
 
@@ -167,7 +165,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // TODO: A std::marker::PhantomData appears to be an empty struct, in the cases we've seen.
         // Is there something smarter we can do here?
         assert!(t.is_struct_like());
-        let components = self.symbol_table.lookup_components_in_type(t).unwrap();
+        let components = t.lookup_components(&self.symbol_table).unwrap();
         assert_eq!(components.len(), 0);
     }
 
@@ -181,7 +179,7 @@ impl<'tcx> GotocCtx<'tcx> {
         //   struct std::ptr::Unique<[u8; 8]>::14713681870393313245 0;
         // };
         assert!(t.is_struct_like());
-        let components = self.symbol_table.lookup_components_in_type(t).unwrap();
+        let components = t.lookup_components(&self.symbol_table).unwrap();
         assert_eq!(components.len(), 2);
         for c in components {
             match c.name().to_string().as_str() {
@@ -202,7 +200,7 @@ impl<'tcx> GotocCtx<'tcx> {
         //   struct [u8::16712579856250238426; 8] *pointer;
         // };
         assert!(t.is_struct_like());
-        let components = self.symbol_table.lookup_components_in_type(t).unwrap();
+        let components = t.lookup_components(&self.symbol_table).unwrap();
         assert_eq!(components.len(), 2);
         for c in components {
             match c.name().to_string().as_str() {


### PR DESCRIPTION
### Description of changes: 

While making some other changes, I realized that functionality I expected to be on the `Type` was actually awkwardly placed as helper functions on the `SymbolTable`.
Moving it where it belongs.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing unit tests.

* Is this a refactor change? Yes.

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
