### PR TITLE
Add warning for unsupported constructs

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -272,12 +272,13 @@ fn print_report<'tcx>(ctx: &GotocCtx, tcx: TyCtxt<'tcx>) {
             .iter()
             .map(|(key, val)| (key.map(|s| String::from(s)), val))
             .collect();
-        let mut msg =
-            String::from("Compilation unit included the following unsupported constructs:\n");
+        let mut msg = String::from("Found the following unsupported constructs:\n");
         unsupported.iter().for_each(|(construct, locations)| {
             msg += &format!("    - {} ({})\n", construct, locations.len())
         });
         msg += "\nVerification will fail if one or more of these constructs is reachable.";
+        msg += "\nSee https://model-checking.github.io/kani/rust-feature-support.html for more \
+        details.";
         tcx.sess.warn(&msg);
     }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -5,7 +5,7 @@
 
 use crate::codegen_cprover_gotoc::GotocCtx;
 use bitflags::_core::any::Any;
-use cbmc::goto_program::symtab_transformer;
+use cbmc::goto_program::{symtab_transformer, Location};
 use cbmc::InternedString;
 use kani_metadata::KaniMetadata;
 use kani_queries::{QueryDb, UserInput};
@@ -120,6 +120,9 @@ impl CodegenBackend for GotocCodegenBackend {
                 }
             }
         }
+
+        // Print compilation report.
+        print_report(&c, tcx);
 
         // perform post-processing symbol table passes
         let passes = self.queries.get_symbol_table_passes();
@@ -256,5 +259,24 @@ where
         serde_json::to_writer_pretty(writer, &source).unwrap();
     } else {
         serde_json::to_writer(writer, &source).unwrap();
+    }
+}
+
+/// Prints a report at the end of the compilation.
+fn print_report<'tcx>(ctx: &GotocCtx, tcx: TyCtxt<'tcx>) {
+    // Print all unsupported constructs.
+    if !ctx.unsupported_constructs.is_empty() {
+        // Sort alphabetically.
+        let unsupported: BTreeMap<String, &Vec<Location>> = ctx
+            .unsupported_constructs
+            .iter()
+            .map(|(key, val)| (key.map(|s| String::from(s)), val))
+            .collect();
+        let mut msg =
+            String::from("Compilation unit included the following unsupported constructs:");
+        unsupported.iter().for_each(|(construct, locations)| {
+            msg += &format!("\n    - {} ({})", construct, locations.len())
+        });
+        tcx.sess.warn(&msg);
     }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -273,10 +273,11 @@ fn print_report<'tcx>(ctx: &GotocCtx, tcx: TyCtxt<'tcx>) {
             .map(|(key, val)| (key.map(|s| String::from(s)), val))
             .collect();
         let mut msg =
-            String::from("Compilation unit included the following unsupported constructs:");
+            String::from("Compilation unit included the following unsupported constructs:\n");
         unsupported.iter().for_each(|(construct, locations)| {
-            msg += &format!("\n    - {} ({})", construct, locations.len())
+            msg += &format!("    - {} ({})\n", construct, locations.len())
         });
+        msg += "\nVerification will fail if one or more of these constructs is reachable.";
         tcx.sess.warn(&msg);
     }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -61,6 +61,8 @@ pub struct GotocCtx<'tcx> {
     pub proof_harnesses: Vec<HarnessMetadata>,
     /// a global counter for generating unique IDs for checks
     pub global_checks_count: u64,
+    /// A map of unsupported constructs that were found while codegen
+    pub unsupported_constructs: FxHashMap<InternedString, Vec<Location>>,
 }
 
 /// Constructor
@@ -83,6 +85,7 @@ impl<'tcx> GotocCtx<'tcx> {
             type_map: FxHashMap::default(),
             proof_harnesses: vec![],
             global_checks_count: 0,
+            unsupported_constructs: FxHashMap::default(),
         }
     }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
@@ -7,7 +7,7 @@ use cbmc::goto_program::{Expr, ExprValue, Location, Stmt, SymbolTable, Type};
 use cbmc::{btree_string_map, InternedString};
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::Ty;
-use tracing::warn;
+use tracing::debug;
 
 // Should move into rvalue
 //make this a member function
