### PR TITLE
Replace vector-map by linear-map dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -171,28 +171,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "contracts"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9424f2ca1e42776615720e5746eed6efa19866fdbaac2923ab51c294ac4d1f2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "cprover_bindings"
 version = "0.0.0"
 dependencies = [
  "lazy_static",
+ "linear-map",
  "num",
  "num-traits",
  "serde",
  "serde_test",
  "string-interner",
  "tracing",
- "vector-map",
 ]
 
 [[package]]
@@ -282,24 +271,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -449,6 +427,16 @@ name = "libc"
 version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+
+[[package]]
+name = "linear-map"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
+dependencies = [
+ "serde",
+ "serde_test",
+]
 
 [[package]]
 name = "lock_api"
@@ -679,12 +667,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,47 +717,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -1182,16 +1123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
-name = "vector-map"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550f72ae94a45c0e2139188709e6c4179f0b5ff9bdaa435239ad19048b0cd68c"
-dependencies = [
- "contracts",
- "rand",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,12 +1138,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -5,6 +5,7 @@
 name = "cprover_bindings"
 version = "0.0.0"
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 [lib]
 test = true
@@ -17,7 +18,7 @@ num-traits = "0.2"
 serde = {version = "1", features = ["derive"]}
 string-interner = "0.14.0"
 tracing = "0.1"
-vector-map = "1.0.1"
+linear-map = {version = "1.2", features = ["serde_impl"]}
 
 [dev-dependencies]
 serde_test = "1"

--- a/cprover_bindings/src/irep/irep.rs
+++ b/cprover_bindings/src/irep/irep.rs
@@ -6,9 +6,9 @@ use super::super::goto_program::{Location, Type};
 use super::super::MachineModel;
 use super::{IrepId, ToIrep};
 use crate::cbmc_string::InternedString;
+use linear_map::LinearMap;
 use num::BigInt;
 use std::fmt::Debug;
-use vector_map::VecMap;
 
 /// The CBMC serialization format for goto-programs.
 /// CBMC implementation code is at:
@@ -17,7 +17,7 @@ use vector_map::VecMap;
 pub struct Irep {
     pub id: IrepId,
     pub sub: Vec<Irep>,
-    pub named_sub: VecMap<IrepId, Irep>,
+    pub named_sub: LinearMap<IrepId, Irep>,
 }
 
 /// Getters
@@ -102,7 +102,7 @@ impl Irep {
     }
 
     pub fn just_id(id: IrepId) -> Irep {
-        Irep { id: id, sub: Vec::new(), named_sub: VecMap::new() }
+        Irep { id: id, sub: Vec::new(), named_sub: LinearMap::new() }
     }
 
     pub fn just_int_id<T>(i: T) -> Irep
@@ -111,7 +111,7 @@ impl Irep {
     {
         Irep::just_id(IrepId::from_int(i))
     }
-    pub fn just_named_sub(named_sub: VecMap<IrepId, Irep>) -> Irep {
+    pub fn just_named_sub(named_sub: LinearMap<IrepId, Irep>) -> Irep {
         Irep { id: IrepId::EmptyString, sub: vec![], named_sub: named_sub }
     }
 
@@ -120,7 +120,7 @@ impl Irep {
     }
 
     pub fn just_sub(sub: Vec<Irep>) -> Irep {
-        Irep { id: IrepId::EmptyString, sub: sub, named_sub: VecMap::new() }
+        Irep { id: IrepId::EmptyString, sub: sub, named_sub: LinearMap::new() }
     }
 
     pub fn nil() -> Irep {

--- a/cprover_bindings/src/irep/serialize.rs
+++ b/cprover_bindings/src/irep/serialize.rs
@@ -5,23 +5,6 @@ use crate::irep::{Irep, IrepId, Symbol, SymbolTable};
 use crate::InternedString;
 use serde::ser::{SerializeMap, Serializer};
 use serde::Serialize;
-use vector_map::VecMap;
-
-// Wrapper type to allow impl of trait (otherwise impossible when both trait and type are external).
-struct MapWrapper<'a, K, V>(&'a VecMap<K, V>);
-
-impl<K: serde::Serialize, V: serde::Serialize> Serialize for MapWrapper<'_, K, V> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut obj = serializer.serialize_map(None)?;
-        for (k, v) in self.0 {
-            obj.serialize_entry(k, v)?;
-        }
-        obj.end()
-    }
-}
 
 impl Serialize for Irep {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -34,7 +17,7 @@ impl Serialize for Irep {
             obj.serialize_entry("sub", &self.sub)?;
         }
         if !self.named_sub.is_empty() {
-            obj.serialize_entry("namedSub", &MapWrapper(&self.named_sub))?;
+            obj.serialize_entry("namedSub", &self.named_sub)?;
         }
         obj.end()
     }

--- a/cprover_bindings/src/irep/to_irep.rs
+++ b/cprover_bindings/src/irep/to_irep.rs
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Converts a typed goto-program into the `Irep` serilization format of CBMC
-// TODO: consider making a macro to replace `vector_map![])` for initilizing btrees.
+// TODO: consider making a macro to replace `linear_map![])` for initilizing btrees.
 use super::super::goto_program;
 use super::super::MachineModel;
 use super::{Irep, IrepId};
-use crate::vector_map;
+use crate::linear_map;
 use goto_program::{
     BinaryOperand, CIntType, DatatypeComponent, Expr, ExprValue, Location, Parameter, SelfOperand,
     Stmt, StmtBody, SwitchCase, SymbolValues, Type, UnaryOperand,
@@ -20,21 +20,21 @@ fn arguments_irep(arguments: &[Expr], mm: &MachineModel) -> Irep {
     Irep {
         id: IrepId::Arguments,
         sub: arguments.iter().map(|x| x.to_irep(mm)).collect(),
-        named_sub: vector_map![],
+        named_sub: linear_map![],
     }
 }
 fn code_irep(kind: IrepId, ops: Vec<Irep>) -> Irep {
     Irep {
         id: IrepId::Code,
         sub: ops,
-        named_sub: vector_map![(IrepId::Statement, Irep::just_id(kind))],
+        named_sub: linear_map![(IrepId::Statement, Irep::just_id(kind))],
     }
 }
 fn side_effect_irep(kind: IrepId, ops: Vec<Irep>) -> Irep {
     Irep {
         id: IrepId::SideEffect,
         sub: ops,
-        named_sub: vector_map![(IrepId::Statement, Irep::just_id(kind))],
+        named_sub: linear_map![(IrepId::Statement, Irep::just_id(kind))],
     }
 }
 fn switch_default_irep(body: &Stmt, mm: &MachineModel) -> Irep {
@@ -120,12 +120,12 @@ impl ToIrepId for UnaryOperand {
 impl ToIrep for DatatypeComponent {
     fn to_irep(&self, mm: &MachineModel) -> Irep {
         match self {
-            DatatypeComponent::Field { name, typ } => Irep::just_named_sub(vector_map![
+            DatatypeComponent::Field { name, typ } => Irep::just_named_sub(linear_map![
                 (IrepId::Name, Irep::just_string_id(name.to_string())),
                 (IrepId::PrettyName, Irep::just_string_id(name.to_string())),
                 (IrepId::Type, typ.to_irep(mm)),
             ]),
-            DatatypeComponent::Padding { name, bits } => Irep::just_named_sub(vector_map![
+            DatatypeComponent::Padding { name, bits } => Irep::just_named_sub(linear_map![
                 (IrepId::CIsPadding, Irep::one()),
                 (IrepId::Name, Irep::just_string_id(name.to_string())),
                 (IrepId::Type, Type::unsigned_int(*bits).to_irep(mm)),
@@ -141,7 +141,7 @@ impl ToIrep for Expr {
             Irep {
                 id: IrepId::Constant,
                 sub: vec![],
-                named_sub: vector_map![(
+                named_sub: linear_map![(
                     IrepId::Value,
                     Irep::just_bitpattern_id(i.clone(), width, self.typ().is_signed(mm))
                 )],
@@ -158,15 +158,15 @@ impl ToIrep for ExprValue {
     fn to_irep(&self, mm: &MachineModel) -> Irep {
         match self {
             ExprValue::AddressOf(e) => {
-                Irep { id: IrepId::AddressOf, sub: vec![e.to_irep(mm)], named_sub: vector_map![] }
+                Irep { id: IrepId::AddressOf, sub: vec![e.to_irep(mm)], named_sub: linear_map![] }
             }
             ExprValue::Array { elems } => Irep {
                 id: IrepId::Array,
                 sub: elems.iter().map(|x| x.to_irep(mm)).collect(),
-                named_sub: vector_map![],
+                named_sub: linear_map![],
             },
             ExprValue::ArrayOf { elem } => {
-                Irep { id: IrepId::ArrayOf, sub: vec![elem.to_irep(mm)], named_sub: vector_map![] }
+                Irep { id: IrepId::ArrayOf, sub: vec![elem.to_irep(mm)], named_sub: linear_map![] }
             }
             ExprValue::Assign { left, right } => {
                 side_effect_irep(IrepId::Assign, vec![left.to_irep(mm), right.to_irep(mm)])
@@ -174,12 +174,12 @@ impl ToIrep for ExprValue {
             ExprValue::BinOp { op, lhs, rhs } => Irep {
                 id: op.to_irep_id(),
                 sub: vec![lhs.to_irep(mm), rhs.to_irep(mm)],
-                named_sub: vector_map![],
+                named_sub: linear_map![],
             },
             ExprValue::BoolConstant(c) => Irep {
                 id: IrepId::Constant,
                 sub: vec![],
-                named_sub: vector_map![(
+                named_sub: linear_map![(
                     IrepId::Value,
                     if *c { Irep::just_id(IrepId::True) } else { Irep::just_id(IrepId::False) },
                 )],
@@ -191,18 +191,18 @@ impl ToIrep for ExprValue {
                     IrepId::ByteExtractLittleEndian
                 },
                 sub: vec![e.to_irep(mm), Expr::int_constant(*offset, Type::ssize_t()).to_irep(mm)],
-                named_sub: vector_map![],
+                named_sub: linear_map![],
             },
             ExprValue::CBoolConstant(i) => Irep {
                 id: IrepId::Constant,
                 sub: vec![],
-                named_sub: vector_map![(
+                named_sub: linear_map![(
                     IrepId::Value,
                     Irep::just_bitpattern_id(if *i { 1u8 } else { 0 }, mm.bool_width(), false)
                 )],
             },
             ExprValue::Dereference(e) => {
-                Irep { id: IrepId::Dereference, sub: vec![e.to_irep(mm)], named_sub: vector_map![] }
+                Irep { id: IrepId::Dereference, sub: vec![e.to_irep(mm)], named_sub: linear_map![] }
             }
             //TODO, determine if there is an endineness problem here
             ExprValue::DoubleConstant(i) => {
@@ -210,7 +210,7 @@ impl ToIrep for ExprValue {
                 Irep {
                     id: IrepId::Constant,
                     sub: vec![],
-                    named_sub: vector_map![(
+                    named_sub: linear_map![(
                         IrepId::Value,
                         Irep::just_bitpattern_id(c, mm.double_width(), false)
                     )],
@@ -221,7 +221,7 @@ impl ToIrep for ExprValue {
                 Irep {
                     id: IrepId::Constant,
                     sub: vec![],
-                    named_sub: vector_map![(
+                    named_sub: linear_map![(
                         IrepId::Value,
                         Irep::just_bitpattern_id(c, mm.float_width(), false)
                     )],
@@ -234,12 +234,12 @@ impl ToIrep for ExprValue {
             ExprValue::If { c, t, e } => Irep {
                 id: IrepId::If,
                 sub: vec![c.to_irep(mm), t.to_irep(mm), e.to_irep(mm)],
-                named_sub: vector_map![],
+                named_sub: linear_map![],
             },
             ExprValue::Index { array, index } => Irep {
                 id: IrepId::Index,
                 sub: vec![array.to_irep(mm), index.to_irep(mm)],
-                named_sub: vector_map![],
+                named_sub: linear_map![],
             },
             ExprValue::IntConstant(_) => {
                 unreachable!("Should have been processed in previous step")
@@ -247,7 +247,7 @@ impl ToIrep for ExprValue {
             ExprValue::Member { lhs, field } => Irep {
                 id: IrepId::Member,
                 sub: vec![lhs.to_irep(mm)],
-                named_sub: vector_map![
+                named_sub: linear_map![
                     (IrepId::CLvalue, Irep::one()),
                     (IrepId::ComponentName, Irep::just_string_id(field.to_string())),
                 ],
@@ -256,12 +256,12 @@ impl ToIrep for ExprValue {
             ExprValue::PointerConstant(0) => Irep {
                 id: IrepId::Constant,
                 sub: vec![],
-                named_sub: vector_map![(IrepId::Value, Irep::just_id(IrepId::NULL))],
+                named_sub: linear_map![(IrepId::Value, Irep::just_id(IrepId::NULL))],
             },
             ExprValue::PointerConstant(i) => Irep {
                 id: IrepId::Constant,
                 sub: vec![],
-                named_sub: vector_map![(
+                named_sub: linear_map![(
                     IrepId::Value,
                     Irep::just_bitpattern_id(*i, mm.pointer_width(), false)
                 )],
@@ -274,28 +274,28 @@ impl ToIrep for ExprValue {
             ExprValue::StringConstant { s } => Irep {
                 id: IrepId::StringConstant,
                 sub: vec![],
-                named_sub: vector_map![(IrepId::Value, Irep::just_string_id(s.to_string()),)],
+                named_sub: linear_map![(IrepId::Value, Irep::just_string_id(s.to_string()),)],
             },
             ExprValue::Struct { values } => Irep {
                 id: IrepId::Struct,
                 sub: values.iter().map(|x| x.to_irep(mm)).collect(),
-                named_sub: vector_map![],
+                named_sub: linear_map![],
             },
             ExprValue::Symbol { identifier } => Irep {
                 id: IrepId::Symbol,
                 sub: vec![],
-                named_sub: vector_map![(
+                named_sub: linear_map![(
                     IrepId::Identifier,
                     Irep::just_string_id(identifier.to_string()),
                 )],
             },
             ExprValue::Typecast(e) => {
-                Irep { id: IrepId::Typecast, sub: vec![e.to_irep(mm)], named_sub: vector_map![] }
+                Irep { id: IrepId::Typecast, sub: vec![e.to_irep(mm)], named_sub: linear_map![] }
             }
             ExprValue::Union { value, field } => Irep {
                 id: IrepId::Union,
                 sub: vec![value.to_irep(mm)],
-                named_sub: vector_map![(
+                named_sub: linear_map![(
                     IrepId::ComponentName,
                     Irep::just_string_id(field.to_string()),
                 )],
@@ -303,15 +303,15 @@ impl ToIrep for ExprValue {
             ExprValue::UnOp { op: UnaryOperand::Bswap, e } => Irep {
                 id: IrepId::Bswap,
                 sub: vec![e.to_irep(mm)],
-                named_sub: vector_map![(IrepId::BitsPerByte, Irep::just_int_id(8u8))],
+                named_sub: linear_map![(IrepId::BitsPerByte, Irep::just_int_id(8u8))],
             },
             ExprValue::UnOp { op: UnaryOperand::BitReverse, e } => {
-                Irep { id: IrepId::BitReverse, sub: vec![e.to_irep(mm)], named_sub: vector_map![] }
+                Irep { id: IrepId::BitReverse, sub: vec![e.to_irep(mm)], named_sub: linear_map![] }
             }
             ExprValue::UnOp { op: UnaryOperand::CountLeadingZeros { allow_zero }, e } => Irep {
                 id: IrepId::CountLeadingZeros,
                 sub: vec![e.to_irep(mm)],
-                named_sub: vector_map![(
+                named_sub: linear_map![(
                     IrepId::CBoundsCheck,
                     if *allow_zero { Irep::zero() } else { Irep::one() }
                 )],
@@ -319,18 +319,18 @@ impl ToIrep for ExprValue {
             ExprValue::UnOp { op: UnaryOperand::CountTrailingZeros { allow_zero }, e } => Irep {
                 id: IrepId::CountTrailingZeros,
                 sub: vec![e.to_irep(mm)],
-                named_sub: vector_map![(
+                named_sub: linear_map![(
                     IrepId::CBoundsCheck,
                     if *allow_zero { Irep::zero() } else { Irep::one() }
                 )],
             },
             ExprValue::UnOp { op, e } => {
-                Irep { id: op.to_irep_id(), sub: vec![e.to_irep(mm)], named_sub: vector_map![] }
+                Irep { id: op.to_irep_id(), sub: vec![e.to_irep(mm)], named_sub: linear_map![] }
             }
             ExprValue::Vector { elems } => Irep {
                 id: IrepId::Vector,
                 sub: elems.iter().map(|x| x.to_irep(mm)).collect(),
-                named_sub: vector_map![],
+                named_sub: linear_map![],
             },
         }
     }
@@ -340,7 +340,7 @@ impl ToIrep for Location {
     fn to_irep(&self, _mm: &MachineModel) -> Irep {
         match self {
             Location::None => Irep::nil(),
-            Location::BuiltinFunction { line, function_name } => Irep::just_named_sub(vector_map![
+            Location::BuiltinFunction { line, function_name } => Irep::just_named_sub(linear_map![
                 (
                     IrepId::File,
                     Irep::just_string_id(format!("<builtin-library-{}>", function_name)),
@@ -348,14 +348,14 @@ impl ToIrep for Location {
                 (IrepId::Function, Irep::just_string_id(function_name.to_string())),
             ])
             .with_named_sub_option(IrepId::Line, line.map(Irep::just_int_id)),
-            Location::Loc { file, function, line, col } => Irep::just_named_sub(vector_map![
+            Location::Loc { file, function, line, col } => Irep::just_named_sub(linear_map![
                 (IrepId::File, Irep::just_string_id(file.to_string())),
                 (IrepId::Line, Irep::just_int_id(*line)),
             ])
             .with_named_sub_option(IrepId::Column, col.map(Irep::just_int_id))
             .with_named_sub_option(IrepId::Function, function.map(Irep::just_string_id)),
             Location::Property { file, function, line, col, property_class, comment } => {
-                Irep::just_named_sub(vector_map![
+                Irep::just_named_sub(linear_map![
                     (IrepId::File, Irep::just_string_id(file.to_string())),
                     (IrepId::Line, Irep::just_int_id(*line)),
                 ])
@@ -368,7 +368,7 @@ impl ToIrep for Location {
                 )
             }
             Location::PropertyUnknownLocation { property_class, comment } => {
-                Irep::just_named_sub(vector_map![
+                Irep::just_named_sub(linear_map![
                     (IrepId::Comment, Irep::just_string_id(comment.to_string())),
                     (IrepId::PropertyClass, Irep::just_string_id(property_class.to_string()))
                 ])
@@ -382,7 +382,7 @@ impl ToIrep for Parameter {
         Irep {
             id: IrepId::Parameter,
             sub: vec![],
-            named_sub: vector_map![(IrepId::Type, self.typ().to_irep(mm))],
+            named_sub: linear_map![(IrepId::Type, self.typ().to_irep(mm))],
         }
         .with_named_sub_option(IrepId::CIdentifier, self.identifier().map(Irep::just_string_id))
         .with_named_sub_option(IrepId::CBaseName, self.base_name().map(Irep::just_string_id))
@@ -543,45 +543,45 @@ impl ToIrep for Type {
                 Irep {
                     id: IrepId::Array,
                     sub: vec![typ.to_irep(mm)],
-                    named_sub: vector_map![(IrepId::Size, size.to_irep(mm))],
+                    named_sub: linear_map![(IrepId::Size, size.to_irep(mm))],
                 }
             }
             //TODO make from_irep that matches this.
             Type::CBitField { typ, width } => Irep {
                 id: IrepId::CBitField,
                 sub: vec![typ.to_irep(mm)],
-                named_sub: vector_map![(IrepId::Width, Irep::just_int_id(*width))],
+                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(*width))],
             },
             Type::Bool => Irep::just_id(IrepId::Bool),
             Type::CInteger(CIntType::Bool) => Irep {
                 id: IrepId::CBool,
                 sub: vec![],
-                named_sub: vector_map![(IrepId::Width, Irep::just_int_id(mm.bool_width()))],
+                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.bool_width()))],
             },
             Type::CInteger(CIntType::Char) => Irep {
                 id: if mm.char_is_unsigned() { IrepId::Unsignedbv } else { IrepId::Signedbv },
                 sub: vec![],
-                named_sub: vector_map![(IrepId::Width, Irep::just_int_id(mm.char_width()),)],
+                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.char_width()),)],
             },
             Type::CInteger(CIntType::Int) => Irep {
                 id: IrepId::Signedbv,
                 sub: vec![],
-                named_sub: vector_map![(IrepId::Width, Irep::just_int_id(mm.int_width()),)],
+                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.int_width()),)],
             },
             Type::CInteger(CIntType::SizeT) => Irep {
                 id: IrepId::Unsignedbv,
                 sub: vec![],
-                named_sub: vector_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
+                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
             },
             Type::CInteger(CIntType::SSizeT) => Irep {
                 id: IrepId::Signedbv,
                 sub: vec![],
-                named_sub: vector_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
+                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
             },
             Type::Code { parameters, return_type } => Irep {
                 id: IrepId::Code,
                 sub: vec![],
-                named_sub: vector_map![
+                named_sub: linear_map![
                     (
                         IrepId::Parameters,
                         Irep::just_sub(parameters.iter().map(|x| x.to_irep(mm)).collect()),
@@ -593,7 +593,7 @@ impl ToIrep for Type {
             Type::Double => Irep {
                 id: IrepId::Floatbv,
                 sub: vec![],
-                named_sub: vector_map![
+                named_sub: linear_map![
                     (IrepId::F, Irep::just_int_id(52)),
                     (IrepId::Width, Irep::just_int_id(64)),
                     (IrepId::CCType, Irep::just_id(IrepId::Double)),
@@ -607,13 +607,13 @@ impl ToIrep for Type {
                 Irep {
                     id: IrepId::Array,
                     sub: vec![typ.to_irep(mm)],
-                    named_sub: vector_map![(IrepId::Size, size.to_irep(mm))],
+                    named_sub: linear_map![(IrepId::Size, size.to_irep(mm))],
                 }
             }
             Type::Float => Irep {
                 id: IrepId::Floatbv,
                 sub: vec![],
-                named_sub: vector_map![
+                named_sub: linear_map![
                     (IrepId::F, Irep::just_int_id(23)),
                     (IrepId::Width, Irep::just_int_id(32)),
                     (IrepId::CCType, Irep::just_id(IrepId::Float)),
@@ -622,7 +622,7 @@ impl ToIrep for Type {
             Type::IncompleteStruct { tag } => Irep {
                 id: IrepId::Struct,
                 sub: vec![],
-                named_sub: vector_map![
+                named_sub: linear_map![
                     (IrepId::Tag, Irep::just_string_id(tag.to_string())),
                     (IrepId::Incomplete, Irep::one()),
                 ],
@@ -630,7 +630,7 @@ impl ToIrep for Type {
             Type::IncompleteUnion { tag } => Irep {
                 id: IrepId::Union,
                 sub: vec![],
-                named_sub: vector_map![
+                named_sub: linear_map![
                     (IrepId::Tag, Irep::just_string_id(tag.to_string())),
                     (IrepId::Incomplete, Irep::one()),
                 ],
@@ -640,23 +640,23 @@ impl ToIrep for Type {
                 Irep {
                     id: IrepId::Array,
                     sub: vec![typ.to_irep(mm)],
-                    named_sub: vector_map![(IrepId::Size, infinity)],
+                    named_sub: linear_map![(IrepId::Size, infinity)],
                 }
             }
             Type::Pointer { typ } => Irep {
                 id: IrepId::Pointer,
                 sub: vec![typ.to_irep(mm)],
-                named_sub: vector_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
+                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
             },
             Type::Signedbv { width } => Irep {
                 id: IrepId::Signedbv,
                 sub: vec![],
-                named_sub: vector_map![(IrepId::Width, Irep::just_int_id(*width))],
+                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(*width))],
             },
             Type::Struct { tag, components } => Irep {
                 id: IrepId::Struct,
                 sub: vec![],
-                named_sub: vector_map![
+                named_sub: linear_map![
                     (IrepId::Tag, Irep::just_string_id(tag.to_string())),
                     (
                         IrepId::Components,
@@ -667,7 +667,7 @@ impl ToIrep for Type {
             Type::StructTag(name) => Irep {
                 id: IrepId::StructTag,
                 sub: vec![],
-                named_sub: vector_map![(
+                named_sub: linear_map![(
                     IrepId::Identifier,
                     Irep::just_string_id(name.to_string()),
                 )],
@@ -679,7 +679,7 @@ impl ToIrep for Type {
             Type::Union { tag, components } => Irep {
                 id: IrepId::Union,
                 sub: vec![],
-                named_sub: vector_map![
+                named_sub: linear_map![
                     (IrepId::Tag, Irep::just_string_id(tag.to_string())),
                     (
                         IrepId::Components,
@@ -690,7 +690,7 @@ impl ToIrep for Type {
             Type::UnionTag(name) => Irep {
                 id: IrepId::UnionTag,
                 sub: vec![],
-                named_sub: vector_map![(
+                named_sub: linear_map![(
                     IrepId::Identifier,
                     Irep::just_string_id(name.to_string()),
                 )],
@@ -698,12 +698,12 @@ impl ToIrep for Type {
             Type::Unsignedbv { width } => Irep {
                 id: IrepId::Unsignedbv,
                 sub: Vec::new(),
-                named_sub: vector_map![(IrepId::Width, Irep::just_int_id(*width))],
+                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(*width))],
             },
             Type::VariadicCode { parameters, return_type } => Irep {
                 id: IrepId::Code,
                 sub: vec![],
-                named_sub: vector_map![
+                named_sub: linear_map![
                     (
                         IrepId::Parameters,
                         Irep::just_sub(parameters.iter().map(|x| x.to_irep(mm)).collect())
@@ -717,7 +717,7 @@ impl ToIrep for Type {
                 Irep {
                     id: IrepId::Vector,
                     sub: vec![typ.to_irep(mm)],
-                    named_sub: vector_map![(IrepId::Size, size.to_irep(mm))],
+                    named_sub: linear_map![(IrepId::Size, size.to_irep(mm))],
                 }
             }
         }

--- a/cprover_bindings/src/utils.rs
+++ b/cprover_bindings/src/utils.rs
@@ -52,16 +52,16 @@ macro_rules! btree_map {
 
 /// Provides a useful shortcut for making BTreeMaps.
 #[macro_export]
-macro_rules! vector_map {
+macro_rules! linear_map {
     ($($x:expr),*) => {{
-        use vector_map::VecMap;
+        use linear_map::LinearMap;
         use std::iter::FromIterator;
-        (VecMap::from_iter(vec![$($x),*]))
+        (LinearMap::from_iter(vec![$($x),*]))
     }};
     ($($x:expr,)*) => {{
-        use vector_map::VecMap;
+        use linear_map::LinearMap;
         use std::iter::FromIterator;
-        (VecMap::from_iter(vec![$($x),*]))
+        (LinearMap::from_iter(vec![$($x),*]))
     }}
 }
 

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -5,6 +5,7 @@
 name = "kani_metadata"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
### Description of changes: 

The `vector-map` crate indirectly depends on a vulnerable version of rand_core. This crate hasn't been released for the past 2 years, and there hasn't been any activity in their github either. I'm replacing it by `linear-map` for now to fix the security warnings.

### Resolved issues:

This should fix the open dependabot alert.

### Call-outs:

Note that linear-map last release was 6 years ago, so we may have to
remove it eventually. At least this crate only depends on serde.

### Testing:

* How is this change tested? Current tests

* Is this a refactor change? N/A

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
