### PR TITLE
Use a c stub instead of a hook for __rust_alloc

### DIFF
--- a/library/kani/kani_lib.c
+++ b/library/kani/kani_lib.c
@@ -17,7 +17,7 @@
     } while (0)
 
 // Check that the input is either a power of 2, or 0. Algorithm from Hackers Delight.
-bool __KANI_is_power_of_two(size_t i) { return (i & (i - 1)) == 0; }
+bool __KANI_is_nonzero_power_of_two(size_t i) { return (i != 0) && (i & (i - 1)) == 0; }
 
 // This is a C implementation of the __rust_alloc function.
 // https://stdrs.dev/nightly/x86_64-unknown-linux-gnu/alloc/alloc/fn.__rust_alloc.html
@@ -34,7 +34,7 @@ uint8_t *__rust_alloc(size_t size, size_t align)
     __KANI_assert(size > 0, "__rust_alloc must be called with a size greater than 0");
     // TODO: Ensure we are doing the right thing with align
     // https://github.com/model-checking/kani/issues/1168
-    __KANI_assert(__KANI_is_power_of_two(align), "Alignment is power of two");
+    __KANI_assert(__KANI_is_nonzero_power_of_two(align), "Alignment is power of two");
     return malloc(size);
 }
 
@@ -53,7 +53,7 @@ uint8_t *__rust_alloc_zeroed(size_t size, size_t align)
     __KANI_assert(size > 0, "__rust_alloc_zeroed must be called with a size greater than 0");
     // TODO: Ensure we are doing the right thing with align
     // https://github.com/model-checking/kani/issues/1168
-    __KANI_assert(__KANI_is_power_of_two(align), "Alignment is power of two");
+    __KANI_assert(__KANI_is_nonzero_power_of_two(align), "Alignment is power of two");
     return calloc(1, size);
 }
 
