### PR TITLE
Tests for `assume`

### DIFF
--- a/tests/kani/Intrinsics/Assume/assume_fail.rs
+++ b/tests/kani/Intrinsics/Assume/assume_fail.rs
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that `assume` fails if the condition is false (undefined behavior)
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    unsafe { core::intrinsics::assume(false) };
+}

--- a/tests/kani/Intrinsics/Assume/assume_ok.rs
+++ b/tests/kani/Intrinsics/Assume/assume_ok.rs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `assume` does not fail if the condition is true
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    unsafe { core::intrinsics::assume(true) };
+}


### PR DESCRIPTION
### Description of changes: 

Adds two simple tests for the `assume` intrinsic. The current implementation is minimal - the cast to `bool` cannot be removed (this induces a type-check error later)

The only problem with this intrinsic is the confusing message shown. For example, when applied to `assume_ok`, the output will show:

```
Check 1: main.assertion.1
         - Status: SUCCESS
         - Description: "assumption failed"
         - Location: assume_ok.rs:9:14 in function main
```
Which is similar to the problem with user-defined assertions ( #189 / #562 ), but worse because the condition is not printed.

### Resolved issues:

Part of #727 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Adds two tests.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
