### PR TITLE
Annotate all tests with #[kani::proof]

### DIFF
--- a/tests/cargo-kani/cbmc-unknown-lang-mode/src/lib.rs
+++ b/tests/cargo-kani/cbmc-unknown-lang-mode/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#[no_mangle]
+#[kani::proof]
 fn test() {
     assert!(1 + 1 == 2);
 }

--- a/tests/cargo-kani/dependencies/src/lib.rs
+++ b/tests/cargo-kani/dependencies/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#[no_mangle]
+#[kani::proof]
 pub fn check_dummy() {
     let x = kani::any::<u8>();
     kani::assume(x > 10);

--- a/tests/cargo-kani/simple-config-toml/src/lib.rs
+++ b/tests/cargo-kani/simple-config-toml/src/lib.rs
@@ -15,8 +15,7 @@ mod tests {
 mod kani_tests {
     use super::*;
 
-    #[allow(dead_code)]
-    #[no_mangle]
+    #[kani::proof]
     fn test_sum() {
         let a: u64 = kani::any();
         let b: u64 = kani::any();

--- a/tests/cargo-kani/simple-config-toml/src/pair.rs
+++ b/tests/cargo-kani/simple-config-toml/src/pair.rs
@@ -24,8 +24,8 @@ mod tests {
 #[cfg(kani)]
 mod kani_tests {
     use super::*;
-    #[allow(dead_code)]
-    #[no_mangle]
+
+    #[kani::proof]
     fn test_one_plus_two() {
         let p = Pair::new(1, 2);
         assert!(p.sum() == 3);

--- a/tests/cargo-kani/simple-extern/src/lib.rs
+++ b/tests/cargo-kani/simple-extern/src/lib.rs
@@ -17,8 +17,7 @@ mod tests {
 mod kani_tests {
     use super::*;
 
-    #[allow(dead_code)]
-    #[no_mangle]
+    #[kani::proof]
     fn test_sum() {
         let a: u32 = kani::any();
 

--- a/tests/cargo-kani/simple-lib/src/lib.rs
+++ b/tests/cargo-kani/simple-lib/src/lib.rs
@@ -15,8 +15,7 @@ mod tests {
 mod kani_tests {
     use super::*;
 
-    #[allow(dead_code)]
-    #[no_mangle]
+    #[kani::proof]
     fn test_sum() {
         let a: u64 = kani::any();
         let b: u64 = kani::any();

--- a/tests/cargo-kani/simple-lib/src/pair.rs
+++ b/tests/cargo-kani/simple-lib/src/pair.rs
@@ -24,8 +24,8 @@ mod tests {
 #[cfg(kani)]
 mod kani_tests {
     use super::*;
-    #[allow(dead_code)]
-    #[no_mangle]
+
+    #[kani::proof]
     fn test_one_plus_two() {
         let p = Pair::new(1, 2);
         assert!(p.sum() == 3);

--- a/tests/cargo-kani/type-mismatch/src/lib.rs
+++ b/tests/cargo-kani/type-mismatch/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-#[no_mangle]
+#[kani::proof]
 fn main() {
     let arr = [1, 2, 3];
     let r: core::ops::Range<usize> = uses_core::foo(&arr[..2]);

--- a/tests/expected/abort/main.rs
+++ b/tests/expected/abort/main.rs
@@ -5,7 +5,8 @@
 
 use std::process;
 
-pub fn main() {
+#[kani::proof]
+fn main() {
     for i in 0..4 {
         if i == 1 {
             // This comes first and it should be reachable.

--- a/tests/expected/allocation/main.rs
+++ b/tests/expected/allocation/main.rs
@@ -5,6 +5,7 @@ fn foo() -> Option<i32> {
     None
 }
 
+#[kani::proof]
 fn main() {
     assert!(foo() == None);
     let x = foo();

--- a/tests/expected/array/main.rs
+++ b/tests/expected/array/main.rs
@@ -6,6 +6,7 @@ fn foo(x: [i32; 5]) -> [i32; 2] {
     [x[0], x[1]]
 }
 
+#[kani::proof]
 fn main() {
     let x = [1, 2, 3, 4, 5];
     let y = foo(x);

--- a/tests/expected/assert-eq/main.rs
+++ b/tests/expected/assert-eq/main.rs
@@ -10,6 +10,7 @@
 ///     "library/std/src/macros.rs line 17 a panicking function core::panicking::panic_fmt is invoked: SUCCESS"
 ///     https://github.com/model-checking/kani/issues/13
 
+#[kani::proof]
 fn main() {
     let x = 1;
     let y = 2;

--- a/tests/expected/assert-location/assert-false/expected
+++ b/tests/expected/assert-location/assert-false/expected
@@ -1,3 +1,3 @@
-assertion failed: false: FAILURE
-"{}", s: FAILURE
-"Fail with custom static message": FAILURE
+line 18 assertion failed: false: FAILURE
+line 23 "{}", s: FAILURE
+line 27 "Fail with custom static message": FAILURE

--- a/tests/expected/assert-location/assert-false/expected
+++ b/tests/expected/assert-location/assert-false/expected
@@ -1,3 +1,3 @@
-line 17 assertion failed: false: FAILURE
-line 22 "{}", s: FAILURE
-line 26 "Fail with custom static message": FAILURE
+assertion failed: false: FAILURE
+"{}", s: FAILURE
+"Fail with custom static message": FAILURE

--- a/tests/expected/assert-location/assert-false/main.rs
+++ b/tests/expected/assert-location/assert-false/main.rs
@@ -12,7 +12,8 @@ fn any_bool() -> bool {
     kani::nondet()
 }
 
-pub fn main() {
+#[kani::proof]
+fn main() {
     if any_bool() {
         assert!(false);
     }

--- a/tests/expected/assert-location/debug-assert/expected
+++ b/tests/expected/assert-location/debug-assert/expected
@@ -1,2 +1,2 @@
-"This should fail and stop the execution": FAILURE
-"This should be unreachable": SUCCESS
+line 13 "This should fail and stop the execution": FAILURE
+line 14 "This should be unreachable": SUCCESS

--- a/tests/expected/assert-location/debug-assert/expected
+++ b/tests/expected/assert-location/debug-assert/expected
@@ -1,2 +1,2 @@
-line 12 "This should fail and stop the execution": FAILURE
-line 13 "This should be unreachable": SUCCESS
+"This should fail and stop the execution": FAILURE
+"This should be unreachable": SUCCESS

--- a/tests/expected/assert-location/debug-assert/main.rs
+++ b/tests/expected/assert-location/debug-assert/main.rs
@@ -7,7 +7,8 @@
 // Also disable reachability checks because they add annotations to each
 // assert's description which would be visible with the old output format
 // kani-flags: --output-format old --no-assertion-reach-checks
-pub fn main() {
+#[kani::proof]
+fn main() {
     for i in 0..4 {
         debug_assert!(i > 0, "This should fail and stop the execution");
         assert!(i == 0, "This should be unreachable");

--- a/tests/expected/binop/main.rs
+++ b/tests/expected/binop/main.rs
@@ -56,6 +56,7 @@ fn ibxor_test(a: i32, b: i32, correct: i32, wrong: i32) {
     assert!(a ^ b == wrong);
 }
 
+#[kani::proof]
 fn main() {
     match kani::nondet::<u8>() {
         0 => iadd_test(1, 2, 3, 4),

--- a/tests/expected/closure/main.rs
+++ b/tests/expected/closure/main.rs
@@ -8,6 +8,7 @@ where
     some_closure(1, 1);
 }
 
+#[kani::proof]
 fn main() {
     let mut num: i32 = kani::any();
     let y = 2;

--- a/tests/expected/closure2/main.rs
+++ b/tests/expected/closure2/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let x = 2;
     let f = |y| x + y;

--- a/tests/expected/closure3/main.rs
+++ b/tests/expected/closure3/main.rs
@@ -8,6 +8,7 @@ where
     f(10)
 }
 
+#[kani::proof]
 fn main() {
     let num: i64 = kani::any();
     if num <= std::i64::MAX - 100 {

--- a/tests/expected/comp/main.rs
+++ b/tests/expected/comp/main.rs
@@ -13,6 +13,7 @@ fn eq2(a: i32, b: i32) {
     assert!(a - b < a);
 }
 
+#[kani::proof]
 fn main() {
     let a = kani::any();
     let b = kani::any();

--- a/tests/expected/copy/main.rs
+++ b/tests/expected/copy/main.rs
@@ -3,6 +3,7 @@
 
 use std::ptr;
 
+#[kani::proof]
 fn main() {
     // TODO: make an overlapping set of locations, and check that it does the right thing for the overlapping region too.
     // https://github.com/model-checking/kani/issues/12

--- a/tests/expected/dry-run-flag-conflict-auto-unwind/main.rs
+++ b/tests/expected/dry-run-flag-conflict-auto-unwind/main.rs
@@ -7,4 +7,5 @@
 // `--dry-run` causes Kani to print out commands instead of running them
 // In `expected` you will find substrings of these commands because the
 // concrete paths depend on your working directory.
+#[kani::proof]
 fn main() {}

--- a/tests/expected/dry-run-flag-conflict/main.rs
+++ b/tests/expected/dry-run-flag-conflict/main.rs
@@ -7,4 +7,5 @@
 // `--dry-run` causes Kani to print out commands instead of running them
 // In `expected` you will find substrings of these commands because the
 // concrete paths depend on your working directory.
+#[kani::proof]
 fn main() {}

--- a/tests/expected/dry-run/main.rs
+++ b/tests/expected/dry-run/main.rs
@@ -6,4 +6,5 @@
 // `--dry-run` causes Kani to print out commands instead of running them
 // In `expected` you will find substrings of these commands because the
 // concrete paths depend on your working directory.
+#[kani::proof]
 fn main() {}

--- a/tests/expected/dynamic-error-trait/main.rs
+++ b/tests/expected/dynamic-error-trait/main.rs
@@ -23,6 +23,7 @@ impl MemoryMapping {
     }
 }
 
+#[kani::proof]
 fn main() {
     let mm = MemoryMapping::new(2);
     if mm.is_ok() {

--- a/tests/expected/dynamic-trait-static-dispatch/main.rs
+++ b/tests/expected/dynamic-trait-static-dispatch/main.rs
@@ -21,6 +21,7 @@ impl Foo for Bar {
 }
 
 // this example works with static dispatch, so should work also while dynamic dispatch is not yet resolved
+#[kani::proof]
 fn main() {
     let bar = Bar {};
     assert!(bar.a() == 3);

--- a/tests/expected/dynamic-trait/main.rs
+++ b/tests/expected/dynamic-trait/main.rs
@@ -48,6 +48,7 @@ fn impl_area(a: impl Shape) -> u32 {
     a.area()
 }
 
+#[kani::proof]
 fn main() {
     let rec = Rectangle { w: 10, h: 5 };
     assert!(rec.vol(3) == 150);

--- a/tests/expected/enum/main.rs
+++ b/tests/expected/enum/main.rs
@@ -14,6 +14,7 @@ fn b() -> Foo {
     Foo::B { x: 30, y: 60.0 }
 }
 
+#[kani::proof]
 fn main() {
     let x = a();
     match x {

--- a/tests/expected/float-nan/main.rs
+++ b/tests/expected/float-nan/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let mut f: f32 = 2.0;
     while f != 0.0 {

--- a/tests/expected/generics/main.rs
+++ b/tests/expected/generics/main.rs
@@ -14,6 +14,7 @@ fn wrapped<T>(x: T) -> Foo<T> {
     Foo { data: ident(x), i: 0 }
 }
 
+#[kani::proof]
 fn main() {
     let x = 10;
     let y = wrapped(x);

--- a/tests/expected/iterator/main.rs
+++ b/tests/expected/iterator/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let mut z = 1;
     for i in 1..4 {

--- a/tests/expected/niche/main.rs
+++ b/tests/expected/niche/main.rs
@@ -16,6 +16,7 @@ fn get_some<'a>(a: &'a i8) -> T<'a> {
     Option2::Some((*a, a))
 }
 
+#[kani::proof]
 fn main() {
     let x = get_opt();
     match x {

--- a/tests/expected/niche2/main.rs
+++ b/tests/expected/niche2/main.rs
@@ -18,6 +18,7 @@ fn get_b() -> Option<Foo> {
     Some(Foo::B([]))
 }
 
+#[kani::proof]
 fn main() {
     match get_none() {
         None => {}

--- a/tests/expected/nondet/main.rs
+++ b/tests/expected/nondet/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let x: i32 = kani::any();
     if (x > -500 && x < 500) {

--- a/tests/expected/one-assert/test.rs
+++ b/tests/expected/one-assert/test.rs
@@ -3,7 +3,7 @@
 
 // kani-flags: --function check_assert
 // compile-flags: --crate-type lib
-#[no_mangle]
+#[kani::proof]
 pub fn check_assert() {
     let x: u8 = kani::any();
     let y = x;

--- a/tests/expected/reach/assert/reachable_fail/test.rs
+++ b/tests/expected/reach/assert/reachable_fail/test.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let x = 5;
     if kani::any() {

--- a/tests/expected/reach/assert/reachable_pass/test.rs
+++ b/tests/expected/reach/assert/reachable_pass/test.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let x = 5;
     if x > 3 {

--- a/tests/expected/reach/assert_eq/unreachable/test.rs
+++ b/tests/expected/reach/assert_eq/unreachable/test.rs
@@ -4,6 +4,7 @@
 // macro. The test has an unreachable assert_eq statement which should be
 // reported as UNREACHABLE
 
+#[kani::proof]
 fn main() {
     let x: i32 = kani::any();
     let y = if x > 10 { 15 } else { 33 };

--- a/tests/expected/reach/assert_ne/unreachable/test.rs
+++ b/tests/expected/reach/assert_ne/unreachable/test.rs
@@ -4,6 +4,7 @@
 // macro. The test has an unreachable assert_ne statement which should be
 // reported as UNREACHABLE
 
+#[kani::proof]
 fn main() {
     let x: u32 = kani::any();
     if x > 0 {

--- a/tests/expected/reach/bounds/reachable_fail/test.rs
+++ b/tests/expected/reach/bounds/reachable_fail/test.rs
@@ -10,6 +10,7 @@ fn get(s: &[i16], index: usize) -> i16 {
     s[index]
 }
 
+#[kani::proof]
 fn main() {
     get(&[7, -83, 19], 15);
 }

--- a/tests/expected/reach/bounds/reachable_pass/test.rs
+++ b/tests/expected/reach/bounds/reachable_pass/test.rs
@@ -9,6 +9,7 @@ fn get(s: &[i16], index: usize) -> i16 {
     if index < s.len() { s[index] } else { -1 }
 }
 
+#[kani::proof]
 fn main() {
     get(&[7, -83, 19], 2);
 }

--- a/tests/expected/reach/bounds/unreachable/test.rs
+++ b/tests/expected/reach/bounds/unreachable/test.rs
@@ -9,6 +9,7 @@ fn get(s: &[i16], index: usize) -> i16 {
     if index < s.len() { s[index] } else { -1 }
 }
 
+#[kani::proof]
 fn main() {
     //get(&[7, -83, 19], 2);
     get(&[5, 206, -46, 321, 8], 8);

--- a/tests/expected/reach/debug-assert-eq/reachable_fail/test.rs
+++ b/tests/expected/reach/debug-assert-eq/reachable_fail/test.rs
@@ -12,6 +12,7 @@ fn check(x: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     check(7);
 }

--- a/tests/expected/reach/debug-assert-eq/reachable_pass/test.rs
+++ b/tests/expected/reach/debug-assert-eq/reachable_pass/test.rs
@@ -11,6 +11,7 @@ fn check(x: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     check(10);
 }

--- a/tests/expected/reach/debug-assert-eq/unreachable/test.rs
+++ b/tests/expected/reach/debug-assert-eq/unreachable/test.rs
@@ -11,6 +11,7 @@ fn check(x: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     check(5);
 }

--- a/tests/expected/reach/debug-assert-ne/reachable_fail/test.rs
+++ b/tests/expected/reach/debug-assert-ne/reachable_fail/test.rs
@@ -12,6 +12,7 @@ fn check(x: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     check(17);
 }

--- a/tests/expected/reach/debug-assert-ne/reachable_pass/test.rs
+++ b/tests/expected/reach/debug-assert-ne/reachable_pass/test.rs
@@ -11,6 +11,7 @@ fn check(x: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     check(10);
 }

--- a/tests/expected/reach/debug-assert-ne/unreachable/test.rs
+++ b/tests/expected/reach/debug-assert-ne/unreachable/test.rs
@@ -11,6 +11,7 @@ fn check(x: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     check(1);
 }

--- a/tests/expected/reach/debug-assert/reachable_fail/test.rs
+++ b/tests/expected/reach/debug-assert/reachable_fail/test.rs
@@ -12,6 +12,7 @@ fn check(x: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     check(-10);
 }

--- a/tests/expected/reach/debug-assert/reachable_pass/test.rs
+++ b/tests/expected/reach/debug-assert/reachable_pass/test.rs
@@ -11,6 +11,7 @@ fn check(x: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     check(-9);
 }

--- a/tests/expected/reach/debug-assert/unreachable/test.rs
+++ b/tests/expected/reach/debug-assert/unreachable/test.rs
@@ -11,6 +11,7 @@ fn check(x: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     check(5);
 }

--- a/tests/expected/reach/div-zero/reachable_fail/test.rs
+++ b/tests/expected/reach/div-zero/reachable_fail/test.rs
@@ -10,6 +10,7 @@ fn div(x: u16, y: u16) -> u16 {
     x / y
 }
 
+#[kani::proof]
 fn main() {
     div(678, 0);
 }

--- a/tests/expected/reach/div-zero/reachable_pass/test.rs
+++ b/tests/expected/reach/div-zero/reachable_pass/test.rs
@@ -9,6 +9,7 @@ fn div(x: u16, y: u16) -> u16 {
     if y != 0 { x / y } else { 0 }
 }
 
+#[kani::proof]
 fn main() {
     div(11, 3);
 }

--- a/tests/expected/reach/div-zero/unreachable/test.rs
+++ b/tests/expected/reach/div-zero/unreachable/test.rs
@@ -9,6 +9,7 @@ fn div(x: u16, y: u16) -> u16 {
     if y != 0 { x / y } else { 0 }
 }
 
+#[kani::proof]
 fn main() {
     div(5, 0);
 }

--- a/tests/expected/reach/overflow-neg/reachable_fail/test.rs
+++ b/tests/expected/reach/overflow-neg/reachable_fail/test.rs
@@ -10,6 +10,7 @@ fn negate(x: i32) -> i32 {
     -x
 }
 
+#[kani::proof]
 fn main() {
     negate(std::i32::MIN);
 }

--- a/tests/expected/reach/overflow-neg/reachable_pass/test.rs
+++ b/tests/expected/reach/overflow-neg/reachable_pass/test.rs
@@ -10,6 +10,7 @@ fn negate(x: i32) -> i32 {
     if x != std::i32::MIN { -x } else { std::i32::MAX }
 }
 
+#[kani::proof]
 fn main() {
     negate(7532);
 }

--- a/tests/expected/reach/overflow-neg/unreachable/test.rs
+++ b/tests/expected/reach/overflow-neg/unreachable/test.rs
@@ -10,6 +10,7 @@ fn negate(x: i32) -> i32 {
     if x != std::i32::MIN { -x } else { std::i32::MAX }
 }
 
+#[kani::proof]
 fn main() {
     negate(std::i32::MIN);
 }

--- a/tests/expected/reach/overflow/reachable_fail/test.rs
+++ b/tests/expected/reach/overflow/reachable_fail/test.rs
@@ -10,6 +10,7 @@ fn cond_reduce(thresh: u32, x: u32) -> u32 {
     if x > thresh { x - 50 } else { x }
 }
 
+#[kani::proof]
 fn main() {
     cond_reduce(60, 70);
     cond_reduce(40, 42);

--- a/tests/expected/reach/overflow/reachable_pass/test.rs
+++ b/tests/expected/reach/overflow/reachable_pass/test.rs
@@ -10,6 +10,7 @@ fn reduce(x: u32) -> u32 {
     if x > 1000 { x - 1000 } else { x }
 }
 
+#[kani::proof]
 fn main() {
     reduce(7);
     reduce(33);

--- a/tests/expected/reach/overflow/unreachable/test.rs
+++ b/tests/expected/reach/overflow/unreachable/test.rs
@@ -10,6 +10,7 @@ fn reduce(x: u32) -> u32 {
     if x > 1000 { x - 1000 } else { x }
 }
 
+#[kani::proof]
 fn main() {
     reduce(7);
     reduce(33);

--- a/tests/expected/reach/rem-zero/reachable_fail/test.rs
+++ b/tests/expected/reach/rem-zero/reachable_fail/test.rs
@@ -10,6 +10,7 @@ fn rem(x: u16, y: u16) -> u16 {
     x % y
 }
 
+#[kani::proof]
 fn main() {
     rem(678, 0);
 }

--- a/tests/expected/reach/rem-zero/reachable_pass/test.rs
+++ b/tests/expected/reach/rem-zero/reachable_pass/test.rs
@@ -9,6 +9,7 @@ fn rem(x: u16, y: u16) -> u16 {
     if y != 0 { x % y } else { 0 }
 }
 
+#[kani::proof]
 fn main() {
     rem(11, 3);
 }

--- a/tests/expected/reach/rem-zero/unreachable/test.rs
+++ b/tests/expected/reach/rem-zero/unreachable/test.rs
@@ -9,6 +9,7 @@ fn rem(x: u16, y: u16) -> u16 {
     if y != 0 { x % y } else { 0 }
 }
 
+#[kani::proof]
 fn main() {
     rem(5, 0);
 }

--- a/tests/expected/reach/turned-off/test.rs
+++ b/tests/expected/reach/turned-off/test.rs
@@ -6,6 +6,7 @@
 
 // kani-flags: --no-assertion-reach-checks
 
+#[kani::proof]
 fn main() {
     let x = if kani::any() { 5 } else { 9 };
     if x > 10 {

--- a/tests/expected/references/main.rs
+++ b/tests/expected/references/main.rs
@@ -12,6 +12,7 @@ impl Foo {
     }
 }
 
+#[kani::proof]
 fn main() {
     let foo = Foo { a: 2, _b: 3.0 };
     let z = foo.get_a();

--- a/tests/expected/report/insufficient_unwind/test.rs
+++ b/tests/expected/report/insufficient_unwind/test.rs
@@ -6,6 +6,7 @@
 
 // kani-flags: --unwind 6
 
+#[kani::proof]
 fn main() {
     let x: bool = kani::any();
     let v = if x { vec![1, 2, 3] } else { vec![1, 1, 1, 1, 1, 1] };

--- a/tests/expected/report/uncolor/test.rs
+++ b/tests/expected/report/uncolor/test.rs
@@ -5,6 +5,7 @@
 // codes when its output is piped/redirected:
 // https://github.com/model-checking/kani/issues/844
 
+#[kani::proof]
 fn main() {
     assert!(1 + 1 == 2);
     assert!(2 + 2 == 3);

--- a/tests/expected/report/unsupported/failure/test.rs
+++ b/tests/expected/report/unsupported/failure/test.rs
@@ -10,6 +10,7 @@ fn unsupp(x: &mut u8) {
     }
 }
 
+#[kani::proof]
 fn main() {
     let mut x = 0;
     if kani::any() {

--- a/tests/expected/report/unsupported/reachable/test.rs
+++ b/tests/expected/report/unsupported/reachable/test.rs
@@ -8,6 +8,7 @@ fn unsupp(x: &mut u8) {
     }
 }
 
+#[kani::proof]
 fn main() {
     let mut x = 0;
     unsupp(&mut x);

--- a/tests/expected/report/unsupported/unreachable/test.rs
+++ b/tests/expected/report/unsupported/unreachable/test.rs
@@ -8,6 +8,7 @@ fn unsupp(x: &mut u8) {
     }
 }
 
+#[kani::proof]
 fn main() {
     let mut x = 0;
     let y = 5;

--- a/tests/expected/slice/main.rs
+++ b/tests/expected/slice/main.rs
@@ -9,6 +9,7 @@ fn bar(x: &[i32; 5]) -> &[i32] {
     &x[1..4]
 }
 
+#[kani::proof]
 fn main() {
     let x = [1, 2, 3, 4, 5];
     let y = foo(&x);

--- a/tests/expected/static-mutable-struct/main.rs
+++ b/tests/expected/static-mutable-struct/main.rs
@@ -20,6 +20,7 @@ fn mutate_the_thing(nx: i64, ny: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     assert!(foo().x == 12);
     if kani::nondet() {

--- a/tests/expected/static-mutable/main.rs
+++ b/tests/expected/static-mutable/main.rs
@@ -13,6 +13,7 @@ fn mutate_the_thing(new: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     if kani::nondet() {
         assert!(10 == foo());

--- a/tests/expected/static/main.rs
+++ b/tests/expected/static/main.rs
@@ -7,6 +7,7 @@ fn foo() -> i32 {
     X
 }
 
+#[kani::proof]
 fn main() {
     assert!(10 == foo());
     assert!(12 == foo());

--- a/tests/expected/test1/main.rs
+++ b/tests/expected/test1/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let mut a: i32 = 0;
     let mut i: i32 = 10;

--- a/tests/expected/test2/main.rs
+++ b/tests/expected/test2/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let mut a: i32 = 4;
     let mut i = 0;

--- a/tests/expected/test3/main.rs
+++ b/tests/expected/test3/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let mut a: f32 = 0.0;
     let mut i = 10;

--- a/tests/expected/test4/main.rs
+++ b/tests/expected/test4/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let mut a = 4;
     let mut i = 0;

--- a/tests/expected/test5/main.rs
+++ b/tests/expected/test5/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     // should succeed
     assert!(div(4, 2) == 2);

--- a/tests/expected/test6/main.rs
+++ b/tests/expected/test6/main.rs
@@ -5,6 +5,7 @@ fn add2(a: i32, b: i32) -> f32 {
     add(a, b as f32)
 }
 
+#[kani::proof]
 fn main() {
     // should succeed: 1 + 1 = 2
     assert!(add2(1, 1) == 2.0);

--- a/tests/expected/transmute/main.rs
+++ b/tests/expected/transmute/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let bitpattern = unsafe { std::mem::transmute::<f32, u32>(1.0) };
     assert!(bitpattern == 0x3F800000);

--- a/tests/expected/unwind_tip/main.rs
+++ b/tests/expected/unwind_tip/main.rs
@@ -10,6 +10,7 @@
 //
 // In this test, we check that Kani warns the user about unwinding failures
 // and makes a recommendation to fix the issue.
+#[kani::proof]
 fn main() {
     let mut a: u32 = kani::any();
 

--- a/tests/expected/vec/main.rs
+++ b/tests/expected/vec/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let mut x: Vec<i32> = Vec::new();
     x.push(10);

--- a/tests/expected/vecdq/main.rs
+++ b/tests/expected/vecdq/main.rs
@@ -3,6 +3,7 @@
 
 use std::collections::VecDeque;
 
+#[kani::proof]
 fn main() {
     let x = kani::any();
     let y = kani::any();

--- a/tests/firecracker/micro-http-parsed-request/ignore-main.rs
+++ b/tests/firecracker/micro-http-parsed-request/ignore-main.rs
@@ -23,6 +23,7 @@ fn fix(n: u32) {
         request_uri.trim_start_matches('/').split_terminator('/').collect();
 }
 
+#[kani::proof]
 fn main() {
     let n: u32 = kani::any();
     bug(n);

--- a/tests/firecracker/virtio-balloon-compact/ignore-main.rs
+++ b/tests/firecracker/virtio-balloon-compact/ignore-main.rs
@@ -53,6 +53,7 @@ fn expand(ranges: Vec<(u32, u32)>) -> Vec<u32> {
     return v;
 }
 
+#[kani::proof]
 fn main() {
     let mut input = vec![0; 2];
     for i in 0..input.len() {

--- a/tests/firecracker/virtio-block-parse/main.rs
+++ b/tests/firecracker/virtio-block-parse/main.rs
@@ -352,6 +352,7 @@ fn is_nonzero_pow2(x: u16) -> bool {
     unsafe { (x != 0) && ((x & (x - 1)) == 0) }
 }
 
+#[kani::proof]
 fn main() {
     let mem = GuestMemoryMmap {};
     let queue_size: u16 = kani::any();

--- a/tests/kani-dependency-test/diamond-dependency/main/src/lib.rs
+++ b/tests/kani-dependency-test/diamond-dependency/main/src/lib.rs
@@ -4,7 +4,7 @@
 use dependency1;
 use dependency2;
 
-#[no_mangle]
+#[kani::proof]
 fn harness() {
     assert!(dependency1::delegate_get_int() == 0);
     assert!(dependency2::delegate_get_int() == 1);

--- a/tests/kani/ArithEqualOperators/main.rs
+++ b/tests/kani/ArithEqualOperators/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let mut a: u32 = kani::any();
     a /= 2;

--- a/tests/kani/ArithOperators/main.rs
+++ b/tests/kani/ArithOperators/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let a: u32 = kani::any();
     assert!(a / 2 <= a);

--- a/tests/kani/ArithOperators/unchecked.rs
+++ b/tests/kani/ArithOperators/unchecked.rs
@@ -15,6 +15,7 @@ macro_rules! verify_no_overflow {
     }};
 }
 
+#[kani::proof]
 fn main() {
     verify_no_overflow!(checked_add, unchecked_add);
     verify_no_overflow!(checked_sub, unchecked_sub);

--- a/tests/kani/ArithOperators/unchecked_add_fail.rs
+++ b/tests/kani/ArithOperators/unchecked_add_fail.rs
@@ -6,7 +6,8 @@
 
 #![feature(unchecked_math)]
 
-pub fn main() {
+#[kani::proof]
+fn main() {
     let a: u8 = kani::nondet();
     let b: u8 = kani::nondet();
     unsafe { a.unchecked_add(b) };

--- a/tests/kani/ArithOperators/unchecked_mul_fail.rs
+++ b/tests/kani/ArithOperators/unchecked_mul_fail.rs
@@ -6,7 +6,8 @@
 
 #![feature(unchecked_math)]
 
-pub fn main() {
+#[kani::proof]
+fn main() {
     let a: u8 = kani::nondet();
     let b: u8 = kani::nondet();
     unsafe { a.unchecked_mul(b) };

--- a/tests/kani/ArithOperators/unchecked_sub_fail.rs
+++ b/tests/kani/ArithOperators/unchecked_sub_fail.rs
@@ -6,6 +6,7 @@
 
 #![feature(unchecked_math)]
 
+#[kani::proof]
 fn main() {
     let a: u8 = kani::nondet();
     let b: u8 = kani::nondet();

--- a/tests/kani/ArithOperators/unsafe.rs
+++ b/tests/kani/ArithOperators/unsafe.rs
@@ -14,6 +14,7 @@ macro_rules! verify_no_overflow {
     }};
 }
 
+#[kani::proof]
 fn main() {
     verify_no_overflow!(checked_add, +);
     verify_no_overflow!(checked_sub, -);

--- a/tests/kani/ArithOperators/wrapping.rs
+++ b/tests/kani/ArithOperators/wrapping.rs
@@ -4,6 +4,7 @@
 // Check that none of these operations trigger spurious overflow checks.
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let a: u8 = kani::nondet();
     let b: u8 = kani::nondet();

--- a/tests/kani/Asm/main_fixme.rs
+++ b/tests/kani/Asm/main_fixme.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![feature(asm)]
 
+#[kani::proof]
 fn main() {
     unsafe {
         asm!("nop");

--- a/tests/kani/Assert/multiple_asserts.rs
+++ b/tests/kani/Assert/multiple_asserts.rs
@@ -4,6 +4,7 @@
 // kani-verify-fail
 // Check that this doesn't trigger a fake loop. See issue #636.
 #[no_mangle]
+#[kani::proof]
 fn main() {
     let x: bool = kani::nondet();
     if x {

--- a/tests/kani/Assert/multiple_asserts.rs
+++ b/tests/kani/Assert/multiple_asserts.rs
@@ -3,7 +3,6 @@
 
 // kani-verify-fail
 // Check that this doesn't trigger a fake loop. See issue #636.
-#[no_mangle]
 #[kani::proof]
 fn main() {
     let x: bool = kani::nondet();

--- a/tests/kani/Assume/main.rs
+++ b/tests/kani/Assume/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let i: i32 = kani::any();
     kani::assume(i < 10);

--- a/tests/kani/Assume/main_fail.rs
+++ b/tests/kani/Assume/main_fail.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let i: i32 = kani::any();
     kani::assume(i < 10);

--- a/tests/kani/BinOp_Offset/main.rs
+++ b/tests/kani/BinOp_Offset/main.rs
@@ -22,6 +22,7 @@ pub fn test_offset_str() {
     }
 }
 
+#[kani::proof]
 fn main() {
     test_offset_array();
     test_offset_str()

--- a/tests/kani/BinOp_Offset/main_fail.rs
+++ b/tests/kani/BinOp_Offset/main_fail.rs
@@ -8,6 +8,7 @@ pub fn test_offset_in_double_array() {
     table[0][kani::any::<usize>()]; // EXPECTED FAIL
 }
 
+#[kani::proof]
 fn main() {
     test_offset_in_double_array();
 }

--- a/tests/kani/BitwiseArithOperators/bool.rs
+++ b/tests/kani/BitwiseArithOperators/bool.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let a: bool = kani::any();
     let b: bool = kani::any();

--- a/tests/kani/BitwiseArithOperators/main.rs
+++ b/tests/kani/BitwiseArithOperators/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     assert!(3 | 5 == 7);
     assert!(7 & 9 == 1);

--- a/tests/kani/BitwiseEqualOperators/main.rs
+++ b/tests/kani/BitwiseEqualOperators/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let mut x = 0;
     x |= 1;

--- a/tests/kani/BitwiseShiftOperators/Usize/main.rs
+++ b/tests/kani/BitwiseShiftOperators/Usize/main.rs
@@ -5,6 +5,7 @@ fn bitmap_new(byte_size: usize, page_size: usize) -> usize {
     let map_size = ((bit_size - 1) >> 6) + 1;
     map_size
 }
+#[kani::proof]
 fn main() {
     let map_size = bitmap_new(1024, 128);
     assert!(map_size == 1);

--- a/tests/kani/BitwiseShiftOperators/main.rs
+++ b/tests/kani/BitwiseShiftOperators/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     assert!(8 >> 4 == 0);
     assert!(1 << 4 == 16);

--- a/tests/kani/Bool-BoolOperators/main.rs
+++ b/tests/kani/Bool-BoolOperators/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     assert!(true);
     assert!(true || false);

--- a/tests/kani/Cast/cast_abstract_args_to_concrete.rs
+++ b/tests/kani/Cast/cast_abstract_args_to_concrete.rs
@@ -22,6 +22,7 @@ extern crate libc;
 
 use std::mem;
 
+#[kani::proof]
 fn main() {
     let _x32 = 1.0f32.powi(2);
     let _x64 = 1.0f64.powi(2);

--- a/tests/kani/Cast/from_be_bytes.rs
+++ b/tests/kani/Cast/from_be_bytes.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::convert::TryInto;
+#[kani::proof]
 fn main() {
     let input: &[u8] = &vec![
         kani::any(),

--- a/tests/kani/Cast/main.rs
+++ b/tests/kani/Cast/main.rs
@@ -5,6 +5,7 @@ pub enum Level {
     Error,
 }
 
+#[kani::proof]
 fn main() {
     let left = Level::Error;
     assert!((left as u8).cmp(&0) == Ordering::Equal);

--- a/tests/kani/Cast/path.rs
+++ b/tests/kani/Cast/path.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::path::Path;
 
+#[kani::proof]
 fn main() {
     let path = Path::new("./foo/bar.txt");
 }

--- a/tests/kani/Cleanup/assert.rs
+++ b/tests/kani/Cleanup/assert.rs
@@ -21,7 +21,8 @@ impl Drop for S {
     }
 }
 
-pub fn main() {
+#[kani::proof]
+fn main() {
     let lhs = S { a: 42, b: 42 };
     let rhs = S { a: 0, b: 0 };
     assert!(lhs == rhs, "A2: A very false statement. Always fail.");

--- a/tests/kani/Cleanup/unwind_fixme.rs
+++ b/tests/kani/Cleanup/unwind_fixme.rs
@@ -24,7 +24,7 @@ impl Drop for DummyResource {
     }
 }
 
-#[no_mangle]
+#[kani::proof]
 pub fn create(empty: bool) -> DummyResource {
     let mut dummy = DummyResource { data: None };
     if empty {

--- a/tests/kani/Closure/main.rs
+++ b/tests/kani/Closure/main.rs
@@ -38,6 +38,7 @@ fn test_env() {
     assert!(r == 9);
 }
 
+#[kani::proof]
 fn main() {
     closure_with_empty_args();
     closure_with_1_arg();

--- a/tests/kani/Closure/tupled_closure.rs
+++ b/tests/kani/Closure/tupled_closure.rs
@@ -19,6 +19,7 @@ impl Foo {
     }
 }
 
+#[kani::proof]
 fn main() {
     let x = Foo {};
     assert!(x.f() == 27);

--- a/tests/kani/CodegenConstValue/bigints.rs
+++ b/tests/kani/CodegenConstValue/bigints.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let x: u128 = u128::MAX;
     let x2: u128 = {

--- a/tests/kani/CodegenConstValue/main.rs
+++ b/tests/kani/CodegenConstValue/main.rs
@@ -8,6 +8,7 @@
 // [main.pointer_dereference.5] line 16 dereference failure: pointer outside object bounds in *lut_ptr: FAILURE
 // Tracking issue: https://github.com/model-checking/kani/issues/307
 const DEC_DIGITS_LUT: &'static [u8] = b"ab";
+#[kani::proof]
 fn main() {
     // The next two assertions don't go through to CBMC
     // 'cos they're constant folded away

--- a/tests/kani/CodegenConstValue/u128.rs
+++ b/tests/kani/CodegenConstValue/u128.rs
@@ -6,6 +6,7 @@ fn assert_bigger(a: u128, b: u128) {
     assert!(a > b);
 }
 
+#[kani::proof]
 fn main() {
     assert_bigger(u128::MAX, 12);
 }

--- a/tests/kani/CodegenMisc/main.rs
+++ b/tests/kani/CodegenMisc/main.rs
@@ -12,6 +12,7 @@ pub type SignalHandler = extern "C" fn(num: c_int, _unused: *mut c_void) -> ();
 
 extern "C" fn handle_signal(_: c_int, _: *mut c_void) {}
 
+#[kani::proof]
 fn main() {
     let x = handle_signal as *const () as usize;
     assert!(x != 0);

--- a/tests/kani/CodegenStatic/main.rs
+++ b/tests/kani/CodegenStatic/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 static STATIC: [&str; 1] = ["FOO"];
+#[kani::proof]
 fn main() {
     let x = STATIC[0];
     let bytes = x.as_bytes();

--- a/tests/kani/CodegenStatic/struct.rs
+++ b/tests/kani/CodegenStatic/struct.rs
@@ -7,6 +7,7 @@ pub struct Foo<const N: usize> {
 
 const x: Foo<3> = Foo { bytes: [1, 2, 3] };
 
+#[kani::proof]
 fn main() {
     assert!(x.bytes[0] == 1);
 }

--- a/tests/kani/CopyIntrinsics/main.rs
+++ b/tests/kani/CopyIntrinsics/main.rs
@@ -87,6 +87,7 @@ fn test_swap() {
     assert!(y == 12);
 }
 
+#[kani::proof]
 fn main() {
     test_copy();
     test_swap();

--- a/tests/kani/Count/Unstable/Ctlz/bounds.rs
+++ b/tests/kani/Count/Unstable/Ctlz/bounds.rs
@@ -6,6 +6,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::ctlz_nonzero;
 
+#[kani::proof]
 fn main() {
     let uv8: u8 = 0;
     let uv16: u16 = 0;

--- a/tests/kani/Count/Unstable/Ctlz/main.rs
+++ b/tests/kani/Count/Unstable/Ctlz/main.rs
@@ -3,6 +3,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{ctlz, ctlz_nonzero};
 
+#[kani::proof]
 fn main() {
     let uv8 = 0b0011_1000_u8;
     let uv16 = uv8 as u16;

--- a/tests/kani/Count/Unstable/Cttz/bounds.rs
+++ b/tests/kani/Count/Unstable/Cttz/bounds.rs
@@ -6,6 +6,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::cttz_nonzero;
 
+#[kani::proof]
 fn main() {
     let uv8: u8 = 0;
     let uv16: u16 = 0;

--- a/tests/kani/Count/Unstable/Cttz/main.rs
+++ b/tests/kani/Count/Unstable/Cttz/main.rs
@@ -3,6 +3,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{cttz, cttz_nonzero};
 
+#[kani::proof]
 fn main() {
     let uv8 = 0b0011_1000_u8;
     let uv16 = uv8 as u16;

--- a/tests/kani/DynTrait/any_cast_int.rs
+++ b/tests/kani/DynTrait/any_cast_int.rs
@@ -29,6 +29,7 @@ fn downcast_to_fewer_traits(s: &(dyn Any + Send)) {
     downcast_to_concrete(c);
 }
 
+#[kani::proof]
 fn main() {
     let i: i32 = 7;
     downcast_to_fewer_traits(&i);

--- a/tests/kani/DynTrait/any_cast_int_fail.rs
+++ b/tests/kani/DynTrait/any_cast_int_fail.rs
@@ -30,6 +30,7 @@ fn downcast_to_fewer_traits(s: &(dyn Any + Send)) {
     downcast_to_concrete(c);
 }
 
+#[kani::proof]
 fn main() {
     let i: i32 = 7;
     downcast_to_fewer_traits(&i);

--- a/tests/kani/DynTrait/boxed_closure.rs
+++ b/tests/kani/DynTrait/boxed_closure.rs
@@ -3,6 +3,7 @@
 
 // Check that we can codegen a boxed dyn closure
 
+#[kani::proof]
 fn main() {
     // Create a boxed once-callable closure
     let f: Box<dyn FnOnce(f32, i32)> = Box::new(|x, y| {

--- a/tests/kani/DynTrait/boxed_closure_fail.rs
+++ b/tests/kani/DynTrait/boxed_closure_fail.rs
@@ -3,6 +3,7 @@
 // kani-verify-fail
 
 // Check that we can codegen a boxed dyn closure and fail an inner assertion
+#[kani::proof]
 fn main() {
     // Create a boxed once-callable closure
     let f: Box<dyn FnOnce(i32)> = Box::new(|x| {

--- a/tests/kani/DynTrait/boxed_debug_cast.rs
+++ b/tests/kani/DynTrait/boxed_debug_cast.rs
@@ -22,6 +22,7 @@ fn f<'a>(x: &'a &Box<dyn Error + Send + Sync>) -> Box<&'a dyn Debug> {
     Box::new(d)
 }
 
+#[kani::proof]
 fn main() {
     let c = Concrete {};
     let x = Box::new(c) as Box<dyn Error + Send + Sync>;

--- a/tests/kani/DynTrait/boxed_trait.rs
+++ b/tests/kani/DynTrait/boxed_trait.rs
@@ -43,6 +43,7 @@ fn do_area_box(x: Box<dyn Shape>) -> u32 {
     x.area()
 }
 
+#[kani::proof]
 fn main() {
     let rec = Box::new(Rectangle { w: 10, h: 5 });
     assert!(rec.vol(3) == 150);

--- a/tests/kani/DynTrait/boxed_trait_fail.rs
+++ b/tests/kani/DynTrait/boxed_trait_fail.rs
@@ -45,6 +45,7 @@ fn do_area_box(x: Box<dyn Shape>) -> u32 {
     x.area()
 }
 
+#[kani::proof]
 fn main() {
     let rec = Box::new(Rectangle { w: 10, h: 5 });
     assert!(rec.vol(3) != 150);

--- a/tests/kani/DynTrait/different_crates.rs
+++ b/tests/kani/DynTrait/different_crates.rs
@@ -42,6 +42,7 @@ fn weird_count(c: &mut dyn Iterator) -> usize {
     c.next().unwrap()
 }
 
+#[kani::proof]
 fn main() {
     let counter: &mut Counter = &mut Counter { count: 0 };
     assert!(std_count(counter as &mut dyn std::iter::Iterator<Item = usize>) == 1);

--- a/tests/kani/DynTrait/different_crates_fail.rs
+++ b/tests/kani/DynTrait/different_crates_fail.rs
@@ -43,6 +43,7 @@ fn weird_count(c: &mut dyn Iterator) -> usize {
     c.next().unwrap()
 }
 
+#[kani::proof]
 fn main() {
     let counter: &mut Counter = &mut Counter { count: 0 };
     assert!(std_count(counter as &mut dyn std::iter::Iterator<Item = usize>) == 0); // Should be 1

--- a/tests/kani/DynTrait/drop_boxed_dyn.rs
+++ b/tests/kani/DynTrait/drop_boxed_dyn.rs
@@ -33,6 +33,7 @@ impl Drop for Concrete2 {
     }
 }
 
+#[kani::proof]
 fn main() {
     {
         let x: Box<dyn T>;

--- a/tests/kani/DynTrait/drop_concrete.rs
+++ b/tests/kani/DynTrait/drop_concrete.rs
@@ -15,6 +15,7 @@ impl Drop for Concrete1 {
     }
 }
 
+#[kani::proof]
 fn main() {
     {
         let _x1 = Concrete1 {};

--- a/tests/kani/DynTrait/drop_dyn_pointer.rs
+++ b/tests/kani/DynTrait/drop_dyn_pointer.rs
@@ -33,6 +33,7 @@ impl Drop for Concrete2 {
     }
 }
 
+#[kani::proof]
 fn main() {
     {
         let _x1: &dyn T = &Concrete1 {};

--- a/tests/kani/DynTrait/drop_nested_boxed_dyn.rs
+++ b/tests/kani/DynTrait/drop_nested_boxed_dyn.rs
@@ -19,6 +19,7 @@ impl Drop for Concrete {
     }
 }
 
+#[kani::proof]
 fn main() {
     // Check normal box
     {

--- a/tests/kani/DynTrait/drop_nested_boxed_dyn_fail.rs
+++ b/tests/kani/DynTrait/drop_nested_boxed_dyn_fail.rs
@@ -16,6 +16,7 @@ impl Drop for Concrete {
     }
 }
 
+#[kani::proof]
 fn main() {
     // Check normal box
     {

--- a/tests/kani/DynTrait/dyn_fn_mut.rs
+++ b/tests/kani/DynTrait/dyn_fn_mut.rs
@@ -12,6 +12,7 @@ pub fn mut_i32_ptr(x: &mut i32) {
     *x = *x + 1;
 }
 
+#[kani::proof]
 fn main() {
     let mut x = 1;
     takes_dyn_fun(Box::new(&mut_i32_ptr), &mut x);

--- a/tests/kani/DynTrait/dyn_fn_mut_fail.rs
+++ b/tests/kani/DynTrait/dyn_fn_mut_fail.rs
@@ -13,6 +13,7 @@ pub fn mut_i32_ptr(x: &mut i32) {
     *x = *x + 1;
 }
 
+#[kani::proof]
 fn main() {
     let mut x = 1;
     takes_dyn_fun(Box::new(&mut_i32_ptr), &mut x);

--- a/tests/kani/DynTrait/dyn_fn_once.rs
+++ b/tests/kani/DynTrait/dyn_fn_once.rs
@@ -12,6 +12,7 @@ pub fn unit_to_u32() -> u32 {
     5
 }
 
+#[kani::proof]
 fn main() {
     assert!(takes_dyn_fun(Box::new(&unit_to_u32)) == 5)
 }

--- a/tests/kani/DynTrait/dyn_fn_once_fail.rs
+++ b/tests/kani/DynTrait/dyn_fn_once_fail.rs
@@ -13,6 +13,7 @@ pub fn unit_to_u32() -> u32 {
     5
 }
 
+#[kani::proof]
 fn main() {
     kani::expect_fail(takes_dyn_fun(Box::new(&unit_to_u32)) == 3, "Wrong u32")
 }

--- a/tests/kani/DynTrait/dyn_fn_param.rs
+++ b/tests/kani/DynTrait/dyn_fn_param.rs
@@ -20,6 +20,7 @@ pub fn unit_to_u32() -> u32 {
     5 as u32
 }
 
+#[kani::proof]
 fn main() {
     takes_dyn_fun(&unit_to_u32)
 }

--- a/tests/kani/DynTrait/dyn_fn_param_closure.rs
+++ b/tests/kani/DynTrait/dyn_fn_param_closure.rs
@@ -12,6 +12,7 @@ fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
     /* The closure does not capture anything and thus has zero size */
     assert!(size_from_vtable(vtable!(fun)) == 0);
 }
+#[kani::proof]
 fn main() {
     let closure = || 5;
     takes_dyn_fun(&closure)

--- a/tests/kani/DynTrait/dyn_fn_param_closure_capture.rs
+++ b/tests/kani/DynTrait/dyn_fn_param_closure_capture.rs
@@ -14,6 +14,7 @@ fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
     assert!(size_from_vtable(vtable!(fun)) == 8);
 }
 
+#[kani::proof]
 fn main() {
     let a = vec![3];
     let closure = || a[0] + 2;

--- a/tests/kani/DynTrait/dyn_fn_param_closure_capture_fail.rs
+++ b/tests/kani/DynTrait/dyn_fn_param_closure_capture_fail.rs
@@ -13,6 +13,7 @@ fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
     kani::expect_fail(size_from_vtable(vtable!(fun)) != 8, "Wrong size");
 }
 
+#[kani::proof]
 fn main() {
     let a = vec![3];
     let closure = || a[0] + 2;

--- a/tests/kani/DynTrait/dyn_fn_param_closure_fail.rs
+++ b/tests/kani/DynTrait/dyn_fn_param_closure_fail.rs
@@ -11,6 +11,7 @@ fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
     /* The closure does not capture anything and thus has zero size */
     kani::expect_fail(size_from_vtable(vtable!(fun)) != 0, "Wrong size");
 }
+#[kani::proof]
 fn main() {
     let closure = || 5;
     takes_dyn_fun(&closure)

--- a/tests/kani/DynTrait/dyn_fn_param_fail.rs
+++ b/tests/kani/DynTrait/dyn_fn_param_fail.rs
@@ -25,6 +25,7 @@ pub fn unit_to_u32() -> u32 {
     5 as u32
 }
 
+#[kani::proof]
 fn main() {
     takes_dyn_fun(&unit_to_u32)
 }

--- a/tests/kani/DynTrait/generic_duplicate_names.rs
+++ b/tests/kani/DynTrait/generic_duplicate_names.rs
@@ -18,6 +18,7 @@ impl<T> Foo<T> for () {
 
 impl Bar for () {}
 
+#[kani::proof]
 fn main() {
     let b: &dyn Bar = &();
     // The vtable for b will now have two Foo::method entries,

--- a/tests/kani/DynTrait/generic_duplicate_names_fail.rs
+++ b/tests/kani/DynTrait/generic_duplicate_names_fail.rs
@@ -19,6 +19,7 @@ impl<T> Foo<T> for () {
 
 impl Bar for () {}
 
+#[kani::proof]
 fn main() {
     let b: &dyn Bar = &();
     // The vtable for b will now have two Foo::method entries,

--- a/tests/kani/DynTrait/generic_duplicate_names_impl.rs
+++ b/tests/kani/DynTrait/generic_duplicate_names_impl.rs
@@ -25,6 +25,7 @@ impl Foo<u32> for () {
 
 impl Bar for () {}
 
+#[kani::proof]
 fn main() {
     let b: &dyn Bar = &();
     // The vtable for b will now have two Foo::method entries,

--- a/tests/kani/DynTrait/generic_duplicate_names_impl_fail.rs
+++ b/tests/kani/DynTrait/generic_duplicate_names_impl_fail.rs
@@ -26,6 +26,7 @@ impl Foo<u32> for () {
 
 impl Bar for () {}
 
+#[kani::proof]
 fn main() {
     let b: &dyn Bar = &();
     // The vtable for b will now have two Foo::method entries,

--- a/tests/kani/DynTrait/main.rs
+++ b/tests/kani/DynTrait/main.rs
@@ -28,6 +28,7 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
     if random_number < 5 { Box::new(Sheep {}) } else { Box::new(Cow {}) }
 }
 
+#[kani::proof]
 fn main() {
     let random_number = kani::any();
     let animal = random_animal(random_number);

--- a/tests/kani/DynTrait/main_fail.rs
+++ b/tests/kani/DynTrait/main_fail.rs
@@ -28,6 +28,7 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
     if random_number < 5 { Box::new(Sheep {}) } else { Box::new(Cow {}) }
 }
 
+#[kani::proof]
 fn main() {
     let random_number = kani::any();
     let animal = random_animal(random_number);

--- a/tests/kani/DynTrait/nested_boxes.rs
+++ b/tests/kani/DynTrait/nested_boxes.rs
@@ -20,6 +20,7 @@ struct Foo {
     pub _b: i8,
 }
 
+#[kani::proof]
 fn main() {
     let dyn_trait1: Box<dyn Send> = Box::new(Foo { _a: 1, _b: 2 });
     let dyn_trait2: Box<dyn Send> = Box::new(dyn_trait1);

--- a/tests/kani/DynTrait/nested_boxes_fail.rs
+++ b/tests/kani/DynTrait/nested_boxes_fail.rs
@@ -22,6 +22,7 @@ struct Foo {
     pub _b: i8,
 }
 
+#[kani::proof]
 fn main() {
     let dyn_trait1: Box<dyn Send> = Box::new(Foo { _a: 1, _b: 2 });
     let dyn_trait2: Box<dyn Send> = Box::new(dyn_trait1);

--- a/tests/kani/DynTrait/nested_closures.rs
+++ b/tests/kani/DynTrait/nested_closures.rs
@@ -4,6 +4,7 @@
 // Check that we can codegen various nesting structures of boxes and
 // pointer to closures.
 
+#[kani::proof]
 fn main() {
     // Create a nested boxed once-callable closure
     let f: Box<Box<dyn FnOnce(i32)>> = Box::new(Box::new(|x| assert!(x == 1)));

--- a/tests/kani/DynTrait/nested_closures_fail.rs
+++ b/tests/kani/DynTrait/nested_closures_fail.rs
@@ -6,6 +6,7 @@
 
 // kani-verify-fail
 
+#[kani::proof]
 fn main() {
     // Create a nested boxed once-callable closure
     let f: Box<Box<dyn FnOnce(i32)>> =

--- a/tests/kani/DynTrait/object_safe_generics.rs
+++ b/tests/kani/DynTrait/object_safe_generics.rs
@@ -30,6 +30,7 @@ impl<T> Foo<T> for () {
 
 impl Bar for () {}
 
+#[kani::proof]
 fn main() {
     let b: &dyn Bar = &();
     // The vtable for b will now have two Foo::method entries,

--- a/tests/kani/DynTrait/object_safe_trait.rs
+++ b/tests/kani/DynTrait/object_safe_trait.rs
@@ -40,6 +40,7 @@ impl NonDispatchable for S {
     }
 }
 
+#[kani::proof]
 fn main() {
     let s = S {};
     S::foo();

--- a/tests/kani/DynTrait/std_lib_add_duplicate.rs
+++ b/tests/kani/DynTrait/std_lib_add_duplicate.rs
@@ -18,6 +18,7 @@ fn weird_add(x: &dyn WeirdAdd, y: i32) -> i32 {
     x.add(y)
 }
 
+#[kani::proof]
 fn main() {
     let x = 2;
     let y = 4;

--- a/tests/kani/DynTrait/vtable_duplicate_field_override.rs
+++ b/tests/kani/DynTrait/vtable_duplicate_field_override.rs
@@ -45,6 +45,7 @@ impl T for S {
     }
 }
 
+#[kani::proof]
 fn main() {
     let t = S::new_box(1, 2, 3);
     let a = <dyn T as A>::foo(&*t);

--- a/tests/kani/DynTrait/vtable_duplicate_fields.rs
+++ b/tests/kani/DynTrait/vtable_duplicate_fields.rs
@@ -38,6 +38,7 @@ impl B for S {
 
 impl T for S {}
 
+#[kani::proof]
 fn main() {
     let t = S::new_box(1, 2);
     let a = <dyn T as A>::foo(&*t);

--- a/tests/kani/DynTrait/vtable_restrictions.rs
+++ b/tests/kani/DynTrait/vtable_restrictions.rs
@@ -45,7 +45,8 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
     if random_number < 5 { Box::new(Sheep {}) } else { Box::new(Cow {}) }
 }
 
-pub fn main() {
+#[kani::proof]
+fn main() {
     let random_number = kani::nondet();
     let animal = random_animal(random_number);
     let s = animal.noise();

--- a/tests/kani/DynTrait/vtable_restrictions_fail_fixme.rs
+++ b/tests/kani/DynTrait/vtable_restrictions_fail_fixme.rs
@@ -55,7 +55,8 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
     if random_number < 5 { Box::new(Sheep {}) } else { Box::new(Cow {}) }
 }
 
-pub fn main() {
+#[kani::proof]
+fn main() {
     let random_number = kani::nondet();
     let animal = random_animal(random_number);
     let s = animal.noise();

--- a/tests/kani/DynTrait/vtable_size_align_drop.rs
+++ b/tests/kani/DynTrait/vtable_size_align_drop.rs
@@ -45,6 +45,7 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
     if random_number < 5 { Box::new(Sheep { sheep_num: 7 }) } else { Box::new(Cow { cow_num: 9 }) }
 }
 
+#[kani::proof]
 fn main() {
     // The vtable is laid out as the right hand side here:
     //

--- a/tests/kani/DynTrait/vtable_size_align_drop_fail.rs
+++ b/tests/kani/DynTrait/vtable_size_align_drop_fail.rs
@@ -47,6 +47,7 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
     if random_number < 5 { Box::new(Sheep { sheep_num: 7 }) } else { Box::new(Cow { cow_num: 9 }) }
 }
 
+#[kani::proof]
 fn main() {
     let ptr_size = size_of::<&usize>() as isize;
 

--- a/tests/kani/EQ-NE/main.rs
+++ b/tests/kani/EQ-NE/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let x: u32 = kani::any();
     if x < u32::MAX >> 1 {

--- a/tests/kani/Enum/discriminant.rs
+++ b/tests/kani/Enum/discriminant.rs
@@ -14,7 +14,8 @@ fn foo(x: u32) -> Option<MyEnum> {
     if x > 10 { Some(MyEnum::Val2) } else { None }
 }
 
-pub fn main() {
+#[kani::proof]
+fn main() {
     let x = foo(15);
     assert!(x.is_some(), "assert");
 }

--- a/tests/kani/Enum/main.rs
+++ b/tests/kani/Enum/main.rs
@@ -7,6 +7,7 @@ fn foo() -> Result<i64, MyInfallible> {
     Ok(1)
 }
 
+#[kani::proof]
 fn main() {
     let v = foo().unwrap();
     assert!(v == 1);

--- a/tests/kani/Enum/min_offset.rs
+++ b/tests/kani/Enum/min_offset.rs
@@ -12,6 +12,7 @@ enum E {
     Bar,
 }
 
+#[kani::proof]
 fn main() {
     let e = E::Foo { a: 32, b: 100 };
     match e {

--- a/tests/kani/Enum/niche.rs
+++ b/tests/kani/Enum/niche.rs
@@ -17,6 +17,7 @@ fn bar() -> Result<(), MyError> {
     Ok(x)
 }
 
-pub fn main() {
+#[kani::proof]
+fn main() {
     bar();
 }

--- a/tests/kani/Enum/result1.rs
+++ b/tests/kani/Enum/result1.rs
@@ -3,6 +3,7 @@
 #[derive(Debug, PartialEq)]
 pub enum Empty {}
 
+#[kani::proof]
 fn main() {
     let res: Result<u32, Empty> = Ok(0);
     if let Ok(num) = res {

--- a/tests/kani/Enum/result2.rs
+++ b/tests/kani/Enum/result2.rs
@@ -3,6 +3,7 @@
 #[derive(Debug, PartialEq)]
 pub enum Empty {}
 
+#[kani::proof]
 fn main() {
     let res: Result<Empty, u32> = Err(0);
     if let Err(num) = res {

--- a/tests/kani/Enum/result3.rs
+++ b/tests/kani/Enum/result3.rs
@@ -10,6 +10,7 @@ fn foo(input: &Result<u32, Unit>) -> u32 {
     if let Ok(num) = input { *num } else { 3 }
 }
 
+#[kani::proof]
 fn main() {
     let input: Result<u32, Unit> = unsafe { kani::any_raw() };
     let x = foo(&input);

--- a/tests/kani/Enum/variants_multiple_len_2.rs
+++ b/tests/kani/Enum/variants_multiple_len_2.rs
@@ -6,6 +6,7 @@ pub enum EnumMultiple {
     Multiple2,
 }
 
+#[kani::proof]
 fn main() {
     let e = EnumMultiple::Multiple1;
 }

--- a/tests/kani/Enum/variants_single_len_1_fields_arbitrary_0.rs
+++ b/tests/kani/Enum/variants_single_len_1_fields_arbitrary_0.rs
@@ -5,6 +5,7 @@ pub enum EnumSingle {
     MySingle,
 }
 
+#[kani::proof]
 fn main() {
     let e = EnumSingle::MySingle;
     assert!(e == EnumSingle::MySingle);

--- a/tests/kani/Enum/variants_single_len_1_fields_arbitrary_1.rs
+++ b/tests/kani/Enum/variants_single_len_1_fields_arbitrary_1.rs
@@ -5,6 +5,7 @@ pub enum EnumSingle {
     MySingle(u32),
 }
 
+#[kani::proof]
 fn main() {
     let e = EnumSingle::MySingle(1);
     assert!(e == EnumSingle::MySingle(1));

--- a/tests/kani/Enum/variants_single_len_1_fields_arbitrary_2.rs
+++ b/tests/kani/Enum/variants_single_len_1_fields_arbitrary_2.rs
@@ -5,6 +5,7 @@ pub enum EnumSingle {
     MySingle(u32, u32),
 }
 
+#[kani::proof]
 fn main() {
     let e = EnumSingle::MySingle(1, 1);
     assert!(e == EnumSingle::MySingle(1, 1));

--- a/tests/kani/Enum/variants_single_len_2_fields_arbitrary_1.rs
+++ b/tests/kani/Enum/variants_single_len_2_fields_arbitrary_1.rs
@@ -8,6 +8,7 @@ pub enum MyInfallible {}
 fn foo() -> Result<i64, MyInfallible> {
     Ok(1)
 }
+#[kani::proof]
 fn main() {
     let v = foo().unwrap();
     assert!(v == 1);

--- a/tests/kani/ExactDiv/main.rs
+++ b/tests/kani/ExactDiv/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let a: u8 = 8;
     let b: u8 = 4;

--- a/tests/kani/FatPointers/boxmuttrait.rs
+++ b/tests/kani/FatPointers/boxmuttrait.rs
@@ -14,6 +14,7 @@ use std::ptr::DynMetadata;
 
 include!("../Helpers/vtable_utils_ignore.rs");
 
+#[kani::proof]
 fn main() {
     let mut log: Box<dyn Write + Send> = Box::new(sink());
     let dest: Box<dyn Write + Send> = Box::new(log.as_mut());

--- a/tests/kani/FatPointers/boxmuttrait_fail.rs
+++ b/tests/kani/FatPointers/boxmuttrait_fail.rs
@@ -4,6 +4,7 @@
 
 use std::io::{sink, Write};
 
+#[kani::proof]
 fn main() {
     let mut log: Box<dyn Write + Send> = Box::new(sink());
     let dest: Box<dyn Write + Send> = Box::new(log.as_mut());

--- a/tests/kani/FatPointers/boxslice1.rs
+++ b/tests/kani/FatPointers/boxslice1.rs
@@ -7,6 +7,7 @@
 // Casts boxed array to boxed slice (example taken from rust documentation)
 use std::str;
 
+#[kani::proof]
 fn main() {
     // This vector of bytes is used to initialize a Box<[u8; 4]>
     let sparkle_heart_vec = vec![240, 159, 146, 150];

--- a/tests/kani/FatPointers/boxslice2.rs
+++ b/tests/kani/FatPointers/boxslice2.rs
@@ -5,6 +5,7 @@
 // Casts boxed array to boxed slice (example taken from rust documentation)
 use std::str;
 
+#[kani::proof]
 fn main() {
     // This vector of bytes is used to initialize a Box<[u8; 4]>
     let sparkle_heart_vec = vec![240, 159, 146, 150];

--- a/tests/kani/FatPointers/boxtrait.rs
+++ b/tests/kani/FatPointers/boxtrait.rs
@@ -27,6 +27,7 @@ impl Trait for Concrete {
     }
 }
 
+#[kani::proof]
 fn main() {
     let mut x: Box<dyn Trait> = Box::new(Concrete::new());
     x.increment();

--- a/tests/kani/FatPointers/boxtrait_fail.rs
+++ b/tests/kani/FatPointers/boxtrait_fail.rs
@@ -28,6 +28,7 @@ impl Trait for Concrete {
     }
 }
 
+#[kani::proof]
 fn main() {
     let mut x: Box<dyn Trait> = Box::new(Concrete::new());
     x.increment();

--- a/tests/kani/FatPointers/fixme_slice2.rs
+++ b/tests/kani/FatPointers/fixme_slice2.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let array = [1, 2, 3, 4, 5, 6];
     let slice = &array[2..5];

--- a/tests/kani/FatPointers/slice1.rs
+++ b/tests/kani/FatPointers/slice1.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let array = [1, 2, 3, 4, 5, 6];
     let slice: &[u32] = &array;

--- a/tests/kani/FatPointers/slice3.rs
+++ b/tests/kani/FatPointers/slice3.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let array = [1, 2, 3, 4, 5, 6];
     let slice1 = &array[2..5];

--- a/tests/kani/FatPointers/structslice.rs
+++ b/tests/kani/FatPointers/structslice.rs
@@ -9,6 +9,7 @@ struct Abstract<'a> {
     uints: &'a [u32],
 }
 
+#[kani::proof]
 fn main() {
     let x = Concrete { array: [1, 2, 3, 4] };
     assert!(x.array[0] == 1);

--- a/tests/kani/FatPointers/trait1.rs
+++ b/tests/kani/FatPointers/trait1.rs
@@ -24,6 +24,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
+#[kani::proof]
 fn main() {
     let _d = DummySubscriber::new();
     let _s = &_d as &dyn Subscriber;

--- a/tests/kani/FatPointers/trait1_fail.rs
+++ b/tests/kani/FatPointers/trait1_fail.rs
@@ -25,6 +25,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
+#[kani::proof]
 fn main() {
     let _d = DummySubscriber::new();
     let _s = &_d as &dyn Subscriber;

--- a/tests/kani/FatPointers/trait2.rs
+++ b/tests/kani/FatPointers/trait2.rs
@@ -24,6 +24,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
+#[kani::proof]
 fn main() {
     let _d = DummySubscriber::new();
     let _s = &_d as *const dyn Subscriber;

--- a/tests/kani/FatPointers/trait2_fail.rs
+++ b/tests/kani/FatPointers/trait2_fail.rs
@@ -25,6 +25,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
+#[kani::proof]
 fn main() {
     let _d = DummySubscriber::new();
     let _s = &_d as *const dyn Subscriber;

--- a/tests/kani/FatPointers/trait3.rs
+++ b/tests/kani/FatPointers/trait3.rs
@@ -28,6 +28,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
+#[kani::proof]
 fn main() {
     let d = DummySubscriber::new();
 

--- a/tests/kani/FatPointers/trait3_fail.rs
+++ b/tests/kani/FatPointers/trait3_fail.rs
@@ -29,6 +29,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
+#[kani::proof]
 fn main() {
     let d = DummySubscriber::new();
 

--- a/tests/kani/FileNameWithSpace/my src/hi.rs
+++ b/tests/kani/FileNameWithSpace/my src/hi.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let cond: bool = kani::any();
     kani::assume(cond);

--- a/tests/kani/FloatingPoint/main.rs
+++ b/tests/kani/FloatingPoint/main.rs
@@ -21,6 +21,7 @@ macro_rules! test_floats {
     };
 }
 
+#[kani::proof]
 fn main() {
     assert!(1.1 == 1.1 * 1.0);
     assert!(1.1 != 1.11 / 1.0);

--- a/tests/kani/ForeignItems/fixme_main.rs
+++ b/tests/kani/ForeignItems/fixme_main.rs
@@ -48,6 +48,7 @@ extern "C" {
     fn takes_struct_ptr2(f: &Foo2) -> u32;
 }
 
+#[kani::proof]
 fn main() {
     unsafe {
         assert!(S == 12);

--- a/tests/kani/ForeignItems/fixme_varadic.rs
+++ b/tests/kani/ForeignItems/fixme_varadic.rs
@@ -13,6 +13,7 @@ extern "C" {
 
 }
 
+#[kani::proof]
 fn main() {
     unsafe {
         assert!(my_add(2 as usize, 3 as usize, 4 as usize) == 7); //works

--- a/tests/kani/ForeignItems/main.rs
+++ b/tests/kani/ForeignItems/main.rs
@@ -36,6 +36,7 @@ extern "C" {
     fn takes_struct_ptr2(f: &Foo2) -> u32;
 }
 
+#[kani::proof]
 fn main() {
     unsafe {
         assert!(S == 12);

--- a/tests/kani/ForeignItems/missing_fn_fail.rs
+++ b/tests/kani/ForeignItems/missing_fn_fail.rs
@@ -10,6 +10,7 @@ extern "C" {
     fn missing_int_converter(i: u32) -> u32;
 }
 
+#[kani::proof]
 fn main() {
     unsafe {
         let x = missing_int_converter(3);

--- a/tests/kani/FunctionAbstractions/mem_replace.rs
+++ b/tests/kani/FunctionAbstractions/mem_replace.rs
@@ -3,6 +3,7 @@
 
 use std::mem;
 
+#[kani::proof]
 fn main() {
     let mut var1 = kani::any::<i32>();
     let mut var2 = kani::any::<i32>();

--- a/tests/kani/FunctionAbstractions/mem_swap.rs
+++ b/tests/kani/FunctionAbstractions/mem_swap.rs
@@ -3,6 +3,7 @@
 
 use std::mem;
 
+#[kani::proof]
 fn main() {
     let mut var1 = kani::any::<i32>();
     let mut var2 = kani::any::<i32>();

--- a/tests/kani/FunctionAbstractions/ptr_read.rs
+++ b/tests/kani/FunctionAbstractions/ptr_read.rs
@@ -3,6 +3,7 @@
 
 use std::ptr::read;
 
+#[kani::proof]
 fn main() {
     let var = 1;
     unsafe {

--- a/tests/kani/FunctionAbstractions/ptr_write.rs
+++ b/tests/kani/FunctionAbstractions/ptr_write.rs
@@ -3,6 +3,7 @@
 
 use std::ptr::write;
 
+#[kani::proof]
 fn main() {
     let mut var = 1;
     unsafe {

--- a/tests/kani/FunctionCall/FnPtr/main.rs
+++ b/tests/kani/FunctionCall/FnPtr/main.rs
@@ -10,6 +10,7 @@ pub struct LocalKey {
 unsafe fn foo(x: i32) -> i32 {
     x + 1
 }
+#[kani::proof]
 fn main() {
     let l = LocalKey { inner: foo };
     unsafe { assert!((l.inner)(3) == 4) }

--- a/tests/kani/FunctionCall/Variadic/fixme_main.rs
+++ b/tests/kani/FunctionCall/Variadic/fixme_main.rs
@@ -14,6 +14,7 @@ pub unsafe extern "C" fn my_add(num: c_long, mut args: ...) -> c_long {
     accum
 }
 
+#[kani::proof]
 fn main() {
     let arg0: c_long = 2;
     let arg1: c_long = 3;

--- a/tests/kani/FunctionCall/Variadic/main.rs
+++ b/tests/kani/FunctionCall/Variadic/main.rs
@@ -12,6 +12,7 @@ type c_long = i64;
 
 pub unsafe extern "C" fn syscall(_num: c_long, _: ...) {}
 
+#[kani::proof]
 fn main() {
     let arg0: c_long = 0;
     let arg1: c_long = 1;

--- a/tests/kani/FunctionCall_ImplicitReturn/main.rs
+++ b/tests/kani/FunctionCall_ImplicitReturn/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     assert!(x_plus_two_1(0) == 2);
     assert!(x_plus_two_2(1) == 3);

--- a/tests/kani/FunctionCall_NoRet-NoParam/main.rs
+++ b/tests/kani/FunctionCall_NoRet-NoParam/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     assert!(true);
     trivial_function();

--- a/tests/kani/FunctionCall_NoRet-Param/main.rs
+++ b/tests/kani/FunctionCall_NoRet-Param/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     check_u32(4);
     check_u32(123);

--- a/tests/kani/FunctionCall_Ret-NoParam/main.rs
+++ b/tests/kani/FunctionCall_Ret-NoParam/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let a = return_u32();
     assert!(a < 10);

--- a/tests/kani/FunctionCall_Ret-Param/main.rs
+++ b/tests/kani/FunctionCall_Ret-Param/main.rs
@@ -8,6 +8,7 @@
 // a verification failure (the loop being unwound depends on
 // a nondet. variable)
 
+#[kani::proof]
 fn main() {
     let x: u32 = kani::any();
     let pi = 3.14159265359;

--- a/tests/kani/Generator/main.rs
+++ b/tests/kani/Generator/main.rs
@@ -21,6 +21,7 @@ fn maybe_call(call: bool) {
     }
 }
 
+#[kani::proof]
 fn main() {
     maybe_call(false);
 }

--- a/tests/kani/IfElseifElse_NonReturning/main.rs
+++ b/tests/kani/IfElseifElse_NonReturning/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let a: u32 = kani::any();
 

--- a/tests/kani/IfElseifElse_Returning/main.rs
+++ b/tests/kani/IfElseifElse_Returning/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let a: u32 = kani::any();
 

--- a/tests/kani/Intrinsics/Assert/inhabited_panic.rs
+++ b/tests/kani/Intrinsics/Assert/inhabited_panic.rs
@@ -9,6 +9,7 @@ use std::mem::MaybeUninit;
 // This should cause the intrinsic `assert_inhabited` to generate a panic during
 // compilation, but at present it triggers the `Nevers` hook instead.
 // See https://github.com/model-checking/kani/issues/751
+#[kani::proof]
 fn main() {
     let _uninit_never: () = unsafe {
         MaybeUninit::<!>::uninit().assume_init();

--- a/tests/kani/Intrinsics/Assert/uninit_valid_panic.rs
+++ b/tests/kani/Intrinsics/Assert/uninit_valid_panic.rs
@@ -7,6 +7,7 @@ use std::intrinsics;
 
 // The code below attempts to leave type `bool` uninitialized, causing the
 // intrinsic `assert_uninit_valid` to generate a panic during compilation.
+#[kani::proof]
 fn main() {
     let _var: () = unsafe {
         intrinsics::assert_uninit_valid::<bool>();

--- a/tests/kani/Intrinsics/Assert/zero_valid.rs
+++ b/tests/kani/Intrinsics/Assert/zero_valid.rs
@@ -18,6 +18,7 @@ fn do_test<T: std::cmp::Eq>(init: T, expected: T) {
     assert!(expected == x);
 }
 
+#[kani::proof]
 fn main() {
     do_test::<bool>(true, false);
     do_test::<i8>(-42, 0);

--- a/tests/kani/Intrinsics/Assert/zero_valid_panic.rs
+++ b/tests/kani/Intrinsics/Assert/zero_valid_panic.rs
@@ -7,6 +7,7 @@ use std::intrinsics;
 
 // The code below attempts to zero-initialize type `&i32`, causing the intrinsic
 // `assert_zero_valid` to generate a panic during compilation.
+#[kani::proof]
 fn main() {
     let _var: () = unsafe {
         intrinsics::assert_zero_valid::<&i32>();

--- a/tests/kani/Intrinsics/Atomic/Stable/CompareExchange/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Stable/CompareExchange/main.rs
@@ -6,6 +6,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[kani::proof]
 fn main() {
     // pub fn compare_exchange(
     //     &self,

--- a/tests/kani/Intrinsics/Atomic/Stable/Exchange/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Stable/Exchange/main.rs
@@ -6,6 +6,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[kani::proof]
 fn main() {
     let a1 = AtomicBool::new(true);
     let a2 = AtomicBool::new(true);

--- a/tests/kani/Intrinsics/Atomic/Stable/Fence/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Stable/Fence/main.rs
@@ -6,6 +6,7 @@
 
 use std::sync::atomic::{fence, Ordering};
 
+#[kani::proof]
 fn main() {
     // pub fn fence(order: Ordering)
     // An atomic fence.

--- a/tests/kani/Intrinsics/Atomic/Stable/FetchAdd/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Stable/FetchAdd/main.rs
@@ -6,6 +6,7 @@
 
 use std::sync::atomic::{AtomicIsize, Ordering};
 
+#[kani::proof]
 fn main() {
     // pub fn fetch_add(&self, val: isize, order: Ordering) -> isize
     // Adds to the current value, returning the previous value.

--- a/tests/kani/Intrinsics/Atomic/Stable/FetchAnd/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Stable/FetchAnd/main.rs
@@ -6,6 +6,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[kani::proof]
 fn main() {
     // pub fn fetch_and(&self, val: bool, order: Ordering) -> bool
     // Performs a logical "and" operation on the current value and

--- a/tests/kani/Intrinsics/Atomic/Stable/FetchOr/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Stable/FetchOr/main.rs
@@ -6,6 +6,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[kani::proof]
 fn main() {
     // pub fn fetch_or(&self, val: bool, order: Ordering) -> bool
     // Performs a logical "or" operation on the current value and

--- a/tests/kani/Intrinsics/Atomic/Stable/FetchSub/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Stable/FetchSub/main.rs
@@ -6,6 +6,7 @@
 
 use std::sync::atomic::{AtomicIsize, Ordering};
 
+#[kani::proof]
 fn main() {
     // pub fn fetch_sub(&self, val: isize, order: Ordering) -> isize
     // Subtracts from the current value, returning the previous value.

--- a/tests/kani/Intrinsics/Atomic/Stable/FetchXor/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Stable/FetchXor/main.rs
@@ -6,6 +6,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[kani::proof]
 fn main() {
     // pub fn fetch_xor(&self, val: bool, order: Ordering) -> bool
     // Performs a bitwise "xor" operation on the current value and

--- a/tests/kani/Intrinsics/Atomic/Stable/Load/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Stable/Load/main.rs
@@ -6,6 +6,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[kani::proof]
 fn main() {
     // pub fn load(&self, order: Ordering) -> bool
     // Loads a value from the bool.

--- a/tests/kani/Intrinsics/Atomic/Stable/Store/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Stable/Store/main.rs
@@ -6,6 +6,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[kani::proof]
 fn main() {
     // ppub fn store(&self, val: bool, order: Ordering)
     // Stores a value into the bool.

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicAdd/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicAdd/main.rs
@@ -9,6 +9,7 @@ use std::intrinsics::{
     atomic_xadd, atomic_xadd_acq, atomic_xadd_acqrel, atomic_xadd_rel, atomic_xadd_relaxed,
 };
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let mut a2 = 0 as u8;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicAnd/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicAnd/main.rs
@@ -9,6 +9,7 @@ use std::intrinsics::{
     atomic_and, atomic_and_acq, atomic_and_acqrel, atomic_and_rel, atomic_and_relaxed,
 };
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let mut a2 = 1 as u8;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicCxchg/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicCxchg/main.rs
@@ -11,6 +11,7 @@ use std::intrinsics::{
     atomic_cxchg_rel, atomic_cxchg_relaxed,
 };
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let mut a2 = 0 as u8;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicCxchgWeak/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicCxchgWeak/main.rs
@@ -11,6 +11,7 @@ use std::intrinsics::{
     atomic_cxchgweak_failrelaxed, atomic_cxchgweak_rel, atomic_cxchgweak_relaxed,
 };
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let mut a2 = 0 as u8;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicFence/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicFence/main.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{atomic_fence, atomic_fence_acq, atomic_fence_acqrel, atomic_fence_rel};
 
+#[kani::proof]
 fn main() {
     unsafe {
         atomic_fence();

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicLoad/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicLoad/main.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{atomic_load, atomic_load_acq, atomic_load_relaxed};
 
+#[kani::proof]
 fn main() {
     let a1 = 1 as u8;
     let a2 = 1 as u8;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicMax/max.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicMax/max.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_max;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicMax/max_acq.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicMax/max_acq.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_max_acq;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicMax/max_acqrel.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicMax/max_acqrel.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_max_acqrel;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicMax/max_rel.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicMax/max_rel.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_max_rel;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicMax/max_relaxed.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicMax/max_relaxed.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_max_relaxed;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicMin/min.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicMin/min.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_min;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicMin/min_acq.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicMin/min_acq.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_min_acq;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicMin/min_acqrel.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicMin/min_acqrel.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_min_acqrel;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicMin/min_rel.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicMin/min_rel.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_min_rel;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicMin/min_relaxed.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicMin/min_relaxed.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_min_relaxed;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicNand/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicNand/main.rs
@@ -9,6 +9,7 @@ use std::intrinsics::{
     atomic_nand, atomic_nand_acq, atomic_nand_acqrel, atomic_nand_rel, atomic_nand_relaxed,
 };
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let mut a2 = 0 as u8;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicOr/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicOr/main.rs
@@ -9,6 +9,7 @@ use std::intrinsics::{
     atomic_or, atomic_or_acq, atomic_or_acqrel, atomic_or_rel, atomic_or_relaxed,
 };
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let mut a2 = 1 as u8;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicSingleThreadFence/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicSingleThreadFence/main.rs
@@ -10,6 +10,7 @@ use std::intrinsics::{
     atomic_singlethreadfence_rel,
 };
 
+#[kani::proof]
 fn main() {
     unsafe {
         atomic_singlethreadfence();

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicStore/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicStore/main.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{atomic_store, atomic_store_rel, atomic_store_relaxed};
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let mut a2 = 1 as u8;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicSub/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicSub/main.rs
@@ -9,6 +9,7 @@ use std::intrinsics::{
     atomic_xsub, atomic_xsub_acq, atomic_xsub_acqrel, atomic_xsub_rel, atomic_xsub_relaxed,
 };
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let mut a2 = 1 as u8;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmax/umax.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmax/umax.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_umax;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmax/umax_acq.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmax/umax_acq.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_umax_acq;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmax/umax_acqrel.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmax/umax_acqrel.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_umax_acqrel;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmax/umax_rel.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmax/umax_rel.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_umax_rel;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmax/umax_relaxed.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmax/umax_relaxed.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_max_relaxed;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmin/umin.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmin/umin.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_umin;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmin/umin_acq.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmin/umin_acq.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_umin_acq;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmin/umin_acqrel.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmin/umin_acqrel.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_umin_acqrel;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmin/umin_rel.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmin/umin_rel.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_umin_rel;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmin/umin_relaxed.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicUmin/umin_relaxed.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::atomic_umin_relaxed;
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let ptr_a1: *mut u8 = &mut a1;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicXchg/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicXchg/main.rs
@@ -9,6 +9,7 @@ use std::intrinsics::{
     atomic_xchg, atomic_xchg_acq, atomic_xchg_acqrel, atomic_xchg_rel, atomic_xchg_relaxed,
 };
 
+#[kani::proof]
 fn main() {
     let mut a1 = 0 as u8;
     let mut a2 = 0 as u8;

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicXor/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicXor/main.rs
@@ -9,6 +9,7 @@ use std::intrinsics::{
     atomic_xor, atomic_xor_acq, atomic_xor_acqrel, atomic_xor_rel, atomic_xor_relaxed,
 };
 
+#[kani::proof]
 fn main() {
     let mut a1 = 1 as u8;
     let mut a2 = 1 as u8;

--- a/tests/kani/Intrinsics/Compiler/variant_count.rs
+++ b/tests/kani/Intrinsics/Compiler/variant_count.rs
@@ -11,6 +11,7 @@ use std::mem;
 
 enum Void {}
 
+#[kani::proof]
 fn main() {
     let _ = mem::variant_count::<Void>();
 }

--- a/tests/kani/Intrinsics/Compiler/variant_count_fixme.rs
+++ b/tests/kani/Intrinsics/Compiler/variant_count_fixme.rs
@@ -13,6 +13,7 @@ enum MyError {
     Error3,
 }
 
+#[kani::proof]
 fn main() {
     assert!(mem::variant_count::<Void>() == 0);
     assert!(mem::variant_count::<MyError>() == 3);

--- a/tests/kani/Intrinsics/Count/ctlz_nonzero_panic.rs
+++ b/tests/kani/Intrinsics/Count/ctlz_nonzero_panic.rs
@@ -15,6 +15,7 @@ macro_rules! test_ctlz_nonzero {
     };
 }
 
+#[kani::proof]
 fn main() {
     test_ctlz_nonzero!(u8);
     test_ctlz_nonzero!(u16);

--- a/tests/kani/Intrinsics/Count/cttz.rs
+++ b/tests/kani/Intrinsics/Count/cttz.rs
@@ -49,6 +49,7 @@ macro_rules! test_cttz_nonzero {
     };
 }
 
+#[kani::proof]
 fn main() {
     test_cttz!(my_cttz_u8, u8);
     test_cttz!(my_cttz_u16, u16);

--- a/tests/kani/Intrinsics/Count/cttz_nonzero_panic.rs
+++ b/tests/kani/Intrinsics/Count/cttz_nonzero_panic.rs
@@ -15,6 +15,7 @@ macro_rules! test_cttz_nonzero {
     };
 }
 
+#[kani::proof]
 fn main() {
     test_cttz_nonzero!(u8);
     test_cttz_nonzero!(u16);

--- a/tests/kani/Intrinsics/Count/fixme_ctlz.rs
+++ b/tests/kani/Intrinsics/Count/fixme_ctlz.rs
@@ -46,6 +46,7 @@ macro_rules! test_ctlz_nonzero {
     };
 }
 
+#[kani::proof]
 fn main() {
     test_ctlz!(my_ctlz_u8, u8);
     test_ctlz!(my_ctlz_u16, u16);

--- a/tests/kani/Intrinsics/FastMath/add_f32.rs
+++ b/tests/kani/Intrinsics/FastMath/add_f32.rs
@@ -4,6 +4,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f32 = kani::any();
     let y: f32 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/add_f64.rs
+++ b/tests/kani/Intrinsics/FastMath/add_f64.rs
@@ -4,6 +4,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f64 = kani::any();
     let y: f64 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/add_overflow_f32.rs
+++ b/tests/kani/Intrinsics/FastMath/add_overflow_f32.rs
@@ -5,6 +5,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f32 = kani::any();
     let y: f32 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/add_overflow_f64.rs
+++ b/tests/kani/Intrinsics/FastMath/add_overflow_f64.rs
@@ -5,6 +5,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f64 = kani::any();
     let y: f64 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/div_f32.rs
+++ b/tests/kani/Intrinsics/FastMath/div_f32.rs
@@ -19,6 +19,7 @@ fn assume_fp_range(val: f32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     let x: f32 = kani::any();
     let y: f32 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/div_f64.rs
+++ b/tests/kani/Intrinsics/FastMath/div_f64.rs
@@ -19,6 +19,7 @@ fn assume_fp_range(val: f64) {
     }
 }
 
+#[kani::proof]
 fn main() {
     let x: f64 = kani::any();
     let y: f64 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/div_overflow_f32.rs
+++ b/tests/kani/Intrinsics/FastMath/div_overflow_f32.rs
@@ -5,6 +5,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f32 = kani::any();
     let y: f32 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/div_overflow_f64.rs
+++ b/tests/kani/Intrinsics/FastMath/div_overflow_f64.rs
@@ -5,6 +5,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f64 = kani::any();
     let y: f64 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/mul_f32.rs
+++ b/tests/kani/Intrinsics/FastMath/mul_f32.rs
@@ -16,6 +16,7 @@ fn assume_fp_range(val: f32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     let x: f32 = kani::any();
     let y: f32 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/mul_f64.rs
+++ b/tests/kani/Intrinsics/FastMath/mul_f64.rs
@@ -16,6 +16,7 @@ fn assume_fp_range(val: f64) {
     }
 }
 
+#[kani::proof]
 fn main() {
     let x: f64 = kani::any();
     let y: f64 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/mul_overflow_f32.rs
+++ b/tests/kani/Intrinsics/FastMath/mul_overflow_f32.rs
@@ -5,6 +5,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f32 = kani::any();
     let y: f32 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/mul_overflow_f64.rs
+++ b/tests/kani/Intrinsics/FastMath/mul_overflow_f64.rs
@@ -5,6 +5,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f64 = kani::any();
     let y: f64 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/sub_f32.rs
+++ b/tests/kani/Intrinsics/FastMath/sub_f32.rs
@@ -4,6 +4,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f32 = kani::any();
     let y: f32 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/sub_f64.rs
+++ b/tests/kani/Intrinsics/FastMath/sub_f64.rs
@@ -4,6 +4,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f64 = kani::any();
     let y: f64 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/sub_overflow_f32.rs
+++ b/tests/kani/Intrinsics/FastMath/sub_overflow_f32.rs
@@ -5,6 +5,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f32 = kani::any();
     let y: f32 = kani::any();

--- a/tests/kani/Intrinsics/FastMath/sub_overflow_f64.rs
+++ b/tests/kani/Intrinsics/FastMath/sub_overflow_f64.rs
@@ -5,6 +5,7 @@
 
 #![feature(core_intrinsics)]
 
+#[kani::proof]
 fn main() {
     let x: f64 = kani::any();
     let y: f64 = kani::any();

--- a/tests/kani/Intrinsics/Likely/main.rs
+++ b/tests/kani/Intrinsics/Likely/main.rs
@@ -27,6 +27,7 @@ fn check_unlikely(x: i32, y: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     let x = kani::any();
     let y = kani::any();

--- a/tests/kani/Intrinsics/NonRet/abort.rs
+++ b/tests/kani/Intrinsics/NonRet/abort.rs
@@ -13,6 +13,7 @@
 // The documentation mentions that `std::process::abort` is preferred if
 // possible: https://doc.rust-lang.org/core/intrinsics/fn.abort.html
 // In Kani, `std::process::abort` is identified as a panicking function
+#[kani::proof]
 fn main() {
     std::intrinsics::abort();
 }

--- a/tests/kani/Intrinsics/NonRet/transmute_zst.rs
+++ b/tests/kani/Intrinsics/NonRet/transmute_zst.rs
@@ -8,6 +8,7 @@
 //
 // Handled as a special case of transmute (non returning intrinsic) that
 // compiles but crashes at runtime, similar to calling `std::intrinsic::abort`
+#[kani::proof]
 fn main() {
     unsafe { std::mem::transmute::<(), !>(()) };
 }

--- a/tests/kani/Intrinsics/Rotate/rotate_left.rs
+++ b/tests/kani/Intrinsics/Rotate/rotate_left.rs
@@ -32,6 +32,7 @@ macro_rules! test_rotate_left {
     };
 }
 
+#[kani::proof]
 fn main() {
     test_rotate_left!(check_rol_u8, u8);
     test_rotate_left!(check_rol_u16, u16);

--- a/tests/kani/Intrinsics/Rotate/rotate_right.rs
+++ b/tests/kani/Intrinsics/Rotate/rotate_right.rs
@@ -39,6 +39,7 @@ macro_rules! test_rotate_right {
     };
 }
 
+#[kani::proof]
 fn main() {
     test_rotate_right!(check_ror_u8, u8);
     test_rotate_right!(check_ror_u16, u16);

--- a/tests/kani/Intrinsics/Saturating/main.rs
+++ b/tests/kani/Intrinsics/Saturating/main.rs
@@ -53,6 +53,7 @@ macro_rules! test_saturating_intrinsics {
     };
 }
 
+#[kani::proof]
 fn main() {
     test_saturating_intrinsics!(u8);
     test_saturating_intrinsics!(u16);

--- a/tests/kani/Intrinsics/Volatile/store.rs
+++ b/tests/kani/Intrinsics/Volatile/store.rs
@@ -14,6 +14,7 @@ struct NonPacked {
     unaligned: u32,
 }
 
+#[kani::proof]
 fn main() {
     let mut packed: NonPacked = unsafe { std::mem::zeroed() };
     // Take the address of a 32-bit integer which is not aligned.

--- a/tests/kani/Intrinsics/Volatile/store_fail.rs
+++ b/tests/kani/Intrinsics/Volatile/store_fail.rs
@@ -16,6 +16,7 @@ struct Packed {
     unaligned: u32,
 }
 
+#[kani::proof]
 fn main() {
     let mut packed: Packed = unsafe { std::mem::zeroed() };
     // Take the address of a 32-bit integer which is not aligned.

--- a/tests/kani/Intrinsics/bitreverse.rs
+++ b/tests/kani/Intrinsics/bitreverse.rs
@@ -25,6 +25,7 @@ macro_rules! test_bitreverse_intrinsic {
 }
 
 #[allow(overflowing_literals)]
+#[kani::proof]
 fn main() {
     test_bitreverse_intrinsic!(u8, check_reverse_u8, get_bit_at_u8);
     test_bitreverse_intrinsic!(u16, check_reverse_u16, get_bit_at_u16);

--- a/tests/kani/Intrinsics/black_box.rs
+++ b/tests/kani/Intrinsics/black_box.rs
@@ -4,6 +4,7 @@
 #![feature(bench_black_box)]
 use std::hint::black_box;
 
+#[kani::proof]
 fn main() {
     // black_box is an identity function that limits compiler optimizations
     let a = 10;

--- a/tests/kani/Intrinsics/fixme_catch_unwind.rs
+++ b/tests/kani/Intrinsics/fixme_catch_unwind.rs
@@ -5,6 +5,7 @@
 // Stable way of calling the `try` intrinsic.
 use std::panic;
 
+#[kani::proof]
 fn main() {
     let result = panic::catch_unwind(|| {
         println!("hello!");

--- a/tests/kani/Intrinsics/fixme_try.rs
+++ b/tests/kani/Intrinsics/fixme_try.rs
@@ -5,6 +5,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::r#try;
 
+#[kani::proof]
 fn main() {
     unsafe {
         // Rust will make a best-effort to swallow the panic, and then execute the cleanup function.

--- a/tests/kani/Intrinsics/needs_drop.rs
+++ b/tests/kani/Intrinsics/needs_drop.rs
@@ -15,6 +15,7 @@ impl<T> Foo<T> {
     }
 }
 
+#[kani::proof]
 fn main() {
     // Integers don't need to be dropped
     let int_foo = Foo::<i32> { _foo: 0 };

--- a/tests/kani/Intrinsics/raw_eq.rs
+++ b/tests/kani/Intrinsics/raw_eq.rs
@@ -4,6 +4,7 @@
 #![feature(const_intrinsic_raw_eq)]
 #![deny(const_err)]
 
+#[kani::proof]
 fn main() {
     // Check that we get the expected results for the `raw_eq` intrinsic
     use std::intrinsics::raw_eq;

--- a/tests/kani/Invariants/array.rs
+++ b/tests/kani/Invariants/array.rs
@@ -8,6 +8,7 @@ extern crate kani;
 
 use kani::Invariant;
 
+#[kani::proof]
 fn main() {
     let arr: [char; 2] = kani::any();
     assert!(arr[0].is_valid());

--- a/tests/kani/Invariants/array_raw_fail.rs
+++ b/tests/kani/Invariants/array_raw_fail.rs
@@ -8,6 +8,7 @@ extern crate kani;
 
 use kani::Invariant;
 
+#[kani::proof]
 fn main() {
     let arr_raw: [char; 2] = unsafe { kani::any_raw() };
     kani::expect_fail(arr_raw[0].is_valid(), "Should fail");

--- a/tests/kani/Invariants/bool.rs
+++ b/tests/kani/Invariants/bool.rs
@@ -3,6 +3,7 @@
 //
 // Ensure that kani::any::<bool> generates only valid booleans.
 
+#[kani::proof]
 fn main() {
     let b: bool = kani::any();
     match b {

--- a/tests/kani/Invariants/bool_raw_fail.rs
+++ b/tests/kani/Invariants/bool_raw_fail.rs
@@ -3,6 +3,7 @@
 //
 // Ensure that kani::any_raw::<bool> may generate invalid booleans.
 
+#[kani::proof]
 fn main() {
     let b: bool = unsafe { kani::any_raw() };
     assert!(matches!(b, true | false), "Rust converts any non-zero value to true");

--- a/tests/kani/Invariants/char.rs
+++ b/tests/kani/Invariants/char.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /// Check that kani::any respect the char::MAX limit.
-pub fn main() {
+#[kani::proof]
+fn main() {
     let c: char = kani::any();
     assert!(c <= char::MAX);
 }

--- a/tests/kani/Invariants/char_fail.rs
+++ b/tests/kani/Invariants/char_fail.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /// Check that kani::any_raw may generate invalid char.
-pub fn main() {
+#[kani::proof]
+fn main() {
     let c: char = unsafe { kani::any_raw() };
     kani::expect_fail(c <= char::MAX, "kani::any_raw() may generate invalid values");
 }

--- a/tests/kani/Invariants/enum.rs
+++ b/tests/kani/Invariants/enum.rs
@@ -60,6 +60,7 @@ check_enum!(check_basic, u8, Basic, 0, 1, 2);
 check_enum!(check_continuous, u8, Continuous, 10, 11, 12);
 check_enum!(check_random, i8, Random, -10, 100, 0);
 
+#[kani::proof]
 fn main() {
     check_basic();
     check_continuous();

--- a/tests/kani/Invariants/enum_raw_fail.rs
+++ b/tests/kani/Invariants/enum_raw_fail.rs
@@ -12,6 +12,7 @@ enum Basic {
     Variant3,
 }
 
+#[kani::proof]
 fn main() {
     let e = unsafe { kani::any_raw::<Basic>() };
     // This enum can be invalid and this code may actually not match any of the options below.

--- a/tests/kani/Invariants/fixme_niche_opt.rs
+++ b/tests/kani/Invariants/fixme_niche_opt.rs
@@ -31,6 +31,7 @@ fn to_option<T: Copy, E>(result: &Result<T, E>) -> Option<T> {
     if let Ok(v) = *result { Some(v) } else { None }
 }
 
+#[kani::proof]
 fn main() {
     let result: Result<(), Error> = Ok(());
     assert!(to_option(&result).is_some());

--- a/tests/kani/Invariants/float.rs
+++ b/tests/kani/Invariants/float.rs
@@ -16,6 +16,7 @@ macro_rules! test {
     }};
 }
 
+#[kani::proof]
 fn main() {
     test!(f32);
     test!(f64);

--- a/tests/kani/Invariants/integer.rs
+++ b/tests/kani/Invariants/integer.rs
@@ -12,6 +12,7 @@ macro_rules! test {
     }};
 }
 
+#[kani::proof]
 fn main() {
     test!(i8);
     test!(i16);

--- a/tests/kani/Invariants/nonzero.rs
+++ b/tests/kani/Invariants/nonzero.rs
@@ -22,6 +22,7 @@ macro_rules! test {
     }};
 }
 
+#[kani::proof]
 fn main() {
     test!(NonZeroI8);
     test!(NonZeroI16);

--- a/tests/kani/Invariants/option.rs
+++ b/tests/kani/Invariants/option.rs
@@ -17,6 +17,7 @@ unsafe impl kani::Invariant for MyType {
     }
 }
 
+#[kani::proof]
 fn main() {
     let option: Option<MyType> = kani::any();
     match option {

--- a/tests/kani/Invariants/option_raw_fail.rs
+++ b/tests/kani/Invariants/option_raw_fail.rs
@@ -17,6 +17,7 @@ unsafe impl kani::Invariant for MyType {
     }
 }
 
+#[kani::proof]
 fn main() {
     let option: Option<MyType> = unsafe { kani::any_raw() };
     if let Some(ref v) = option {

--- a/tests/kani/Invariants/result.rs
+++ b/tests/kani/Invariants/result.rs
@@ -30,6 +30,7 @@ unsafe impl kani::Invariant for Error {
     }
 }
 
+#[kani::proof]
 fn main() {
     let result: Result<MyType, Error> = kani::any();
     match result {

--- a/tests/kani/Invariants/result_raw_fail.rs
+++ b/tests/kani/Invariants/result_raw_fail.rs
@@ -30,6 +30,7 @@ unsafe impl kani::Invariant for Error {
     }
 }
 
+#[kani::proof]
 fn main() {
     let result: Result<MyType, Error> = unsafe { kani::any_raw() };
     if let Ok(ref v) = result {

--- a/tests/kani/Iterator/try_fold.rs
+++ b/tests/kani/Iterator/try_fold.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // cbmc-flags: --unwind 3
 
+#[kani::proof]
 fn main() {
     let arr = [(1, 2), (2, 2)];
     let result = arr.iter().try_fold((), |acc, &i| Some(()));

--- a/tests/kani/LT-GT-LE-GE/main.rs
+++ b/tests/kani/LT-GT-LE-GE/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let a: u32 = kani::any();
     let b = a / 2;

--- a/tests/kani/LoopLoop_NonReturning/main.rs
+++ b/tests/kani/LoopLoop_NonReturning/main.rs
@@ -3,6 +3,7 @@
 
 // cbmc-flags: --unwind 10
 
+#[kani::proof]
 fn main() {
     let mut a: u32 = kani::any();
 

--- a/tests/kani/LoopLoop_NonReturning/main_no_unwind_asserts.rs
+++ b/tests/kani/LoopLoop_NonReturning/main_no_unwind_asserts.rs
@@ -21,6 +21,7 @@
 //
 // ** 0 of 1 failed (1 iterations)
 // VERIFICATION SUCCESSFUL
+#[kani::proof]
 fn main() {
     let mut a: u32 = kani::any();
 

--- a/tests/kani/LoopWhile_NonReturning/main.rs
+++ b/tests/kani/LoopWhile_NonReturning/main.rs
@@ -3,6 +3,7 @@
 
 // cbmc-flags: --unwind 11
 
+#[kani::proof]
 fn main() {
     let mut a: u32 = kani::any();
 

--- a/tests/kani/LoopWhile_NonReturning/main_no_unwind_asserts.rs
+++ b/tests/kani/LoopWhile_NonReturning/main_no_unwind_asserts.rs
@@ -22,6 +22,7 @@
 //
 // ** 0 of 1 failed (1 iterations)
 // VERIFICATION SUCCESSFUL
+#[kani::proof]
 fn main() {
     let mut a: u32 = kani::any();
 

--- a/tests/kani/MemReplace/main.rs
+++ b/tests/kani/MemReplace/main.rs
@@ -4,6 +4,7 @@ enum Dummy {
     Dumb,
 }
 
+#[kani::proof]
 fn main() {
     // invoke replace on a zero-sized type
     let mut value: Dummy = Dummy::Dumb;

--- a/tests/kani/Never/main.rs
+++ b/tests/kani/Never/main.rs
@@ -13,4 +13,5 @@ pub fn bar(infalliable: Infallible) -> i32 {
 }
 
 // Give an empty main to make rustc happy.
+#[kani::proof]
 fn main() {}

--- a/tests/kani/Never/never_return.rs
+++ b/tests/kani/Never/never_return.rs
@@ -10,7 +10,6 @@ pub fn err() -> ! {
 }
 
 // Give an empty main to make rustc happy.
-#[no_mangle]
 #[kani::proof]
 fn main() {
     let var = kani::any::<i32>();

--- a/tests/kani/Never/never_return.rs
+++ b/tests/kani/Never/never_return.rs
@@ -11,6 +11,7 @@ pub fn err() -> ! {
 
 // Give an empty main to make rustc happy.
 #[no_mangle]
+#[kani::proof]
 fn main() {
     let var = kani::any::<i32>();
     if var > 0 {

--- a/tests/kani/NondetSlices/test1.rs
+++ b/tests/kani/NondetSlices/test1.rs
@@ -15,6 +15,7 @@ fn check(slice: &[u8]) {
     }
 }
 
+#[kani::proof]
 fn main() {
     let arr = [1, 2, 3];
     // The slice returned can be any of the following:

--- a/tests/kani/NondetSlices/test2.rs
+++ b/tests/kani/NondetSlices/test2.rs
@@ -7,6 +7,7 @@ fn check(s: &[u8]) {
     assert!(len >= 0 && len < 6, "Expected slice length to be between 0 and 5. Got {}.", len);
 }
 
+#[kani::proof]
 fn main() {
     // returns a slice of length between 0 and 5 with non-det content
     let slice: kani::slice::NonDetSlice<u8, 5> = kani::slice::any_slice();

--- a/tests/kani/NondetVectors/bytes.rs
+++ b/tests/kani/NondetVectors/bytes.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::convert::TryInto;
 
+#[kani::proof]
 fn main() {
     let input: &[u8] = &vec![
         kani::any(),

--- a/tests/kani/NondetVectors/fixme_main.rs
+++ b/tests/kani/NondetVectors/fixme_main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 const FIFO_SIZE: usize = 2;
+#[kani::proof]
 fn main() {
     let len: usize = kani::any();
     if !(len <= FIFO_SIZE) {

--- a/tests/kani/Options/check_tests.rs
+++ b/tests/kani/Options/check_tests.rs
@@ -18,7 +18,7 @@ mod test {
     use my_mod::fn_under_verification;
 
     #[test]
-    #[no_mangle]
+    #[kani::proof]
     fn test_harness() {
         let input: i32 = kani::nondet();
         kani::assume(input > 1);

--- a/tests/kani/Overflow/pointer_overflow_fail.rs
+++ b/tests/kani/Overflow/pointer_overflow_fail.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-verify-fail
 
-pub fn main() {
+#[kani::proof]
+fn main() {
     let a = [0; 5];
     let i: i32 = 0;
     let ptr1: *const i32 = &a[0];

--- a/tests/kani/Overflow/pointer_overflow_fixme.rs
+++ b/tests/kani/Overflow/pointer_overflow_fixme.rs
@@ -3,7 +3,8 @@
 // kani-verify-fail
 // This should fail, but doesn't due to https://github.com/diffblue/cbmc/issues/6631
 
-pub fn main() {
+#[kani::proof]
+fn main() {
     let a = [0; 5];
     let i: i32 = 0;
     let ptr1: *const i32 = &a[1];

--- a/tests/kani/Parenths/main.rs
+++ b/tests/kani/Parenths/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let a = 10;
     let b = (a + 6) / 2;

--- a/tests/kani/PointerOffset/Stable/main.rs
+++ b/tests/kani/PointerOffset/Stable/main.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     // pub unsafe fn offset_from(self, origin: *const T) -> isize
     // Calculates the distance between two pointers. The returned value

--- a/tests/kani/PointerOffset/Unstable/main.rs
+++ b/tests/kani/PointerOffset/Unstable/main.rs
@@ -4,6 +4,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::ptr_offset_from;
 
+#[kani::proof]
 fn main() {
     let a = [0; 5];
     let b = [0; 5];

--- a/tests/kani/PointerOffset/Unstable/main_fail.rs
+++ b/tests/kani/PointerOffset/Unstable/main_fail.rs
@@ -5,6 +5,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::ptr_offset_from;
 
+#[kani::proof]
 fn main() {
     let a = [0; 5];
     let b = [0; 5];

--- a/tests/kani/Pointers_Basic/fixme_from_raw.rs
+++ b/tests/kani/Pointers_Basic/fixme_from_raw.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-verify-fail
 
+#[kani::proof]
 fn main() {
     let address = 0x01234usize;
     let ptr = address as *mut i32;

--- a/tests/kani/Pointers_Basic/main.rs
+++ b/tests/kani/Pointers_Basic/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let x = 3;
     let y = &x;

--- a/tests/kani/Pointers_Functions/main.rs
+++ b/tests/kani/Pointers_Functions/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let mut x = 1;
     add_two(&mut x);

--- a/tests/kani/Pointers_InAssert/main.rs
+++ b/tests/kani/Pointers_InAssert/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let mut a = 5;
     let mut c = &mut a;

--- a/tests/kani/Pointers_OtherTypes/main.rs
+++ b/tests/kani/Pointers_OtherTypes/main.rs
@@ -8,6 +8,7 @@
 // [main.NaN.1] line 25 NaN on * in var_30 * 0.0f: FAILURE
 // Tracking issue: https://github.com/model-checking/kani/issues/307
 
+#[kani::proof]
 fn main() {
     let mut x = 1;
     add_two(&mut x);

--- a/tests/kani/Pointers_OutOfScopeFail/fixme_main.rs
+++ b/tests/kani/Pointers_OutOfScopeFail/fixme_main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-verify-fail
 
+#[kani::proof]
 fn main() {
     // declare pointer to integer
     let p_subscoped: *const u32;

--- a/tests/kani/Print/main.rs
+++ b/tests/kani/Print/main.rs
@@ -3,6 +3,7 @@
 
 // This test checks that the print macros do not result in verification failure
 
+#[kani::proof]
 fn main() {
     println!("Hello, world!");
     let a = 5;

--- a/tests/kani/Print/side_effects.rs
+++ b/tests/kani/Print/side_effects.rs
@@ -11,6 +11,7 @@ fn subtract_two(x: &mut i32) -> i32 {
     y
 }
 
+#[kani::proof]
 fn main() {
     let mut x = 5;
     println!("calling function with side-effect from println!: {}", subtract_two(&mut x));

--- a/tests/kani/ProjectionElem/ConstantIndex/main.rs
+++ b/tests/kani/ProjectionElem/ConstantIndex/main.rs
@@ -96,6 +96,7 @@ fn test4() {
     assert!(encode_utf8_raw(code, dst) == 0);
 }
 
+#[kani::proof]
 fn main() {
     test1();
     test2();

--- a/tests/kani/Refs/fixme_main.rs
+++ b/tests/kani/Refs/fixme_main.rs
@@ -79,6 +79,7 @@ impl<'a> ArgParser<'a> {
     }
 }
 
+#[kani::proof]
 fn main() {
     let a: ArgParser = ArgParser { arguments: BTreeMap::new() };
     a.format_arguments();

--- a/tests/kani/Repr/main.rs
+++ b/tests/kani/Repr/main.rs
@@ -13,6 +13,7 @@ fn mmap() -> *mut MyCVoid {
     0 as *mut MyCVoid
 }
 
+#[kani::proof]
 fn main() {
     let v = mmap();
     assert!(v != MAP_FAILED);

--- a/tests/kani/SIMD/Compare/main.rs
+++ b/tests/kani/SIMD/Compare/main.rs
@@ -31,6 +31,7 @@ macro_rules! assert_cmp {
 // Vectors are compared element-wise producing:
 //  * 0 when comparison is false
 //  * -1 (all bits set) otherwise
+#[kani::proof]
 fn main() {
     let x = i64x2(0, 0);
     let y = i64x2(0, 1);

--- a/tests/kani/SIMD/Construction/main.rs
+++ b/tests/kani/SIMD/Construction/main.rs
@@ -12,6 +12,7 @@ extern "platform-intrinsic" {
     fn simd_insert<T, U>(x: T, idx: u32, b: U) -> T;
 }
 
+#[kani::proof]
 fn main() {
     let y = i64x2(0, 1);
     let z = i64x2(1, 2);

--- a/tests/kani/SIMD/Operators/main.rs
+++ b/tests/kani/SIMD/Operators/main.rs
@@ -29,6 +29,7 @@ macro_rules! assert_op {
 
 // Tests inspired by Rust's examples in
 // https://github.com/rust-lang/rust/blob/0d97f7a96877a96015d70ece41ad08bb7af12377/src/test/ui/simd-intrinsic/simd-intrinsic-generic-arithmetic.rs
+#[kani::proof]
 fn main() {
     let x = i64x2(0, 0);
     let y = i64x2(0, 1);

--- a/tests/kani/SIMD/Operators/overflow.rs
+++ b/tests/kani/SIMD/Operators/overflow.rs
@@ -27,7 +27,8 @@ macro_rules! assert_op {
 
 // Tests inspired by Rust's examples in
 // https://github.com/rust-lang/rust/blob/0d97f7a96877a96015d70ece41ad08bb7af12377/src/test/ui/simd-intrinsic/simd-intrinsic-generic-arithmetic.rs
-pub fn main() {
+#[kani::proof]
+fn main() {
     let v1 = i8x2(2, 2);
     let max_min = i8x2(i8::MIN, i8::MAX);
 

--- a/tests/kani/SIMD/Shuffle/main.rs
+++ b/tests/kani/SIMD/Shuffle/main.rs
@@ -17,6 +17,7 @@ extern "platform-intrinsic" {
     fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
 }
 
+#[kani::proof]
 fn main() {
     {
         let y = i64x2(0, 1);

--- a/tests/kani/Scopes_NonReturning/main.rs
+++ b/tests/kani/Scopes_NonReturning/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let a: u32 = kani::any();
     let b = a / 2;

--- a/tests/kani/Scopes_Returning/main.rs
+++ b/tests/kani/Scopes_Returning/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let x = { 5 };
     assert!(x == 5);

--- a/tests/kani/Serde/main.rs
+++ b/tests/kani/Serde/main.rs
@@ -17,6 +17,7 @@ impl fmt::Display for OneOf {
     }
 }
 
+#[kani::proof]
 fn main() {
     let v = OneOf { names: &["one"] };
     println!("{}", v);

--- a/tests/kani/SizeAndAlignOfDst/main_assert_fixme.rs
+++ b/tests/kani/SizeAndAlignOfDst/main_assert_fixme.rs
@@ -60,6 +60,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
+#[kani::proof]
 fn main() {
     let s: Arc<Mutex<dyn Subscriber>> = Arc::new(Mutex::new(DummySubscriber::new()));
     let mut data = s.lock().unwrap();

--- a/tests/kani/SizeAndAlignOfDst/main_fixme.rs
+++ b/tests/kani/SizeAndAlignOfDst/main_fixme.rs
@@ -53,6 +53,7 @@ impl Subscriber for DummySubscriber {
     fn interest_list(&self) {}
 }
 
+#[kani::proof]
 fn main() {
     let s: Arc<Mutex<dyn Subscriber>> = Arc::new(Mutex::new(DummySubscriber::new()));
 }

--- a/tests/kani/Slice/codegen.rs
+++ b/tests/kani/Slice/codegen.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let name = String::from("Mark");
     let name_str = name.as_str();

--- a/tests/kani/Slice/drop_in_place.rs
+++ b/tests/kani/Slice/drop_in_place.rs
@@ -11,6 +11,7 @@ pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
     unsafe { drop_in_place(to_drop) }
 }
 
+#[kani::proof]
 fn main() {
     let mut x = 3;
     drop_in_place(x);

--- a/tests/kani/Slice/fixme_issue_707.rs
+++ b/tests/kani/Slice/fixme_issue_707.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let [x, y @ .., z] = [1, 2, 3, 4];
     assert!(x == 1);

--- a/tests/kani/Slice/main.rs
+++ b/tests/kani/Slice/main.rs
@@ -3,6 +3,7 @@
 
 // cbmc-flags: --unwind 6
 
+#[kani::proof]
 fn main() {
     let name: &str = "hello";
     assert!(name == "hello");

--- a/tests/kani/Slice/pathbuf.rs
+++ b/tests/kani/Slice/pathbuf.rs
@@ -4,6 +4,7 @@
 
 use std::fs;
 use std::path::PathBuf;
+#[kani::proof]
 fn main() {
     let buf = PathBuf::new();
     let _x = fs::remove_dir_all(buf);

--- a/tests/kani/Slice/slice.rs
+++ b/tests/kani/Slice/slice.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let list = [1, 2, 3];
     let slice = &list[1..2];

--- a/tests/kani/Slice/slice_from_raw.rs
+++ b/tests/kani/Slice/slice_from_raw.rs
@@ -5,6 +5,7 @@
 use std::slice;
 
 // From Listing 19-7: Creating a slice from an arbitrary memory location. https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
+#[kani::proof]
 fn main() {
     let address = 0x01234usize;
     let r = address as *mut i32;

--- a/tests/kani/Static/main.rs
+++ b/tests/kani/Static/main.rs
@@ -11,6 +11,7 @@ pub enum MyEnum {
     ChoiceC,
 }
 
+#[kani::proof]
 fn main() {
     assert!(!X);
     unsafe {

--- a/tests/kani/Static/method_static_var.rs
+++ b/tests/kani/Static/method_static_var.rs
@@ -14,6 +14,7 @@ fn new_id() -> i8 {
     }
 }
 
+#[kani::proof]
 fn main() {
     let id_1 = new_id();
     let id_2 = new_id();

--- a/tests/kani/Static/table_of_pairs.rs
+++ b/tests/kani/Static/table_of_pairs.rs
@@ -7,6 +7,7 @@ fn test_equal(a: u64, b: u64) -> bool {
     a == b
 }
 
+#[kani::proof]
 fn main() {
     let x = TABLE[0];
     assert!(test_equal(x.1, 2));

--- a/tests/kani/Static/table_of_pairs2.rs
+++ b/tests/kani/Static/table_of_pairs2.rs
@@ -12,6 +12,7 @@ fn test_equal(a: u64, b: u64) -> bool {
     a == b
 }
 
+#[kani::proof]
 fn main() {
     let x = TABLE1[0];
     assert!(test_equal(x.1, 1));

--- a/tests/kani/Strings/boxed_str.rs
+++ b/tests/kani/Strings/boxed_str.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let s = String::from("hello");
     let _b = s.into_boxed_str();

--- a/tests/kani/Strings/copy_empty_string_by_intrinsic.rs
+++ b/tests/kani/Strings/copy_empty_string_by_intrinsic.rs
@@ -24,6 +24,7 @@ fn copy_string(s: &str, l: usize) {
     }
 }
 
+#[kani::proof]
 fn main() {
     copy_string("x", 1);
     copy_string("", 0);

--- a/tests/kani/Strings/copy_empty_string_by_intrinsic_fixme.rs
+++ b/tests/kani/Strings/copy_empty_string_by_intrinsic_fixme.rs
@@ -37,6 +37,7 @@ fn copy_string(s: &str, l: usize) {
     }
 }
 
+#[kani::proof]
 fn main() {
     // Verification fails for both of these cases.
     copy_string("x", 1);

--- a/tests/kani/Strings/copy_empty_string_by_ref.rs
+++ b/tests/kani/Strings/copy_empty_string_by_ref.rs
@@ -7,6 +7,7 @@ fn take_string_ref(s: &str, l: usize) {
     assert!(s.len() == l)
 }
 
+#[kani::proof]
 fn main() {
     take_string_ref(&"x".to_string(), 1);
     take_string_ref(&"".to_string(), 0);

--- a/tests/kani/Strings/main.rs
+++ b/tests/kani/Strings/main.rs
@@ -9,6 +9,7 @@ fn test1() {
     assert!(string.len() == 3);
 }
 
+#[kani::proof]
 fn main() {
     test1();
 }

--- a/tests/kani/Strings/os_str.rs
+++ b/tests/kani/Strings/os_str.rs
@@ -44,6 +44,7 @@ impl OsStr {
     }
 }
 
+#[kani::proof]
 fn main() {
     let x = OsStr::new("hi");
     x.as_bytes();

--- a/tests/kani/Strings/os_str_reduced.rs
+++ b/tests/kani/Strings/os_str_reduced.rs
@@ -28,6 +28,7 @@ fn test2() {
     assert!(inner.inner[1] == 'i' as u8);
 }
 
+#[kani::proof]
 fn main() {
     test1();
     test2();

--- a/tests/kani/SubSlice/subslice1.rs
+++ b/tests/kani/SubSlice/subslice1.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let arr = [1, 2, 3];
     // s is a slice (&[i32])

--- a/tests/kani/SubSlice/subslice2_fixme.rs
+++ b/tests/kani/SubSlice/subslice2_fixme.rs
@@ -30,6 +30,7 @@
 // This issue is captured in:
 // https://github.com/model-checking/kani/issues/708
 
+#[kani::proof]
 fn main() {
     let arr = [1, 2, 3];
     // s is a slice (&[i32])

--- a/tests/kani/SubSlice/subslice3.rs
+++ b/tests/kani/SubSlice/subslice3.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let slice = &[1, 2, 3][..];
     if let [head, tail @ ..] = slice {

--- a/tests/kani/SwitchInt/main.rs
+++ b/tests/kani/SwitchInt/main.rs
@@ -30,6 +30,7 @@ fn doswitch_bytes() -> i32 {
     return 2;
 }
 
+#[kani::proof]
 fn main() {
     let v = doswitch_int();
     assert!(v == 1);

--- a/tests/kani/Transparent/transparent1.rs
+++ b/tests/kani/Transparent/transparent1.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[kani::proof]
 fn main() {
     let mut x: u32 = 4;
     let pointer0: std::ptr::NonNull<u32> = std::ptr::NonNull::new(&mut x).unwrap();

--- a/tests/kani/Transparent/transparent2.rs
+++ b/tests/kani/Transparent/transparent2.rs
@@ -23,6 +23,7 @@ where
     }
 }
 
+#[kani::proof]
 fn main() {
     let mut x: u32 = 4;
     let container = Container::new(&mut x);

--- a/tests/kani/Transparent/transparent3.rs
+++ b/tests/kani/Transparent/transparent3.rs
@@ -10,6 +10,7 @@ pub struct Container<T> {
     container: Pointer<T>,
 }
 
+#[kani::proof]
 fn main() {
     let x: u32 = 4;
     let my_pointer = Pointer { pointer: &x };

--- a/tests/kani/Transparent/transparent4.rs
+++ b/tests/kani/Transparent/transparent4.rs
@@ -13,6 +13,7 @@ pub struct Container<T> {
     container: Pointer<T>,
 }
 
+#[kani::proof]
 fn main() {
     let x: u32 = 4;
     let my_container = Container { container: Pointer { pointer: &x } };

--- a/tests/kani/Unit/main.rs
+++ b/tests/kani/Unit/main.rs
@@ -18,6 +18,7 @@ fn ret_unit() {
     ()
 }
 
+#[kani::proof]
 fn main() {
     assert!(() == ());
     let u = ret_unit();

--- a/tests/kani/UnsafeBlocks_Useless/main.rs
+++ b/tests/kani/UnsafeBlocks_Useless/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let x = unsafe {
         assert!(true);

--- a/tests/kani/Unwind-Attribute/fixme_lib.rs
+++ b/tests/kani/Unwind-Attribute/fixme_lib.rs
@@ -6,6 +6,7 @@
 // Added to fix me because there are no tests for the annotations themselves.
 // TODO : The unwind value needs to be parsed and the unwind needs to be applied to each harness, we do not test this behavior yet.
 
+#[kani::proof]
 fn main() {
     assert!(1 == 2);
 }

--- a/tests/kani/Vectors/fixme_702.rs
+++ b/tests/kani/Vectors/fixme_702.rs
@@ -3,6 +3,7 @@
 
 // Failing example from https://github.com/model-checking/kani/issues/702
 // Push 5 elements to force the vector to resize, then check that the values were correctly copied.
+#[kani::proof]
 fn main() {
     let mut v = Vec::new();
     v.push(72);

--- a/tests/kani/Vectors/fixme_763.rs
+++ b/tests/kani/Vectors/fixme_763.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 // Failing example from https://github.com/model-checking/kani/issues/763
+#[kani::proof]
 fn main() {
     let x = Vec::<i32>::new();
     for i in x {}

--- a/tests/kani/Vectors/fixme_main.rs
+++ b/tests/kani/Vectors/fixme_main.rs
@@ -10,6 +10,7 @@ pub struct GuestRegionMmap {
 }
 
 // TODO: running this with --unwrap 2 causes CBMC to hang in propositional reduction.
+#[kani::proof]
 fn main() {
     let r = GuestRegionMmap { guest_base: GuestAddress(0) };
     let mut regions: Vec<GuestRegionMmap> = vec![];

--- a/tests/kani/Vectors/push_u8.rs
+++ b/tests/kani/Vectors/push_u8.rs
@@ -4,6 +4,7 @@
 // Check that Kani doesn't get stuck on a program involving a Vector of u8
 // https://github.com/model-checking/kani/issues/703
 
+#[kani::proof]
 fn main() {
     let mut v: Vec<u8> = Vec::new();
     v.push(5);

--- a/tests/kani/Vectors/vector_extend.rs
+++ b/tests/kani/Vectors/vector_extend.rs
@@ -4,6 +4,7 @@
 // Check that we can handle set len on drop. If drop_in_place is not
 // called correctly, this will fail to actually extend the vector.
 
+#[kani::proof]
 fn main() {
     let mut v: Vec<u32> = Vec::new();
     v.extend(42..=42);

--- a/tests/kani/Vectors/vector_extend_fail.rs
+++ b/tests/kani/Vectors/vector_extend_fail.rs
@@ -5,6 +5,7 @@
 
 // kani-verify-fail
 
+#[kani::proof]
 fn main() {
     let mut v: Vec<u32> = Vec::new();
     v.extend(42..=42);

--- a/tests/kani/Vectors/vector_extend_in_new.rs
+++ b/tests/kani/Vectors/vector_extend_in_new.rs
@@ -7,6 +7,7 @@
 // There is an implicit loop, so we need an explicit unwind
 // cbmc-flags: --unwind 3 --unwinding-assertions
 
+#[kani::proof]
 fn main() {
     let a: Vec<Vec<i32>> = vec![vec![0; 2]; 1];
     assert!(a.len() == 1);

--- a/tests/kani/Vectors/vector_extend_loop.rs
+++ b/tests/kani/Vectors/vector_extend_loop.rs
@@ -3,6 +3,7 @@
 
 // kani-flags: --unwind 3
 
+#[kani::proof]
 fn main() {
     let mut v: Vec<u32> = Vec::new();
     for (start, len) in vec![(0, 1), (1, 2)] {

--- a/tests/kani/VolatileIntrinsics/core_intrinsics.rs
+++ b/tests/kani/VolatileIntrinsics/core_intrinsics.rs
@@ -6,6 +6,7 @@
 
 use std::intrinsics::*;
 
+#[kani::proof]
 fn main() {
     let mut a: Box<u8> = Box::new(0);
     unsafe {

--- a/tests/kani/VolatileIntrinsics/main.rs
+++ b/tests/kani/VolatileIntrinsics/main.rs
@@ -114,6 +114,7 @@ fn test_copy_volatile_nonoverlapping() {
     }
 }
 
+#[kani::proof]
 fn main() {
     test_volatile_store();
     test_copy_volatile();

--- a/tests/kani/Whitespace/main.rs
+++ b/tests/kani/Whitespace/main.rs
@@ -3,6 +3,7 @@
 
 // cbmc-flags: --unwind 2
 
+#[kani::proof]
 fn main() {
     let mut iter = "A few words".split_whitespace();
     match iter.next() {

--- a/tests/kani/i32-Unary-/main.rs
+++ b/tests/kani/i32-Unary-/main.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let a: i32 = kani::any();
     if -100000 < a && a < 100000 {

--- a/tests/prusti/100_doors.rs
+++ b/tests/prusti/100_doors.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let mut door_open = [false; 10];
     for pass in 1..11 {

--- a/tests/prusti/Ackermann_function.rs
+++ b/tests/prusti/Ackermann_function.rs
@@ -8,6 +8,7 @@ fn ack(m: u64, n: u64) -> u64 {
     }
 }
 
+#[kani::proof]
 fn main() {
     let a = ack(2, 4);
     assert!(a == 11);

--- a/tests/prusti/Binary_search.rs
+++ b/tests/prusti/Binary_search.rs
@@ -47,6 +47,7 @@ fn get() -> [i32; 11] {
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 }
 
+#[kani::proof]
 fn main() {
     let x = get();
     let y = kani::any();

--- a/tests/prusti/Fibonacci_sequence.rs
+++ b/tests/prusti/Fibonacci_sequence.rs
@@ -21,6 +21,7 @@ impl Iterator for Fib {
     }
 }
 
+#[kani::proof]
 fn main() {
     let mut fib = Fib::new();
     assert!(fib.nth(10).unwrap() == 55);

--- a/tests/prusti/Heapsort.rs
+++ b/tests/prusti/Heapsort.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
 fn main() {
     let mut v = [3, 0, 1, 2];
     create_heap(&mut v, |x, y| x < y);

--- a/tests/prusti/Selection_sort.rs
+++ b/tests/prusti/Selection_sort.rs
@@ -18,6 +18,7 @@ fn selection_sort(array: &mut [i32]) {
     }
 }
 
+#[kani::proof]
 fn main() {
     let mut array = [9, 4, 8, 3];
     selection_sort(&mut array);

--- a/tests/prusti/Tower_of_Hanoi.rs
+++ b/tests/prusti/Tower_of_Hanoi.rs
@@ -7,6 +7,7 @@ fn move_(n: i32, from: i32, to: i32, via: i32) {
     }
 }
 
+#[kani::proof]
 fn main() {
     move_(4, 1, 2, 3);
 }

--- a/tests/prusti/borrow_first.rs
+++ b/tests/prusti/borrow_first.rs
@@ -14,6 +14,7 @@ fn foo(vec: &mut Vec<i32>) -> &i32 {
     &vec[last]
 }
 
+#[kani::proof]
 fn main() {
     let mut v = vec![-1, 2, 3];
     let r = foo(&mut v);

--- a/tests/ui/arguments-proof/expected
+++ b/tests/ui/arguments-proof/expected
@@ -1,6 +1,1 @@
-  --> main.rs:13:1
-   |
-13 | #[kani::proof(some, argument2)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
    = help: message: #[kani::proof] does not take any arguments

--- a/tests/ui/arguments-proof/main.rs
+++ b/tests/ui/arguments-proof/main.rs
@@ -6,6 +6,7 @@
 // This test is to check Kani's error handling for harnesses that have proof attributes
 // with arguments when the expected declaration takes no arguments.
 
+#[kani::proof]
 fn main() {
     assert!(1 == 2);
 }

--- a/tests/ui/cbmc_checks/float-overflow/check_message.rs
+++ b/tests/ui/cbmc_checks/float-overflow/check_message.rs
@@ -12,6 +12,7 @@ fn dummy(result: f32) -> f32 {
 }
 
 #[kani::proof]
+#[kani::proof]
 fn main() {
     dummy(any::<f32>() + any::<f32>());
     dummy(any::<f32>() - any::<f32>());

--- a/tests/ui/cbmc_checks/float-overflow/check_message.rs
+++ b/tests/ui/cbmc_checks/float-overflow/check_message.rs
@@ -12,7 +12,6 @@ fn dummy(result: f32) -> f32 {
 }
 
 #[kani::proof]
-#[kani::proof]
 fn main() {
     dummy(any::<f32>() + any::<f32>());
     dummy(any::<f32>() - any::<f32>());

--- a/tests/ui/cbmc_checks/pointer/check_message.rs
+++ b/tests/ui/cbmc_checks/pointer/check_message.rs
@@ -8,7 +8,6 @@ fn not_zero(p1: *const i32) {
 }
 
 #[kani::proof]
-#[kani::proof]
 fn main() {
     let mut ptr = 10 as *const i32;
     if kani::any() {

--- a/tests/ui/cbmc_checks/pointer/check_message.rs
+++ b/tests/ui/cbmc_checks/pointer/check_message.rs
@@ -8,6 +8,7 @@ fn not_zero(p1: *const i32) {
 }
 
 #[kani::proof]
+#[kani::proof]
 fn main() {
     let mut ptr = 10 as *const i32;
     if kani::any() {

--- a/tests/ui/cbmc_checks/signed-overflow/check_message.rs
+++ b/tests/ui/cbmc_checks/signed-overflow/check_message.rs
@@ -14,6 +14,7 @@ fn dummy(var: i32) {
 
 
 #[kani::proof]
+#[kani::proof]
 fn main() {
     dummy(any::<i32>() + any::<i32>());
     dummy(any::<i32>() - any::<i32>());

--- a/tests/ui/cbmc_checks/signed-overflow/check_message.rs
+++ b/tests/ui/cbmc_checks/signed-overflow/check_message.rs
@@ -12,8 +12,6 @@ fn dummy(var: i32) {
     kani::assume(var != 0);
 }
 
-
-#[kani::proof]
 #[kani::proof]
 fn main() {
     dummy(any::<i32>() + any::<i32>());

--- a/tests/ui/cbmc_checks/unsigned-overflow/check_message.rs
+++ b/tests/ui/cbmc_checks/unsigned-overflow/check_message.rs
@@ -13,6 +13,7 @@ fn dummy(var: u32) {
 }
 
 #[kani::proof]
+#[kani::proof]
 fn main() {
     dummy(any::<u32>() + any::<u32>());
     dummy(any::<u32>() - any::<u32>());

--- a/tests/ui/cbmc_checks/unsigned-overflow/check_message.rs
+++ b/tests/ui/cbmc_checks/unsigned-overflow/check_message.rs
@@ -13,7 +13,6 @@ fn dummy(var: u32) {
 }
 
 #[kani::proof]
-#[kani::proof]
 fn main() {
     dummy(any::<u32>() + any::<u32>());
     dummy(any::<u32>() - any::<u32>());

--- a/tests/ui/check_operations/operations.rs
+++ b/tests/ui/check_operations/operations.rs
@@ -8,7 +8,6 @@ extern crate kani;
 use kani::any;
 
 #[kani::proof]
-#[kani::proof]
 fn main() {
     let _ = any::<u8>() + any::<u8>();
     let _ = any::<u8>() - any::<u8>();

--- a/tests/ui/check_operations/operations.rs
+++ b/tests/ui/check_operations/operations.rs
@@ -8,6 +8,7 @@ extern crate kani;
 use kani::any;
 
 #[kani::proof]
+#[kani::proof]
 fn main() {
     let _ = any::<u8>() + any::<u8>();
     let _ = any::<u8>() - any::<u8>();

--- a/tests/ui/logging/warning/trivial.rs
+++ b/tests/ui/logging/warning/trivial.rs
@@ -18,7 +18,6 @@ fn is_true(b: bool) {
 
 // This should print a warning since this is a no-op.
 #[kani::proof]
-#[kani::proof]
 fn harness() {
     is_true(true);
 }

--- a/tests/ui/logging/warning/trivial.rs
+++ b/tests/ui/logging/warning/trivial.rs
@@ -18,6 +18,7 @@ fn is_true(b: bool) {
 
 // This should print a warning since this is a no-op.
 #[kani::proof]
+#[kani::proof]
 fn harness() {
     is_true(true);
 }

--- a/tests/ui/multiple-proof-attributes/expected
+++ b/tests/ui/multiple-proof-attributes/expected
@@ -1,9 +1,1 @@
 warning: Only one '#[kani::proof]' allowed
-  --> main.rs:14:1
-   |
-14 | #[kani::proof]
-   | ^^^^^^^^^^^^^^
-   |
-   = note: this warning originates in the attribute macro `kani::proof` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-warning: 1 warning emitted

--- a/tests/ui/multiple-proof-attributes/main.rs
+++ b/tests/ui/multiple-proof-attributes/main.rs
@@ -6,13 +6,9 @@
 // This test is to check Kani's error handling for harnesses that have multiple proof annotations
 // declared.
 
+#[kani::proof]
+#[kani::proof]
 fn main() {
-    assert!(1 == 2);
-}
-
-#[kani::proof]
-#[kani::proof]
-fn harness() {
     let mut counter = 0;
     loop {
         counter += 1;

--- a/tests/ui/regular-output-format-fail/expected
+++ b/tests/ui/regular-output-format-fail/expected
@@ -1,4 +1,2 @@
-Check 1: main.assertion.2
 Description: "assertion failed: 1 + 1 == 3"
-Description: "pointer to dead object"
 Failed Checks: assertion failed: 1 + 1 == 3

--- a/tests/ui/regular-output-format-fail/fail.rs
+++ b/tests/ui/regular-output-format-fail/fail.rs
@@ -3,6 +3,7 @@
 
 // kani-flags: --output-format regular
 
+#[kani::proof]
 fn main() {
     assert!(1 + 1 == 3);
 }

--- a/tests/ui/regular-output-format-pass/expected
+++ b/tests/ui/regular-output-format-pass/expected
@@ -1,3 +1,1 @@
-Check 1: main.assertion.2
 Description: "assertion failed: 1 + 1 == 2"
-Description: "pointer to dead object"

--- a/tests/ui/regular-output-format-pass/main.rs
+++ b/tests/ui/regular-output-format-pass/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 // kani-flags: --output-format regular
+#[kani::proof]
 fn main() {
     assert!(1 + 1 == 2);
 }

--- a/tests/ui/terse-output-format-fail/expected
+++ b/tests/ui/terse-output-format-fail/expected
@@ -1,3 +1,2 @@
 VERIFICATION RESULT:
- ** 1 of 3 failed
 Failed Checks: assertion failed: 1 + 1 == 3

--- a/tests/ui/terse-output-format-fail/fail.rs
+++ b/tests/ui/terse-output-format-fail/fail.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 // kani-flags: --output-format terse
+#[kani::proof]
 fn main() {
     assert!(1 + 1 == 3);
 }

--- a/tests/ui/terse-output-format-pass/expected
+++ b/tests/ui/terse-output-format-pass/expected
@@ -1,2 +1,1 @@
 VERIFICATION RESULT:
-** 0 of 3 failed

--- a/tests/ui/terse-output-format-pass/main.rs
+++ b/tests/ui/terse-output-format-pass/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 // kani-flags: --output-format terse
+#[kani::proof]
 fn main() {
     assert!(1 + 1 == 2);
 }

--- a/tests/ui/unsupported-annotation/expected
+++ b/tests/ui/unsupported-annotation/expected
@@ -1,7 +1,1 @@
 error[E0433]: failed to resolve: could not find `test_annotation` in `kani`
-  --> main.rs:14:9
-   |
-14 | #[kani::test_annotation]
-   |         ^^^^^^^^^^^^^^^ could not find `test_annotation` in `kani`
-
-error: aborting due to previous error

--- a/tests/ui/unsupported-annotation/main.rs
+++ b/tests/ui/unsupported-annotation/main.rs
@@ -6,6 +6,7 @@
 // This test is to check Kani's error handling for harnesses that have multiple proof annotations
 // declared.
 
+#[kani::proof]
 fn main() {
     assert!(1 == 2);
 }

--- a/tests/ui/unsupported-features/thread/main.rs
+++ b/tests/ui/unsupported-features/thread/main.rs
@@ -8,7 +8,6 @@ thread_local! {
 }
 
 #[kani::proof]
-#[kani::proof]
 fn main() {
     COND.with(|&b|{
         kani::assume(b);

--- a/tests/ui/unsupported-features/thread/main.rs
+++ b/tests/ui/unsupported-features/thread/main.rs
@@ -8,6 +8,7 @@ thread_local! {
 }
 
 #[kani::proof]
+#[kani::proof]
 fn main() {
     COND.with(|&b|{
         kani::assume(b);

--- a/tests/ui/unwind-multiple-arguments/expected
+++ b/tests/ui/unwind-multiple-arguments/expected
@@ -1,5 +1,1 @@
 error: Exactly one Unwind Argument as Integer accepted
-  --> main.rs:14:1
-   |
-14 | #[kani::unwind(10,5)]
-   | ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unwind-multiple-arguments/main.rs
+++ b/tests/ui/unwind-multiple-arguments/main.rs
@@ -6,6 +6,7 @@
 // This test is to check Kani's error handling for harnesses that have unwind attributes
 // that have multiple arguments provided when only one is allowed.
 
+#[kani::proof]
 fn main() {
     assert!(1 == 2);
 }

--- a/tests/ui/unwind-without-proof/expected
+++ b/tests/ui/unwind-without-proof/expected
@@ -1,6 +1,1 @@
 error: The unwind attribute also requires the '#[kani::proof]' attribute
-  --> main.rs:13:1
-   |
-13 | #[kani::unwind(7)]
-   | ^^^^^^^^^^^^^^^^^^
-   |

--- a/tests/ui/unwind-without-proof/main.rs
+++ b/tests/ui/unwind-without-proof/main.rs
@@ -6,6 +6,7 @@
 // This test is to check Kani's error handling for harnesses that have unwind attributes
 // without '#[kani::proof]' attribute declared
 
+#[kani::proof]
 fn main() {
     assert!(1 == 2);
 }


### PR DESCRIPTION
### Description of changes: 

80% of these changes were from:

```
shopt -s globstar

for file in **/*.rs; do
    # there were still some pub main?
    sed -i 's/pub fn main/fn main/g' "$file"
    # add proof harness annotation to all
    sed -i 's/fn main/#[kani::proof]\nfn main/g' "$file"
done
```

But there were additional manual changes needed under `tests/expected` and `tests/ui` to fix issues with things like line numbers.

### Call-outs:

* This patch is required to allow me to change the default behavior to "run all proof harnesses" and also to remove the hack to only sometimes provide `--crate-type=lib`. Those changes are not in this PR. I've separated this monster out.

* Alt-click on the files in the github code review ui will expand or collapse all files, allowing you you quickly look at only certain files.

### Testing:

* How is this change tested? existing suite

* Is this a refactor change? yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
