### PR TITLE
Replace ctags with universal-ctags on Ubuntu 20.04 and macOs

### DIFF
--- a/scripts/setup/macos-10.15/install_deps.sh
+++ b/scripts/setup/macos-10.15/install_deps.sh
@@ -10,12 +10,11 @@ set -eux
 brew update
 
 # Install dependencies via `brew`
-brew install ctags wget
+brew install universal-ctags wget
 
 # Add Python package dependencies
 PYTHON_DEPS=(
   autopep8
-  toml # Used for parsing `cargo-kani` config toml
   colorama # Used for introducing colors into terminal output
 )
 

--- a/scripts/setup/ubuntu/install_deps.sh
+++ b/scripts/setup/ubuntu/install_deps.sh
@@ -8,7 +8,6 @@ set -eu
 DEPS=(
   bison
   cmake
-  ctags
   curl
   flex
   g++
@@ -31,8 +30,8 @@ DEPS=(
 
 # Version specific dependencies.
 declare -A VERSION_DEPS
-VERSION_DEPS["20.04"]="python-is-python3"
-VERSION_DEPS["18.04"]=""
+VERSION_DEPS["20.04"]="universal-ctags python-is-python3"
+VERSION_DEPS["18.04"]="exuberant-ctags"
 
 UBUNTU_VERSION=$(lsb_release -rs)
 OTHER_DEPS="${VERSION_DEPS[${UBUNTU_VERSION}]:-""}"
@@ -45,12 +44,11 @@ set -x
 # https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners
 sudo apt-get --yes update
 
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes "${DEPS[@]}" "${OTHER_DEPS[@]}"
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes "${DEPS[@]}" ${OTHER_DEPS[@]}
 
 # Add Python package dependencies
 PYTHON_DEPS=(
   autopep8
-  toml # Used for parsing `cargo-kani` config toml
   colorama # Used for introducing colors into terminal output
 )
 


### PR DESCRIPTION
### Description of changes: 

1. Use `universal-ctags` instead of `ctags` as a dependency on Ubuntu 20.04 and macos-10.15.
2. Removed `toml` python package that is no longer needed (was used in the `cargo-kani` python script)

### Resolved issues:

Resolves #1166


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Regressions

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
