### PR TITLE
Only compile as binary target if verifying main function

### DIFF
--- a/src/cargo-kani/src/call_single_file.rs
+++ b/src/cargo-kani/src/call_single_file.rs
@@ -56,6 +56,10 @@ impl KaniSession {
             }
         } else {
             if self.args.function != "main" {
+                // Unless entry function for proof harness is main, compile code as lib.
+                // This ensures that rustc won't prune functions that are not reachable
+                // from main as well as enable compilation of crates that don't have a main
+                // function.
                 args.push("--crate-type".into());
                 args.push("lib".into());
             }

--- a/src/cargo-kani/src/call_single_file.rs
+++ b/src/cargo-kani/src/call_single_file.rs
@@ -54,6 +54,11 @@ impl KaniSession {
             if !args.contains(&t) {
                 args.push(t);
             }
+        } else {
+            if self.args.function != "main" {
+                args.push("--crate-type".into());
+                args.push("lib".into());
+            }
         }
 
         let mut cmd = Command::new(&self.kani_rustc);

--- a/tests/expected/reach/unreachable/expected
+++ b/tests/expected/reach/unreachable/expected
@@ -1,2 +1,2 @@
 UNREACHABLE
- ** 1 of 5 failed (1 unreachable)
+ ** 1 of 3 failed (1 unreachable)

--- a/tests/expected/reach/unreachable/test.rs
+++ b/tests/expected/reach/unreachable/test.rs
@@ -16,5 +16,3 @@ fn foo(x: i32) {
         assert!(x <= 5);
     }
 }
-
-fn main() {}


### PR DESCRIPTION
### Description of changes: 

In order to verify a harness using `kani` command, user either have to
have a `main` function defined in their crate or they have to set the
env variable RUSTFLAGS to include --crate-type lib.

With these changes, Kani will pick the crate type based on the
--function argument.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
