### PR TITLE
Update rust toolchain to nightly-2022-03-09

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2022-02-22"
+channel = "nightly-2022-03-09"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -22,7 +22,7 @@ impl<'tcx> GotocCtx<'tcx> {
         match self.current_fn().readable_name() {
             // https://github.com/model-checking/kani/issues/202
             "fmt::ArgumentV1::<'a>::as_usize" => true,
-            // https://github.com/model-checking/kani/issues/204
+            // https://github.com/model-checking/kani/issues/281
             name if name.starts_with("bridge::client") => true,
             // https://github.com/model-checking/kani/issues/282
             "bridge::closure::Closure::<'a, A, R>::call" => true,

--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -23,8 +23,6 @@ impl<'tcx> GotocCtx<'tcx> {
             // https://github.com/model-checking/kani/issues/202
             "fmt::ArgumentV1::<'a>::as_usize" => true,
             // https://github.com/model-checking/kani/issues/204
-            name if name.ends_with("__getit") => true,
-            // https://github.com/model-checking/kani/issues/281
             name if name.starts_with("bridge::client") => true,
             // https://github.com/model-checking/kani/issues/282
             "bridge::closure::Closure::<'a, A, R>::call" => true,

--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -138,12 +138,12 @@ impl<'tcx> GotocCtx<'tcx> {
         match v {
             ConstValue::Scalar(s) => self.codegen_scalar(s, lit_ty, span),
             ConstValue::Slice { data, start, end } => {
-                self.codegen_slice_value(v, lit_ty, span, &data, start, end)
+                self.codegen_slice_value(v, lit_ty, span, &data.inner(), start, end)
             }
             ConstValue::ByRef { alloc, offset } => {
                 debug!("ConstValue by ref {:?} {:?}", alloc, offset);
-                let mem_var =
-                    self.codegen_allocation_auto_imm_name(alloc, |tcx| tcx.next_global_name());
+                let mem_var = self
+                    .codegen_allocation_auto_imm_name(alloc.inner(), |tcx| tcx.next_global_name());
                 mem_var
                     .cast_to(Type::unsigned_int(8).to_pointer())
                     .plus(Expr::int_constant(offset.bytes(), Type::unsigned_int(64)))
@@ -389,7 +389,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 // crates do not conflict. The name alone is insufficient becase Rust
                 // allows different versions of the same crate to be used.
                 let name = format!("{}::{:?}", self.full_crate_name(), alloc_id);
-                self.codegen_allocation(alloc, |_| name.clone(), Some(name.clone()))
+                self.codegen_allocation(alloc.inner(), |_| name.clone(), Some(name.clone()))
             }
         };
         assert!(res_t.is_pointer() || res_t.is_transparent_type(&self.symbol_table));

--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/static_var.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/static_var.rs
@@ -18,7 +18,7 @@ impl<'tcx> GotocCtx<'tcx> {
         debug!("codegen_static");
         let alloc = self.tcx.eval_static_initializer(def_id).unwrap();
         let symbol_name = item.symbol_name(self.tcx).to_string();
-        self.codegen_allocation(alloc, |_| symbol_name.clone(), Some(symbol_name.clone()));
+        self.codegen_allocation(alloc.inner(), |_| symbol_name.clone(), Some(symbol_name.clone()));
     }
 
     pub fn declare_static(&mut self, def_id: DefId, item: MonoItem<'tcx>) {

--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -409,16 +409,14 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn ty_pretty_name(&self, t: Ty<'tcx>) -> InternedString {
         use rustc_hir::def::Namespace;
         use rustc_middle::ty::print::Printer;
-        let mut name = String::new();
-        let printer = FmtPrinter::new(self.tcx, &mut name, Namespace::TypeNS);
+        let printer = FmtPrinter::new(self.tcx, Namespace::TypeNS);
 
         // Monomorphizing the type ensures we get a cannonical form for dynamic trait
         // objects with auto traits, such as:
         //   StructTag("tag-std::boxed::Box<(dyn std::error::Error + std::marker::Send + std::marker::Sync)>") }
         //   StructTag("tag-std::boxed::Box<dyn std::error::Error + std::marker::Send + std::marker::Sync>") }
         let t = self.monomorphize(t);
-        with_no_trimmed_paths!(printer.print_type(t).unwrap());
-        name.intern()
+        with_no_trimmed_paths!(printer.print_type(t).unwrap().into_buffer()).intern()
     }
 
     pub fn ty_mangled_name(&self, t: Ty<'tcx>) -> InternedString {
@@ -652,13 +650,13 @@ impl<'tcx> GotocCtx<'tcx> {
         layout: &Layout,
         initial_offset: usize,
     ) -> Vec<DatatypeComponent> {
-        match &layout.fields {
+        match &layout.fields() {
             FieldsShape::Arbitrary { offsets, memory_index } => {
                 assert_eq!(flds.len(), offsets.len());
                 assert_eq!(offsets.len(), memory_index.len());
                 let mut final_fields = Vec::with_capacity(flds.len());
                 let mut offset: u64 = initial_offset.try_into().unwrap();
-                for idx in layout.fields.index_by_increasing_offset() {
+                for idx in layout.fields().index_by_increasing_offset() {
                     let fld_offset = offsets[idx].bits();
                     let (fld_name, fld_ty) = &flds[idx];
                     if let Some(padding) =
@@ -674,7 +672,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 }
 
                 // If we don't meet our expected alignment, pad until we do
-                let align = layout.align.abi.bits();
+                let align = layout.align().abi.bits();
                 let overhang = offset % align;
                 if overhang != 0 {
                     final_fields.push(
@@ -691,7 +689,7 @@ impl<'tcx> GotocCtx<'tcx> {
             }
             // Primitives, such as NEVER, have no fields
             FieldsShape::Primitive => vec![],
-            _ => unreachable!("{}\n{:?}", self.current_fn().readable_name(), layout.fields),
+            _ => unreachable!("{}\n{:?}", self.current_fn().readable_name(), layout.fields()),
         }
     }
 
@@ -700,7 +698,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let flds: Vec<_> =
             tys.iter().enumerate().map(|(i, t)| (GotocCtx::tuple_fld_name(i), *t)).collect();
         // tuple cannot have other initial offset
-        self.codegen_struct_fields(flds, layout.layout, 0)
+        self.codegen_struct_fields(flds, &layout.layout, 0)
     }
 
     /// A closure in Rust MIR takes two arguments:
@@ -903,7 +901,7 @@ impl<'tcx> GotocCtx<'tcx> {
         self.ensure_struct(self.ty_mangled_name(ty), Some(self.ty_pretty_name(ty)), |ctx, _| {
             let variant = &def.variants.raw[0];
             let layout = ctx.layout_of(ty);
-            ctx.codegen_variant_struct_fields(variant, subst, layout.layout, 0)
+            ctx.codegen_variant_struct_fields(variant, subst, &layout.layout, 0)
         })
     }
 
@@ -993,7 +991,7 @@ impl<'tcx> GotocCtx<'tcx> {
                         Some(variant) => {
                             // a single enum is pretty much like a struct
                             let layout = ctx.layout_of(ty).layout;
-                            ctx.codegen_variant_struct_fields(variant, subst, layout, 0)
+                            ctx.codegen_variant_struct_fields(variant, subst, &layout, 0)
                         }
                     }
                 }
@@ -1053,7 +1051,7 @@ impl<'tcx> GotocCtx<'tcx> {
         variants
             .iter()
             .filter_map(|lo| {
-                if lo.fields.count() == 0 {
+                if lo.fields().count() == 0 {
                     None
                 } else {
                     // get the offset of the leftmost field, which is the one
@@ -1062,8 +1060,8 @@ impl<'tcx> GotocCtx<'tcx> {
                     // necessarily the 0th field since the compiler may reorder
                     // fields.
                     Some(
-                        lo.fields
-                            .offset(lo.fields.index_by_increasing_offset().nth(0).unwrap())
+                        lo.fields()
+                            .offset(lo.fields().index_by_increasing_offset().nth(0).unwrap())
                             .bits_usize(),
                     )
                 }
@@ -1171,11 +1169,11 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     fn codegen_vector(&mut self, ty: Ty<'tcx>) -> Type {
-        let layout = &self.layout_of(ty).layout.abi;
+        let layout = &self.layout_of(ty).layout.abi();
         debug! {"handling simd with layout {:?}", layout};
 
         let (element, size) = match layout {
-            Vector { element, count } => (element.clone(), *count),
+            Vector { element, count } => (element.clone(), count),
             _ => unreachable!(),
         };
 
@@ -1183,7 +1181,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let rust_type = self.codegen_prim_typ(prim_type);
         let cbmc_type = self.codegen_ty(rust_type);
 
-        Type::vector(cbmc_type, size)
+        Type::vector(cbmc_type, *size)
     }
 
     /// the function type of the current instance

--- a/src/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -12,7 +12,7 @@ use kani_queries::{QueryDb, UserInput};
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::{CodegenResults, CrateInfo};
 use rustc_data_structures::fx::FxHashMap;
-use rustc_errors::ErrorReported;
+use rustc_errors::ErrorGuaranteed;
 use rustc_metadata::EncodedMetadata;
 use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_middle::mir::mono::{CodegenUnit, MonoItem};
@@ -167,7 +167,7 @@ impl CodegenBackend for GotocCodegenBackend {
         ongoing_codegen: Box<dyn Any>,
         _sess: &Session,
         _filenames: &OutputFilenames,
-    ) -> Result<(CodegenResults, FxHashMap<WorkProductId, WorkProduct>), ErrorReported> {
+    ) -> Result<(CodegenResults, FxHashMap<WorkProductId, WorkProduct>), ErrorGuaranteed> {
         Ok(*ongoing_codegen
             .downcast::<(CodegenResults, FxHashMap<WorkProductId, WorkProduct>)>()
             .unwrap())
@@ -178,7 +178,7 @@ impl CodegenBackend for GotocCodegenBackend {
         _sess: &Session,
         _codegen_results: CodegenResults,
         _outputs: &OutputFilenames,
-    ) -> Result<(), ErrorReported> {
+    ) -> Result<(), ErrorGuaranteed> {
         Ok(())
     }
 }

--- a/tests/ui/unsupported-features/thread/expected
+++ b/tests/ui/unsupported-features/thread/expected
@@ -1,0 +1,1 @@
+Failed Checks: Rvalue::ThreadLocalRef is not currently supported by Kani.

--- a/tests/ui/unsupported-features/thread/main.rs
+++ b/tests/ui/unsupported-features/thread/main.rs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Checks for failures due to unsupported features related to threads.
+
+thread_local! {
+    static COND : bool = kani::any();
+}
+
+#[kani::proof]
+fn main() {
+    COND.with(|&b|{
+        kani::assume(b);
+        assert!(b, "This should fail because we do not support thread local");
+    });
+}
+

--- a/tools/bookrunner/librustdoc/clean/mod.rs
+++ b/tools/bookrunner/librustdoc/clean/mod.rs
@@ -191,9 +191,9 @@ impl Clean<Lifetime> for hir::Lifetime {
     fn clean(&self, cx: &mut DocContext<'_>) -> Lifetime {
         let def = cx.tcx.named_region(self.hir_id);
         if let Some(
-            rl::Region::EarlyBound(_, node_id, _)
-            | rl::Region::LateBound(_, _, node_id, _)
-            | rl::Region::Free(_, node_id),
+            rl::Region::EarlyBound(_, node_id)
+            | rl::Region::LateBound(_, _, node_id)
+            | rl::Region::Free(node_id, _),
         ) = def
         {
             if let Some(lt) = cx.substs.get(&node_id).and_then(|p| p.as_lt()).cloned() {
@@ -279,6 +279,7 @@ impl Clean<WherePredicate> for hir::WherePredicate<'_> {
     }
 }
 
+#[allow(unreachable_patterns)]
 impl<'a> Clean<Option<WherePredicate>> for ty::Predicate<'a> {
     fn clean(&self, cx: &mut DocContext<'_>) -> Option<WherePredicate> {
         let bound_predicate = self.kind();
@@ -1850,7 +1851,7 @@ fn clean_maybe_renamed_item(
             ItemKind::Fn(ref sig, ref generics, body_id) => {
                 clean_fn_or_proc_macro(item, sig, generics, body_id, &mut name, cx)
             }
-            ItemKind::Macro(ref macro_def) => {
+            ItemKind::Macro(ref macro_def, _) => {
                 let ty_vis = cx.tcx.visibility(def_id).clean(cx);
                 MacroItem(Macro {
                     source: display_macro_source(cx, name, macro_def, def_id, ty_vis),

--- a/tools/bookrunner/librustdoc/clean/types.rs
+++ b/tools/bookrunner/librustdoc/clean/types.rs
@@ -289,12 +289,12 @@ crate fn rustc_span(def_id: DefId, tcx: TyCtxt<'_>) -> Span {
 }
 
 impl Item {
-    crate fn stability<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<&'tcx Stability> {
+    crate fn stability<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<Stability> {
         self.def_id.as_def_id().and_then(|did| tcx.lookup_stability(did))
     }
 
     crate fn const_stability<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<ConstStability> {
-        self.def_id.as_def_id().and_then(|did| tcx.lookup_const_stability(did)).map(|cs| *cs)
+        self.def_id.as_def_id().and_then(|did| tcx.lookup_const_stability(did)).map(|cs| cs)
     }
 
     crate fn deprecation(&self, tcx: TyCtxt<'_>) -> Option<Deprecation> {

--- a/tools/bookrunner/librustdoc/clean/utils.rs
+++ b/tools/bookrunner/librustdoc/clean/utils.rs
@@ -473,10 +473,7 @@ fn snippet_equal_to_token(tcx: TyCtxt<'_>, matcher: &TokenTree) -> Option<String
     let mut parser =
         match rustc_parse::maybe_new_parser_from_source_str(&sess, file_name, snippet.clone()) {
             Ok(parser) => parser,
-            Err(diagnostics) => {
-                for mut diagnostic in diagnostics {
-                    diagnostic.cancel();
-                }
+            Err(_diagnostics) => {
                 return None;
             }
         };
@@ -484,7 +481,7 @@ fn snippet_equal_to_token(tcx: TyCtxt<'_>, matcher: &TokenTree) -> Option<String
     // Reparse a single token tree.
     let mut reparsed_trees = match parser.parse_all_token_trees() {
         Ok(reparsed_trees) => reparsed_trees,
-        Err(mut diagnostic) => {
+        Err(diagnostic) => {
             diagnostic.cancel();
             return None;
         }

--- a/tools/bookrunner/librustdoc/html/render/print_item.rs
+++ b/tools/bookrunner/librustdoc/html/render/print_item.rs
@@ -1714,10 +1714,10 @@ fn document_non_exhaustive(w: &mut Buffer, item: &clean::Item) {
 
 fn document_type_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
     fn write_size_of_layout(w: &mut Buffer, layout: &Layout, tag_size: u64) {
-        if layout.abi.is_unsized() {
+        if layout.abi().is_unsized() {
             write!(w, "(unsized)");
         } else {
-            let bytes = layout.size.bytes() - tag_size;
+            let bytes = layout.size().bytes() - tag_size;
             write!(w, "{size} byte{pl}", size = bytes, pl = if bytes == 1 { "" } else { "s" },);
         }
     }
@@ -1744,10 +1744,10 @@ fn document_type_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
                  chapter for details on type layout guarantees.</p></div>"
             );
             w.write_str("<p><strong>Size:</strong> ");
-            write_size_of_layout(w, ty_layout.layout, 0);
+            write_size_of_layout(w, &ty_layout.layout, 0);
             writeln!(w, "</p>");
             if let Variants::Multiple { variants, tag, tag_encoding, .. } =
-                &ty_layout.layout.variants
+                &ty_layout.layout.variants()
             {
                 if !variants.is_empty() {
                     w.write_str(

--- a/tools/bookrunner/librustdoc/passes/check_code_block_syntax.rs
+++ b/tools/bookrunner/librustdoc/passes/check_code_block_syntax.rs
@@ -5,7 +5,9 @@ use rustc_middle::lint::LintDiagnosticBuilder;
 use rustc_parse::parse_stream_from_source_str;
 use rustc_session::parse::ParseSess;
 use rustc_span::source_map::{FilePathMapping, SourceMap};
-use rustc_span::{hygiene::AstPass, ExpnData, ExpnKind, FileName, InnerSpan, DUMMY_SP};
+use rustc_span::{
+    hygiene::AstPass, ExpnData, ExpnKind, FileName, InnerSpan, LocalExpnId, DUMMY_SP,
+};
 
 use crate::clean;
 use crate::core::DocContext;
@@ -34,7 +36,8 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
             None,
             None,
         );
-        let span = DUMMY_SP.fresh_expansion(expn_data, self.cx.tcx.create_stable_hashing_context());
+        let expn_id = LocalExpnId::fresh(expn_data, self.cx.tcx.create_stable_hashing_context());
+        let span = DUMMY_SP.fresh_expansion(expn_id);
 
         let is_empty = rustc_driver::catch_fatal_errors(|| {
             parse_stream_from_source_str(


### PR DESCRIPTION
### Description of changes: 

Update the toolchain and fix the issues found during this process. This change includes:

- Changes to APIs where field is no longer accessible only the method (e.g.: `field` -> `field()`.
- Fix issue with missing symbol for thread local (added testcase too).
- New field for `TestDesc` adding a description to ignore testcases.
- Change to ConstAllocation structure.
- Fix related to refactoring of Diagnostic / DiagnosticBuilder.
- Other smaller fixes.

### Resolved issues:

Resolves #915 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
