### PR TITLE
Intrinsics table update based on audit

### DIFF
--- a/docs/src/rust-feature-support/intrinsics.md
+++ b/docs/src/rust-feature-support/intrinsics.md
@@ -17,7 +17,7 @@ Name | Support | Notes |
 abort | Yes | |
 add_with_overflow | Yes | |
 arith_offset | No | |
-assert_inhabited | | |
+assert_inhabited | Yes | |
 assert_uninit_valid | Yes | |
 assert_zero_valid | Yes | |
 assume | Yes | |
@@ -167,7 +167,7 @@ nearbyintf32 | No | |
 nearbyintf64 | No | |
 needs_drop | Yes | |
 nontemporal_store | No | |
-offset | Yes | |
+offset | Partial | Doesn't check [all UB conditions](https://doc.rust-lang.org/std/primitive.pointer.html#safety-2) |
 powf32 | No | |
 powf64 | No | |
 powif32 | No | |
@@ -179,7 +179,7 @@ prefetch_write_data | No | |
 prefetch_write_instruction | No | |
 ptr_guaranteed_eq | Yes | |
 ptr_guaranteed_ne | Yes | |
-ptr_offset_from | Partial | Missing undefined behavior checks |
+ptr_offset_from | Partial | Doesn't check [all UB conditions](https://doc.rust-lang.org/std/primitive.pointer.html#safety-4) |
 raw_eq | Partial | Cannot detect [uninitialized memory](#uninitialized-memory) |
 rintf32 | No | |
 rintf64 | No | |
@@ -197,7 +197,7 @@ size_of_val | Yes | |
 sqrtf32 | No | |
 sqrtf64 | No | |
 sub_with_overflow | Yes | |
-transmute | Yes | |
+transmute | Partial | Doesn't check [all UB conditions](https://doc.rust-lang.org/nomicon/transmutes.html) |
 truncf32 | No | |
 truncf64 | No | |
 try | No | [#267](https://github.com/model-checking/kani/issues/267) |


### PR DESCRIPTION
### Description of changes: 

Small updates on the intrinsics table:
 * `assert_inhabited`: Missed values because of a mistake in #1142. It used to have `Partial` status and refer to #751 which is now resolved, so should be `Yes` now.
 * `offset`, `ptr_offset_from` and `transmute`: Change status to `Partial` because not all UB conditions are checked.
 * 
### Testing:

* How is this change tested? N/A

* Is this a refactor change? No.

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
