### PR TITLE
Hide --lib-c and add assume-false to unknown fns

### DIFF
--- a/src/cargo-kani/src/args.rs
+++ b/src/cargo-kani/src/args.rs
@@ -75,8 +75,9 @@ pub struct KaniArgs {
     /// Entry point for verification
     #[structopt(long, default_value = "main")]
     pub function: String,
-    /// Link external C files referenced by Rust code
-    #[structopt(long, parse(from_os_str))]
+    /// Link external C files referenced by Rust code.
+    /// This is an experimental feature.
+    #[structopt(long, parse(from_os_str), hidden = true)]
     pub c_lib: Vec<PathBuf>,
     /// Enable test function verification. Only use this option when the entry point is a test function.
     #[structopt(long)]

--- a/src/cargo-kani/src/call_goto_instrument.rs
+++ b/src/cargo-kani/src/call_goto_instrument.rs
@@ -79,7 +79,7 @@ impl KaniSession {
     fn undefined_functions(&self, file: &Path) -> Result<()> {
         let args: Vec<OsString> = vec![
             "--generate-function-body-options".into(),
-            "assert-false".into(),
+            "assert-false-assume-false".into(),
             "--generate-function-body".into(),
             ".*".into(),
             "--drop-unused-functions".into(),

--- a/tests/ui/cbmc_checks/float-overflow/check_message.rs
+++ b/tests/ui/cbmc_checks/float-overflow/check_message.rs
@@ -8,7 +8,7 @@ use kani::any;
 
 // Use the result so rustc doesn't optimize them away.
 fn dummy(result: f32) -> f32 {
-    result.round()
+    result
 }
 
 #[kani::proof]

--- a/tests/ui/missing-function/expected
+++ b/tests/ui/missing-function/expected
@@ -1,0 +1,5 @@
+Status: UNREACHABLE\
+Description: "assertion failed: x == 5"
+
+VERIFICATION:- FAILED
+

--- a/tests/ui/missing-function/extern_c.rs
+++ b/tests/ui/missing-function/extern_c.rs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags: --function harness
+
+// This test is to check Kani's error handling for missing functions.
+// TODO: Verify that this prints a compiler warning:
+//  - https://github.com/model-checking/kani/issues/576
+
+
+extern "C" {
+    fn missing_function() -> u32;
+}
+
+#[kani::proof]
+fn harness() {
+    let x = unsafe { missing_function() };
+    assert!(x == 5);
+}


### PR DESCRIPTION
### Description of changes: 

 - Support to --lib-c is not well tested. Keep it as experimental.
 - Change how CBMC behaves when a function that is not defined is
   reachable. This mitigates issues #576. We should still add an
   unimplemented assertion so we can flip the results of other checks to
   undetermined.

### Resolved issues:

None


### Call-outs:

I had to change the float test since fround() function is missing. 

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
