### PR TITLE
Add a licenses note file to the release bundle.

### DIFF
--- a/tools/make-kani-release/license-notes.txt
+++ b/tools/make-kani-release/license-notes.txt
@@ -1,0 +1,36 @@
+
+This file contains an inventory of software (and their licenses) that are included as part of the Kani Rust Verifier.
+
+kani: https://github.com/model-checking/kani
+License: Apache-2.0 OR MIT
+
+rustc: https://github.com/rust-lang/rust
+License: Apache-2.0 OR MIT (plus some BSD)
+More info: https://github.com/rust-lang/rust/blob/master/COPYRIGHT
+
+cbmc: https://github.com/diffblue/cbmc
+License: BSD-4-Clause
+More info: https://github.com/diffblue/cbmc/blob/develop/LICENSE
+Acknowledgement:
+     This product includes software developed by Daniel Kroening,
+     Edmund Clarke,
+     Computer Science Department, University of Oxford
+     Computer Science Department, Carnegie Mellon University
+
+cbmc-viewer: https://github.com/model-checking/cbmc-viewer
+License: Apache-2.0
+
+colorama: https://github.com/tartley/colorama
+License: BSD-3-Clause
+
+voluptuous: https://github.com/alecthomas/voluptuous
+License: BSD-3-Clause
+
+jinja2: https://github.com/pallets/jinja
+License: BSD-3-Clause
+
+setuptools: https://github.com/pypa/setuptools
+License: MIT
+
+MarkupSafe: https://github.com/pallets/markupsafe
+License: BSD-3-Clause

--- a/tools/make-kani-release/src/main.rs
+++ b/tools/make-kani-release/src/main.rs
@@ -101,6 +101,9 @@ fn bundle_kani(dir: &Path) -> Result<()> {
     // 4. Record the exact toolchain we use
     std::fs::write(dir.join("rust-toolchain-version"), env!("RUSTUP_TOOLCHAIN"))?;
 
+    // 5. Include a licensing note
+    cp(Path::new("tools/make-kani-release/license-notes.txt"), dir)?;
+
     Ok(())
 }
 /// Copy CBMC files into `dir`


### PR DESCRIPTION
### Description of changes: 

A quick inventory of the licenses included in Kani.

### Resolved issues:

Towards #1045 

### Call-outs:

1. CBMC probably has the worst license ("advertising clause"), though Rust frustratingly says "and some BSD" without really getting into the details.

### Testing:

* How is this change tested? Quick check that the file was included correctly.

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
