### PR TITLE
Correct types for alignment expressions

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
@@ -78,9 +78,9 @@ impl<'tcx> GotocCtx<'tcx> {
         Expr::statement_expression(body, t).with_location(loc)
     }
 
-    /// Generates an expression `((dst as usize) % align_of(T) == 0`
-    /// to determine if a pointer `dst` with pointee type `T` is aligned.
-    pub fn is_ptr_aligned(&mut self, typ: Ty<'tcx>, dst: Expr) -> Expr {
+    /// Generates an expression `(ptr as usize) % align_of(T) == 0`
+    /// to determine if a pointer `ptr` with pointee type `T` is aligned.
+    pub fn is_ptr_aligned(&mut self, typ: Ty<'tcx>, ptr: Expr) -> Expr {
         // Ensure `typ` is a pointer, then extract the pointee type
         assert!(is_pointer(typ));
         let pointee_type = pointee_type(typ).unwrap();
@@ -88,9 +88,9 @@ impl<'tcx> GotocCtx<'tcx> {
         let layout = self.layout_of(pointee_type);
         let align = Expr::int_constant(layout.align.abi.bytes(), Type::size_t());
         // Cast the pointer to `usize` and return the alignment expression
-        let cast_dst = dst.cast_to(Type::size_t());
+        let cast_ptr = ptr.cast_to(Type::size_t());
         let zero = Type::size_t().zero();
-        cast_dst.rem(align).eq(zero)
+        cast_ptr.rem(align).eq(zero)
     }
 
     pub fn unsupported_msg(item: &str, url: Option<&str>) -> String {


### PR DESCRIPTION
### Description of changes: 

Corrects the types used to build alignment expressions.

Previously, the type was obtained using `instance.substs.type_at(0)` which returns the first monomorphized type for `T` in a generic function. This often matches the pointee type for intrinsic arguments (e.g., `T` resolves to both the monomorphized type and the pointee type in `fn volatile_store<T>(dst: *mut T, val: T)`), but it's not what should be used to build these expressions.

The changes in this PR also ensure that alignment expressions are only built for pointer types (renames `is_aligned` to `is_ptr_aligned` and asserts the type passed is a pointer).

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regression, in particular tests including alignment checks.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
