### PR TITLE
Remove --object-bits option

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -81,8 +81,10 @@ impl KaniSession {
     ) -> Result<Vec<OsString>> {
         let mut args = self.cbmc_check_flags();
 
-        args.push("--object-bits".into());
-        args.push(self.args.object_bits.to_string().into());
+        if let Some(object_bits) = self.args.cbmc_object_bits() {
+            args.push("--object-bits".into());
+            args.push(object_bits.to_string().into());
+        }
 
         if let Some(unwind_value) = resolve_unwind_value(&self.args, harness_metadata) {
             args.push("--unwind".into());

--- a/tests/expected/dry-run-flag-conflict/expected
+++ b/tests/expected/dry-run-flag-conflict/expected
@@ -1,1 +1,1 @@
-Conflicting flags: `--object-bits` was specified twice.
+error: Invalid flag: --function should be provided to Kani directly, not via

--- a/tests/expected/dry-run-flag-conflict/main.rs
+++ b/tests/expected/dry-run-flag-conflict/main.rs
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// kani-flags: --enable-unstable --dry-run --function main
+// cbmc-flags: --function main
 
-// kani-flags: --dry-run --object-bits 10 --enable-unstable --function main
-// cbmc-flags: --object-bits 8
+//! This testcase is to ensure that user cannot pass --function as cbmc-flags
+//! with our driver logic.
 
-// `--dry-run` causes Kani to print out commands instead of running them
-// In `expected` you will find substrings of these commands because the
-// concrete paths depend on your working directory.
+/// This shouldn't run.
 #[kani::proof]
 fn main() {}

--- a/tests/firecracker/virtio-balloon-compact/ignore-main.rs
+++ b/tests/firecracker/virtio-balloon-compact/ignore-main.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
-// Try with: kani ignore-main.rs -- --default-unwind 3 --unwinding-assertions --pointer-check --object-bits 11
+// Try with: kani ignore-main.rs --default-unwind 3 --enable-unstable --cbmc-args --object-bits 11
 // With kissat as the solver (--external-sat-solver /path/to/kissat) this takes ~5mins
 
 pub const MAX_PAGE_COMPACT_BUFFER: usize = 2048;


### PR DESCRIPTION
### Description of changes: 

Delete --object-bits option from Kani. We still set the default to 16 if the user doesn't pick a value via `--cbmc-args`.

### Resolved issues:

Part of #1106 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
