### PR TITLE
Add a test for `breakpoint`

### DIFF
--- a/tests/kani/Intrinsics/breakpoint.rs
+++ b/tests/kani/Intrinsics/breakpoint.rs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `breakpoint` is supported (generates a `SKIP` statement)
+// and that it does not affect the verification result
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    unsafe { std::intrinsics::breakpoint() };
+    assert!(true);
+}


### PR DESCRIPTION
### Description of changes: 

Adds a test for `breakpoint`. It checks that is supported (`breakpoint` generates a `SKIP` statement)
and that it does not affect the verification result by adding an `assert!(true)` after it.

If you have ideas on how to test "skip" intrinsics, please let me know.

### Resolved issues:

Part of #727 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Adds one test.

* Is this a refactor change? N/A

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
