### PR TITLE
Re-enable reachability checks for tests that were failing due to #861

### DIFF
--- a/docs/src/install-guide.md
+++ b/docs/src/install-guide.md
@@ -5,7 +5,7 @@ Kani must currently be built from source.
 In general, the following dependencies are required. Note: These dependencies may be installed by running the CI scripts shown below and there is no need to install them separately, for their respective OS.
 
 1. Cargo installed via rustup
-2. [CBMC](https://github.com/diffblue/cbmc) (>= 5.50.0)
+2. [CBMC](https://github.com/diffblue/cbmc) (>= 5.52.0)
 3. [CBMC Viewer](https://github.com/awslabs/aws-viewer-for-cbmc) (>= 2.10)
 
 ## Installing on Ubuntu 20.04

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -19,7 +19,7 @@ KANI_DIR=$SCRIPT_DIR/..
 export KANI_FAIL_ON_UNEXPECTED_DESCRIPTION="true"
 
 # Required dependencies
-check-cbmc-version.py --major 5 --minor 50
+check-cbmc-version.py --major 5 --minor 52
 check-cbmc-viewer-version.py --major 2 --minor 10
 
 # Formatting check

--- a/tests/kani/DynTrait/drop_nested_boxed_dyn.rs
+++ b/tests/kani/DynTrait/drop_nested_boxed_dyn.rs
@@ -5,12 +5,6 @@
 // There is an implicit self-recursive call to drop_in_place, so we
 // need to set an unwind bound.
 
-// Temporarily disabling assertion reachability checks because they trigger a
-// crash in CBMC:
-// https://github.com/diffblue/cbmc/issues/6691
-// https://github.com/model-checking/kani/issues/861
-// kani-flags: --no-assertion-reach-checks
-
 // cbmc-flags: --unwind 2 --unwinding-assertions
 
 static mut CELL: i32 = 0;

--- a/tests/kani/DynTrait/dyn_fn_mut.rs
+++ b/tests/kani/DynTrait/dyn_fn_mut.rs
@@ -4,12 +4,6 @@
 // Check that we can pass a dyn FnMut pointer to a stand alone
 // function definition.
 
-// Temporarily disabling assertion reachability checks because they trigger a
-// CBMC crash
-// https://github.com/diffblue/cbmc/issues/6691
-// https://github.com/model-checking/kani/issues/861
-// kani-flags: --no-assertion-reach-checks
-
 fn takes_dyn_fun(mut fun: Box<dyn FnMut(&mut i32)>, x_ptr: &mut i32) {
     fun(x_ptr)
 }

--- a/tests/kani/DynTrait/dyn_fn_once.rs
+++ b/tests/kani/DynTrait/dyn_fn_once.rs
@@ -4,12 +4,6 @@
 // Check that we can pass a dyn FnOnce pointer to a stand alone
 // function definition.
 
-// Temporarily disabling assertion reachability checks because they trigger a
-// CBMC crash
-// https://github.com/diffblue/cbmc/issues/6691
-// https://github.com/model-checking/kani/issues/861
-// kani-flags: --no-assertion-reach-checks
-
 fn takes_dyn_fun(fun: Box<dyn FnOnce() -> u32>) -> u32 {
     fun()
 }

--- a/tests/kani/DynTrait/nested_boxes.rs
+++ b/tests/kani/DynTrait/nested_boxes.rs
@@ -4,12 +4,6 @@
 // This test checks the size and align fields for 3-deep nested trait pointers. The
 // outter 2 dynamic trait objects have fat pointers as their backing data.
 
-// Temporarily disabling assertion reachability checks because they trigger a
-// CBMC crash
-// https://github.com/diffblue/cbmc/issues/6691
-// https://github.com/model-checking/kani/issues/861
-// kani-flags: --no-assertion-reach-checks
-
 // cbmc-flags: --unwind 2 --unwinding-assertions
 
 #![feature(core_intrinsics)]

--- a/tests/kani/DynTrait/nested_closures.rs
+++ b/tests/kani/DynTrait/nested_closures.rs
@@ -4,12 +4,6 @@
 // Check that we can codegen various nesting structures of boxes and
 // pointer to closures.
 
-// Temporarily disabling assertion reachability checks because they trigger a
-// CBMC crash
-// https://github.com/diffblue/cbmc/issues/6691
-// https://github.com/model-checking/kani/issues/861
-// kani-flags: --no-assertion-reach-checks
-
 fn main() {
     // Create a nested boxed once-callable closure
     let f: Box<Box<dyn FnOnce(i32)>> = Box::new(Box::new(|x| assert!(x == 1)));

--- a/tests/kani/FatPointers/boxmuttrait.rs
+++ b/tests/kani/FatPointers/boxmuttrait.rs
@@ -3,11 +3,7 @@
 
 // Disable undefined function checks because of a failure
 // https://github.com/model-checking/kani/issues/555
-// Also temporarily disabling assertion reachability checks because they trigger
-// a CBMC crash
-// https://github.com/diffblue/cbmc/issues/6691
-// https://github.com/model-checking/kani/issues/861
-// kani-flags: --no-undefined-function-checks --no-assertion-reach-checks
+// kani-flags: --no-undefined-function-checks
 
 #![feature(core_intrinsics)]
 #![feature(ptr_metadata)]

--- a/tests/kani/Vectors/vector_extend_in_new.rs
+++ b/tests/kani/Vectors/vector_extend_in_new.rs
@@ -4,12 +4,6 @@
 // Check that we can handle set len on drop for an implicit extend with
 // the vec![i; j] constructor.
 
-// Temporarily disabling assertion reachability checks because they trigger a
-// CBMC crash
-// https://github.com/diffblue/cbmc/issues/6691
-// https://github.com/model-checking/kani/issues/861
-// kani-flags: --no-assertion-reach-checks
-
 // There is an implicit loop, so we need an explicit unwind
 // cbmc-flags: --unwind 3 --unwinding-assertions
 


### PR DESCRIPTION
### Description of changes: 

In #919, assertion reachability checks were disabled in some tests because of a crash in CBMC 5.50.0. This PR re-enables them now that we're using CBMC 5.52.0.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
