### PR TITLE
Quick kani bug fixes

### DIFF
--- a/src/cargo-kani/src/call_symtab.rs
+++ b/src/cargo-kani/src/call_symtab.rs
@@ -8,9 +8,9 @@ use std::process::Command;
 use crate::session::KaniSession;
 
 impl KaniSession {
-    /// Given a `file` (a .symtab.json), produce `{file}.out` by calling symtab2gb
+    /// Given a `file.symtab.json`, produce `{file}.symtab.out` by calling symtab2gb
     pub fn symbol_table_to_gotoc(&self, file: &Path) -> Result<PathBuf> {
-        let output_filename = crate::util::append_path(file, "out");
+        let output_filename = file.with_extension("out");
 
         {
             let mut temps = self.temporaries.borrow_mut();

--- a/src/cargo-kani/src/main.rs
+++ b/src/cargo-kani/src/main.rs
@@ -104,7 +104,7 @@ fn standalone_main() -> Result<()> {
     for harness in &harnesses {
         let harness_filename = harness.pretty_name.replace("::", "-");
         let report_dir = report_base.join(format!("report-{}", harness_filename));
-        let specialized_obj = append_path(&linked_obj, &format!("-for-{}", harness_filename));
+        let specialized_obj = append_path(&linked_obj, &format!("for-{}", harness_filename));
         {
             let mut temps = ctx.temporaries.borrow_mut();
             temps.push(specialized_obj.to_owned());

--- a/src/cargo-kani/src/session.rs
+++ b/src/cargo-kani/src/session.rs
@@ -52,7 +52,7 @@ impl KaniSession {
 
 impl Drop for KaniSession {
     fn drop(&mut self) {
-        if !self.args.keep_temps {
+        if !self.args.keep_temps && !self.args.dry_run {
             let temporaries = self.temporaries.borrow();
 
             for file in temporaries.iter() {


### PR DESCRIPTION
### Description of changes: 

Quick fixes that irked me today.

1. I accidentally named the intermediate output "specialized proof harnesses" like `ordering2.out.-for-main`. This removes the extra - so it's `ordering2.out.for-main`
2. I decided it was a bit weird to have `.symtab.json.out` so it's `.symtab.out` now.
3. A "dry run" deleted my old temps! Stop that.

### Testing:

* How is this change tested? existing tests. manual check on dry run deleting files.

* Is this a refactor change? yes, mostly

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
