### PR TITLE
Audit for unchecked intrinsics

### DIFF
--- a/tests/kani/ArithOperators/div_fail.rs
+++ b/tests/kani/ArithOperators/div_fail.rs
@@ -3,11 +3,12 @@
 // kani-verify-fail
 
 // Check that division triggers overflow checks.
-// Covers the case where `x == T::MIN && y == -1`.
+// Covers the case where `a == T::MIN && b == -1`.
 
 #[kani::proof]
 fn main() {
     let a: i8 = i8::MIN;
-    let b: i8 = -1;
+    let b: i8 = kani::any();
+    kani::assume(b == -1);
     let _ = a / b;
 }

--- a/tests/kani/ArithOperators/div_fail.rs
+++ b/tests/kani/ArithOperators/div_fail.rs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that division triggers overflow checks.
+// Covers the case where `x == T::MIN && y == -1`.
+
+#[kani::proof]
+fn main() {
+    let a: i8 = i8::MIN;
+    let b: i8 = -1;
+    let _ = a / b;
+}

--- a/tests/kani/ArithOperators/div_zero_fail.rs
+++ b/tests/kani/ArithOperators/div_zero_fail.rs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that division triggers overflow checks.
+// Covers the case where `b == 0`.
+
+#[kani::proof]
+fn main() {
+    let a: i8 = kani::any();
+    let b: i8 = 0;
+    let _ = a / b;
+}

--- a/tests/kani/ArithOperators/div_zero_fail.rs
+++ b/tests/kani/ArithOperators/div_zero_fail.rs
@@ -8,6 +8,7 @@
 #[kani::proof]
 fn main() {
     let a: i8 = kani::any();
-    let b: i8 = 0;
+    let b: i8 = kani::any();
+    kani::assume(b == 0);
     let _ = a / b;
 }

--- a/tests/kani/ArithOperators/rem_fail.rs
+++ b/tests/kani/ArithOperators/rem_fail.rs
@@ -3,7 +3,7 @@
 // kani-verify-fail
 
 // Check that remainder triggers overflow checks.
