### PR TITLE
Remove expression from cbmc check descriptions

### DIFF
--- a/scripts/cbmc_json_parser.py
+++ b/scripts/cbmc_json_parser.py
@@ -355,9 +355,10 @@ CBMC_DESCRIPTIONS = {
         CProverCheck("invalid integer address")
     ],
     "array_bounds": [
-        CProverCheck("lower bound", "access out of bounds"),
-        # This one is redundant: CProverCheck("dynamic object upper bound", "access out of bounds"),
-        CProverCheck("upper bound", "access out of bounds"), ],
+        CProverCheck("lower bound", "index out of bounds"),  # Irrelevant check. Only usize allowed as index.
+        # This one is redundant:
+        # CProverCheck("dynamic object upper bound", "access out of bounds"),
+        CProverCheck("upper bound", "index out of bounds: the length is less than or equal to the given index"), ],
     "bit_count": [
         CProverCheck("count trailing zeros is undefined for value zero"),
         CProverCheck("count leading zeros is undefined for value zero")],

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -13,6 +13,11 @@ export PATH=$SCRIPT_DIR:$PATH
 EXTRA_X_PY_BUILD_ARGS="${EXTRA_X_PY_BUILD_ARGS:-}"
 KANI_DIR=$SCRIPT_DIR/..
 
+# This variable forces an error when there is a mismatch on the expected
+# descriptions from cbmc checks.
+# TODO: We should add a more robust mechanism to detect python unexpected behavior.
+export KANI_FAIL_ON_UNEXPECTED_DESCRIPTION="true"
+
 # Required dependencies
 check-cbmc-version.py --major 5 --minor 50
 check-cbmc-viewer-version.py --major 2 --minor 10

--- a/tests/cargo-kani/output-format/main.expected
+++ b/tests/cargo-kani/output-format/main.expected
@@ -1,2 +1,2 @@
 Description: "assertion failed: 1 + 1 == 2"
-Description: "dead object in OBJECT_SIZE(&temp_0)"
+Description: "pointer to dead object"

--- a/tests/expected/array/expected
+++ b/tests/expected/array/expected
@@ -1,14 +1,4 @@
 SUCCESS\
-array 'y'.0 upper bound in y.0[var_8]
-SUCCESS\
-array 'y'.0 upper bound in y.0[var_12]
-FAILURE\
-array 'y'.0 upper bound in y.0[var_16]
-SUCCESS\
-array 'x'.0 upper bound in x.0[var_3]
-SUCCESS\
-array 'x'.0 upper bound in x.0[var_5]
-SUCCESS\
 assertion failed: y[0] == 1
 SUCCESS\
 assertion failed: y[1] == 2

--- a/tests/ui/cbmc_checks/float-overflow/check_message.rs
+++ b/tests/ui/cbmc_checks/float-overflow/check_message.rs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Check we don't print temporary variables as part of CBMC messages.
+extern crate kani;
+
+use kani::any;
+
+// Use the result so rustc doesn't optimize them away.
+fn dummy(result: f32) -> f32 {
+    result.round()
+}
+
+#[kani::proof]
+fn main() {
+    dummy(any::<f32>() + any::<f32>());
+    dummy(any::<f32>() - any::<f32>());
+    dummy(any::<f32>() * any::<f32>());
+    dummy(any::<f32>() / any::<f32>()); // This is not emitting CBMC check.
+    dummy(any::<f32>() % any::<f32>()); // This is not emitting CBMC check.
+    dummy(-any::<f32>()); // This is not emitting CBMC check.
+}
+

--- a/tests/ui/cbmc_checks/float-overflow/expected
+++ b/tests/ui/cbmc_checks/float-overflow/expected
@@ -1,10 +1,9 @@
-Failed Checks: NaN on +
+Failed Checks: NaN on addition
 Failed Checks: arithmetic overflow on floating-point addition
-Failed Checks: NaN on -
+Failed Checks: NaN on subtraction
 Failed Checks: arithmetic overflow on floating-point subtraction
