### PR TITLE
Tests for "absolute" intrinsics

### DIFF
--- a/tests/kani/Intrinsics/Math/fabsf32.rs
+++ b/tests/kani/Intrinsics/Math/fabsf32.rs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `fabsf32` returns the expected results: absolute value if argument
+// is not NaN, otherwise NaN
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn test_abs_finite() {
+    let x: f32 = kani::any();
+    kani::assume(!x.is_nan());
+    let abs_x = unsafe { std::intrinsics::fabsf32(x) };
+    if x < 0.0 {
+        assert!(-x == abs_x);
+    } else {
+        assert!(x == abs_x);
+    }
+}
+
+#[kani::proof]
+fn test_abs_nan() {
+    let x: f32 = kani::any();
+    kani::assume(x.is_nan());
+    let abs_x = unsafe { std::intrinsics::fabsf32(x) };
+    assert!(abs_x.is_nan());
+}

--- a/tests/kani/Intrinsics/Math/fabsf64.rs
+++ b/tests/kani/Intrinsics/Math/fabsf64.rs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `fabsf64` returns the expected results: absolute value if argument
+// is not NaN, otherwise NaN
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn test_abs_finite() {
+    let x: f64 = kani::any();
+    kani::assume(!x.is_nan());
+    let abs_x = unsafe { std::intrinsics::fabsf64(x) };
+    if x < 0.0 {
+        assert!(-x == abs_x);
+    } else {
+        assert!(x == abs_x);
+    }
+}
+
+#[kani::proof]
+fn test_abs_nan() {
+    let x: f64 = kani::any();
+    kani::assume(x.is_nan());
+    let abs_x = unsafe { std::intrinsics::fabsf64(x) };
+    assert!(abs_x.is_nan());
+}


### PR DESCRIPTION
### Description of changes: 

The implementation of "absolute" intrinsics (`fabsf32` and `fabsf64`) relies on CBMC's `fabsf` and `fabs`. This PR adds tests for them.

### Resolved issues:

Part of #727 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Adds two tests.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
