### PR TITLE
Use parentheses in the assert_eq macros to avoid chained comparison operators error

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -63,20 +63,24 @@ macro_rules! assert {
 #[macro_export]
 macro_rules! assert_eq {
     ($left:expr, $right:expr $(,)?) => ({
-        assert!($left == $right);
+        // Add parentheses around the operands to avoid a "comparison operators
+        // cannot be chained" error, but exclude the parentheses in the message
+        kani::assert(($left) == ($right), concat!("assertion failed: ", stringify!($left == $right)));
     });
     ($left:expr, $right:expr, $($arg:tt)+) => ({
-        assert!($left == $right, $($arg)+);
+        assert!(($left) == ($right), $($arg)+);
     });
 }
 
 #[macro_export]
 macro_rules! assert_ne {
     ($left:expr, $right:expr $(,)?) => ({
-        assert!($left != $right);
+        // Add parentheses around the operands to avoid a "comparison operators
+        // cannot be chained" error, but exclude the parentheses in the message
+        kani::assert(($left) != ($right), concat!("assertion failed: ", stringify!($left != $right)));
     });
     ($left:expr, $right:expr, $($arg:tt)+) => ({
-        assert!($left != $right, $($arg)+);
+        assert!(($left) != ($right), $($arg)+);
     });
 }
 

--- a/tests/expected/assert-eq-chained/expected
+++ b/tests/expected/assert-eq-chained/expected
@@ -1,0 +1,13 @@
+Status: SUCCESS\
+Description: "assertion failed: x > 3 == true"
+
+Status: SUCCESS\
+Description: "assertion failed: x == 1 == false"
+
+Status: SUCCESS\
+Description: "assertion failed: x < 10 != false"
+
+Status: FAILURE\
+Description: "assertion failed: x == 7 != false"
+
+VERIFICATION:- FAILED

--- a/tests/expected/assert-eq-chained/main.rs
+++ b/tests/expected/assert-eq-chained/main.rs
@@ -1,0 +1,14 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// This test checks that chained operators work with Kani's overridden assert_eq
+// macros
+
+#[kani::proof]
+fn check_chained_operators() {
+    let x = 5;
+    assert_eq!(x > 3, true);
+    debug_assert_eq!(x == 1, false);
+    assert_ne!(x < 10, false);
+    debug_assert_ne!(x == 7, false); // fails
+}


### PR DESCRIPTION
### Description of changes: 

Using chained comparison operators in the `assert_eq` macros, e.g. `assert_eq!(x > 5, true)` currently results in an error (see #1200). This PR adds parentheses in the macro definition to avoid such an error.

### Resolved issues:

Resolves #1200 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Added one test

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
