### PR TITLE
Ensure cargo-kani setup is idempotent

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -107,6 +107,7 @@ jobs:
           docker run -w /tmp/kani/tests/cargo-kani/simple-lib  kani-latest  cargo kani
           docker run -w /tmp/kani/tests/cargo-kani/simple-visualize  kani-latest  cargo kani
           docker run -w /tmp/kani/tests/cargo-kani/build-rs-works  kani-latest  cargo kani
+          docker run kani-latest  cargo-kani setup --use-local-bundle ./kani-latest-x86_64-unknown-linux-gnu.tar.gz
 
       # We can't run macos in a container, so we can only test locally.
       # Hopefully any dependency issues won't be unique to macos.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,12 @@ fn setup(use_local_bundle: Option<OsString>) -> Result<()> {
         if !kani_dir.exists() {
             std::fs::create_dir(&kani_dir)?;
         }
-        Command::new("tar").arg("--strip-components=1").arg("-zxf").arg(&path).current_dir(&kani_dir).run()?;
+        Command::new("tar")
+            .arg("--strip-components=1")
+            .arg("-zxf")
+            .arg(&path)
+            .current_dir(&kani_dir)
+            .run()?;
     } else {
         let filename = download_filename();
         println!("[2/6] Downloading Kani release bundle: {}", &filename);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,8 +111,8 @@ fn setup(use_local_bundle: Option<OsString>) -> Result<()> {
     std::fs::create_dir_all(&base_dir)?;
 
     if let Some(pathstr) = use_local_bundle {
+        println!("[2/6] Installing local Kani bundle: {}", pathstr.to_string_lossy());
         let path = Path::new(&pathstr).canonicalize()?;
-        println!("[2/6] Installing local Kani bundle: {}", path.display());
         // When given a local bundle, it's often "-latest" but we expect "-1.0" or something.
         // tar supports "stripping" the first directory from the bundle, so do that and
         // extract it directly into the expected (kani_dir) directory (instead of base_dir).


### PR DESCRIPTION
### Description of changes: 

Quick fixes for lack of idempotency in `cargo-kani setup`

### Resolved issues:

Resolves #1156

### Call-outs:

1. First fix is symlink creation. It would fail if it already existed. I also switched to using the native rust instead of shelling out to `ln -s`
2. Second fix was the rename in the `--use-local-bundle` code. I changed this to directly extract the bundle to the correct location in the first place, making its effective behavior more like the download case.
3. Minor fix: `canonicalize` can fail if the file doesn't exist. Print the file before canonicalizing.

### Testing:

* How is this change tested? A re-install test added to the release bundle tests

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
