### PR TITLE
Add support to min_specialization for arbitrary / invariant

### DIFF
--- a/library/kani/src/arbitrary.rs
+++ b/library/kani/src/arbitrary.rs
@@ -14,7 +14,7 @@ impl<T> Arbitrary for T
 where
     T: Invariant,
 {
-    fn any() -> Self {
+    default fn any() -> Self {
         let value = unsafe { any_raw::<T>() };
         assume(value.is_valid());
         value

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![feature(rustc_attrs)] // Used for rustc_diagnostic_item.
+#![feature(min_specialization)] // Used for default implementation of Arbitrary.
 
 pub mod arbitrary;
 pub mod invariant;

--- a/tests/kani/Arbitrary/vector_wrapper.rs
+++ b/tests/kani/Arbitrary/vector_wrapper.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
-// Check that the Invariant implementation for Option respect underlying types invariant.
+// Check that users can implement Invariant and Arbitrary to the same struct.
 #![cfg_attr(kani, feature(min_specialization))]
 
 extern crate kani;

--- a/tests/kani/Arbitrary/vector_wrapper.rs
+++ b/tests/kani/Arbitrary/vector_wrapper.rs
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Check that the Invariant implementation for Option respect underlying types invariant.
+#![cfg_attr(kani, feature(min_specialization))]
+
+extern crate kani;
+use kani::{Arbitrary, Invariant};
+
+// Dummy wrappar that keeps track of the vector size.
+struct VecWrapper {
+    has_data: bool,
+    data: Vec<u8>,
+}
+
+impl VecWrapper {
+    fn new() -> Self {
+        VecWrapper { has_data: false, data: Vec::new() }
+    }
+
+    fn from(buf: &[u8]) -> Self {
+        VecWrapper { has_data: true, data: Vec::from(buf) }
+    }
+}
+
+unsafe impl Invariant for VecWrapper {
+    fn is_valid(&self) -> bool {
+        self.has_data ^ self.data.is_empty()
+    }
+}
+
+impl Arbitrary for VecWrapper {
+    fn any() -> Self {
+        if kani::any() { VecWrapper::new() } else { VecWrapper::from(&[kani::any(), kani::any()]) }
+    }
+}
+
+#[kani::proof]
+fn check() {
+    let wrap: VecWrapper = kani::any();
+    assert!(wrap.is_valid());
+}


### PR DESCRIPTION
### Description of changes: 

We would like to enable users to provide custom implementations of Invariant and Arbitrary for the same struct.

Use feature `min_specialization` to allow that. Note that users will also need to enable that same feature in their code.

### Resolved issues:

None


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
