### PR TITLE
Remove skipping of bridge::client functions

### DIFF
--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -22,8 +22,6 @@ impl<'tcx> GotocCtx<'tcx> {
         match self.current_fn().readable_name() {
             // https://github.com/model-checking/kani/issues/202
             "fmt::ArgumentV1::<'a>::as_usize" => true,
-            // https://github.com/model-checking/kani/issues/281
-            name if name.starts_with("bridge::client") => true,
             // https://github.com/model-checking/kani/issues/282
             "bridge::closure::Closure::<'a, A, R>::call" => true,
             // Generators


### PR DESCRIPTION
### Description of changes: 

Kani currently skips codegen of any objects starting with `bridge::closure`, likely due to previous crashes seen in the std library regression (`scripts/std-lib/regression.sh`), but the crashes are no longer reproducible.

### Resolved issues:

Resolves #281 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? std library regression included in the kani regressions

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
