### PR TITLE
Hide abstraction options because they don't work

### DIFF
--- a/src/cargo-kani/src/args.rs
+++ b/src/cargo-kani/src/args.rs
@@ -101,11 +101,15 @@ pub struct KaniArgs {
     #[structopt(long, allow_hyphen_values = true, min_values(0))] // consumes everything
     pub cbmc_args: Vec<OsString>,
 
+    // Hide option till https://github.com/model-checking/kani/issues/697 is
+    // fixed
     /// Use abstractions for the standard library
-    #[structopt(long)]
+    #[structopt(long, hidden = true)]
     pub use_abs: bool,
+    // Hide option till https://github.com/model-checking/kani/issues/697 is
+    // fixed
     /// Choose abstraction for modules of standard library if available
-    #[structopt(long, default_value = "std", possible_values = &AbstractionType::variants(), case_insensitive = true)]
+    #[structopt(long, default_value = "std", possible_values = &AbstractionType::variants(), case_insensitive = true, hidden = true)]
     pub abs_type: AbstractionType,
 
     /// Restrict the targets of virtual table function pointer calls


### PR DESCRIPTION
### Description of changes: 

Abstraction options are currently broken (#697). This PR hides them from the Kani help (`kani --help`) until the options are fixed.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