-Failed Checks: NaN on *
+Failed Checks: NaN on multiplication
 Failed Checks: arithmetic overflow on floating-point multiplication
-Failed Checks: division by zero
-Failed Checks: NaN on /
+Failed Checks: NaN on division
 Failed Checks: arithmetic overflow on floating-point division
 Failed Checks: division by zero

--- a/tests/ui/cbmc_checks/float-overflow/expected
+++ b/tests/ui/cbmc_checks/float-overflow/expected
@@ -1,0 +1,10 @@
+Failed Checks: NaN on +
+Failed Checks: arithmetic overflow on floating-point addition
+Failed Checks: NaN on -
+Failed Checks: arithmetic overflow on floating-point subtraction
+Failed Checks: NaN on *
+Failed Checks: arithmetic overflow on floating-point multiplication
+Failed Checks: division by zero
+Failed Checks: NaN on /
+Failed Checks: arithmetic overflow on floating-point division
+Failed Checks: division by zero

--- a/tests/ui/cbmc_checks/pointer/check_message.rs
+++ b/tests/ui/cbmc_checks/pointer/check_message.rs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Check we don't print temporary variables as part of CBMC messages.
+
+fn not_zero(p1: *const i32) {
+    assert!(unsafe { *p1 != 0 });
+}
+
+#[kani::proof]
+fn main() {
+    let mut ptr = 10 as *const i32;
+    if kani::any() {
+        let var1 = 0;
+        ptr = &var1 as *const i32;
+    }
+    not_zero(ptr);
+}
+

--- a/tests/ui/cbmc_checks/pointer/expected
+++ b/tests/ui/cbmc_checks/pointer/expected
@@ -1,0 +1,5 @@
+Failed Checks: dereference failure: pointer NULL
+Failed Checks: dereference failure: deallocated dynamic object
+Failed Checks: dereference failure: dead object
+Failed Checks: dereference failure: pointer outside object bounds
+Failed Checks: dereference failure: invalid integer address

--- a/tests/ui/cbmc_checks/signed-overflow/check_message.rs
+++ b/tests/ui/cbmc_checks/signed-overflow/check_message.rs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Check we don't print temporary variables as part of CBMC messages.
+// cbmc-flags: --signed-overflow-check
+extern crate kani;
+
+use kani::any;
+
+// Ensure rustc encodes the operation.
+fn dummy(var: i32) {
+    kani::assume(var != 0);
+}
+
+
+#[kani::proof]
+fn main() {
+    dummy(any::<i32>() + any::<i32>());
+    dummy(any::<i32>() - any::<i32>());
+    dummy(any::<i32>() * any::<i32>());
+    dummy(any::<i32>() / any::<i32>()); // This is not emitting CBMC check.
+    dummy(any::<i32>() % any::<i32>()); // This is not emitting CBMC check.
+    dummy(any::<i32>() << any::<i32>());
+    dummy(any::<i32>() >> any::<i32>());
+    dummy(-any::<i32>()); // This is not emitting CBMC check.
+}
+

--- a/tests/ui/cbmc_checks/signed-overflow/expected
+++ b/tests/ui/cbmc_checks/signed-overflow/expected
@@ -1,0 +1,14 @@
+Failed Checks: arithmetic overflow on signed +
+Failed Checks: arithmetic overflow on signed -
+Failed Checks: arithmetic overflow on signed *
+Failed Checks: division by zero
+Failed Checks: arithmetic overflow on signed division
+Failed Checks: division by zero
+Failed Checks: result of signed mod is not representable
+Failed Checks: shift distance is negative
+Failed Checks: shift distance too large
+Failed Checks: shift operand is negative
+Failed Checks: arithmetic overflow on signed shl
+Failed Checks: shift distance is negative
+Failed Checks: shift distance too large
+Failed Checks: arithmetic overflow on signed unary minus

