### PR TITLE
Improve unsupported platform error message in installer

### DIFF
--- a/src/kani-verifier/src/lib.rs
+++ b/src/kani-verifier/src/lib.rs
@@ -90,6 +90,15 @@ fn fail_if_in_dev_environment() -> Result<()> {
     Ok(())
 }
 
+/// Give users a better error message than "404" if we're on an unsupported platform.
+fn fail_if_unsupported_target() -> Result<()> {
+    // This is basically going to be reduced to a compile-time constant
+    match TARGET {
+        "x86_64-unknown-linux-gnu" | "x86_64-apple-darwin" => Ok(()),
+        _ => bail!("Kani does not support this platform (Rust target {})", TARGET),
+    }
+}
+
 /// Sets up Kani by unpacking/installing to `~/.kani/kani-VERSION`
 fn setup(use_local_bundle: Option<OsString>) -> Result<()> {
     let kani_dir = kani_dir();
@@ -115,6 +124,7 @@ fn setup(use_local_bundle: Option<OsString>) -> Result<()> {
     } else {
         let filename = download_filename();
         println!("[2/6] Downloading Kani release bundle: {}", &filename);
+        fail_if_unsupported_target()?;
         let bundle = base_dir.join(filename);
         Command::new("curl")
             .args(&["-sSLf", "-o"])


### PR DESCRIPTION
### Description of changes: 

This gives a better error when trying to `cargo-kani setup` on an unsupported platform.

### Resolved issues:


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? That it doesn't fire is being tested by existing CI

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
