### PR TITLE
Audit for `copy` intrinsic

### DIFF
--- a/tests/expected/intrinsics/copy/copy-overflow/expected
+++ b/tests/expected/intrinsics/copy/copy-overflow/expected
@@ -1,0 +1,2 @@
+FAILURE\
+copy: attempt to compute number in bytes which would overflow

--- a/tests/expected/intrinsics/copy/copy-overflow/main.rs
+++ b/tests/expected/intrinsics/copy/copy-overflow/main.rs
@@ -1,0 +1,18 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Checks that `copy` triggers an overflow failure if the `count` argument can
+// overflow a `usize`
+#[kani::proof]
+fn test_copy_unaligned() {
+    let arr: [i32; 3] = [0, 1, 0];
+    let src: *const i32 = arr.as_ptr();
+    // Passing `max_count` is guaranteed to overflow
+    // the count in bytes for `i32` pointers
+    let max_count = usize::MAX / 4 + 1;
+
+    unsafe {
+        let dst = src.add(1) as *mut i32;
+        core::intrinsics::copy(src, dst, max_count);
+    }
+}

--- a/tests/expected/intrinsics/copy/copy-unaligned-dst/expected
+++ b/tests/expected/intrinsics/copy/copy-unaligned-dst/expected
@@ -1,0 +1,2 @@
+FAILURE\
+`dst` is properly aligned

--- a/tests/expected/intrinsics/copy/copy-unaligned-dst/main.rs
+++ b/tests/expected/intrinsics/copy/copy-unaligned-dst/main.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Checks that `copy` fails when `dst` is not aligned.
+#[kani::proof]
+fn test_copy_unaligned() {
+    let arr: [i32; 3] = [0, 1, 0];
+    let src: *const i32 = arr.as_ptr();
+
+    unsafe {
+        // Get an unaligned pointer with a single-byte offset
+        let dst_i8: *const i8 = src.add(1) as *mut i8;
+        let dst_unaligned = unsafe { dst_i8.add(1) as *mut i32 };
+        core::intrinsics::copy(src, dst_unaligned, 1);
+    }
+}

--- a/tests/expected/intrinsics/copy/copy-unaligned-src/expected
+++ b/tests/expected/intrinsics/copy/copy-unaligned-src/expected
@@ -1,0 +1,2 @@
+FAILURE\
+`src` is properly aligned

--- a/tests/expected/intrinsics/copy/copy-unaligned-src/main.rs
+++ b/tests/expected/intrinsics/copy/copy-unaligned-src/main.rs
@@ -1,0 +1,17 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Checks that `copy` fails when `src` is not aligned.
+#[kani::proof]
+fn test_copy_unaligned() {
+    let arr: [i32; 3] = [0, 1, 0];
+    let src: *const i32 = arr.as_ptr();
+
+    unsafe {
+        // Get an unaligned pointer with a single-byte offset
+        let src_i8: *const i8 = src as *const i8;
+        let src_unaligned = unsafe { src_i8.add(1) as *const i32 };
+        let dst = src.add(1) as *mut i32;
+        core::intrinsics::copy(src_unaligned, dst, 1);
+    }
+}

--- a/tests/expected/intrinsics/copy/copy-unreadable-src/expected
+++ b/tests/expected/intrinsics/copy/copy-unreadable-src/expected
@@ -1,0 +1,2 @@
+FAILURE\
+memmove source region readable

--- a/tests/expected/intrinsics/copy/copy-unreadable-src/main.rs
+++ b/tests/expected/intrinsics/copy/copy-unreadable-src/main.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Checks that `copy` fails when `src` is not valid for reads.
+#[kani::proof]
+fn test_copy_invalid() {
+    let arr: [i32; 3] = [0, 1, 0];
+    let src: *const i32 = arr.as_ptr();
+
+    unsafe {
+        // Get an invalid pointer with a negative offset
+        let src_invalid = unsafe { src.sub(1) as *const i32 };
+        let dst = src.add(1) as *mut i32;
+        core::intrinsics::copy(src_invalid, dst, 1);
+    }
+}

