### PR TITLE
Remove implementation for the `unreachable` intrinsic

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -607,12 +607,6 @@ impl<'tcx> GotocCtx<'tcx> {
             }
             "unchecked_sub" => codegen_op_with_overflow_check!(sub_overflow),
             "unlikely" => self.codegen_expr_to_place(p, fargs.remove(0)),
-            "unreachable" => self.codegen_assert(
-                Expr::bool_false(),
-                PropertyClass::DefaultAssertion,
-                "unreachable",
-                loc,
-            ),
             "volatile_copy_memory" => unstable_codegen!(codegen_intrinsic_copy!(Memmove)),
             "volatile_copy_nonoverlapping_memory" => {
                 unstable_codegen!(codegen_intrinsic_copy!(Memcpy))

--- a/tests/expected/intrinsics/unreachable/expected
+++ b/tests/expected/intrinsics/unreachable/expected
@@ -1,0 +1,2 @@
+FAILURE\
+"unreachable code"

--- a/tests/expected/intrinsics/unreachable/main.rs
+++ b/tests/expected/intrinsics/unreachable/main.rs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn main() {
+    unsafe {
+        std::intrinsics::unreachable();
+    }
+}


### PR DESCRIPTION
### Description of changes: 

The implementation we had for the `unreachable` intrinsic is unreachable itself. The code being executed is actually the `TerminatorKind::Unreachable`, which generates an assert-false statement with the message "unreachable code".

Adding a test to ensure this keeps happening.

### Resolved issues:

Part of #727 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Adds one test.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
