### PR TITLE
Migrate tests to new output format

### DIFF
--- a/tests/cargo-kani/dependencies/Cargo.toml
+++ b/tests/cargo-kani/dependencies/Cargo.toml
@@ -10,6 +10,3 @@ edition = "2021"
 [dependencies]
 memchr = { version = "2", default-features = false }
 rand = "0.8.4"
-
-[kani.flags]
-output-format = "old"

--- a/tests/cargo-kani/dependencies/check_dummy.expected
+++ b/tests/cargo-kani/dependencies/check_dummy.expected
@@ -1,1 +1,2 @@
-[check_dummy.assertion.1] line 8 assertion failed: x > 2: SUCCESS
+SUCCESS\
+assertion failed: x > 2

--- a/tests/cargo-kani/simple-config-toml/Cargo.toml
+++ b/tests/cargo-kani/simple-config-toml/Cargo.toml
@@ -10,6 +10,5 @@ edition = "2018"
 [workspace]
 
 [kani.flags]
-output-format = "old"
 cbmc-args = []
 gen-c = true

--- a/tests/cargo-kani/simple-config-toml/test_one_plus_two.expected
+++ b/tests/cargo-kani/simple-config-toml/test_one_plus_two.expected
@@ -1,1 +1,2 @@
-[pair::kani_tests::test_one_plus_two.assertion.1] line 31 assertion failed: p.sum() == 3: SUCCESS
+SUCCESS\
+assertion failed: p.sum() == 3

--- a/tests/cargo-kani/simple-config-toml/test_sum.expected
+++ b/tests/cargo-kani/simple-config-toml/test_sum.expected
@@ -1,1 +1,2 @@
-[kani_tests::test_sum.assertion.1] line 24 assertion failed: p.sum() == a.wrapping_add(b): SUCCESS
+SUCCESS\
+assertion failed: p.sum() == a.wrapping_add(b)

--- a/tests/cargo-kani/simple-extern/Cargo.toml
+++ b/tests/cargo-kani/simple-extern/Cargo.toml
@@ -11,4 +11,3 @@ edition = "2018"
 
 [kani.flags]
 c-lib = ["src/helper.c"]
-output-format = "old"

--- a/tests/cargo-kani/simple-extern/test_sum.expected
+++ b/tests/cargo-kani/simple-extern/test_sum.expected
@@ -1,1 +1,2 @@
-[external_c_assertion.assertion.1] line 14 assertion rust_add1(x) == x + 1: SUCCESS
+SUCCESS\
+assertion rust_add1(x) == x + 1

--- a/tests/cargo-kani/simple-lib/Cargo.toml
+++ b/tests/cargo-kani/simple-lib/Cargo.toml
@@ -8,6 +8,3 @@ edition = "2018"
 [dependencies]
 
 [workspace]
-
-[kani.flags]
-output-format = "old"

--- a/tests/cargo-kani/simple-lib/test_one_plus_two.expected
+++ b/tests/cargo-kani/simple-lib/test_one_plus_two.expected
@@ -1,1 +1,2 @@
-[pair::kani_tests::test_one_plus_two.assertion.1] line 31 assertion failed: p.sum() == 3: SUCCESS
+SUCCESS\
+assertion failed: p.sum() == 3

--- a/tests/cargo-kani/simple-lib/test_sum.expected
+++ b/tests/cargo-kani/simple-lib/test_sum.expected
@@ -1,1 +1,2 @@
-[kani_tests::test_sum.assertion.1] line 24 assertion failed: p.sum() == a.wrapping_add(b): SUCCESS
+SUCCESS\
+assertion failed: p.sum() == a.wrapping_add(b)

--- a/tests/cargo-kani/simple-main/Cargo.toml
+++ b/tests/cargo-kani/simple-main/Cargo.toml
@@ -8,6 +8,3 @@ edition = "2018"
 [dependencies]
 
 [workspace]
-
-[kani.flags]
-output-format = "old"

--- a/tests/cargo-kani/simple-main/main.expected
+++ b/tests/cargo-kani/simple-main/main.expected
@@ -1,2 +1,3 @@
-[main.assertion.1] line 4 assertion failed: 1 == 2: FAILURE
-VERIFICATION FAILED
+FAILURE\
+assertion failed: 1 == 2
+VERIFICATION:- FAILED

--- a/tests/cargo-kani/simple-proof-annotation/Cargo.toml
+++ b/tests/cargo-kani/simple-proof-annotation/Cargo.toml
@@ -7,6 +7,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-
-[kani.flags]
-output-format = "old"

--- a/tests/cargo-kani/simple-proof-annotation/main.expected
+++ b/tests/cargo-kani/simple-proof-annotation/main.expected
@@ -1,1 +1,2 @@
-line 5 assertion failed: 1 == 2: FAILURE
+FAILURE\
+assertion failed: 1 == 2

--- a/tests/cargo-kani/simple-unwind-annotation/Cargo.toml
+++ b/tests/cargo-kani/simple-unwind-annotation/Cargo.toml
@@ -9,5 +9,4 @@ edition = "2021"
 [dependencies]
 
 [kani.flags]
-output-format = "old"
 function = "harness"

--- a/tests/cargo-kani/simple-unwind-annotation/main.expected
+++ b/tests/cargo-kani/simple-unwind-annotation/main.expected
@@ -1,1 +1,2 @@
-[harness.assertion.2] line 21 assertion failed: counter < 10: FAILURE
+FAILURE\
+assertion failed: counter < 10

--- a/tests/expected/abort/expected
+++ b/tests/expected/abort/expected
@@ -1,2 +1,4 @@
-line 14 a panicking function std::process::abort is invoked: FAILURE
-line 18 a panicking function std::process::abort is invoked: SUCCESS
+FAILURE\
+a panicking function std::process::abort is invoked
+SUCCESS\
+a panicking function std::process::abort is invoked

