### PR TITLE
Build a release bundle for macos

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -71,7 +71,15 @@ jobs:
           folder: docs/book/
 
   releasebundle:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-10.15, ubuntu-20.04]
+        include:
+          - os: macos-10.15
+            artifact: kani-latest-x86_64-apple-darwin.tar.gz
+          - os: ubuntu-20.04
+            artifact: kani-latest-x86_64-unknown-linux-gnu.tar.gz
     steps:
       - name: Checkout Kani
         uses: actions/checkout@v2
@@ -87,10 +95,27 @@ jobs:
           cargo package -p kani-verifier
       
       - name: Build container test
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
           docker build -t kani-latest -f scripts/ci/Dockerfile.release-bundle-test .
 
       - name: Run installed tests
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
           docker run -w /tmp/kani/tests/cargo-kani/simple-lib  kani-latest  cargo kani
           docker run -w /tmp/kani/tests/cargo-kani/simple-visualize  kani-latest  cargo kani
+
+      - name: Local install test
+        if: ${{ matrix.os == 'macos-10.15' }}
+        run: |
+          cargo install --path ./target/package/kani-verifier-*[^e]
+          cargo-kani setup --use-local-bundle ./kani-latest-x86_64-apple-darwin.tar.gz
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+          if-no-files-found: error
+          # Aggressively short retention: we don't really need these
+          retention-days: 3

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
-            os: ubuntu-20.04
+            os: ${{ matrix.os }}
       
       - name: Build release bundle
         run: |

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -110,6 +110,8 @@ jobs:
         run: |
           cargo install --path ./target/package/kani-verifier-*[^e]
           cargo-kani setup --use-local-bundle ./kani-latest-x86_64-apple-darwin.tar.gz
+          (cd tests/cargo-kani/simple-lib && cargo kani)
+          (cd tests/cargo-kani/simple-visualize && cargo kani)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -105,6 +105,8 @@ jobs:
           docker run -w /tmp/kani/tests/cargo-kani/simple-lib  kani-latest  cargo kani
           docker run -w /tmp/kani/tests/cargo-kani/simple-visualize  kani-latest  cargo kani
 
+      # We can't run macos in a container, so we can only test locally.
+      # Hopefully any dependency issues won't be unique to macos.
       - name: Local install test
         if: ${{ matrix.os == 'macos-10.15' }}
         run: |


### PR DESCRIPTION
### Description of changes: 

Add a "release bundle" CI step for macos as well.

Turns out, things just work! I opened #1067 to remind me about an issue that I initially thought would affect us, but only seems applicable to macos-arm. So, not relevant yet.

### Resolved issues:

Resolves #1036 

Towards #1045 

### Call-outs:

* Eventually we'll want to "refactor" how we do CI. IMO, we should run regressions on what we build with release bundle, then we'd just have these builds, and not the original ones... eventually.

### Testing:

* How is this change tested? New CI. I did test downloading the artifact and running it locally, however.

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
