### PR TITLE
Use signed types for signed scalars

### DIFF
--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -159,13 +159,13 @@ impl<'tcx> GotocCtx<'tcx> {
             (Scalar::Int(_), ty::Int(it)) => match it {
                 // We treat the data as bit vector. Thus, we extract the value as unsigned and set
                 // the type to signed int.
-                IntTy::I8 => Expr::int_constant(s.to_u8().unwrap(), Type::signed_int(8)),
-                IntTy::I16 => Expr::int_constant(s.to_u16().unwrap(), Type::signed_int(16)),
-                IntTy::I32 => Expr::int_constant(s.to_u32().unwrap(), Type::signed_int(32)),
-                IntTy::I64 => Expr::int_constant(s.to_u64().unwrap(), Type::signed_int(64)),
-                IntTy::I128 => Expr::int_constant(s.to_u128().unwrap(), Type::signed_int(128)),
+                IntTy::I8 => Expr::int_constant(s.to_i8().unwrap(), Type::signed_int(8)),
+                IntTy::I16 => Expr::int_constant(s.to_i16().unwrap(), Type::signed_int(16)),
+                IntTy::I32 => Expr::int_constant(s.to_i32().unwrap(), Type::signed_int(32)),
+                IntTy::I64 => Expr::int_constant(s.to_i64().unwrap(), Type::signed_int(64)),
+                IntTy::I128 => Expr::int_constant(s.to_i128().unwrap(), Type::signed_int(128)),
                 IntTy::Isize => {
-                    Expr::int_constant(s.to_machine_usize(self).unwrap(), Type::ssize_t())
+                    Expr::int_constant(s.to_machine_isize(self).unwrap(), Type::ssize_t())
                 }
             },
             (Scalar::Int(_), ty::Uint(it)) => match it {

--- a/src/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/src/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -157,8 +157,6 @@ impl<'tcx> GotocCtx<'tcx> {
         debug! {"codegen_scalar\n{:?}\n{:?}\n{:?}\n{:?}",s, ty, span, &ty.kind()};
         match (s, &ty.kind()) {
             (Scalar::Int(_), ty::Int(it)) => match it {
-                // We treat the data as bit vector. Thus, we extract the value as unsigned and set
-                // the type to signed int.
                 IntTy::I8 => Expr::int_constant(s.to_i8().unwrap(), Type::signed_int(8)),
                 IntTy::I16 => Expr::int_constant(s.to_i16().unwrap(), Type::signed_int(16)),
                 IntTy::I32 => Expr::int_constant(s.to_i32().unwrap(), Type::signed_int(32)),


### PR DESCRIPTION
### Description of changes: 

I've debugged #996 and there are multiple causes:
 1. The creation of unsigned integer constants to encode signed scalars.
 2. The creation of unsigned integer constants for setting a discriminant.
 3. Something else?

This PR is the first step towards #996 by using signed integers to encode signed scalars. My guess is that the sign was stored somewhere else in previous versions, but this is not needed anymore.

In regards to (2), I was able to find the issue but I don't know what's the best approach to solve it.

With these changes, the assertion in `cprover_bindings/src/irep/irep_id.rs:843` results in the following failures:

```
    [kani] kani/Cast/main.rs
    [kani] kani/CopyIntrinsics/main.rs
    [kani] kani/Enum/neg_discriminant.rs
    [kani] kani/Invariants/enum.rs
    [kani] kani/LexicographicCmp/main.rs
    [kani] kani/Vectors/push_u8.rs
    [kani] kani/Vectors/vector_extend.rs
    [kani] kani/Vectors/vector_extend_in_new.rs
    [kani] kani/Vectors/vector_extend_loop.rs
    [kani] kani/VolatileIntrinsics/main.rs
```

### Resolved issues:

Towards #996 

### Testing:

* How is this change tested? Existing regression.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
