### PR TITLE
Codegen unimplemented for the array subslice pattern

### DIFF
--- a/docs/src/rust-feature-support.md
+++ b/docs/src/rust-feature-support.md
@@ -52,7 +52,7 @@ Reference | Feature | Support | Notes |
 8.2.16 | Match expressions | Yes | |
 8.2.17 | Return expressions | Yes | |
 8.2.18 | Await expressions | No | See [Notes - Concurrency](#concurrency) |
-9 | Patterns | Partial | Needs more testing |
+9 | Patterns | Partial | [#707](https://github.com/model-checking/kani/issues/707) |
 10.1.1 | Boolean type | Yes | |
 10.1.2 | Numeric types | Yes | |
 10.1.3 | Textual types | Yes | |

--- a/tests/expected/slice-pattern-array/expected
+++ b/tests/expected/slice-pattern-array/expected
@@ -1,0 +1,2 @@
+Status: FAILURE\
+Description: "Sub-array binding is not currently supported by Kani. Please post your example at https://github.com/model-checking/kani/issues/707"

--- a/tests/expected/slice-pattern-array/main.rs
+++ b/tests/expected/slice-pattern-array/main.rs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Checks sub-array slice pattern, which is currently not supported:
+// https://github.com/model-checking/kani/issues/707
+
+#[kani::proof]
+fn main() {
+    let [x, y @ .., z] = [1, 2, 3, 4];
+    assert_eq!(x, 1);
+    assert_eq!(y, [2, 3]);
+    assert_eq!(z, 4);
+}


### PR DESCRIPTION
### Description of changes: 

Kani currently panics if the program uses the array subslice pattern (see #707). With this PR, Kani will now codegen unimplemented (assert/assume false), which will result in verification failure with an informative message if it's reachable.

### Resolved issues:

Resolves the crash in #707 (but doesn't add support for the array subslice pattern).

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? One test added.

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
