### PR TITLE
Borrow the arguments of the print macros to avoid moving them

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -103,7 +103,7 @@ macro_rules! evaluate_print_args {
         // Evaluate each of the arguments since they may have side effects
         {
             $(
-                $arg;
+                let _ = &$arg;
             )*
         }
     };

--- a/tests/kani/Print/arg_not_moved.rs
+++ b/tests/kani/Print/arg_not_moved.rs
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// This test checks that Kani's overridden versions of the print macros do not
+// take ownership of variables passed as arguments
+
+#[derive(Debug)]
+struct Foo {
+    x: i32,
+}
+
+#[kani::proof]
+fn main() {
+    let foo = Foo { x: 5 };
+    // calling `println` with `foo` should not move it
+    println!("{:?}", foo);
+    // make sure reading `foo` does not produce a "use of moved value" error
+    let y = foo.x;
+    assert!(y == 5);
+}


### PR DESCRIPTION
### Description of changes: 

Kani's overridden versions of the print macros may result in moving the arguments. This could cause borrow-after-move compiler errors. This PR fixes the print macros by ensuring that the arguments are borrowed (as is the case with the std versions), to avoid this error.

### Resolved issues:

Resolves #1052 and fixes the error in https://github.com/model-checking/kani/issues/674#issuecomment-1069730955


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? One test added

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