@@ -71,7 +71,7 @@ void __rust_dealloc(uint8_t *ptr, size_t size, size_t align)
 {
     // TODO: Ensure we are doing the right thing with align
     // https://github.com/model-checking/kani/issues/1168
-    __KANI_assert(__KANI_is_power_of_two(align), "Alignment is power of two");
+    __KANI_assert(__KANI_is_nonzero_power_of_two(align), "Alignment is power of two");
 
     __KANI_assert(__CPROVER_OBJECT_SIZE(ptr) == size,
                   "rust_dealloc must be called on an object whose allocated size matches its layout");
@@ -96,7 +96,7 @@ uint8_t *__rust_realloc(uint8_t *ptr, size_t old_size, size_t align, size_t new_
 
     // TODO: Ensure we are doing the right thing with align
     // https://github.com/model-checking/kani/issues/1168
-    __KANI_assert(__KANI_is_power_of_two(align), "Alignment is power of two");
+    __KANI_assert(__KANI_is_nonzero_power_of_two(align), "Alignment is power of two");
 
     uint8_t *result = malloc(new_size);
     if (result) {

--- a/library/kani/kani_lib.c
+++ b/library/kani/kani_lib.c
@@ -9,11 +9,11 @@
 #include <string.h>
 
 // `assert` then `assume`
-#define __KANI_assert(cond, msg)     \
-    do {                             \
-        bool temp = (cond);          \
-        __CPROVER_assert(temp, msg); \
-        __CPROVER_assume(temp);      \
+#define __KANI_assert(cond, msg)            \
+    do {                                    \
+        bool __KANI_temp = (cond);          \
+        __CPROVER_assert(__KANI_temp, msg); \
+        __CPROVER_assume(__KANI_temp);      \
     } while (0)
 
 // Check that the input is either a power of 2, or 0. Algorithm from Hackers Delight.

--- a/library/kani/kani_lib.c
+++ b/library/kani/kani_lib.c
@@ -19,7 +19,7 @@
 // https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc
 uint8_t *__rust_alloc(size_t size, size_t align)
 {
-    __CPROVER_assert(size > 0, "__rust_alloc called with a size of 0");
+    __CPROVER_assert(size > 0, "__rust_alloc must be called with a size greater than 0");
     __CPROVER_assume(size > 0);
     // Note: we appear to do nothing with `align`
     // TODO: https://github.com/model-checking/kani/issues/1168
@@ -38,7 +38,7 @@ uint8_t *__rust_alloc(size_t size, size_t align)
 // hhttps://doc.rust-lang.org/std/alloc/fn.alloc_zeroed.html
 uint8_t *__rust_alloc_zeroed(size_t size, size_t align)
 {
-    __CPROVER_assert(size > 0, "__rust_alloc called with a size of 0");
+    __CPROVER_assert(size > 0, "__rust_alloc_zeroed must be called with a size greater than 0");
     __CPROVER_assume(size > 0);
     // Note: we appear to do nothing with `align`
     // TODO: https://github.com/model-checking/kani/issues/1168
@@ -59,7 +59,9 @@ void __rust_dealloc(uint8_t *ptr, size_t size, size_t align)
 {
     // Note: we appear to do nothing with `align`
     // TODO: https://github.com/model-checking/kani/issues/1168
-    assert(__CPROVER_OBJECT_SIZE(ptr) == size);
+    __CPROVER_assert(__CPROVER_OBJECT_SIZE(ptr) == size,
+                     "rust_dealloc must be called on an object whose allocated size matches its layout");
+    __CPROVER_assume(__CPROVER_OBJECT_SIZE(ptr) == size);
     free(ptr);
 }
 
@@ -74,11 +76,11 @@ void __rust_dealloc(uint8_t *ptr, size_t size, size_t align)
 uint8_t *__rust_realloc(uint8_t *ptr, size_t old_size, size_t align, size_t new_size)
 {
     // Passing a NULL pointer is undefined behavior
-    __CPROVER_assert(ptr != 0, "realloc called with a null pointer");
+    __CPROVER_assert(ptr != 0, "rust_realloc must be called with a non-null pointer");
     __CPROVER_assume(ptr != 0);
 
     // Passing a new_size of 0 is undefined behavior
-    __CPROVER_assert(new_size > 0, "realloc called with a size of 0");
+    __CPROVER_assert(new_size > 0, "rust_realloc must be called with a size greater than 0");
     __CPROVER_assume(new_size > 0);
 
     uint8_t *result = malloc(new_size);

--- a/library/kani/kani_lib.c
+++ b/library/kani/kani_lib.c
@@ -16,6 +16,9 @@
         __CPROVER_assume(temp);      \
     } while (0)
 
+// Check that the input is either a power of 2, or 0. Algorithm from Hackers Delight.
+bool __KANI_is_power_of_two(size_t i) { return (i & (i - 1)) == 0; }
+
 // This is a C implementation of the __rust_alloc function.
 // https://stdrs.dev/nightly/x86_64-unknown-linux-gnu/alloc/alloc/fn.__rust_alloc.html
 // It has the following Rust signature:
@@ -29,8 +32,9 @@
 uint8_t *__rust_alloc(size_t size, size_t align)
 {
     __KANI_assert(size > 0, "__rust_alloc must be called with a size greater than 0");
-    // Note: we appear to do nothing with `align`
-    // TODO: https://github.com/model-checking/kani/issues/1168
+    // TODO: Ensure we are doing the right thing with align
+    // https://github.com/model-checking/kani/issues/1168
+    __KANI_assert(__KANI_is_power_of_two(align), "Alignment is power of two");
     return malloc(size);
 }
 
@@ -47,8 +51,9 @@ uint8_t *__rust_alloc(size_t size, size_t align)
 uint8_t *__rust_alloc_zeroed(size_t size, size_t align)
 {
     __KANI_assert(size > 0, "__rust_alloc_zeroed must be called with a size greater than 0");
-    // Note: we appear to do nothing with `align`
-    // TODO: https://github.com/model-checking/kani/issues/1168
+    // TODO: Ensure we are doing the right thing with align
+    // https://github.com/model-checking/kani/issues/1168
+    __KANI_assert(__KANI_is_power_of_two(align), "Alignment is power of two");
     return calloc(1, size);
 }
 
@@ -64,8 +69,10 @@ uint8_t *__rust_alloc_zeroed(size_t size, size_t align)
 // https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.dealloc
 void __rust_dealloc(uint8_t *ptr, size_t size, size_t align)
 {
-    // Note: we appear to do nothing with `align`
-    // TODO: https://github.com/model-checking/kani/issues/1168
+    // TODO: Ensure we are doing the right thing with align
+    // https://github.com/model-checking/kani/issues/1168
+    __KANI_assert(__KANI_is_power_of_two(align), "Alignment is power of two");
+
     __KANI_assert(__CPROVER_OBJECT_SIZE(ptr) == size,
                   "rust_dealloc must be called on an object whose allocated size matches its layout");
     free(ptr);
@@ -86,6 +93,10 @@ uint8_t *__rust_realloc(uint8_t *ptr, size_t old_size, size_t align, size_t new_
 
     // Passing a new_size of 0 is undefined behavior
     __KANI_assert(new_size > 0, "rust_realloc must be called with a size greater than 0");
+
+    // TODO: Ensure we are doing the right thing with align
+    // https://github.com/model-checking/kani/issues/1168
+    __KANI_assert(__KANI_is_power_of_two(align), "Alignment is power of two");
 
     uint8_t *result = malloc(new_size);
     if (result) {

--- a/library/kani/kani_lib.c
+++ b/library/kani/kani_lib.c
@@ -7,6 +7,62 @@
 #include <stdlib.h>
 #include <string.h>
 
+// This is a C implementation of the __rust_alloc function.
+// https://stdrs.dev/nightly/x86_64-unknown-linux-gnu/alloc/alloc/fn.__rust_alloc.html
+// It has the following Rust signature:
+//   `unsafe fn __rust_alloc(size: usize, align: usize) -> *mut u8`
+// This low-level function is called by std::alloc:alloc, and its
+// implementation is provided by the compiler backend, so we need to provide an
+// implementation for it to prevent verification failure due to missing function
+// definition.
+// For safety, refer to the documentation of GlobalAlloc::alloc:
+// https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc
+uint8_t *__rust_alloc(size_t size, size_t align)
+{
+    __CPROVER_assert(size > 0, "__rust_alloc called with a size of 0");
+    __CPROVER_assume(size > 0);
+    // Note: we appear to do nothing with `align`
+    // TODO: https://github.com/model-checking/kani/issues/1168
+    return malloc(size);
+}
+
+// This is a C implementation of the __rust_alloc_zeroed function.
+// https://stdrs.dev/nightly/x86_64-unknown-linux-gnu/alloc/alloc/fn.__rust_alloc_zeroed.html
+// It has the following Rust signature:
+//   unsafe fn __rust_alloc_zeroed(size: usize, align: usize) -> *mut u8
+// This low-level function is called by std::alloc:alloc_zeroed, and its
+// implementation is provided by the compiler backend, so we need to provide an
+// implementation for it to prevent verification failure due to missing function
+// definition.
+// For safety, refer to the documentation of GlobalAlloc::alloc_zeroed:
+// hhttps://doc.rust-lang.org/std/alloc/fn.alloc_zeroed.html
+uint8_t *__rust_alloc_zeroed(size_t size, size_t align)
+{
+    __CPROVER_assert(size > 0, "__rust_alloc called with a size of 0");
+    __CPROVER_assume(size > 0);
+    // Note: we appear to do nothing with `align`
+    // TODO: https://github.com/model-checking/kani/issues/1168
+    return calloc(1, size);
+}
+
+// This is a C implementation of the __rust_dealloc function.
+// https://stdrs.dev/nightly/x86_64-unknown-linux-gnu/alloc/alloc/fn.__rust_dealloc.html
+// It has the following Rust signature:
+//   `unsafe fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize)`
+// This low-level function is called by std::alloc:dealloc, and its
+// implementation is provided by the compiler backend, so we need to provide an
+// implementation for it to prevent verification failure due to missing function
+// definition.
+// For safety, refer to the documentation of GlobalAlloc::dealloc:
+// https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.dealloc
+void __rust_dealloc(uint8_t *ptr, size_t size, size_t align)
+{
+    // Note: we appear to do nothing with `align`
+    // TODO: https://github.com/model-checking/kani/issues/1168
+    assert(__CPROVER_OBJECT_SIZE(ptr) == size);
+    free(ptr);
+}
+
 // This is a C implementation of the __rust_realloc function that has the following signature:
 //     fn __rust_realloc(ptr: *mut u8, old_size: usize, align: usize, new_size: usize) -> *mut u8;
 // This low-level function is called by std::alloc:realloc, and its

--- a/tests/expected/realloc/null/expected
+++ b/tests/expected/realloc/null/expected
@@ -1,4 +1,4 @@
 Status: FAILURE\
-Description: "realloc called with a null pointer"
+Description: "rust_realloc must be called with a non-null pointer"
 
 VERIFICATION:- FAILED

--- a/tests/expected/realloc/zero_size/expected
+++ b/tests/expected/realloc/zero_size/expected
@@ -1,4 +1,4 @@
 Status: FAILURE\
-Description: "realloc called with a size of 0"
+Description: "rust_realloc must be called with a size greater than 0"
 
 VERIFICATION:- FAILED


### PR DESCRIPTION
### Description of changes: 

Currently, kani uses a hook to override `alloc`.
Instead, lets use a standard library model which is easier to understand and debug.

### Resolved issues:

Resolves #1172


### Call-outs:

It seems we can't totally remove this hook, because using the raw `exchange_malloc` causes regression failures #1170

### Testing:

* How is this change tested? Yes, existing tests

* Is this a refactor change? Depends what you mean by "refactor".

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
