### PR TITLE
Bump CBMC Viewer version to 3.2

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,12 +8,6 @@ inputs:
 runs:
   using: composite
   steps:
-      # This is unfortunate, but cbmc-viewer currently requires Python >= 3.8
-      - name: Install Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
       - name: Install dependencies
         run: ./scripts/setup/${{ inputs.os }}/install_deps.sh
         shell: bash
@@ -23,7 +17,7 @@ runs:
         shell: bash
 
       - name: Install cbmc-viewer
-        run: ./scripts/setup/install_viewer.sh 2.11
+        run: ./scripts/setup/install_viewer.sh 3.2
         shell: bash
 
       - name: Install Rust toolchain

--- a/docs/src/install-guide.md
+++ b/docs/src/install-guide.md
@@ -55,7 +55,7 @@ cd kani
 git submodule update --init
 ./scripts/setup/ubuntu/install_deps.sh
 ./scripts/setup/ubuntu/install_cbmc.sh
-./scripts/setup/install_viewer.sh 2.11
+./scripts/setup/install_viewer.sh 3.2
 ./scripts/setup/install_rustup.sh
 # If you haven't already:
 source $HOME/.cargo/env
@@ -72,7 +72,7 @@ cd kani
 git submodule update --init
 ./scripts/setup/macos-10.15/install_deps.sh
 ./scripts/setup/macos-10.15/install_cbmc.sh
-./scripts/setup/install_viewer.sh 2.11
+./scripts/setup/install_viewer.sh 3.2
 ./scripts/setup/install_rustup.sh
 # If you haven't already:
 source $HOME/.cargo/env


### PR DESCRIPTION
### Description of changes: 

Upgrade to CBMC viewer 3.2 which was just released today and reduces the required Python version from 3.8 to 3.6, so it can be used on Ubuntu 18.04 with the pre-installed version of Python.

### Resolved issues:

This should allow us to install Kani on Ubuntu 18.04.


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
