### PR TITLE
Integrate s2n-quic in the regressions

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -24,7 +24,12 @@ jobs:
           cargo build --workspace
 
       - name: Execute Kani regression
+        if: ${{ github.event_name == 'pull_request' }}
         run: ./scripts/kani-regression.sh
+
+      - name: Execute all Kani regressions
+        if: ${{ github.event_name == 'push' }}
+        run: ./scripts/kani-regression.sh all
 
   bookrunner:
     runs-on: ubuntu-20.04

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "firecracker"]
 	path = firecracker
 	url = https://github.com/firecracker-microvm/firecracker.git
+[submodule "tests/perf/s2n-quic"]
+	path = tests/perf/s2n-quic
+	url = https://github.com/zhassan-aws/s2n-quic

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -8,6 +8,17 @@ fi
 set -o pipefail
 set -o nounset
 
+ARG=
+# Check for optional arguments
+if (( "$#" > 0 )); then
+  ARG=$1
+  if [ "$ARG" != "all" ]; then
+    echo "Unexpected argument: $ARG"
+    echo "Usage: $0 [all]"
+    exit 1
+  fi
+fi
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export PATH=$SCRIPT_DIR:$PATH
 EXTRA_X_PY_BUILD_ARGS="${EXTRA_X_PY_BUILD_ARGS:-}"
@@ -48,6 +59,10 @@ TESTS=(
     "kani-fixme kani-fixme"
     "ui expected"
 )
+
+if [ "$ARG" = "all" ]; then
+  TESTS+=("perf cargo-kani")
+fi
 
 # Extract testing suite information and run compiletest
 for testp in "${TESTS[@]}"; do


### PR DESCRIPTION
### Description of changes: 

Integrate s2n-quic as a submodule and run the current Kani proofs on every push.

The s2n-quic proofs are added to a new `perf` test suite that is **not** run by default with `./scripts/kani-regressions`. One has to pass an additional argument, `all`, to run this suite.

### Resolved issues:

Resolves #958 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
