### PR TITLE
Bump viewer to 3.2 fully

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ fn setup(use_local_bundle: Option<OsString>) -> Result<()> {
 
     // TODO: this is a repetition of versions from elsewhere
     Command::new("python3")
-        .args(&["-m", "pip", "install", "cbmc-viewer==2.11", "--target"])
+        .args(&["-m", "pip", "install", "cbmc-viewer==3.2", "--target"])
         .arg(&pyroot)
         .run()?;
     Command::new("python3")


### PR DESCRIPTION
### Description of changes: 

Fix omission I noticed before we forget. There's one place left mentioning 2.11 not 3.2 for viewer.

### Resolved issues:


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
