### PR TITLE
Update the rust toolchain to `nightly-2022-05-03`

### DIFF
--- a/cprover_bindings/src/goto_program/typ.rs
+++ b/cprover_bindings/src/goto_program/typ.rs
@@ -973,6 +973,19 @@ impl Type {
         Pointer { typ: Box::new(self) }
     }
 
+    /// Convert type to its unsigned counterpart if possible.
+    /// For types that are already unsigned, this will return self.
+    /// Note: This will expand any typedef.
+    pub fn to_unsigned(&self) -> Option<Self> {
+        let concrete = self.unwrap_typedef();
+        match concrete {
+            CInteger(CIntType::SSizeT) => Some(CInteger(CIntType::SizeT)),
+            Signedbv { ref width } => Some(Unsignedbv { width: *width }),
+            Unsignedbv { .. } => Some(self.clone()),
+            _ => None,
+        }
+    }
+
     pub fn signed_int<T>(w: T) -> Self
     where
         T: TryInto<u64>,

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -482,7 +482,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     };
                     let relative_max =
                         niche_variants.end().as_u32() - niche_variants.start().as_u32();
-                    let is_niche = if tag.value == Primitive::Pointer {
+                    let is_niche = if tag.primitive() == Primitive::Pointer {
                         discr_ty.null().eq(relative_discr.clone())
                     } else {
                         relative_discr

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -475,9 +475,11 @@ impl<'tcx> GotocCtx<'tcx> {
 
                     // Compute relative discriminant value (`niche_val - niche_start`).
                     //
-                    // We remap `niche_start..=niche_start + n` (which may wrap around) to (non-wrap-around)
-                    // `0..=n`, to be able to check whether the discriminant corresponds to a niche variant with
-                    // one comparison.
+                    // "We remap `niche_start..=niche_start + n` (which may wrap around) to
+                    // (non-wrap-around) `0..=n`, to be able to check whether the discriminant
+                    // corresponds to a niche variant with one comparison."
+                    // https://github.com/rust-lang/rust/blob/fee75fbe11b1fad5d93c723234178b2a329a3c03/compiler/rustc_codegen_ssa/src/mir/place.rs#L247
+                    //
                     // Note: niche_variants can only represent values that fit in a u32.
                     let discr_mir_ty = self.codegen_enum_discr_typ(ty);
                     let discr_type = self.codegen_ty(discr_mir_ty);
@@ -1271,8 +1273,8 @@ fn wrapping_sub(expr: &Expr, constant: u64) -> Expr {
         // No need to subtract.
         expr.clone()
     } else {
-        let unsigned = Type::unsigned_int(expr.typ().width().unwrap());
-        let constant = Expr::int_constant(constant as i64, unsigned.clone());
+        let unsigned = expr.typ().to_unsigned().unwrap();
+        let constant = Expr::int_constant(constant, unsigned.clone());
         expr.clone().cast_to(unsigned).sub(constant)
     }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -472,19 +472,25 @@ impl<'tcx> GotocCtx<'tcx> {
                         FieldsShape::Arbitrary { offsets, .. } => offsets[0].bytes_usize(),
                         _ => unreachable!("niche encoding must have arbitrary fields"),
                     };
-                    let discr_ty = self.codegen_enum_discr_typ(ty);
-                    let discr_ty = self.codegen_ty(discr_ty);
-                    let niche_val = self.codegen_get_niche(e, offset, discr_ty.clone());
-                    let relative_discr = if *niche_start == 0 {
-                        niche_val
-                    } else {
-                        wrapping_sub(&niche_val, *niche_start)
-                    };
+
+                    // Compute relative discriminant value (`niche_val - niche_start`).
+                    //
+                    // We remap `niche_start..=niche_start + n` (which may wrap around) to (non-wrap-around)
+                    // `0..=n`, to be able to check whether the discriminant corresponds to a niche variant with
+                    // one comparison.
+                    // Note: niche_variants can only represent values that fit in a u32.
+                    let discr_mir_ty = self.codegen_enum_discr_typ(ty);
+                    let discr_type = self.codegen_ty(discr_mir_ty);
+                    let niche_val = self.codegen_get_niche(e, offset, discr_type.clone());
+                    let relative_discr =
+                        wrapping_sub(&niche_val, u64::try_from(*niche_start).unwrap());
                     let relative_max =
                         niche_variants.end().as_u32() - niche_variants.start().as_u32();
                     let is_niche = if tag.primitive() == Primitive::Pointer {
-                        discr_ty.null().eq(relative_discr.clone())
+                        tracing::trace!(?tag, "Primitive::Pointer");
+                        discr_type.null().eq(relative_discr.clone())
                     } else {
+                        tracing::trace!(?tag, "Not Primitive::Pointer");
                         relative_discr
                             .clone()
                             .le(Expr::int_constant(relative_max, relative_discr.typ().clone()))
@@ -1260,26 +1266,13 @@ impl<'tcx> GotocCtx<'tcx> {
 /// Perform a wrapping subtraction of an Expr with a constant "expr - constant"
 /// where "-" is wrapping subtraction, i.e., the result should be interpreted as
 /// an unsigned value (2's complement).
-fn wrapping_sub(expr: &Expr, constant: u128) -> Expr {
-    // While the wrapping subtraction can be done through a regular subtraction
-    // and then casting the result to an unsigned, doing so may result in CBMC
-    // flagging the operation with a signed to unsigned overflow failure (see
-    // https://github.com/model-checking/kani/issues/356).
-    // To avoid those overflow failures, the wrapping subtraction operation is
-    // computed as:
-    //   if expr >= constant {
-    //       // result is positive, so overflow may not occur
-    //       expr - constant
-    //   } else {
-    //       // compute the 2's complement to avoid overflow
-    //       expr - constant + 2^32
-    //   }
-    let s64 = Type::signed_int(64);
-    let expr = expr.clone().cast_to(s64.clone());
-    let twos_complement: i64 = u32::MAX as i64 + 1 - i64::try_from(constant).unwrap();
-    let constant = Expr::int_constant(constant, s64.clone());
-    expr.clone().ge(constant.clone()).ternary(
-        expr.clone().sub(constant),
-        expr.plus(Expr::int_constant(twos_complement, s64.clone())),
-    )
+fn wrapping_sub(expr: &Expr, constant: u64) -> Expr {
+    if constant == 0 {
+        // No need to subtract.
+        expr.clone()
+    } else {
+        let unsigned = Type::unsigned_int(expr.typ().width().unwrap());
+        let constant = Expr::int_constant(constant as i64, unsigned.clone());
+        expr.clone().cast_to(unsigned).sub(constant)
+    }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -603,6 +603,7 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn codegen_statement(&mut self, stmt: &Statement<'tcx>) -> Stmt {
         let _trace_span = info_span!("CodegenStatement", statement = ?stmt).entered();
         debug!("handling statement {:?}", stmt);
+        let location = self.codegen_span(&stmt.source_info.span);
         match &stmt.kind {
             StatementKind::Assign(box (l, r)) => {
                 let lty = self.place_ty(l);
@@ -617,15 +618,15 @@ impl<'tcx> GotocCtx<'tcx> {
                     // where the reference is implicit.
                     unwrap_or_return_codegen_unimplemented_stmt!(self, self.codegen_place(l))
                         .goto_expr
-                        .assign(self.codegen_rvalue(r).address_of(), Location::none())
+                        .assign(self.codegen_rvalue(r).address_of(), location)
                 } else if rty.is_bool() {
                     unwrap_or_return_codegen_unimplemented_stmt!(self, self.codegen_place(l))
                         .goto_expr
-                        .assign(self.codegen_rvalue(r).cast_to(Type::c_bool()), Location::none())
+                        .assign(self.codegen_rvalue(r).cast_to(Type::c_bool()), location)
                 } else {
                     unwrap_or_return_codegen_unimplemented_stmt!(self, self.codegen_place(l))
                         .goto_expr
-                        .assign(self.codegen_rvalue(r), Location::none())
+                        .assign(self.codegen_rvalue(r), location)
                 }
             }
             StatementKind::Deinit(place) => {
@@ -634,15 +635,15 @@ impl<'tcx> GotocCtx<'tcx> {
                 let dst_mir_ty = self.place_ty(place);
                 let dst_type = self.codegen_ty(dst_mir_ty);
                 let layout = self.layout_of(dst_mir_ty);
-                if layout.is_zst() || self.ignore_var_ty(dst_mir_ty) {
+                if layout.is_zst() || dst_type.sizeof_in_bits(&self.symbol_table) == 0 {
                     // We ignore assignment for all zero size types
                     // Ignore generators too for now:
                     // https://github.com/model-checking/kani/issues/416
-                    Stmt::skip(Location::none())
+                    Stmt::skip(location)
                 } else {
                     unwrap_or_return_codegen_unimplemented_stmt!(self, self.codegen_place(place))
                         .goto_expr
-                        .assign(dst_type.nondet(), Location::none())
+                        .assign(dst_type.nondet(), location)
                 }
             }
             StatementKind::SetDiscriminant { place, variant_index } => {
@@ -655,16 +656,16 @@ impl<'tcx> GotocCtx<'tcx> {
                             .codegen_unimplemented(
                                 "ty::Generator",
                                 Type::code(vec![], Type::empty()),
-                                Location::none(),
+                                location.clone(),
                                 "https://github.com/model-checking/kani/issues/416",
                             )
-                            .as_stmt(Location::none());
+                            .as_stmt(location);
                     }
                     _ => unreachable!(),
                 };
                 let layout = self.layout_of(pt);
                 match &layout.variants {
-                    Variants::Single { .. } => Stmt::skip(Location::none()),
+                    Variants::Single { .. } => Stmt::skip(location),
                     Variants::Multiple { tag, tag_encoding, .. } => match tag_encoding {
                         TagEncoding::Direct => {
                             let discr = def.discriminant_for_variant(self.tcx, *variant_index);
@@ -688,7 +689,7 @@ impl<'tcx> GotocCtx<'tcx> {
                             )
                             .goto_expr
                             .member("case", &self.symbol_table)
-                            .assign(discr, Location::none())
+                            .assign(discr, location)
                         }
                         TagEncoding::Niche { dataful_variant, niche_variants, niche_start } => {
                             if dataful_variant != variant_index {
@@ -715,16 +716,16 @@ impl<'tcx> GotocCtx<'tcx> {
                                 )
                                 .goto_expr;
                                 self.codegen_get_niche(place, offset, discr_ty)
-                                    .assign(value, Location::none())
+                                    .assign(value, location)
                             } else {
-                                Stmt::skip(Location::none())
+                                Stmt::skip(location)
                             }
                         }
                     },
                 }
             }
-            StatementKind::StorageLive(_) => Stmt::skip(Location::none()), // TODO: fix me
-            StatementKind::StorageDead(_) => Stmt::skip(Location::none()), // TODO: fix me
+            StatementKind::StorageLive(_) => Stmt::skip(location), // TODO: fix me
+            StatementKind::StorageDead(_) => Stmt::skip(location), // TODO: fix me
             StatementKind::CopyNonOverlapping(box mir::CopyNonOverlapping {
                 ref src,
                 ref dst,
@@ -737,7 +738,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 let sz = Expr::int_constant(sz, Type::size_t());
                 let n = sz.mul(count);
                 let dst = dst.cast_to(Type::void_pointer());
-                let e = BuiltinFn::Memcpy.call(vec![dst, src, n.clone()], Location::none());
+                let e = BuiltinFn::Memcpy.call(vec![dst, src, n.clone()], location.clone());
 
                 // The C implementation of memcpy does not allow an invalid pointer for
                 // the src/dst, but the LLVM implementation specifies that a copy with
@@ -745,18 +746,13 @@ impl<'tcx> GotocCtx<'tcx> {
                 // the empty string; CBMC will fail on passing a reference to empty
                 // string unless we codegen this zero check.
                 // https://llvm.org/docs/LangRef.html#llvm-memcpy-intrinsic
-                Stmt::if_then_else(
-                    n.is_zero().not(),
-                    e.as_stmt(Location::none()),
-                    None,
-                    Location::none(),
-                )
+                Stmt::if_then_else(n.is_zero().not(), e.as_stmt(location.clone()), None, location)
             }
             StatementKind::FakeRead(_)
             | StatementKind::Retag(_, _)
             | StatementKind::AscribeUserType(_, _)
             | StatementKind::Nop
-            | StatementKind::Coverage { .. } => Stmt::skip(Location::none()),
+            | StatementKind::Coverage { .. } => Stmt::skip(location),
         }
         .with_location(self.codegen_span(&stmt.source_info.span))
     }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -628,6 +628,23 @@ impl<'tcx> GotocCtx<'tcx> {
                         .assign(self.codegen_rvalue(r), Location::none())
                 }
             }
+            StatementKind::Deinit(place) => {
+                // From rustc doc: "This writes `uninit` bytes to the entire place."
+                // Thus, we assign nondet() value to the entire place.
+                let dst_mir_ty = self.place_ty(place);
+                let dst_type = self.codegen_ty(dst_mir_ty);
+                let layout = self.layout_of(dst_mir_ty);
+                if layout.is_zst() || self.ignore_var_ty(dst_mir_ty) {
+                    // We ignore assignment for all zero size types
+                    // Ignore generators too for now:
+                    // https://github.com/model-checking/kani/issues/416
+                    Stmt::skip(Location::none())
+                } else {
+                    unwrap_or_return_codegen_unimplemented_stmt!(self, self.codegen_place(place))
+                        .goto_expr
+                        .assign(dst_type.nondet(), Location::none())
+                }
+            }
             StatementKind::SetDiscriminant { place, variant_index } => {
                 // this requires place points to an enum type.
                 let pt = self.place_ty(place);
@@ -740,7 +757,6 @@ impl<'tcx> GotocCtx<'tcx> {
             | StatementKind::AscribeUserType(_, _)
             | StatementKind::Nop
             | StatementKind::Coverage { .. } => Stmt::skip(Location::none()),
-            StatementKind::Deinit(_) => todo!("Unimplemented statement. See: "),
         }
         .with_location(self.codegen_span(&stmt.source_info.span))
     }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -686,11 +686,12 @@ impl<'tcx> GotocCtx<'tcx> {
                                 let niche_value =
                                     variant_index.as_u32() - niche_variants.start().as_u32();
                                 let niche_value = (niche_value as u128).wrapping_add(*niche_start);
-                                let value = if niche_value == 0 && tag.value == Primitive::Pointer {
-                                    discr_ty.null()
-                                } else {
-                                    Expr::int_constant(niche_value, discr_ty.clone())
-                                };
+                                let value =
+                                    if niche_value == 0 && tag.primitive() == Primitive::Pointer {
+                                        discr_ty.null()
+                                    } else {
+                                        Expr::int_constant(niche_value, discr_ty.clone())
+                                    };
                                 let place = unwrap_or_return_codegen_unimplemented_stmt!(
                                     self,
                                     self.codegen_place(place)
@@ -739,6 +740,7 @@ impl<'tcx> GotocCtx<'tcx> {
             | StatementKind::AscribeUserType(_, _)
             | StatementKind::Nop
             | StatementKind::Coverage { .. } => Stmt::skip(Location::none()),
+            StatementKind::Deinit(_) => todo!("Unimplemented statement. See: "),
         }
         .with_location(self.codegen_span(&stmt.source_info.span))
     }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -1206,7 +1206,7 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn codegen_enum_discr_typ(&self, ty: Ty<'tcx>) -> Ty<'tcx> {
         let layout = self.layout_of(ty);
         match &layout.variants {
-            Variants::Multiple { tag, .. } => self.codegen_prim_typ(tag.value),
+            Variants::Multiple { tag, .. } => self.codegen_prim_typ(tag.primitive()),
             _ => unreachable!("only enum has discriminant"),
         }
     }
@@ -1263,7 +1263,7 @@ impl<'tcx> GotocCtx<'tcx> {
             _ => unreachable!(),
         };
 
-        let rustc_target::abi::Scalar { value: prim_type, .. } = element;
+        let prim_type = element.primitive();
         let rust_type = self.codegen_prim_typ(prim_type);
         let cbmc_type = self.codegen_ty(rust_type);
 

--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -107,7 +107,6 @@ impl KaniSession {
             args.push("--pointer-check".into());
         }
         if self.args.checks.overflow_on() {
-            args.push("--conversion-check".into());
             args.push("--div-by-zero-check".into());
             args.push("--float-overflow-check".into());
             args.push("--nan-check".into());
@@ -116,7 +115,15 @@ impl KaniSession {
             // --unsigned-overflow-check
             // --signed-overflow-check
             // So these options are deliberately skipped to avoid erroneously re-checking operations.
+
+            // TODO: Implement conversion checks as an optional check.
+            // They are a well defined operation in rust, but they may yield unexpected results to
+            // many users. https://github.com/model-checking/kani/issues/840
+            // We might want to create a transformation pass instead of enabling CBMC since Kani
+            // compiler sometimes rely on the bitwise conversion of signed <-> unsigned.
+            // args.push("--conversion-check".into());
         }
+
         if self.args.checks.unwinding_on() {
             args.push("--unwinding-assertions".into());
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2022-03-23"
+channel = "nightly-2022-05-03"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/expected/dry-run/expected
+++ b/tests/expected/dry-run/expected
@@ -3,4 +3,4 @@ symtab2gb
 goto-cc
 --function main
 goto-instrument
-cbmc --bounds-check --pointer-check --conversion-check --div-by-zero-check --float-overflow-check --nan-check --undefined-shift-check --unwinding-assertions --object-bits 16
+cbmc --bounds-check --pointer-check --div-by-zero-check --float-overflow-check --nan-check --undefined-shift-check --unwinding-assertions --object-bits 16

--- a/tests/kani/Enum/discriminant_128bits.rs
+++ b/tests/kani/Enum/discriminant_128bits.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
-// Check niche optimization for mix of option, tuple and nonnull.
+// Check niche optimization for an object that is 128 bits long.
 
 use std::mem::{discriminant, size_of_val};
 use std::num::NonZeroU128;

--- a/tests/kani/Enum/discriminant_128bits.rs
+++ b/tests/kani/Enum/discriminant_128bits.rs
@@ -1,0 +1,18 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Check niche optimization for mix of option, tuple and nonnull.
+
+use std::mem::{discriminant, size_of_val};
+use std::num::NonZeroU128;
+
+fn create() -> Option<NonZeroU128> {
+    unsafe { Some(NonZeroU128::new_unchecked(120u128.into())) }
+}
+
+#[kani::proof]
+fn check_option_128bits() {
+    let opt = create();
+    assert!(opt.is_some());
+    assert_eq!(size_of_val(&opt), size_of_val(&opt.unwrap()));
+}

--- a/tests/ui/code-location/expected
+++ b/tests/ui/code-location/expected
@@ -1,7 +1,7 @@
 module/mod.rs:10:5 in function module::not_empty
 main.rs:13:5 in function same_file
 /toolchains/
-alloc/src/vec/mod.rs:2821:81 in function <std::vec::Vec<T, A> as std::ops::Drop>::drop
+alloc/src/vec/mod.rs:2881:81 in function <std::vec::Vec<T, A> as std::ops::Drop>::drop
 
 VERIFICATION:- SUCCESSFUL
 

--- a/tools/bookrunner/librustdoc/clean/inline.rs
+++ b/tools/bookrunner/librustdoc/clean/inline.rs
@@ -104,7 +104,7 @@ crate fn try_inline(
             record_extern_fqn(cx, did, ItemType::Module);
             clean::ModuleItem(build_module(cx, did, visited))
         }
-        Res::Def(DefKind::Static, did) => {
+        Res::Def(DefKind::Static(..), did) => {
             record_extern_fqn(cx, did, ItemType::Static);
             clean::StaticItem(build_static(cx, did, cx.tcx.is_mutable_static(did)))
         }

--- a/tools/bookrunner/librustdoc/clean/types.rs
+++ b/tools/bookrunner/librustdoc/clean/types.rs
@@ -4,6 +4,7 @@
 // See GitHub history for details.
 use std::default::Default;
 use std::hash::Hash;
+use std::iter;
 use std::lazy::SyncOnceCell as OnceCell;
 use std::sync::Arc;
 use std::{slice, vec};
@@ -21,6 +22,7 @@ use rustc_hir::def_id::{CrateNum, DefId, DefIndex, LOCAL_CRATE};
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::{BodyId, Mutability};
 use rustc_index::vec::IndexVec;
+use rustc_middle::ty::fast_reject::SimplifiedType;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::hygiene::MacroKind;
 use rustc_span::source_map::DUMMY_SP;
@@ -935,67 +937,68 @@ crate enum PrimitiveType {
     Never,
 }
 
+type SimplifiedTypes = FxHashMap<PrimitiveType, ArrayVec<SimplifiedType, 2>>;
 impl PrimitiveType {
-    crate fn impls(&self, tcx: TyCtxt<'_>) -> &'static ArrayVec<DefId, 4> {
-        Self::all_impls(tcx).get(self).expect("missing impl for primitive type")
-    }
+    crate fn simplified_types() -> &'static SimplifiedTypes {
+        use ty::fast_reject::SimplifiedTypeGen::*;
+        use ty::{FloatTy, IntTy, UintTy};
+        use PrimitiveType::*;
+        static CELL: OnceCell<SimplifiedTypes> = OnceCell::new();
 
-    crate fn all_impls(tcx: TyCtxt<'_>) -> &'static FxHashMap<PrimitiveType, ArrayVec<DefId, 4>> {
-        static CELL: OnceCell<FxHashMap<PrimitiveType, ArrayVec<DefId, 4>>> = OnceCell::new();
-
+        let single = |x| iter::once(x).collect();
         CELL.get_or_init(move || {
-            use self::PrimitiveType::*;
-
-            let single = |a: Option<DefId>| a.into_iter().collect();
-            let both = |a: Option<DefId>, b: Option<DefId>| -> ArrayVec<_, 4> {
-                a.into_iter().chain(b).collect()
-            };
-
-            let lang_items = tcx.lang_items();
             map! {
-                Isize => single(lang_items.isize_impl()),
-                I8 => single(lang_items.i8_impl()),
-                I16 => single(lang_items.i16_impl()),
-                I32 => single(lang_items.i32_impl()),
-                I64 => single(lang_items.i64_impl()),
-                I128 => single(lang_items.i128_impl()),
-                Usize => single(lang_items.usize_impl()),
-                U8 => single(lang_items.u8_impl()),
-                U16 => single(lang_items.u16_impl()),
-                U32 => single(lang_items.u32_impl()),
-                U64 => single(lang_items.u64_impl()),
-                U128 => single(lang_items.u128_impl()),
-                F32 => both(lang_items.f32_impl(), lang_items.f32_runtime_impl()),
-                F64 => both(lang_items.f64_impl(), lang_items.f64_runtime_impl()),
-                Char => single(lang_items.char_impl()),
-                Bool => single(lang_items.bool_impl()),
-                Str => both(lang_items.str_impl(), lang_items.str_alloc_impl()),
-                Slice => {
-                    lang_items
-                        .slice_impl()
-                        .into_iter()
-                        .chain(lang_items.slice_u8_impl())
-                        .chain(lang_items.slice_alloc_impl())
-                        .chain(lang_items.slice_u8_alloc_impl())
-                        .collect()
-                },
-                Array => single(lang_items.array_impl()),
-                Tuple => ArrayVec::new(),
-                Unit => ArrayVec::new(),
-                RawPointer => {
-                    lang_items
-                        .const_ptr_impl()
-                        .into_iter()
-                        .chain(lang_items.mut_ptr_impl())
-                        .chain(lang_items.const_slice_ptr_impl())
-                        .chain(lang_items.mut_slice_ptr_impl())
-                        .collect()
-                },
-                Reference => ArrayVec::new(),
+                Isize => single(IntSimplifiedType(IntTy::Isize)),
+                I8 => single(IntSimplifiedType(IntTy::I8)),
+                I16 => single(IntSimplifiedType(IntTy::I16)),
+                I32 => single(IntSimplifiedType(IntTy::I32)),
+                I64 => single(IntSimplifiedType(IntTy::I64)),
+                I128 => single(IntSimplifiedType(IntTy::I128)),
+                Usize => single(UintSimplifiedType(UintTy::Usize)),
+                U8 => single(UintSimplifiedType(UintTy::U8)),
+                U16 => single(UintSimplifiedType(UintTy::U16)),
+                U32 => single(UintSimplifiedType(UintTy::U32)),
+                U64 => single(UintSimplifiedType(UintTy::U64)),
+                U128 => single(UintSimplifiedType(UintTy::U128)),
+                F32 => single(FloatSimplifiedType(FloatTy::F32)),
+                F64 => single(FloatSimplifiedType(FloatTy::F64)),
+                Str => single(StrSimplifiedType),
+                Bool => single(BoolSimplifiedType),
+                Char => single(CharSimplifiedType),
+                Array => single(ArraySimplifiedType),
+                Slice => single(SliceSimplifiedType),
+                // FIXME: If we ever add an inherent impl for tuples
+                // with different lengths, they won't show in rustdoc.
+                //
+                // Either manually update this arrayvec at this point
+                // or start with a more complex refactoring.
+                Tuple => [TupleSimplifiedType(2), TupleSimplifiedType(3)].into(),
+                Unit => single(TupleSimplifiedType(0)),
+                RawPointer => [PtrSimplifiedType(Mutability::Not), PtrSimplifiedType(Mutability::Mut)].into(),
+                Reference => [RefSimplifiedType(Mutability::Not), RefSimplifiedType(Mutability::Mut)].into(),
+                // FIXME: This will be wrong if we ever add inherent impls
+                // for function pointers.
                 Fn => ArrayVec::new(),
-                Never => ArrayVec::new(),
+                Never => single(NeverSimplifiedType),
             }
         })
+    }
+
+    crate fn impls<'tcx>(&self, tcx: TyCtxt<'tcx>) -> impl Iterator<Item = DefId> + 'tcx {
+        Self::simplified_types()
+            .get(self)
+            .into_iter()
+            .flatten()
+            .flat_map(move |&simp| tcx.incoherent_impls(simp))
+            .copied()
+    }
+
+    crate fn all_impls(tcx: TyCtxt<'_>) -> impl Iterator<Item = DefId> + '_ {
+        Self::simplified_types()
+            .values()
+            .flatten()
+            .flat_map(move |&simp| tcx.incoherent_impls(simp))
+            .copied()
     }
 
     crate fn as_sym(&self) -> Symbol {

--- a/tools/bookrunner/librustdoc/clean/utils.rs
+++ b/tools/bookrunner/librustdoc/clean/utils.rs
@@ -113,7 +113,7 @@ crate fn build_deref_target_impls(cx: &mut DocContext<'_>, items: &[Item], ret: 
 
         if let Some(prim) = target.primitive_type() {
             let _prof_timer = cx.tcx.sess.prof.generic_activity("build_primitive_inherent_impls");
-            for &did in prim.impls(tcx).iter().filter(|did| !did.is_local()) {
+            for did in prim.impls(tcx).filter(|did| !did.is_local()) {
                 inline::build_impl(cx, None, did, None, ret);
             }
         } else if let Type::Path { path } = target {
@@ -229,7 +229,7 @@ crate fn register_res(cx: &mut DocContext<'_>, res: Res) -> DefId {
         // These should be added to the cache using `record_extern_fqn`.
         Res::Def(
             kind @ (AssocTy | AssocFn | AssocConst | Variant | Fn | TyAlias | Enum | Trait | Struct
-            | Union | Mod | ForeignTy | Const | Static | Macro(..) | TraitAlias),
+            | Union | Mod | ForeignTy | Const | Static(..) | Macro(..) | TraitAlias),
             i,
         ) => (i, kind.into()),
         // This is part of a trait definition; document the trait.

--- a/tools/bookrunner/librustdoc/doctest.rs
+++ b/tools/bookrunner/librustdoc/doctest.rs
@@ -333,12 +333,32 @@ pub fn make_test(
             // Any errors in parsing should also appear when the doctest is compiled for real, so just
             // send all the errors that librustc_ast emits directly into a `Sink` instead of stderr.
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
-            supports_color =
-                EmitterWriter::stderr(ColorConfig::Auto, None, false, false, Some(80), false)
-                    .supports_color();
 
-            let emitter =
-                EmitterWriter::new(box io::sink(), None, false, false, false, None, false);
+            let fallback_bundle =
+                rustc_errors::fallback_fluent_bundle(rustc_errors::DEFAULT_LOCALE_RESOURCES, false);
+            supports_color = EmitterWriter::stderr(
+                ColorConfig::Auto,
+                None,
+                None,
+                fallback_bundle.clone(),
+                false,
+                false,
+                Some(80),
+                false,
+            )
+            .supports_color();
+
+            let emitter = EmitterWriter::new(
+                box io::sink(),
+                None,
+                None,
+                fallback_bundle,
+                false,
+                false,
+                false,
+                None,
+                false,
+            );
 
             // FIXME(misdreavus): pass `-Z treat-err-as-bug` to the doctest parser
             let handler = Handler::with_emitter(false, None, box emitter);

--- a/tools/bookrunner/librustdoc/formats/item_type.rs
+++ b/tools/bookrunner/librustdoc/formats/item_type.rs
@@ -116,7 +116,7 @@ impl From<DefKind> for ItemType {
             DefKind::Fn => Self::Function,
             DefKind::Mod => Self::Module,
             DefKind::Const => Self::Constant,
-            DefKind::Static => Self::Static,
+            DefKind::Static(..) => Self::Static,
             DefKind::Struct => Self::Struct,
             DefKind::Union => Self::Union,
             DefKind::Trait => Self::Trait,


### PR DESCRIPTION
### Description of changes: 

Update the rust toolchain to `nightly-2022-05-03`. There were many issues that had to be fixed to upgrade the toolchain. I split the changes into the following commits:
1. Fix compilation (usually due to API changes).
2. Fix handling of Box due to changes in its internal representation (https://github.com/rust-lang/rust/pull/96010).
3. Implement new statement kind (Deinit).
4. Fix discriminant handling. The constant conversion to i64 was panicking and the niche_value conversion was also triggering an overflow error. I disabled the conversion checks for now and simplified the entire logic.

### Resolved issues:

Resolves #1162

### Call-outs:

This change disables conversion checks. I am open to discussion, but I think this check is too strict and it was rather complicating our codegen logic. I propose to instrument casting later based on user configuration.

### Testing:

* How is this change tested? Old tests

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
