### PR TITLE
Single-commit gh-pages

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -65,10 +65,11 @@ jobs:
       # When we're pushed to main branch, only then actually publish the docs.
       - name: Publish Documentation
         if: ${{ github.event_name == 'push' && startsWith('refs/heads/main', github.ref) }}
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4.3.3
         with:
           branch: gh-pages
           folder: docs/book/
+          single-commit: true
 
   releasebundle:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Description of changes: 

1. Bump version on our gh-pages publishing actions.
2. Use `single-commit` to have it nuke history.

Why? We haven't looked at this history basically ever. This reduces repository/clone size further. I'm proposing we just let it nuke history.

### Resolved issues:


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
