### PR TITLE
Change kani-compiler crash message.

### DIFF
--- a/src/kani-compiler/src/codegen_cprover_gotoc/utils/mod.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/utils/mod.rs
@@ -12,6 +12,4 @@ mod utils;
 pub use names::*;
 pub use utils::*;
 
-pub fn init() {
-    debug::init()
-}
+pub use debug::init;


### PR DESCRIPTION
We were using rustc panic_hook which was printing the rustc error
message including version and link to bug reporting. This change gets
rid of that and adds our own default panic hook.

I kept the codegen panic hook to add more information to the codegen
stage.

This fixes https://github.com/model-checking/kani/issues/959


### Description of changes: 

Describe Kani's current behavior and how your code changes that behavior. If there are no issues this PR is resolving, explain why this change is necessary.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
