### PR TITLE
Remove the intrinsics hook, directly call the codegen functions

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -368,17 +368,8 @@ impl<'tcx> GotocCtx<'tcx> {
         }
     }
 
-    fn codegen_funcall(
-        &mut self,
-        func: &Operand<'tcx>,
-        args: &[Operand<'tcx>],
-        destination: &Option<(Place<'tcx>, BasicBlock)>,
-        span: Span,
-    ) -> Stmt {
-        let loc = self.codegen_span(&span);
-        let funct = self.operand_ty(func);
-        let mut fargs: Vec<_> = args
-            .iter()
+    pub fn codegen_funcall_args(&mut self, args: &[Operand<'tcx>]) -> Vec<Expr> {
+        args.iter()
             .filter_map(|o| {
                 let ot = self.operand_ty(o);
                 if self.ignore_var_ty(ot) {
@@ -389,12 +380,23 @@ impl<'tcx> GotocCtx<'tcx> {
                     Some(self.codegen_operand(o))
                 }
             })
-            .collect();
+            .collect()
+    }
 
+    fn codegen_funcall(
+        &mut self,
+        func: &Operand<'tcx>,
+        args: &[Operand<'tcx>],
+        destination: &Option<(Place<'tcx>, BasicBlock)>,
+        span: Span,
+    ) -> Stmt {
         if self.is_intrinsic(func) {
-            return self.codegen_intrinsic(func, fargs, destination, span);
+            return self.codegen_funcall_of_intrinsic(func, args, destination, span);
         }
 
+        let loc = self.codegen_span(&span);
+        let funct = self.operand_ty(func);
+        let mut fargs = self.codegen_funcall_args(args);
         match &funct.kind() {
             ty::FnDef(defid, subst) => {
                 let instance =

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -390,6 +390,11 @@ impl<'tcx> GotocCtx<'tcx> {
                 }
             })
             .collect();
+
+        if self.is_intrinsic(func) {
+            return self.codegen_intrinsic(func, fargs, destination, span);
+        }
+
         match &funct.kind() {
             ty::FnDef(defid, subst) => {
                 let instance =


### PR DESCRIPTION

### Description of changes: 

Currently, intrinsics are resolved using a "hook", which is difficult to understand and debug.
Instead, just use normal function calls to codegen them.
### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