--- a/tests/expected/abort/main.rs
+++ b/tests/expected/abort/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
-//
 // Test that the abort() function is respected and nothing beyond it will execute.
 
 use std::process;

--- a/tests/expected/allocation/expected
+++ b/tests/expected/allocation/expected
@@ -1,2 +1,4 @@
-line 10 assertion failed: foo() == None: SUCCESS
-line 13 assertion failed: foo() == y: SUCCESS
+SUCCESS\
+assertion failed: foo() == None
+SUCCESS\
+assertion failed: foo() == y

--- a/tests/expected/allocation/main.rs
+++ b/tests/expected/allocation/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn foo() -> Option<i32> {
     None
 }

--- a/tests/expected/array/expected
+++ b/tests/expected/array/expected
@@ -1,9 +1,18 @@
-array 'y'.0 upper bound in y.0[var_8]: SUCCESS
-array 'y'.0 upper bound in y.0[var_12]: SUCCESS
-array 'y'.0 upper bound in y.0[var_16]: FAILURE
-array 'x'.0 upper bound in x.0[var_3]: SUCCESS
-array 'x'.0 upper bound in x.0[var_5]: SUCCESS
-line 14 assertion failed: y[0] == 1: SUCCESS
-line 15 assertion failed: y[1] == 2: SUCCESS
-line 16 index out of bounds: the length is less than or equal to the given index: FAILURE
-line 16 assertion failed: y[z] == 3: FAILURE
+SUCCESS\
+array 'y'.0 upper bound in y.0[var_8]
+SUCCESS\
+array 'y'.0 upper bound in y.0[var_12]
+FAILURE\
+array 'y'.0 upper bound in y.0[var_16]
+SUCCESS\
+array 'x'.0 upper bound in x.0[var_3]
+SUCCESS\
+array 'x'.0 upper bound in x.0[var_5]
+SUCCESS\
+assertion failed: y[0] == 1
+SUCCESS\
+assertion failed: y[1] == 2
+FAILURE\
+index out of bounds: the length is less than or equal to the given index
+FAILURE\
+assertion failed: y[z] == 3

