### PR TITLE
Documentation: Updates for "Usage - On a single file"

### DIFF
--- a/docs/src/kani-single-file.md
+++ b/docs/src/kani-single-file.md
@@ -1,59 +1,40 @@
-# Kani on a single file
+# Usage on a single file
 
-For small examples, or initial learning, it's very common to run Kani on just one source file.
-The command line format for invoking Kani directly has a few common formats:
+For small examples or initial learning, it's very common to run Kani on just one source file.
+
+The command line format for invoking Kani directly is the following:
 
 ```
-kani filename.rs
-# or
-kani filename.rs [--kani-flags]
-# or
-kani filename.rs [--kani-flags] --cbmc-args [--cbmc-flags]
+kani filename.rs [<kani-args>]*
 ```
 
 For example,
 
 ```
-kani filenames.rs --visualize --cbmc-args --object-bits 11 --unwind 15
+kani example.rs
 ```
 
-## Common Kani arguments
+runs Kani on all the proof harnesses from file `example.rs`.
+A proof harness is simply a function with the `#[kani::proof]` annotation.
 
-**`--visualize`** will generate a report in the local directory accessible through `report/html/index.html`.
-This report will shows coverage information, as well as give traces for each failure Kani finds.
+## Common arguments
 
-**`--harness <name>`** Kani defaults to checking all proof harnesses.
-You can switch to checking just one harness using this flag.
-Proof harnesses are functions that have been given the `#[kani::proof]` annotation.
+The most common `kani` arguments are the following:
 
-**`--gen-c`** will generate a C file that roughly corresponds to the input Rust file.
-This can sometimes be helpful when trying to debug a problem with Kani.
+ * `--harness <name>`: By default, Kani checks all proof harnesses it finds. You
+   can switch to checking a single harness using this flag.
 
-**`--keep-temps`** will preserve generated files that Kani generates.
-In particular, this will include a `.json` file which is the "CBMC symbol table".
-This can be helpful in trying to diagnose bugs in Kani, and may sometimes be requested in Kani bug reports.
+ * `--unwind <n>`: Set a global upper [loop
+   unwinding](./tutorial-loop-unwinding.md) bound on all loops. This can force
+   termination when CBMC tries to unwind loops indefinitely.
 
-## Common CBMC arguments
+ * `output-format <regular|terse|old>`: By default (`regular`), Kani
+   post-processes CBMC's output to produce more comprehensible results. In
+   contrast, `terse` outputs only a summary of these results, and `old` forces
+   Kani to emit the original output from CBMC.
 
-Kani invokes CBMC to do the underlying solving.
-(CBMC is the "C Bounded Model Checker" but is actually a framework that supports model checking multiple languages.)
-CBMC arguments are sometimes necessary to get good results.
+ * `--visualize`: Generates an HTML report in the local directory accessible
+   through `report/html/index.html`. This report shows coverage information and
+   provides traces (i.e., counterexamples) for each failure found by Kani.
 
-To give arguments to CBMC, you pass `--cbmc-args` to Kani.
-This "switches modes" from Kani arguments to CBMC arguments.
-Everything else given on the command line will be assumed to be a CBMC argument, and so all Kani arguments should be provided before this flag.
-
-**`--unwind <n>`** Give a global upper bound on all loops.
-This can force termination when CBMC tries to unwind loops indefinitely.
-
-**`--object-bits <n>`** CBMC, by default, assumes there are only going to be 256 objects allocated on the heap in a single trace.
-This corresponds to a default of `--object-bits 8`.
-Rust programs often will use more than this, and so need to raise this limit.
-However, very large traces with many allocations often prove intractable to solve.
-If you run into this issue, a good first start is to raise the limit to 2048, i.e. `--object-bits 11`.
-
-**`--unwindset label_1:bound_1,label_2:bound_2,...`** Give specific unwinding bounds on specific loops.
-The labels for each loop can be discovered by running with the following CBMC flag:
-
-**`--show-loops`** Print the labels of each loop in the program.
-Useful for `--unwindset`.
+Run `kani --help` to see a complete list of arguments.

--- a/docs/src/kani-single-file.md
+++ b/docs/src/kani-single-file.md
@@ -28,7 +28,7 @@ The most common `kani` arguments are the following:
    unwinding](./tutorial-loop-unwinding.md) bound on all loops. This can force
    termination when CBMC tries to unwind loops indefinitely.
 
- * `output-format <regular|terse|old>`: By default (`regular`), Kani
+ * `--output-format <regular|terse|old>`: By default (`regular`), Kani
    post-processes CBMC's output to produce more comprehensible results. In
    contrast, `terse` outputs only a summary of these results, and `old` forces
    Kani to emit the original output from CBMC.


### PR DESCRIPTION
### Description of changes: 

Removes the CBMC arguments section because we plan on keeping the flag hidden. Sets the "common arguments" to `--function`, `--unwind`, `--output-format` and `--visualize`, which nowadays are the most common ones.

Feel free to share your opinion.

### Resolved issues:

Part of #700 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? N/A

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
