### PR TITLE
Remove VSCode rust-analyzer setting that no longer exists

### DIFF
--- a/docs/src/rustc-hacks.md
+++ b/docs/src/rustc-hacks.md
@@ -14,7 +14,6 @@ In order to get these features working for `rustc` crates, you can do the follow
 
 Add the following to the `rust-analyzer` extension settings in `settings.json`:
 ```json
-    "rust-analyzer.updates.channel": "nightly",
     "rust-analyzer.rustcSource": "discover",
     "rust-analyzer.workspace.symbol.search.scope": "workspace_and_dependencies",
 ```


### PR DESCRIPTION
### Description of changes: 

Updating the dev-docs to remove a VSCode rust-analyzer extension setting that was recently removed (see https://github.com/rust-lang/rust-analyzer/issues/11468)

### Resolved issues:



### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