--- a/tests/ui/cbmc_checks/signed-overflow/expected
+++ b/tests/ui/cbmc_checks/signed-overflow/expected
@@ -1,6 +1,6 @@
-Failed Checks: arithmetic overflow on signed +
-Failed Checks: arithmetic overflow on signed -
-Failed Checks: arithmetic overflow on signed *
+Failed Checks: arithmetic overflow on signed addition
+Failed Checks: arithmetic overflow on signed subtraction
+Failed Checks: arithmetic overflow on signed multiplication
 Failed Checks: division by zero
 Failed Checks: arithmetic overflow on signed division
 Failed Checks: division by zero

--- a/tests/ui/cbmc_checks/unsigned-overflow/check_message.rs
+++ b/tests/ui/cbmc_checks/unsigned-overflow/check_message.rs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Check we don't print temporary variables as part of CBMC messages.
+// cbmc-flags: --unsigned-overflow-check
+extern crate kani;
+
+use kani::any;
+
+// Ensure rustc encodes the operation.
+fn dummy(var: u32) {
+    kani::assume(var != 0);
+}
+
+#[kani::proof]
+fn main() {
+    dummy(any::<u32>() + any::<u32>());
+    dummy(any::<u32>() - any::<u32>());
+    dummy(any::<u32>() * any::<u32>());
+    dummy(any::<u32>() / any::<u32>());
+    dummy(any::<u32>() % any::<u32>());
+    dummy(any::<u32>() << any::<u32>());
+    dummy(any::<u32>() >> any::<u32>());
+}
+

--- a/tests/ui/cbmc_checks/unsigned-overflow/expected
+++ b/tests/ui/cbmc_checks/unsigned-overflow/expected
@@ -1,0 +1,7 @@
+Failed Checks: arithmetic overflow on unsigned +
+Failed Checks: arithmetic overflow on unsigned -
+Failed Checks: arithmetic overflow on unsigned *
+Failed Checks: division by zero
+Failed Checks: division by zero
+Failed Checks: shift distance too large
+Failed Checks: shift distance too large

--- a/tests/ui/cbmc_checks/unsigned-overflow/expected
+++ b/tests/ui/cbmc_checks/unsigned-overflow/expected
@@ -1,6 +1,6 @@
-Failed Checks: arithmetic overflow on unsigned +
-Failed Checks: arithmetic overflow on unsigned -
-Failed Checks: arithmetic overflow on unsigned *
+Failed Checks: arithmetic overflow on unsigned addition
+Failed Checks: arithmetic overflow on unsigned subtraction
+Failed Checks: arithmetic overflow on unsigned multiplication
 Failed Checks: division by zero
 Failed Checks: division by zero
 Failed Checks: shift distance too large

--- a/tests/ui/regular-output-format-fail/expected
+++ b/tests/ui/regular-output-format-fail/expected
@@ -1,4 +1,4 @@
 Check 1: main.assertion.1
 Description: "assertion failed: 1 + 1 == 3"
-Description: "dead object in OBJECT_SIZE(&temp_0)"
+Description: "pointer to dead object"
 Failed Checks: assertion failed: 1 + 1 == 3

--- a/tests/ui/regular-output-format-pass/expected
+++ b/tests/ui/regular-output-format-pass/expected
@@ -1,3 +1,3 @@
 Check 1: main.assertion.1
 Description: "assertion failed: 1 + 1 == 2"
-Description: "dead object in OBJECT_SIZE(&temp_0)"
+Description: "pointer to dead object"


### PR DESCRIPTION
### Description of changes: 

We have no control over the expression printed. These checks usually end up printing some temporary variables which are rather confusing. For now, we use the post-processor to modify the message displayed to remove the expressions.

### Resolved issues:

Resolves #874


### Call-outs:

The new tests ensures that the logic doesn't break Kani but they are not really testing the message replacement today. I couldn't find any way to do that using `compiletest`.

### Testing:

* How is this change tested? New tests

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
