### PR TITLE
Remove ReadPtr hook

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -245,43 +245,6 @@ impl<'tcx> GotocHook<'tcx> for Panic {
     }
 }
 
-struct PtrRead;
-
-impl<'tcx> GotocHook<'tcx> for PtrRead {
-    fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
-        let name = with_no_trimmed_paths!(tcx.def_path_str(instance.def_id()));
-        name == "core::ptr::read"
-            || name == "core::ptr::read_unaligned"
-            || name == "core::ptr::read_volatile"
-            || name == "std::ptr::read"
-            || name == "std::ptr::read_unaligned"
-            || name == "std::ptr::read_volatile"
-    }
-
-    fn handle(
-        &self,
-        tcx: &mut GotocCtx<'tcx>,
-        _instance: Instance<'tcx>,
-        mut fargs: Vec<Expr>,
-        assign_to: Place<'tcx>,
-        target: Option<BasicBlock>,
-        span: Option<Span>,
-    ) -> Stmt {
-        let loc = tcx.codegen_span_option(span);
-        let target = target.unwrap();
-        let src = fargs.remove(0);
-        Stmt::block(
-            vec![
-                unwrap_or_return_codegen_unimplemented_stmt!(tcx, tcx.codegen_place(&assign_to))
-                    .goto_expr
-                    .assign(src.dereference().with_location(loc), loc),
-                Stmt::goto(tcx.current_fn().find_label(&target), loc),
-            ],
-            loc,
-        )
-    }
-}
-
 struct RustAlloc;
 // Removing this hook causes regression failures.
 // https://github.com/model-checking/kani/issues/1170
@@ -362,7 +325,6 @@ pub fn fn_hooks<'tcx>() -> GotocHooks<'tcx> {
             Rc::new(Assert),
             Rc::new(ExpectFail),
             Rc::new(Nondet),
-            Rc::new(PtrRead),
             Rc::new(RustAlloc),
             Rc::new(SliceFromRawPart),
         ],


### PR DESCRIPTION
### Description of changes: 

The PtrRead hook is no longer necessary given that we support the underlying intrinsics.

### Resolved issues:

Resolves #1175


### Call-outs:

Thanks to optimizations in latest CBMC revision, performance seems comparable before and after this change.
### Testing:

* How is this change tested? Existing unit tests

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
