### PR TITLE
Update Python requirement in docs

### DIFF
--- a/docs/src/install-guide.md
+++ b/docs/src/install-guide.md
@@ -17,7 +17,7 @@ Currently, only two platforms are supported:
 
 The following must already be installed:
 
-* **Python version 3.6 or greater.**
+* **Python version 3.8 or greater** and the package installer pip.
 * Rust installed via `rustup`
 * `ctags` is required for Kani's `--visualize` option to work correctly.
 


### PR DESCRIPTION
### Description of changes: 

Due to the reliance on `cbmc-viewer==2.11` this needs to be python >=3.8 and pip is also required. With Python 3.6 only cbmc-viewer 2.9 and 3.2 are supported.

### Resolved issues:

None

### Call-outs:

None

### Testing:

N.a.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
