### PR TITLE
Add test for wrapping intrinsics

### DIFF
--- a/tests/kani/Intrinsics/Math/Arith/wrapping_ops.rs
+++ b/tests/kani/Intrinsics/Math/Arith/wrapping_ops.rs
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Check that the `wrapping_<op>` intrinsics perform wrapping arithmetic
+// operations as expected and do not trigger spurious overflow checks.
+//
+// This test is a modified version of the examples found in
+// https://doc.rust-lang.org/std/primitive.u32.html for wrapping operations
+#![feature(core_intrinsics)]
+use std::intrinsics::{wrapping_add, wrapping_mul, wrapping_sub};
+
+#[kani::proof]
+fn test_wrapping_add() {
+    // The compiler detects overflows at compile time if we use constants so we
+    // declare a nondet. variable and assume the value to avoid annotations
+    let x: u32 = kani::any();
+    kani::assume(x == 200);
+    assert!(wrapping_add(x, 55) == 255);
+    assert!(wrapping_add(x, u32::MAX) == 199);
+}
+
+#[kani::proof]
+fn test_wrapping_sub() {
+    let x: u32 = kani::any();
+    kani::assume(x == 100);
+    assert_eq!(wrapping_sub(x, u32::MAX), 101);
+    assert_eq!(wrapping_sub(x, 100), 0);
+}
+
+#[kani::proof]
+fn test_wrapping_mul() {
+    let x: u8 = kani::any();
+    kani::assume(x == 12);
+    assert_eq!(wrapping_mul(10u8, x), 120);
+    assert_eq!(wrapping_mul(25u8, x), 44);
+}


### PR DESCRIPTION
### Description of changes: 

There are some tests for the stable wrapping operations, but not for the underlying intrinsic. This test ensures the intrinsics work as expected without spurious overflow checks.

### Resolved issues:

Part of #727 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Adds a new test.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