@@ -57,7 +57,7 @@ impl<'tcx> GotocCtx<'tcx> {
         debug!("codegen_unimplemented: {} at {}", operation_name, loc.short_string());
         let key: InternedString = operation_name.into();
         if !self.unsupported_constructs.contains_key(&key) {
-            self.unsupported_constructs.insert(key.clone(), Vec::new());
+            self.unsupported_constructs.insert(key, Vec::new());
         }
         self.unsupported_constructs.get_mut(&key).unwrap().push(loc.clone());
 

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
@@ -48,7 +48,6 @@ impl<'tcx> GotocCtx<'tcx> {
     /// This allows us to continue to make progress parsing rust code, while remaining sound (thanks to the `assert(false)`)
     ///
     /// TODO: https://github.com/model-checking/kani/issues/8 assume the required validity constraints for the nondet return
-    /// TODO: https://github.com/model-checking/kani/issues/9 Have a parameter that decides whether to `assume(0)` to block further traces or not
     pub fn codegen_unimplemented(
         &mut self,
         operation_name: &str,
@@ -56,7 +55,7 @@ impl<'tcx> GotocCtx<'tcx> {
         loc: Location,
         url: &str,
     ) -> Expr {
-        // Save this occurrence so we can emit in the compilation report.
+        // Save this occurrence so we can emit a warning in the compilation report.
         debug!("codegen_unimplemented: {} at {}", operation_name, loc.short_string());
         let key: InternedString = operation_name.into();
         if !self.unsupported_constructs.contains_key(&key) {

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
@@ -46,8 +46,6 @@ impl<'tcx> GotocCtx<'tcx> {
     /// This means that if the unimplemented feature is dynamically used by the code being verified, we will see an assertion failure.
     /// If it is not used, we the assertion will pass.
     /// This allows us to continue to make progress parsing rust code, while remaining sound (thanks to the `assert(false)`)
-    ///
-    /// TODO: https://github.com/model-checking/kani/issues/8 assume the required validity constraints for the nondet return
     pub fn codegen_unimplemented(
         &mut self,
         operation_name: &str,

--- a/tests/kani/Options/check_tests.rs
+++ b/tests/kani/Options/check_tests.rs
@@ -20,7 +20,7 @@ mod test {
     #[test]
     #[kani::proof]
     fn test_harness() {
-        let input: i32 = kani::nondet();
+        let input: i32 = kani::any();
         kani::assume(input > 1);
         fn_under_verification(input);
     }

--- a/tests/ui/unsupported-features/thread/expected
+++ b/tests/ui/unsupported-features/thread/expected
@@ -1,1 +1,4 @@
+warning: Compilation unit included the following unsupported constructs:\
+Rvalue::ThreadLocalRef
+
 Failed Checks: Rvalue::ThreadLocalRef is not currently supported by Kani.

--- a/tests/ui/unsupported-features/thread/expected
+++ b/tests/ui/unsupported-features/thread/expected
@@ -1,4 +1,4 @@
-warning: Compilation unit included the following unsupported constructs:\
+warning: Found the following unsupported constructs:\
 Rvalue::ThreadLocalRef\
 \
 Verification will fail if one or more of these constructs is reachable.\

--- a/tests/ui/unsupported-features/thread/expected
+++ b/tests/ui/unsupported-features/thread/expected
@@ -1,6 +1,7 @@
 warning: Compilation unit included the following unsupported constructs:\
 Rvalue::ThreadLocalRef\
 \
-Verification will fail if one or more of these constructs is reachable.
+Verification will fail if one or more of these constructs is reachable.\
+See https://model-checking.github.io/kani/rust-feature-support.html for more details.
 
 Failed Checks: Rvalue::ThreadLocalRef is not currently supported by Kani.

--- a/tests/ui/unsupported-features/thread/expected
+++ b/tests/ui/unsupported-features/thread/expected
@@ -1,4 +1,6 @@
 warning: Compilation unit included the following unsupported constructs:\
-Rvalue::ThreadLocalRef
+Rvalue::ThreadLocalRef\
+\
+Verification will fail if one or more of these constructs is reachable.
 
 Failed Checks: Rvalue::ThreadLocalRef is not currently supported by Kani.


### PR DESCRIPTION
### Description of changes: 

For now, at the end of each compilation unit, we will print one single warning if we found any unsupported construct. This warning will list the name and number of occurrences of each unsupported constructs that was found.

Output example:

```
warning: Compilation unit included the following unsupported constructs:
             - 'arith_offset' intrinsic (4)
             - 'copy' intrinsic (3)
```

### Resolved issues:

Resolves #922 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
