### PR TITLE
Treat warnings as errors in kani-compiler crate

### DIFF
--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -9,7 +9,6 @@ use cbmc::InternString;
 use kani_metadata::HarnessMetadata;
 use rustc_ast::ast;
 use rustc_ast::{Attribute, LitKind};
-use rustc_middle::mir::coverage::Op;
 use rustc_middle::mir::{HasLocalDecls, Local};
 use rustc_middle::ty::{self, Instance};
 use std::collections::BTreeMap;

--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -4,7 +4,7 @@ use super::typ::{is_pointer, pointee_type, TypeExt};
 use crate::codegen_cprover_gotoc::utils::{dynamic_fat_ptr, slice_fat_ptr};
 use crate::codegen_cprover_gotoc::{GotocCtx, VtableCtx};
 use cbmc::goto_program::{Expr, Location, Stmt, Symbol, Type};
-use cbmc::utils::{aggr_tag, BUG_REPORT_URL};
+use cbmc::utils::BUG_REPORT_URL;
 use cbmc::MachineModel;
 use cbmc::NO_PRETTY_NAME;
 use cbmc::{btree_string_map, InternString, InternedString};

--- a/src/kani-compiler/src/codegen_cprover_gotoc/context/current_fn.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/context/current_fn.rs
@@ -76,11 +76,6 @@ impl CurrentFnCtx<'tcx> {
 
 /// Getters
 impl CurrentFnCtx<'tcx> {
-    /// The basic block we are currently compiling
-    pub fn current_bb(&self) -> BasicBlock {
-        self.current_bb.unwrap()
-    }
-
     /// The function we are currently compiling
     pub fn instance(&self) -> Instance<'tcx> {
         self.instance

--- a/src/kani-compiler/src/main.rs
+++ b/src/kani-compiler/src/main.rs
@@ -6,7 +6,7 @@
 //!
 //! Like miri, clippy, and other tools developed on the top of rustc, we rely on the
 //! rustc_private feature and a specific version of rustc.
-
+#![deny(warnings)]
 #![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(extern_types)]
@@ -16,20 +16,15 @@
 #![feature(box_patterns)]
 #![feature(once_cell)]
 #![feature(rustc_private)]
-extern crate rustc_arena;
 extern crate rustc_ast;
-extern crate rustc_attr;
 extern crate rustc_codegen_ssa;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_errors;
-extern crate rustc_fs_util;
 extern crate rustc_hir;
 extern crate rustc_index;
-extern crate rustc_llvm;
 extern crate rustc_metadata;
 extern crate rustc_middle;
-extern crate rustc_serialize;
 extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_target;


### PR DESCRIPTION
### Description of changes: 

Removed warnings and added `#![deny(warnings)]` to kani-compiler crate. Hopefully, this will keep our compilation cleaner.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