--- a/tests/expected/array/main.rs
+++ b/tests/expected/array/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 // cbmc-flags: --bounds-check
 fn foo(x: [i32; 5]) -> [i32; 2] {
     [x[0], x[1]]

--- a/tests/expected/assert-eq/expected
+++ b/tests/expected/assert-eq/expected
@@ -1,3 +1,6 @@
-line 17 assertion failed: x + 1 == y: SUCCESS
-line 18 assertion failed: x == y: FAILURE
-line 19 assertion failed: x != y: SUCCESS
+SUCCESS\
+assertion failed: x + 1 == y
+FAILURE\
+assertion failed: x == y
+SUCCESS\
+assertion failed: x != y

--- a/tests/expected/assert-eq/main.rs
+++ b/tests/expected/assert-eq/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 /// This test touches a surprising amount of MIR, thanks to the `assert_eq!`, which translates into something like
 /// if(x != y) { String msg = format_error_message(<x as debug>::fmt(x), <y as debug>::fmt(y)); panic!(msg)} else {}
 /// This leads us to the land of foreign types, ReifyFnPointer, and transmute.

--- a/tests/expected/binop/expected
+++ b/tests/expected/binop/expected
@@ -1,42 +1,84 @@
-line 6 attempt to add with overflow: SUCCESS
-line 6 assertion failed: a + b == correct: SUCCESS
-line 7 attempt to add with overflow: SUCCESS
-line 7 assertion failed: a + b == wrong: FAILURE
-line 11 attempt to subtract with overflow: SUCCESS
-line 11 assertion failed: a - b == correct: SUCCESS
-line 12 attempt to subtract with overflow: SUCCESS
-line 12 assertion failed: a - b == wrong: FAILURE
-line 16 attempt to multiply with overflow: SUCCESS
-line 16 assertion failed: a * b == correct: SUCCESS
-line 17 attempt to multiply with overflow: SUCCESS
-line 17 assertion failed: a * b == wrong: FAILURE
-line 21 attempt to divide by zero: SUCCESS
-line 21 attempt to divide with overflow: SUCCESS
-line 21 assertion failed: a / b == correct: SUCCESS
-line 22 attempt to divide by zero: SUCCESS
-line 22 attempt to divide with overflow: SUCCESS
-line 22 assertion failed: a / b == wrong: FAILURE
-line 26 attempt to calculate the remainder with a divisor of zero: SUCCESS
-line 26 attempt to calculate the remainder with overflow: SUCCESS
-line 26 assertion failed: a % b == correct: SUCCESS
-line 27 attempt to calculate the remainder with a divisor of zero: SUCCESS
-line 27 attempt to calculate the remainder with overflow: SUCCESS
-line 27 assertion failed: a % b == wrong: FAILURE
-line 31 attempt to shift left with overflow: SUCCESS
-line 31 assertion failed: a << b == correct: SUCCESS
-line 32 attempt to shift left with overflow: SUCCESS
-line 32 assertion failed: a << b == wrong: FAILURE
-line 36 attempt to shift right with overflow: SUCCESS
-line 36 assertion failed: a >> b == correct: SUCCESS
-line 37 attempt to shift right with overflow: SUCCESS
-line 37 assertion failed: a >> b == wrong: FAILURE
-line 41 attempt to shift right with overflow: SUCCESS
-line 41 assertion failed: a >> b == correct: SUCCESS
-line 42 attempt to shift right with overflow: SUCCESS
-line 42 assertion failed: a >> b == wrong: FAILURE
-line 46 assertion failed: a & b == correct: SUCCESS
-line 47 assertion failed: a & b == wrong: FAILURE
-line 51 assertion failed: a | b == correct: SUCCESS
-line 52 assertion failed: a | b == wrong: FAILURE
-line 56 assertion failed: a ^ b == correct: SUCCESS
-line 57 assertion failed: a ^ b == wrong: FAILURE
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+assertion failed: a + b == correct
+SUCCESS\
+attempt to add with overflow
+FAILURE\
+assertion failed: a + b == wrong
+SUCCESS\
+attempt to subtract with overflow
+SUCCESS\
+assertion failed: a - b == correct
+SUCCESS\
+attempt to subtract with overflow
+FAILURE\
+assertion failed: a - b == wrong
+SUCCESS\
+attempt to multiply with overflow
+SUCCESS\
+assertion failed: a * b == correct
+SUCCESS\
+attempt to multiply with overflow
+FAILURE\
+assertion failed: a * b == wrong
+SUCCESS\
+attempt to divide by zero
+SUCCESS\
+attempt to divide with overflow
+SUCCESS\
+assertion failed: a / b == correct
+SUCCESS\
+attempt to divide by zero
+SUCCESS\
+attempt to divide with overflow
+FAILURE\
+assertion failed: a / b == wrong
+SUCCESS\
+attempt to calculate the remainder with a divisor of zero
+SUCCESS\
+attempt to calculate the remainder with overflow
+SUCCESS\
+assertion failed: a % b == correct
+SUCCESS\
+attempt to calculate the remainder with a divisor of zero
+SUCCESS\
+attempt to calculate the remainder with overflow
+FAILURE\
+assertion failed: a % b == wrong
+SUCCESS\
+attempt to shift left with overflow
+SUCCESS\
+assertion failed: a << b == correct
+SUCCESS\
+attempt to shift left with overflow
+FAILURE\
+assertion failed: a << b == wrong
+SUCCESS\
+attempt to shift right with overflow
+SUCCESS\
+assertion failed: a >> b == correct
+SUCCESS\
+attempt to shift right with overflow
+FAILURE\
+assertion failed: a >> b == wrong
+SUCCESS\
+attempt to shift right with overflow
+SUCCESS\
+assertion failed: a >> b == correct
+SUCCESS\
+attempt to shift right with overflow
+FAILURE\
+assertion failed: a >> b == wrong
+SUCCESS\
+assertion failed: a & b == correct
+FAILURE\
+assertion failed: a & b == wrong
+SUCCESS\
+assertion failed: a | b == correct
+FAILURE\
+assertion failed: a | b == wrong
+SUCCESS\
+assertion failed: a ^ b == correct
+FAILURE\
+assertion failed: a ^ b == wrong

--- a/tests/expected/binop/main.rs
+++ b/tests/expected/binop/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn iadd_test(a: i32, b: i32, correct: i32, wrong: i32) {
     assert!(a + b == correct);
     assert!(a + b == wrong);

--- a/tests/expected/closure/expected
+++ b/tests/expected/closure/expected
@@ -1,5 +1,10 @@
-attempt to add with overflow: SUCCESS
-attempt to add with overflow: SUCCESS
-attempt to add with overflow: SUCCESS
-attempt to add with overflow: SUCCESS
-assertion failed: original_num + 12 == num: SUCCESS
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+assertion failed: original_num + 12 == num

--- a/tests/expected/closure/main.rs
+++ b/tests/expected/closure/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn call_with_one<F>(mut some_closure: F) -> ()
 where
     F: FnMut(i64, i64) -> (),

--- a/tests/expected/closure2/expected
+++ b/tests/expected/closure2/expected
@@ -1,4 +1,8 @@
-line 7 attempt to add with overflow: SUCCESS
-line 9 attempt to add with overflow: SUCCESS
-line 10 assertion failed: z == 102: SUCCESS
-line 11 assertion failed: g(z) == 206: SUCCESS
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+assertion failed: z == 102
+SUCCESS\
+assertion failed: g(z) == 206

--- a/tests/expected/closure2/main.rs
+++ b/tests/expected/closure2/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn main() {
     let x = 2;
     let f = |y| x + y;

--- a/tests/expected/closure3/expected
+++ b/tests/expected/closure3/expected
@@ -1,3 +1,6 @@
-line 16 attempt to add with overflow: SUCCESS
-line 17 attempt to add with overflow: SUCCESS
-line 17 assertion failed: num + 10 == y: SUCCESS
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+assertion failed: num + 10 == y

--- a/tests/expected/closure3/main.rs
+++ b/tests/expected/closure3/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn call_with_one<F, T>(f: F) -> T
 where
     F: FnOnce(i64) -> T,

--- a/tests/expected/comp/expected
+++ b/tests/expected/comp/expected
@@ -1,11 +1,22 @@
-line 7 attempt to add with overflow: SUCCESS
-line 7 attempt to add with overflow: SUCCESS
-line 7 assertion failed: a + b == b + a: SUCCESS
-line 8 attempt to add with overflow: SUCCESS
-line 8 attempt to add with overflow: SUCCESS
-line 8 attempt to add with overflow: SUCCESS
-line 8 assertion failed: a + b != a + b + 1: SUCCESS
-line 13 attempt to add with overflow: SUCCESS
-line 13 assertion failed: a + b > a: SUCCESS
-line 14 attempt to subtract with overflow: SUCCESS
-line 14 assertion failed: a - b < a: SUCCESS
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+assertion failed: a + b == b + a
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+assertion failed: a + b != a + b + 1
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+assertion failed: a + b > a
+SUCCESS\
+attempt to subtract with overflow
+SUCCESS\
+assertion failed: a - b < a

--- a/tests/expected/comp/main.rs
+++ b/tests/expected/comp/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 #[allow(dead_code)]
 fn eq1(a: i32, b: i32) {
     assert!(a + b == b + a);

--- a/tests/expected/copy/expected
+++ b/tests/expected/copy/expected
@@ -1,3 +1,6 @@
-memmove source region readable: SUCCESS
-memmove destination region writeable: SUCCESS
-assertion failed: *dst == expected_val: SUCCESS
+SUCCESS\
+memmove source region readable
+SUCCESS\
+memmove destination region writeable
+SUCCESS\
+assertion failed: *dst == expected_val

--- a/tests/expected/copy/main.rs
+++ b/tests/expected/copy/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 use std::ptr;
 
 fn main() {

--- a/tests/expected/dry-run-flag-conflict-auto-unwind/main.rs
+++ b/tests/expected/dry-run-flag-conflict-auto-unwind/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
-
 // kani-flags: --dry-run --auto-unwind
 // cbmc-flags: --unwind 2
 

--- a/tests/expected/dry-run-flag-conflict/main.rs
+++ b/tests/expected/dry-run-flag-conflict/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
-
 // kani-flags: --dry-run --object-bits 10
 // cbmc-flags: --object-bits 8
 

--- a/tests/expected/dry-run/main.rs
+++ b/tests/expected/dry-run/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
-
 // kani-flags: --dry-run
 
 // `--dry-run` causes Kani to print out commands instead of running them

--- a/tests/expected/dynamic-error-trait/expected
+++ b/tests/expected/dynamic-error-trait/expected
@@ -1,2 +1,4 @@
-assertion failed: mm.size == 2: SUCCESS
-assertion failed: mm.size == 3: FAILURE
+SUCCESS\
+assertion failed: mm.size == 2
+FAILURE\
+assertion failed: mm.size == 3

--- a/tests/expected/dynamic-error-trait/main.rs
+++ b/tests/expected/dynamic-error-trait/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
-
 // cbmc-flags: --unwind 2 --unwinding-assertions
 
 use std::io::{self, Read, Write};

--- a/tests/expected/dynamic-trait-static-dispatch/expected
+++ b/tests/expected/dynamic-trait-static-dispatch/expected
@@ -1,2 +1,4 @@
-line 27 assertion failed: bar.a() == 3: SUCCESS
-line 28 assertion failed: bar.b() == 5: SUCCESS
+SUCCESS\
+assertion failed: bar.a() == 3
+SUCCESS\
+assertion failed: bar.b() == 5

--- a/tests/expected/dynamic-trait-static-dispatch/main.rs
+++ b/tests/expected/dynamic-trait-static-dispatch/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 use std::io::{self};
 
 pub trait Foo {

--- a/tests/expected/dynamic-trait/expected
+++ b/tests/expected/dynamic-trait/expected
@@ -1,16 +1,32 @@
-line 25 attempt to multiply with overflow: SUCCESS
-line 28 attempt to multiply with overflow: SUCCESS
-line 28 attempt to multiply with overflow: SUCCESS
-line 34 attempt to multiply with overflow: SUCCESS
-line 37 attempt to multiply with overflow: SUCCESS
-line 37 attempt to multiply with overflow: SUCCESS
-line 54 assertion failed: rec.vol(3) == 150: SUCCESS
-line 55 assertion failed: impl_area(rec.clone()) == 50: SUCCESS
-line 58 assertion failed: vol == 100: SUCCESS
-line 61 assertion failed: square.vol(3) == 27: SUCCESS
-line 62 assertion failed: do_vol(&square, 2) == 18: SUCCESS
-line 63 assertion failed: impl_area(square.clone()) == 9: SUCCESS
-line 65 assertion failed: !square.compare_area(&square): SUCCESS
-line 66 assertion failed: !square.compare_area(&rec): SUCCESS
-line 67 assertion failed: rec.compare_area(&square): SUCCESS
-line 68 assertion failed: !rec.compare_area(&rec): SUCCESS
+SUCCESS\
+attempt to multiply with overflow
+SUCCESS\
+attempt to multiply with overflow
+SUCCESS\
+attempt to multiply with overflow
+SUCCESS\
+attempt to multiply with overflow
+SUCCESS\
+attempt to multiply with overflow
+SUCCESS\
+attempt to multiply with overflow
+SUCCESS\
+assertion failed: rec.vol(3) == 150
+SUCCESS\
+assertion failed: impl_area(rec.clone()) == 50
+SUCCESS\
+assertion failed: vol == 100
+SUCCESS\
+assertion failed: square.vol(3) == 27
+SUCCESS\
+assertion failed: do_vol(&square, 2) == 18
+SUCCESS\
+assertion failed: impl_area(square.clone()) == 9
+SUCCESS\
+assertion failed: !square.compare_area(&square)
+SUCCESS\
+assertion failed: !square.compare_area(&rec)
+SUCCESS\
+assertion failed: rec.compare_area(&square)
+SUCCESS\
+assertion failed: !rec.compare_area(&rec)

--- a/tests/expected/dynamic-trait/main.rs
+++ b/tests/expected/dynamic-trait/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 trait Shape {
     fn area(&self) -> u32;
     fn vol(&self, z: u32) -> u32;

--- a/tests/expected/enum/expected
+++ b/tests/expected/enum/expected
@@ -1,7 +1,14 @@
-line 20 unreachable code: SUCCESS
-line 21 assertion failed: x == 10: SUCCESS
-line 22 assertion failed: false: SUCCESS
-line 24 unreachable code: SUCCESS
-line 25 assertion failed: false: SUCCESS
-line 27 assertion failed: x == 30 && y == 60.0: SUCCESS
-line 28 assertion failed: x == 31: FAILURE
+SUCCESS\
+unreachable code
+SUCCESS\
+assertion failed: x == 10
+SUCCESS\
+assertion failed: false
+SUCCESS\
+unreachable code
+SUCCESS\
+assertion failed: false
+SUCCESS\
+assertion failed: x == 30 && y == 60.0
+FAILURE\
+assertion failed: x == 31

--- a/tests/expected/enum/main.rs
+++ b/tests/expected/enum/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 enum Foo {
     A(i32),
     B { x: i32, y: f64 },

--- a/tests/expected/float-nan/expected
+++ b/tests/expected/float-nan/expected
@@ -1,5 +1,10 @@
-line 14 assertion failed: 1.0 / f != 0.0 / f: SUCCESS
-line 16 assertion failed: !(1.0 / f == 0.0 / f): SUCCESS
-line 18 assertion failed: 1.0 / f == 0.0 / f: FAILURE
-line 20 assertion failed: 0.0 / f == 0.0 / f: FAILURE
-line 22 assertion failed: 0.0 / f != 0.0 / f: SUCCESS
+SUCCESS\
+assertion failed: 1.0 / f != 0.0 / f
+SUCCESS\
+assertion failed: !(1.0 / f == 0.0 / f)
+FAILURE\
+assertion failed: 1.0 / f == 0.0 / f
+FAILURE\
+assertion failed: 0.0 / f == 0.0 / f
+SUCCESS\
+assertion failed: 0.0 / f != 0.0 / f

--- a/tests/expected/float-nan/main.rs
+++ b/tests/expected/float-nan/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn main() {
     let mut f: f32 = 2.0;
     while f != 0.0 {

--- a/tests/expected/generics/expected
+++ b/tests/expected/generics/expected
@@ -1,2 +1,4 @@
-line 23 assertion failed: x == y.data: SUCCESS
-line 24 assertion failed: z == w.data: SUCCESS
+SUCCESS\
+assertion failed: x == y.data
+SUCCESS\
+assertion failed: z == w.data

--- a/tests/expected/generics/main.rs
+++ b/tests/expected/generics/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 struct Foo<T> {
     data: T,
     i: i32,

--- a/tests/expected/iterator/expected
+++ b/tests/expected/iterator/expected
@@ -1,3 +1,6 @@
-line 7 unreachable code: SUCCESS
-line 8 attempt to multiply with overflow: SUCCESS
-line 10 assertion failed: z == 6: SUCCESS
+SUCCESS\
+unreachable code
+SUCCESS\
+attempt to multiply with overflow
+SUCCESS\
+assertion failed: z == 6

--- a/tests/expected/iterator/main.rs
+++ b/tests/expected/iterator/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn main() {
     let mut z = 1;
     for i in 1..4 {

--- a/tests/expected/niche/expected
+++ b/tests/expected/niche/expected
@@ -1,5 +1,10 @@
-line 24 assertion failed: false: SUCCESS
-line 22 unreachable code: SUCCESS
-line 27 unreachable code: SUCCESS
-line 28 assertion failed: false: SUCCESS
-line 29 assertion failed: a == *b: SUCCESS
+SUCCESS\
+assertion failed: false
+SUCCESS\
+unreachable code
+SUCCESS\
+unreachable code
+SUCCESS\
+assertion failed: false
+SUCCESS\
+assertion failed: a == *b

--- a/tests/expected/niche/main.rs
+++ b/tests/expected/niche/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 enum Option2<T> {
     Some(T),
     None,

--- a/tests/expected/niche2/expected
+++ b/tests/expected/niche2/expected
@@ -1,4 +1,8 @@
-line 25 assertion failed: false: SUCCESS
-line 29 assertion failed: x == 10: SUCCESS
-line 30 assertion failed: false: SUCCESS
-line 35 assertion failed: false: SUCCESS
+SUCCESS\
+assertion failed: false
+SUCCESS\
+assertion failed: x == 10
+SUCCESS\
+assertion failed: false
+SUCCESS\
+assertion failed: false

--- a/tests/expected/niche2/main.rs
+++ b/tests/expected/niche2/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 enum Foo {
     A(i32),
     B([i32; 0]),

--- a/tests/expected/nondet/expected
+++ b/tests/expected/nondet/expected
@@ -1,5 +1,10 @@
-line 9 attempt to multiply with overflow: SUCCESS
-line 9 attempt to multiply with overflow: SUCCESS
-line 9 attempt to subtract with overflow: SUCCESS
-line 9 attempt to add with overflow: SUCCESS
-line 9 assertion failed: x * x - 2 * x + 1 != 4 || (x == -1 || x == 3): SUCCESS
+SUCCESS\
+attempt to multiply with overflow
+SUCCESS\
+attempt to multiply with overflow
+SUCCESS\
+attempt to subtract with overflow
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+assertion failed: x * x - 2 * x + 1 != 4 || (x == -1 || x == 3)

--- a/tests/expected/nondet/main.rs
+++ b/tests/expected/nondet/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn main() {
     let x: i32 = kani::any();
     if (x > -500 && x < 500) {

--- a/tests/expected/one-assert/expected
+++ b/tests/expected/one-assert/expected
@@ -1,1 +1,1 @@
-** 0 of 2 failed (1 iterations)
+** 0 of 2 failed

--- a/tests/expected/one-assert/test.rs
+++ b/tests/expected/one-assert/test.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
-
 // kani-flags: --function check_assert
 // compile-flags: --crate-type lib
 #[no_mangle]

--- a/tests/expected/references/expected
+++ b/tests/expected/references/expected
@@ -1,1 +1,2 @@
-line 19 assertion failed: z == 2: SUCCESS
+SUCCESS\
+assertion failed: z == 2

--- a/tests/expected/references/main.rs
+++ b/tests/expected/references/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 struct Foo {
     a: i32,
     _b: f64,

--- a/tests/expected/slice/expected
+++ b/tests/expected/slice/expected
@@ -1,4 +1,8 @@
-line 17 assertion failed: y.len() == 5: SUCCESS
-line 18 index out of bounds: the length is less than or equal to the given index: SUCCESS
-line 18 assertion failed: y[1] == 2: SUCCESS
-line 19 assertion failed: z.len() == 3: SUCCESS
+SUCCESS\
+assertion failed: y.len() == 5
+SUCCESS\
+index out of bounds: the length is less than or equal to the given index
+SUCCESS\
+assertion failed: y[1] == 2
+SUCCESS\
+assertion failed: z.len() == 3

--- a/tests/expected/slice/main.rs
+++ b/tests/expected/slice/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn foo(x: &[i32; 5]) -> &[i32] {
     &x[..]
 }

--- a/tests/expected/static-mutable-struct/expected
+++ b/tests/expected/static-mutable-struct/expected
@@ -1,11 +1,22 @@
-line 25 assertion failed: foo().x == 12: SUCCESS
-line 27 assertion failed: foo().y == 12: FAILURE
-line 30 assertion failed: foo().x == 14: FAILURE
-line 32 assertion failed: foo().y == 14: SUCCESS
-line 35 assertion failed: foo().x == 1: SUCCESS
-line 37 assertion failed: foo().y == 1: FAILURE
-line 40 assertion failed: foo().x == 2: FAILURE
-line 42 assertion failed: foo().y == 2: SUCCESS
-line 45 assertion failed: foo().x == 1 << 62: SUCCESS
-line 47 assertion failed: foo().x == 1 << 31: FAILURE
-line 49 assertion failed: foo().y == 1 << 31: SUCCESS
+SUCCESS\
+assertion failed: foo().x == 12
+FAILURE\
+assertion failed: foo().y == 12
+FAILURE\
+assertion failed: foo().x == 14
+SUCCESS\
+assertion failed: foo().y == 14
+SUCCESS\
+assertion failed: foo().x == 1
+FAILURE\
+assertion failed: foo().y == 1
+FAILURE\
+assertion failed: foo().x == 2
+SUCCESS\
+assertion failed: foo().y == 2
+SUCCESS\
+assertion failed: foo().x == 1 << 62
+FAILURE\
+assertion failed: foo().x == 1 << 31
+SUCCESS\
+assertion failed: foo().y == 1 << 31

--- a/tests/expected/static-mutable-struct/main.rs
+++ b/tests/expected/static-mutable-struct/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 #[derive(Copy, Clone)]
 struct TestStruct {
     x: i64,

--- a/tests/expected/static-mutable/expected
+++ b/tests/expected/static-mutable/expected
@@ -1,4 +1,8 @@
-line 19 assertion failed: 10 == foo(): FAILURE
-line 21 assertion failed: 12 == foo(): SUCCESS
-line 23 assertion failed: 10 == foo(): SUCCESS
-line 24 assertion failed: 12 == foo(): FAILURE
+FAILURE\
+assertion failed: 10 == foo()
+SUCCESS\
+assertion failed: 12 == foo()
+SUCCESS\
+assertion failed: 10 == foo()
+FAILURE\
+assertion failed: 12 == foo()

--- a/tests/expected/static-mutable/main.rs
+++ b/tests/expected/static-mutable/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 static mut X: i32 = 12;
 
 fn foo() -> i32 {

--- a/tests/expected/static/expected
+++ b/tests/expected/static/expected
@@ -1,2 +1,4 @@
-line 12 assertion failed: 10 == foo(): FAILURE
-line 13 assertion failed: 12 == foo(): SUCCESS
+FAILURE\
+assertion failed: 10 == foo()
+SUCCESS\
+assertion failed: 12 == foo()

--- a/tests/expected/static/main.rs
+++ b/tests/expected/static/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 static X: i32 = 12;
 
 fn foo() -> i32 {

--- a/tests/expected/test1/expected
+++ b/tests/expected/test1/expected
@@ -1,5 +1,10 @@
-line 9 attempt to add with overflow: SUCCESS
-line 10 attempt to subtract with overflow: SUCCESS
-line 14 assertion failed: a == 54: FAILURE
-line 16 assertion failed: a == 55: SUCCESS
-line 18 assertion failed: a >= 55: SUCCESS
+SUCCESS\
+attempt to add with overflow
+SUCCESS\
+attempt to subtract with overflow
+FAILURE\
+assertion failed: a == 54
+SUCCESS\
+assertion failed: a == 55
+SUCCESS\
+assertion failed: a >= 55

--- a/tests/expected/test1/main.rs
+++ b/tests/expected/test1/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn main() {
     let mut a: i32 = 0;
     let mut i: i32 = 10;

--- a/tests/expected/test2/expected
+++ b/tests/expected/test2/expected
@@ -1,5 +1,10 @@
-line 9 attempt to shift right with overflow: SUCCESS
-line 10 attempt to add with overflow: SUCCESS
-line 15 assertion failed: i == 3: FAILURE
-line 17 assertion failed: i == 2: SUCCESS
-line 19 assertion failed: i == 2 || i == 3: SUCCESS
+SUCCESS\
+attempt to shift right with overflow
+SUCCESS\
+attempt to add with overflow
+FAILURE\
+assertion failed: i == 3
+SUCCESS\
+assertion failed: i == 2
+SUCCESS\
+assertion failed: i == 2 || i == 3

--- a/tests/expected/test2/main.rs
+++ b/tests/expected/test2/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn main() {
     let mut a: i32 = 4;
     let mut i = 0;

--- a/tests/expected/test3/expected
+++ b/tests/expected/test3/expected
@@ -1,9 +1,18 @@
-line 11 attempt to subtract with overflow: SUCCESS
-line 17 assertion failed: a == 10.0 && i == 1: FAILURE
-line 19 assertion failed: a == 9.0 && i == 0: FAILURE
-line 21 assertion failed: a == 9.0 && i == 1: FAILURE
-line 23 assertion failed: a == 10.0 && i == 0: SUCCESS
-line 25 assertion failed: a == 9.0 || i == 0: SUCCESS
-line 27 assertion failed: a == 10.0 || i == 1: SUCCESS
-line 29 assertion failed: a == 9.0 || i == 1: FAILURE
-line 31 assertion failed: a == 10.0 || i == 0: SUCCESS
+SUCCESS\
+attempt to subtract with overflow
+FAILURE\
+assertion failed: a == 10.0 && i == 1
+FAILURE\
+assertion failed: a == 9.0 && i == 0
+FAILURE\
+assertion failed: a == 9.0 && i == 1
+SUCCESS\
+assertion failed: a == 10.0 && i == 0
+SUCCESS\
+assertion failed: a == 9.0 || i == 0
+SUCCESS\
+assertion failed: a == 10.0 || i == 1
+FAILURE\
+assertion failed: a == 9.0 || i == 1
+SUCCESS\
+assertion failed: a == 10.0 || i == 0

--- a/tests/expected/test3/main.rs
+++ b/tests/expected/test3/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn main() {
     let mut a: f32 = 0.0;
     let mut i = 10;

--- a/tests/expected/test4/expected
+++ b/tests/expected/test4/expected
@@ -1,6 +1,12 @@
-line 10 attempt to add with overflow: SUCCESS
-line 15 assertion failed: i == 3: FAILURE
-line 17 assertion failed: i == 2: SUCCESS
-line 19 assertion failed: i == 2 || i == 3: SUCCESS
-line 23 attempt to divide by zero: SUCCESS
-line 23 attempt to divide with overflow: SUCCESS
+SUCCESS\
+attempt to add with overflow
+FAILURE\
+assertion failed: i == 3
+SUCCESS\
+assertion failed: i == 2
+SUCCESS\
+assertion failed: i == 2 || i == 3
+SUCCESS\
+attempt to divide by zero
+SUCCESS\
+attempt to divide with overflow

--- a/tests/expected/test4/main.rs
+++ b/tests/expected/test4/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn main() {
     let mut a = 4;
     let mut i = 0;

--- a/tests/expected/test5/expected
+++ b/tests/expected/test5/expected
@@ -1,4 +1,8 @@
-line 7 assertion failed: div(4, 2) == 2: SUCCESS
-line 9 assertion failed: div(6, 2) == 2: FAILURE
-line 13 attempt to divide by zero: SUCCESS
-line 13 attempt to divide with overflow: SUCCESS
+SUCCESS\
+assertion failed: div(4, 2) == 2
+FAILURE\
+assertion failed: div(6, 2) == 2
+SUCCESS\
+attempt to divide by zero
+SUCCESS\
+attempt to divide with overflow

--- a/tests/expected/test5/main.rs
+++ b/tests/expected/test5/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn main() {
     // should succeed
     assert!(div(4, 2) == 2);

--- a/tests/expected/test6/expected
+++ b/tests/expected/test6/expected
@@ -1,2 +1,4 @@
-line 11 assertion failed: add2(1, 1) == 2.0: SUCCESS
-line 13 assertion failed: add2(2, 1) == 2.0: FAILURE
+SUCCESS\
+assertion failed: add2(1, 1) == 2.0
+FAILURE\
+assertion failed: add2(2, 1) == 2.0

--- a/tests/expected/test6/main.rs
+++ b/tests/expected/test6/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn add2(a: i32, b: i32) -> f32 {
     add(a, b as f32)
 }

--- a/tests/expected/transmute/expected
+++ b/tests/expected/transmute/expected
@@ -1,2 +1,4 @@
-line 7 assertion failed: bitpattern == 0x3F800000: SUCCESS
-line 13 assertion failed: f == 1.0: SUCCESS
+SUCCESS\
+assertion failed: bitpattern == 0x3F800000
+SUCCESS\
+assertion failed: f == 1.0

--- a/tests/expected/transmute/main.rs
+++ b/tests/expected/transmute/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn main() {
     let bitpattern = unsafe { std::mem::transmute::<f32, u32>(1.0) };
     assert!(bitpattern == 0x3F800000);

--- a/tests/expected/vec/expected
+++ b/tests/expected/vec/expected
@@ -1,17 +1,34 @@
-[malloc.assertion.1] line 26 max allocation size exceeded: SUCCESS
-[malloc.assertion.2] line 31 max allocation may fail: SUCCESS
-[realloc.precondition_instance.1] line 20 free argument must be NULL or valid pointer: SUCCESS
-[realloc.precondition_instance.2] line 20 free argument must be dynamic object: SUCCESS
-[realloc.precondition_instance.3] line 20 free argument has offset zero: SUCCESS
-[realloc.precondition_instance.4] line 20 double free: SUCCESS
-[realloc.precondition_instance.5] line 20 free called for new[] object: SUCCESS
-[realloc.precondition_instance.6] line 20 free called for stack-allocated object: SUCCESS
-[realloc.precondition_instance.7] line 30 free argument must be NULL or valid pointer: SUCCESS
-[realloc.precondition_instance.8] line 30 free argument must be dynamic object: SUCCESS
-[realloc.precondition_instance.9] line 30 free argument has offset zero: SUCCESS
-[realloc.precondition_instance.10] line 30 double free: SUCCESS
-[realloc.precondition_instance.11] line 30 free called for new[] object: SUCCESS
-[realloc.precondition_instance.12] line 30 free called for stack-allocated object: SUCCESS
-line 8 assertion failed: x[0] == 10: SUCCESS
-line 10 assertion failed: y == 10: SUCCESS
-line 11 assertion failed: y != 10: FAILURE
+SUCCESS\
+max allocation size exceeded
+SUCCESS\
+max allocation may fail
+SUCCESS\
+free argument must be NULL or valid pointer
+SUCCESS\
+free argument must be dynamic object
+SUCCESS\
+free argument has offset zero
+SUCCESS\
+double free
+SUCCESS\
+free called for new[] object
+SUCCESS\
+free called for stack-allocated object
+SUCCESS\
+free argument must be NULL or valid pointer
+SUCCESS\
+free argument must be dynamic object
+SUCCESS\
+free argument has offset zero
+SUCCESS\
+double free
+SUCCESS\
+free called for new[] object
+SUCCESS\
+free called for stack-allocated object
+SUCCESS\
+assertion failed: x[0] == 10
+SUCCESS\
+assertion failed: y == 10
+FAILURE\
+assertion failed: y != 10

--- a/tests/expected/vec/main.rs
+++ b/tests/expected/vec/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 fn main() {
     let mut x: Vec<i32> = Vec::new();
     x.push(10);

--- a/tests/expected/vecdq/expected
+++ b/tests/expected/vecdq/expected
@@ -1,19 +1,38 @@
-assertion failed: q.len() == 2: SUCCESS
-assertion failed: q.pop_front().unwrap() == x: SUCCESS
-assertion failed: q.pop_front().unwrap() == y: SUCCESS
-max allocation size exceeded: SUCCESS
-max allocation may fail: SUCCESS
-max allocation size exceeded: SUCCESS
-max allocation may fail: SUCCESS
-free argument must be NULL or valid pointer: SUCCESS
-free argument must be dynamic object: SUCCESS
-free argument has offset zero: SUCCESS
-double free: SUCCESS
-free called for new[] object: SUCCESS
-free called for stack-allocated object: SUCCESS
-free argument must be NULL or valid pointer: SUCCESS
-free argument must be dynamic object: SUCCESS
-free argument has offset zero: SUCCESS
-double free: SUCCESS
-free called for new[] object: SUCCESS
-free called for stack-allocated object: SUCCESS
+SUCCESS\
+assertion failed: q.len() == 2
+SUCCESS\
+assertion failed: q.pop_front().unwrap() == x
+SUCCESS\
+assertion failed: q.pop_front().unwrap() == y
+SUCCESS\
+max allocation size exceeded
+SUCCESS\
+max allocation may fail
+SUCCESS\
+max allocation size exceeded
+SUCCESS\
+max allocation may fail
+SUCCESS\
+free argument must be NULL or valid pointer
+SUCCESS\
+free argument must be dynamic object
+SUCCESS\
+free argument has offset zero
+SUCCESS\
+double free
+SUCCESS\
+free called for new[] object
+SUCCESS\
+free called for stack-allocated object
+SUCCESS\
+free argument must be NULL or valid pointer
+SUCCESS\
+free argument must be dynamic object
+SUCCESS\
+free argument has offset zero
+SUCCESS\
+double free
+SUCCESS\
+free called for new[] object
+SUCCESS\
+free called for stack-allocated object

--- a/tests/expected/vecdq/main.rs
+++ b/tests/expected/vecdq/main.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --output-format old
 use std::collections::VecDeque;
 
 fn main() {

--- a/tests/kani/DynTrait/dyn_fn_mut_fail.rs
+++ b/tests/kani/DynTrait/dyn_fn_mut_fail.rs
@@ -5,8 +5,6 @@
 // function definition. Expected to fail because we are comparing
 // to an incorrect value.
 
-// kani-flags: --output-format old
-
 fn takes_dyn_fun(mut fun: Box<dyn FnMut(&mut i32)>, x_ptr: &mut i32) {
     fun(x_ptr)
 }

--- a/tests/kani/DynTrait/dyn_fn_once_fail.rs
+++ b/tests/kani/DynTrait/dyn_fn_once_fail.rs
@@ -5,8 +5,6 @@
 // function definition. Expected to fail because we are comparing
 // to an incorrect value.
 
-// kani-flags: --output-format old
-
 fn takes_dyn_fun(fun: Box<dyn FnOnce() -> u32>) -> u32 {
     fun()
 }


### PR DESCRIPTION
### Description of changes: 

Some of the recently introduced features (e.g. reachability checks from #798, and removal of temporary variables from #906) depend on the CBMC result parser/post-processor, which doesn't run with the old format (the CBMC native output invoked using `--output-format old`). Thus, we need to move away from the old format, and perhaps obsolete it altogether. This PR migrates all of our regressions to the new format except for a few:
1. tests/expected/assert-location/*: These are checking that the line numbers produced by Kani are correct, which are only available with the old format (until https://github.com/diffblue/cbmc/issues/6651 is integrated)
2. The docs tests (e.g. docs/src/tutorial/kani-first-steps): These will be updated in a follow-up PR, which will include updating the related sections of the docs.

The commands used for updating the expected files for the reference are:
```
sed -i 's/\(.*\): SUCCESS/SUCCESS\\\n\1/' expected
sed -i 's/\(.*\): FAILURE/FAILURE\\\n\1/' expected
```

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
