### PR TITLE
Separate cmbc-linked and harness-specialized goto binaries

### DIFF
--- a/src/cargo-kani/src/call_goto_cc.rs
+++ b/src/cargo-kani/src/call_goto_cc.rs
@@ -11,15 +11,9 @@ use crate::session::KaniSession;
 
 impl KaniSession {
     /// Given a set of goto binaries (`inputs`), produce `output` by linking everything
-    /// together (including essential libraries) and also specializing to the proof harness
-    /// `function`.
-    pub fn link_c_lib(&self, inputs: &[PathBuf], output: &Path, function: &str) -> Result<()> {
-        {
-            let mut temps = self.temporaries.borrow_mut();
-            temps.push(output.to_owned());
-        }
-
-        let mut args: Vec<OsString> = vec!["--function".into(), function.into()];
+    /// together (including essential libraries). The result is generic over all proof harnesses.
+    pub fn link_goto_binary(&self, inputs: &[PathBuf], output: &Path) -> Result<()> {
+        let mut args: Vec<OsString> = Vec::new();
         args.extend(inputs.iter().map(|x| x.clone().into_os_string()));
         args.extend(self.args.c_lib.iter().map(|x| x.clone().into_os_string()));
 
@@ -42,6 +36,21 @@ impl KaniSession {
         // TODO get goto-cc path from self
         let mut cmd = Command::new("goto-cc");
         cmd.args(args);
+
+        self.run_suppress(cmd)?;
+
+        Ok(())
+    }
+
+    /// Produce a goto binary with its entry point set to a particular proof harness.
+    pub fn specialize_to_proof_harness(
+        &self,
+        input: &Path,
+        output: &Path,
+        function: &str,
+    ) -> Result<()> {
+        let mut cmd = Command::new("goto-cc");
+        cmd.arg(input).args(["--function", function, "-o"]).arg(output);
 
         self.run_suppress(cmd)?;
 

--- a/tests/expected/dry-run/expected
+++ b/tests/expected/dry-run/expected
@@ -1,4 +1,6 @@
 kani-rustc --goto-c
 symtab2gb
-goto-cc --function main
+goto-cc
+--function main
+goto-instrument
 cbmc --bounds-check --pointer-check --pointer-primitive-check --conversion-check --div-by-zero-check --float-overflow-check --nan-check --pointer-overflow-check --undefined-shift-check --unwinding-assertions --object-bits 16


### PR DESCRIPTION
### Description of changes: 

This divides our compilation process into two clear phases: 

1. Produce a fully linked goto binary.
2. Specialize that binary to a particular proof harness.

This will support running multiple proof harnesses in futures PRs, as we can then re-specialize from the original linked binary to each proof harness.

(Also, I refactored some code related to globbing because I saw it and it bothered me.)

### Call outs:

* `cargo-kani` now leaves `cbmc-linked.out` and `cbmc-for-${HARNESS}.out` under `target/$TARGET/debug/deps`.

### Testing:

* How is this change tested? existing tests

* Is this a refactor change? yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
