### PR TITLE
Update rust toolchain to nightly-2022-03-23

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2022-03-09"
+channel = "nightly-2022-03-23"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -916,7 +916,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
                 // Packed types ignore the alignment of their fields.
                 if let ty::Adt(def, _) = t.kind() {
-                    if def.repr.packed() {
+                    if def.repr().packed() {
                         unsized_align = sized_align.clone();
                     }
                 }

--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -210,7 +210,7 @@ impl<'tcx> GotocCtx<'tcx> {
             (Scalar::Int(_), ty::Adt(adt, subst)) => {
                 if adt.is_struct() || adt.is_union() {
                     // in this case, we must have a one variant ADT. there are two cases
-                    let variant = &adt.variants.raw[0];
+                    let variant = &adt.variants().raw[0];
                     // if there is no field, then it's just a ZST
                     if variant.fields.is_empty() {
                         if adt.is_struct() {
@@ -238,7 +238,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     match &layout.variants {
                         Variants::Single { index } => {
                             // here we must have one variant
-                            let variant = &adt.variants[*index];
+                            let variant = &adt.variants()[*index];
 
                             match variant.fields.len() {
                                 0 => Expr::struct_expr_from_values(

--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
@@ -189,7 +189,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     ty::Tuple(_) => {
                         res.member(&Self::tuple_fld_name(f.index()), &self.symbol_table)
                     }
-                    ty::Adt(def, _) if def.repr.simd() => {
+                    ty::Adt(def, _) if def.repr().simd() => {
                         // this is a SIMD vector - the index represents one
                         // of the elements, so we want to index as an array
                         // Example:
@@ -204,7 +204,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     }
                     // if we fall here, then we are handling either a struct or a union
                     ty::Adt(def, _) => {
-                        let field = &def.variants.raw[0].fields[f.index()];
+                        let field = &def.variants().raw[0].fields[f.index()];
                         res.member(&field.name.to_string(), &self.symbol_table)
                     }
                     ty::Closure(..) => res.member(&f.index().to_string(), &self.symbol_table),
@@ -425,7 +425,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 let t = before.mir_typ();
                 match t.kind() {
                     ty::Adt(def, _) => {
-                        let variant = def.variants.get(idx).unwrap();
+                        let variant = def.variants().get(idx).unwrap();
                         let typ = TypeOrVariant::Variant(variant);
                         let expr = match &self.layout_of(t).variants {
                             Variants::Single { .. } => before.goto_expr,

--- a/src/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -196,7 +196,7 @@ fn check_options(session: &Session, need_metadata_module: bool) {
     }
 
     if need_metadata_module {
-        session.err("Kani cannot generate metadata module.")
+        session.err("Kani cannot generate metadata module.");
     }
 
     session.abort_if_errors();

--- a/tools/bookrunner/librustdoc/clean/inline.rs
+++ b/tools/bookrunner/librustdoc/clean/inline.rs
@@ -244,7 +244,7 @@ fn build_enum(cx: &mut DocContext<'_>, did: DefId) -> clean::Enum {
     clean::Enum {
         generics: clean_ty_generics(cx, cx.tcx.generics_of(did), predicates),
         variants_stripped: false,
-        variants: cx.tcx.adt_def(did).variants.iter().map(|v| v.clean(cx)).collect(),
+        variants: cx.tcx.adt_def(did).variants().iter().map(|v| v.clean(cx)).collect(),
     }
 }
 

--- a/tools/bookrunner/librustdoc/clean/mod.rs
+++ b/tools/bookrunner/librustdoc/clean/mod.rs
@@ -1481,7 +1481,7 @@ impl<'tcx> Clean<Type> for Ty<'tcx> {
                 })
             }
             ty::Adt(def, substs) => {
-                let did = def.did;
+                let did = def.did();
                 let kind = match def.adt_kind() {
                     AdtKind::Struct => ItemType::Struct,
                     AdtKind::Union => ItemType::Union,

--- a/tools/bookrunner/librustdoc/clean/types.rs
+++ b/tools/bookrunner/librustdoc/clean/types.rs
@@ -727,7 +727,9 @@ impl AttributesExt for [ast::Attribute] {
                         {
                             match Cfg::parse(cfg_mi) {
                                 Ok(new_cfg) => cfg &= new_cfg,
-                                Err(e) => sess.span_err(e.span, e.msg),
+                                Err(e) => {
+                                    sess.span_err(e.span, e.msg);
+                                }
                             }
                         }
                     }

--- a/tools/bookrunner/librustdoc/doctest.rs
+++ b/tools/bookrunner/librustdoc/doctest.rs
@@ -1,7 +1,7 @@
 use rustc_ast as ast;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::{ColorConfig, ErrorGuaranteed};
+use rustc_errors::ColorConfig;
 use rustc_hir as hir;
 use rustc_hir::intravisit;
 use rustc_hir::HirId;

--- a/tools/bookrunner/librustdoc/html/render/print_item.rs
+++ b/tools/bookrunner/librustdoc/html/render/print_item.rs
@@ -1770,7 +1770,7 @@ fn document_type_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
                     };
 
                     for (index, layout) in variants.iter_enumerated() {
-                        let name = adt.variants[index].name;
+                        let name = adt.variants()[index].name;
                         write!(w, "<li><code>{name}</code>: ", name = name);
                         write_size_of_layout(w, layout, tag_size);
                         writeln!(w, "</li>");

--- a/tools/bookrunner/librustdoc/passes/check_code_block_syntax.rs
+++ b/tools/bookrunner/librustdoc/passes/check_code_block_syntax.rs
@@ -80,7 +80,7 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
 
         // lambda that will use the lint to start a new diagnostic and add
         // a suggestion to it when needed.
-        let diag_builder = |lint: LintDiagnosticBuilder<'_>| {
+        let diag_builder = |lint: LintDiagnosticBuilder<'_, ()>| {
             let explanation = if is_ignore {
                 "`ignore` code blocks require valid Rust code for syntax highlighting; \
                     mark blocks that do not contain Rust code as text"


### PR DESCRIPTION
### Description of changes: 

All changes were fairly straight forward, and they were due to the following rustc changes:
  - A few member variable -> function refactoring.
  - Change to ty::AdtDef internal representation.
  - The function span_error now returns a value.
  - Added a new field to the return value of ptr_metadata_ty.

### Resolved issues:

Resolves #987 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Regular tests

* Is this a refactor change? Nope

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