--- a/tests/expected/intrinsics/copy/copy-unwritable-dst/expected
+++ b/tests/expected/intrinsics/copy/copy-unwritable-dst/expected
@@ -1,0 +1,2 @@
+FAILURE\
+memmove destination region writeable

--- a/tests/expected/intrinsics/copy/copy-unwritable-dst/main.rs
+++ b/tests/expected/intrinsics/copy/copy-unwritable-dst/main.rs
@@ -1,0 +1,15 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Checks that `copy` fails when `dst` is not valid for writes.
+#[kani::proof]
+fn test_copy_invalid() {
+    let arr: [i32; 3] = [0, 1, 0];
+    let src: *const i32 = arr.as_ptr();
+
+    unsafe {
+        // Get an invalid pointer with an out-of-bounds offset
+        let dst_invalid = src.add(3) as *mut i32;
+        core::intrinsics::copy(src, dst_invalid, 1);
+    }
+}

--- a/tests/kani/Intrinsics/Copy/copy.rs
+++ b/tests/kani/Intrinsics/Copy/copy.rs
@@ -1,0 +1,33 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `copy` works as expected: Copies a number `n` of elements from
+// pointer `src` to pointer `dst`, even if their regions overlap.
+
+#[kani::proof]
+fn test_copy_simple() {
+    let mut expected_val = 42;
+    let src: *mut i32 = &mut expected_val as *mut i32;
+    let mut old_val = 99;
+    let dst: *mut i32 = &mut old_val;
+    unsafe {
+        core::intrinsics::copy(src, dst, 1);
+        assert!(*dst == expected_val);
+    }
+}
+
+#[kani::proof]
+fn test_copy_with_overlap() {
+    let arr: [i32; 3] = [0, 1, 0];
+    let src: *const i32 = arr.as_ptr();
+
+    unsafe {
+        let dst = src.add(1) as *mut i32;
+        core::intrinsics::copy(src, dst, 2);
+        // The first value does not change
+        assert!(arr[0] == 0);
+        // The next values are copied from `arr[0..=1]`
+        assert!(arr[1] == 0);
+        assert!(arr[2] == 1);
+    }
+}

--- a/tests/kani/Intrinsics/Copy/copy_nonoverlapping.rs
+++ b/tests/kani/Intrinsics/Copy/copy_nonoverlapping.rs
@@ -5,18 +5,8 @@
 use std::mem;
 use std::ptr;
 
-fn test_copy() {
-    // TODO: make an overlapping set of locations, and check that it does the right thing for the overlapping region too.
-    // https://github.com/model-checking/kani/issues/12
-    let mut expected_val = 42;
-    let src: *mut i32 = &mut expected_val as *mut i32;
-    let mut old_val = 99;
-    let dst: *mut i32 = &mut old_val;
-    unsafe {
-        ptr::copy(src, dst, 1);
-        assert!(*dst == expected_val);
-    }
-}
+// Note: Calls to `copy_nonoverlapping` are handled by `codegen_statement`
+// and not `codegen_intrinsic`: https://github.com/model-checking/kani/issues/1198
 
 /// https://doc.rust-lang.org/std/ptr/fn.copy_nonoverlapping.html
 /// Moves all the elements of `src` into `dst`, leaving `src` empty.
@@ -89,7 +79,6 @@ fn test_swap() {
 
 #[kani::proof]
 fn main() {
-    test_copy();
     test_swap();
     test_append();
 }


### PR DESCRIPTION
### Description of changes: 

Completes the audit for the `copy` intrinsic, which was disabled in #1081:
 * Adds alignment checks for both `src` and `dst`.
 * Adds overflow check for the count in bytes (this is not mentioned in the documentation).
 * Refactors the code into a function because macros are harder to debug.
 * Adds tests for all possible cases.

Initially, the changes in this PR were for both `copy` and `copy_nonoverlapping`, but as it has been noted in #1176 the `copy_nonoverlapping` case is handled somewhere else.

### Resolved issues:

Creates #1198 
Part of #1163 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regression and 7 new/restored tests.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
