### PR TITLE
Allow cargo-kani to run outside a Cargo project

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Run installed tests
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
+          docker run kani-latest  cargo kani --version
           docker run -w /tmp/kani/tests/cargo-kani/simple-lib  kani-latest  cargo kani
           docker run -w /tmp/kani/tests/cargo-kani/simple-visualize  kani-latest  cargo kani
           docker run -w /tmp/kani/tests/cargo-kani/build-rs-works  kani-latest  cargo kani

--- a/kani-driver/src/args_toml.rs
+++ b/kani-driver/src/args_toml.rs
@@ -13,7 +13,12 @@ use toml::Value;
 ///
 /// The arguments passed via command line have precedence over the ones from the Cargo.toml.
 pub fn join_args(input_args: Vec<OsString>) -> Result<Vec<OsString>> {
-    let file = std::fs::read_to_string(cargo_locate_project()?)?;
+    let toml_path = cargo_locate_project();
+    if toml_path.is_err() {
+        // We're not inside a Cargo project. Don't error... yet.
+        return Ok(input_args);
+    }
+    let file = std::fs::read_to_string(toml_path?)?;
     let (kani_args, cbmc_args) = toml_to_args(&file)?;
     merge_args(input_args, kani_args, cbmc_args)
 }


### PR DESCRIPTION
### Description of changes: 

Allow `cargo-kani` to run at all without being in a Cargo project.

### Resolved issues:

Resolves #1154

### Call-outs:

A normal run outside a project goes from:

```
$ cargo kani
Error: error: could not find `Cargo.toml` in `/home/ubuntu` or any parent directory
```

to

```
$ cargo kani
error: could not find `Cargo.toml` in `/home/ubuntu` or any parent directory
Error: cargo exited with status exit status: 101
```

So still pretty good. But now we can run `cargo kani --version`

### Testing:

* How is this change tested? added test in docker

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