-// Covers the case where `x == T::MIN && y == -1`.
+// Covers the case where `a == T::MIN && b == -1`.
 
 #[kani::proof]
 fn main() {

--- a/tests/kani/ArithOperators/rem_fail.rs
+++ b/tests/kani/ArithOperators/rem_fail.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that remainder triggers overflow checks.
+// Covers the case where `x == T::MIN && y == -1`.
+
+#[kani::proof]
+fn main() {
+    let a: i8 = i8::MIN;
+    let b: i8 = kani::any();
+    kani::assume(b == -1);
+    let _ = a % b;
+}

--- a/tests/kani/ArithOperators/rem_zero_fail.rs
+++ b/tests/kani/ArithOperators/rem_zero_fail.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that remainder triggers overflow checks.
+// Covers the case where `b == 0`.
+
+#[kani::proof]
+fn main() {
+    let a: i8 = kani::any();
+    let b: i8 = kani::any();
+    kani::assume(b == 0);
+    let _ = a % b;
+}

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/add_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/add_fail.rs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that `unchecked_add` triggers overflow checks.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    let a: i32 = kani::any();
+    let b: i32 = kani::any();
+    unsafe { std::intrinsics::unchecked_add(a, b) };
+}

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/div_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/div_fail.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that `unchecked_div` triggers overflow checks.
+// Covers the case where `a == T::MIN && b == -1`.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    let a: i32 = i32::MIN;
+    let b: i32 = -1;
+    unsafe { std::intrinsics::unchecked_div(a, b) };
+}

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/div_zero_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/div_zero_fail.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that `unchecked_div` triggers overflow checks.
+// Covers the case where `b == 0`.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    let a: i32 = kani::any();
+    let b: i32 = 0;
+    unsafe { std::intrinsics::unchecked_div(a, b) };
+}

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/mul_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/mul_fail.rs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that `unchecked_mul` triggers overflow checks.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    let a: i32 = kani::any();
+    let b: i32 = kani::any();
+    unsafe { std::intrinsics::unchecked_mul(a, b) };
+}

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/no_overflows.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/no_overflows.rs
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Check that none of these operations trigger spurious overflow checks.
+#![feature(core_intrinsics)]
+use std::intrinsics::{
+    unchecked_add, unchecked_div, unchecked_mul, unchecked_rem, unchecked_shl, unchecked_shr,
+    unchecked_sub,
+};
+
+// `checked_shr` and `checked_shl` require `u32` for their argument. We use
+// `u32` in those cases and `u8` for the rest because they perform better.
+macro_rules! verify_no_overflow {
+    ($ty:ty, $cf: ident, $uf: ident) => {{
+        let a: $ty = kani::any();
+        let b: $ty = kani::any();
+        let checked = a.$cf(b);
+        kani::assume(checked.is_some());
+        let unchecked = unsafe { $uf(a, b) };
+        assert!(checked.unwrap() == unchecked);
+    }};
+}
+
+#[kani::proof]
+fn test_unchecked_add() {
+    verify_no_overflow!(u8, checked_add, unchecked_add);
+}
+
+#[kani::proof]
+fn test_unchecked_sub() {
+    verify_no_overflow!(u8, checked_sub, unchecked_sub);
+}
+
+#[kani::proof]
+fn test_unchecked_mul() {
+    verify_no_overflow!(u8, checked_mul, unchecked_mul);
+}
+
+#[kani::proof]
+fn test_unchecked_div() {
+    verify_no_overflow!(u8, checked_div, unchecked_div);
+}
+
+#[kani::proof]
+fn test_unchecked_rem() {
+    verify_no_overflow!(u8, checked_rem, unchecked_rem);
+}
+
+#[kani::proof]
+fn test_unchecked_shl() {
+    verify_no_overflow!(u32, checked_shl, unchecked_shl);
+}
+
+#[kani::proof]
+fn test_unchecked_shr() {
+    verify_no_overflow!(u32, checked_shr, unchecked_shr);
+}

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/rem_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/rem_fail.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that `unchecked_rem` triggers overflow checks.
+// Covers the case where `a == T::MIN && b == -1`.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    let a: i32 = i32::MIN;
+    let b: i32 = -1;
+    unsafe { std::intrinsics::unchecked_rem(a, b) };
+}

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/rem_zero_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/rem_zero_fail.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that `unchecked_rem` triggers overflow checks.
+// Covers the case where `b == 0`.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    let a: i32 = kani::any();
+    let b: i32 = 0;
+    unsafe { std::intrinsics::unchecked_rem(a, b) };
+}

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/shl_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/shl_fail.rs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that `unchecked_shl` triggers overflow checks.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    let a: u32 = kani::any();
+    let b: u32 = kani::any();
+    unsafe { std::intrinsics::unchecked_shl(a, b) };
+}

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/shr_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/shr_fail.rs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that `unchecked_shr` triggers overflow checks.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    let a: u32 = kani::any();
+    let b: u32 = kani::any();
+    unsafe { std::intrinsics::unchecked_shr(a, b) };
+}

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/sub_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/sub_fail.rs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+// Check that `unchecked_sub` triggers overflow checks.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    let a: i32 = kani::any();
+    let b: i32 = kani::any();
+    unsafe { std::intrinsics::unchecked_sub(a, b) };
+}


### PR DESCRIPTION
### Description of changes: 

Reviews and adds tests for all `unchecked_*` operations.

The most notable change is the addition of an overflow check for `unchecked_div` and `unchecked_rem`, which were not failing in the case where `a == T::MIN && b == -1`. This check was already written for `exact_div` so I refactored it into a function which is now used for unchecked div/rem. 

Then, I was afraid this was also the case for standard div/rem operations, but turns out this overflow check is already covered so no changes are needed. The tests I wrote to verify this are included as well.

### Resolved issues:

Part of #727 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Adds many tests, in particular the ones to check an overflow that was previously not checked.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
