### PR TITLE
Enable `cttz` test to run with value zero

### DIFF
--- a/tests/kani/Intrinsics/Count/cttz.rs
+++ b/tests/kani/Intrinsics/Count/cttz.rs
@@ -27,9 +27,6 @@ macro_rules! test_cttz {
             count
         }
         let var: $ty = kani::any();
-        // FIXME: Remove the assumption below when CBMC returns the correct value for 0
-        // https://github.com/model-checking/kani/issues/881
-        kani::assume(var != 0);
         // Check that the result is correct
         assert!($fn_name(var) == cttz(var));
         // Check that the stable version returns the same value


### PR DESCRIPTION
### Description of changes: 

Removes an assumption from the `cttz` that was blocking a buggy failure in CBMC 5.52.

### Resolved issues:

Resolves #881 

### Testing:

* How is this change tested? Existing regression + changed test.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
