### PR TITLE
Move kani metadata into kani_metadata

### DIFF
--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -3,10 +3,10 @@
 
 //! This file contains functions related to codegenning MIR functions into gotoc
 
-use crate::codegen_cprover_gotoc::context::metadata::HarnessMetadata;
 use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::goto_program::{Expr, Stmt, Symbol};
 use cbmc::InternString;
+use kani_metadata::HarnessMetadata;
 use rustc_ast::ast;
 use rustc_ast::{Attribute, LitKind};
 use rustc_middle::mir::coverage::Op;

--- a/src/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -3,11 +3,11 @@
 
 //! This file contains the code necessary to interface with the compiler backend
 
-use crate::codegen_cprover_gotoc::context::metadata::KaniMetadata;
 use crate::codegen_cprover_gotoc::GotocCtx;
 use bitflags::_core::any::Any;
 use cbmc::goto_program::symtab_transformer;
 use cbmc::InternedString;
+use kani_metadata::KaniMetadata;
 use kani_queries::{QueryDb, UserInput};
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::{CodegenResults, CrateInfo};

--- a/src/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -14,7 +14,6 @@
 //! Any MIR specific functionality (e.g. codegen etc) should live in specialized files that use
 //! this structure as input.
 use super::current_fn::CurrentFnCtx;
-use super::metadata::HarnessMetadata;
 use super::vtable_ctx::VtableCtx;
 use crate::codegen_cprover_gotoc::overrides::{fn_hooks, GotocHooks};
 use crate::codegen_cprover_gotoc::utils::full_crate_name;
@@ -22,6 +21,7 @@ use cbmc::goto_program::{DatatypeComponent, Expr, Location, Stmt, Symbol, Symbol
 use cbmc::utils::aggr_tag;
 use cbmc::{InternStringOption, InternedString, NO_PRETTY_NAME};
 use cbmc::{MachineModel, RoundingMode};
+use kani_metadata::HarnessMetadata;
 use kani_queries::{QueryDb, UserInput};
 use rustc_data_structures::owning_ref::OwningRef;
 use rustc_data_structures::rustc_erase_owner;

--- a/src/kani-compiler/src/codegen_cprover_gotoc/context/mod.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/context/mod.rs
@@ -8,7 +8,6 @@
 
 mod current_fn;
 mod goto_ctx;
-pub mod metadata;
 mod vtable_ctx;
 
 pub use goto_ctx::GotocCtx;

--- a/src/kani_metadata/src/harness.rs
+++ b/src/kani_metadata/src/harness.rs
@@ -1,13 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This module should be factored out into its own separate crate eventually,
-//! but leaving it here for now...
+use serde::{Deserialize, Serialize};
 
-use serde::Serialize;
-
-/// We emit this structure for each annotated proof harness we find
-#[derive(Serialize)]
+/// We emit this structure for each annotated proof harness (`#[kani::proof]`) we find
+#[derive(Serialize, Deserialize)]
 pub struct HarnessMetadata {
     /// The name the user gave to the function
     pub pretty_name: String,
@@ -19,10 +16,4 @@ pub struct HarnessMetadata {
     pub original_line: String,
     /// Optional data to store unwind value
     pub unwind_value: Option<u32>,
-}
-
-/// The structure of `.kani-metadata.json` files, which are emitted for each crate
-#[derive(Serialize)]
-pub struct KaniMetadata {
-    pub proof_harnesses: Vec<HarnessMetadata>,
 }

--- a/src/kani_metadata/src/lib.rs
+++ b/src/kani_metadata/src/lib.rs
@@ -1,6 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+mod harness;
 mod vtable;
 
+pub use harness::*;
 pub use vtable::*;
+
+use serde::{Deserialize, Serialize};
+
+/// The structure of `.kani-metadata.json` files, which are emitted for each crate
+#[derive(Serialize, Deserialize)]
+pub struct KaniMetadata {
+    pub proof_harnesses: Vec<HarnessMetadata>,
+}


### PR DESCRIPTION
### Description of changes: 

Small change to move the rest of the metadata into `kani_metadata`.


### Testing:

* How is this change tested? existing tests

* Is this a refactor change? yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
