### PR TITLE
Rewrite loops with multiple back edges to having a single back edge only

### DIFF
--- a/docs/src/tutorial/arbitrary-variables/Cargo.toml
+++ b/docs/src/tutorial/arbitrary-variables/Cargo.toml
@@ -11,4 +11,4 @@ vector-map = "1.0.1"
 [workspace]
 
 [workspace.metadata.kani]
-flags = { default-checks = false, unwind = "2" }
+flags = { unwind = "3" }

--- a/kani-driver/src/call_goto_instrument.rs
+++ b/kani-driver/src/call_goto_instrument.rs
@@ -23,6 +23,8 @@ impl KaniSession {
             self.just_drop_unused_functions(output)?;
         }
 
+        self.rewrite_back_edges(output)?;
+
         if self.args.gen_c {
             if !self.args.quiet {
                 println!("Generated C code written to {}", output.to_string_lossy());
@@ -93,6 +95,16 @@ impl KaniSession {
     fn just_drop_unused_functions(&self, file: &Path) -> Result<()> {
         let args: Vec<OsString> = vec![
             "--drop-unused-functions".into(),
+            file.to_owned().into_os_string(), // input
+            file.to_owned().into_os_string(), // output
+        ];
+
+        self.call_goto_instrument(args)
+    }
+
+    fn rewrite_back_edges(&self, file: &Path) -> Result<()> {
+        let args: Vec<OsString> = vec![
+            "--ensure-one-backedge-per-target".into(),
             file.to_owned().into_os_string(), // input
             file.to_owned().into_os_string(), // output
         ];

--- a/tests/kani/AssociatedTypes/into_iter.rs
+++ b/tests/kani/AssociatedTypes/into_iter.rs
@@ -19,7 +19,7 @@ impl<'a> MyStruct<'a> {
 }
 
 #[kani::proof]
-#[kani::unwind(2)]
+#[kani::unwind(3)]
 pub fn check_into_iter_type() {
     let original = "h";
     let mut wrapper = MyStruct::new(original.chars());

--- a/tests/kani/Intrinsics/Count/ctpop.rs
+++ b/tests/kani/Intrinsics/Count/ctpop.rs
@@ -20,11 +20,6 @@ macro_rules! test_ctpop {
                 if bit != 0 {
                     count += 1;
                 }
-                // The assertion below mitigates a low performance issue in this
-                // test due to the loop having a conditional jump at the end,
-                // see https://github.com/model-checking/kani/issues/1046 for
-                // more details.
-                assert!(count >= 0);
             }
             count
         }


### PR DESCRIPTION
This is a re-creation of #900 after the Kani history rewrite. I can't force-push to that branch to do the rebase, so I'm just recreating it.

### Description of changes: 

rustc reasonably translates if statements at end of a loop body to
backwards jumps to the loop head. This, however, causes CBMC's symbolic
execution to spuriously treat these as nested loops. This commit now
enables a rewrite step that had previously been built for exactly such
cases.

### Resolved issues:

Resolves #1046 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
