### PR TITLE
Remove redundant check from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,12 @@ See [the installation guide](https://model-checking.github.io/kani/install-guide
 Similar to testing, you write a harness, but with Kani you can check all possible values using `kani::any()`:
 
 ```rust
-use my_crate::{function_under_test, is_valid, meets_specification};
+use my_crate::{function_under_test, meets_specification};
 
 #[kani::proof]
 fn check_my_property() {
    // Create a nondeterministic input
    let input = kani::any();
-
-   // Constrain it to represent valid values
-   kani::assume(is_valid(input));
 
    // Call the function under verification
    let output = function_under_test(input);


### PR DESCRIPTION
### Description of changes: 

In the example, we were calling is_valid after `kani::any()` which is redundant since the type has to implement the Arbitrary type.

### Resolved issues:

N/A

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
