### PR TITLE
Bump version to 0.2.0-dev of our crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,14 +348,14 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "kani"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "atty",
  "bitflags",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "home",
@@ -399,11 +399,11 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.1.0"
+version = "0.2.0-dev"
 
 [[package]]
 name = "kani_metadata"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "cprover_bindings",
  "serde",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "kani_queries"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "tracing",
 ]
@@ -899,7 +899,7 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "std"
-version = "0.1.0"
+version = "0.2.0-dev"
 
 [[package]]
 name = "string-interner"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.1.0"
+version = "0.2.0-dev"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.1.0"
+version = "0.2.0-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/kani-compiler/kani_queries/Cargo.toml
+++ b/kani-compiler/kani_queries/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_queries"
-version = "0.1.0"
+version = "0.2.0-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.1.0"
+version = "0.2.0-dev"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.1.0"
+version = "0.2.0-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.1.0"
+version = "0.2.0-dev"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.1.0"
+version = "0.2.0-dev"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.1.0"
+version = "0.2.0-dev"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
### Description of changes: 

Now that we have released **0.1.0**, I'm changing our crates to have version **0.2.0-dev**.

### Resolved issues:

N/A

### Call-outs:

 - I didn't bother bumping the versions of tools/*. They are still 0.0.0

### Testing:

* How is this change tested? Regression

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
