### PR TITLE
Update build workflow with `cargo-kani`

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -35,5 +35,7 @@ runs:
         run: |
           export RUST_BACKTRACE=1
           cargo build -p kani-compiler
+          cargo build -p cargo-kani
+          cargo build -p kani-link-restrictions
         shell: bash
 

--- a/scripts/ci/detect_bookrunner_failures.sh
+++ b/scripts/ci/detect_bookrunner_failures.sh
@@ -10,7 +10,7 @@ set -eu
 # The threshold is roughly computed as: `1.05 * <number of expected failures>`
 # The extra 5% allows us to account for occasional timeouts. It is reviewed and
 # updated whenever the Rust toolchain version is updated.
-EXPECTED=621
+EXPECTED=94
 THRESHOLD=$(expr ${EXPECTED} \* 105 / 100) # Add 5% threshold
 
 if [[ $# -ne 1 ]]; then


### PR DESCRIPTION
### Description of changes: 

Updates the build workflow to build `cargo-kani` and `kani-link-restrictions`. Changes the expected number of failures to 94.

### Resolved issues:

Resolves #876 

### Call-outs:

Building `kani-link-restrictions` appears to be necessary, otherwise I get this error:
```
Error: Unable to find kani-link-restrictions. Looked for /home/ubuntu/kani/target/debug/kani-link-restrictions

Stack backtrace:
   0: anyhow::error::<impl anyhow::Error>::msg
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.52/src/error.rs:79:36
   1: cargo_kani::session::InstallType::kani_link_restrictions
             at ./src/cargo-kani/src/session.rs:215:21
   2: cargo_kani::session::KaniSession::new
             at ./src/cargo-kani/src/session.rs:49:37
   3: cargo_kani::standalone_main
             at ./src/cargo-kani/src/main.rs:70:15
   4: cargo_kani::main
             at ./src/cargo-kani/src/main.rs:27:39
   5: core::ops::function::FnOnce::call_once
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/core/src/ops/function.rs:227:5
   6: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/std/src/sys_common/backtrace.rs:122:18
   7: std::rt::lang_start::{{closure}}
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/std/src/rt.rs:145:18
   8: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/core/src/ops/function.rs:259:13
   9: std::panicking::try::do_call
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/std/src/panicking.rs:492:40
  10: std::panicking::try
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/std/src/panicking.rs:456:19
  11: std::panic::catch_unwind
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/std/src/panic.rs:137:14
  12: std::rt::lang_start_internal::{{closure}}
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/std/src/rt.rs:128:48
  13: std::panicking::try::do_call
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/std/src/panicking.rs:492:40
  14: std::panicking::try
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/std/src/panicking.rs:456:19
  15: std::panic::catch_unwind
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/std/src/panic.rs:137:14
  16: std::rt::lang_start_internal
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/std/src/rt.rs:128:20
  17: std::rt::lang_start
             at /rustc/03a8cc7df1d65554a4d40825b0490c93ac0f0236/library/std/src/rt.rs:144:17
  18: main
  19: __libc_start_main
  20: _start
```
Do we need an issue for this?
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? CI.

* Is this a refactor change? No.

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
