### PR TITLE
Fix initial index in CBMC output parser

### DIFF
--- a/scripts/cbmc_json_parser.py
+++ b/scripts/cbmc_json_parser.py
@@ -683,7 +683,7 @@ def construct_terse_property_message(properties):
     number_tests_failed = 0
     output_message = ""
     failed_tests = []
-    index = 0
+    index = -1
     verification_status = GlobalMessages.FAILED
 
     # Parse each property instance in properties
@@ -752,7 +752,7 @@ def construct_property_message(properties):
     number_tests_undetermined = 0
     output_message = ""
     failed_tests = []
-    index = 0
+    index = -1
     verification_status = GlobalMessages.FAILED
 
     output_message = "RESULTS:\n"

--- a/scripts/cbmc_json_parser.py
+++ b/scripts/cbmc_json_parser.py
@@ -683,11 +683,10 @@ def construct_terse_property_message(properties):
     number_tests_failed = 0
     output_message = ""
     failed_tests = []
-    index = -1
     verification_status = GlobalMessages.FAILED
 
     # Parse each property instance in properties
-    for index, property_instance in enumerate(properties):
+    for property_instance in properties:
         status = property_instance["status"]
         if status == "FAILURE":
             number_tests_failed += 1
@@ -696,7 +695,7 @@ def construct_terse_property_message(properties):
             pass
 
     # Ex - OUTPUT: ** 1 of 54 failed
-    output_message += f"VERIFICATION RESULT: \n ** {number_tests_failed} of {index+1} failed\n"
+    output_message += f"VERIFICATION RESULT: \n ** {number_tests_failed} of {len(properties)} failed\n"
 
     # The Verification is successful and the program is verified
     if number_tests_failed == 0:
@@ -752,7 +751,6 @@ def construct_property_message(properties):
     number_tests_undetermined = 0
     output_message = ""
     failed_tests = []
-    index = -1
     verification_status = GlobalMessages.FAILED
 
     output_message = "RESULTS:\n"
@@ -791,7 +789,7 @@ def construct_property_message(properties):
 
         output_message += "\n"
 
-    output_message += f"\nSUMMARY: \n ** {number_tests_failed} of {index+1} failed"
+    output_message += f"\nSUMMARY: \n ** {number_tests_failed} of {len(properties)} failed"
     other_status = []
     if number_tests_undetermined > 0:
         other_status.append(f"{number_tests_undetermined} undetermined")

--- a/tests/expected/empty/expected
+++ b/tests/expected/empty/expected
@@ -1,0 +1,2 @@
+0 of 0 failed
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/empty/main.rs
+++ b/tests/expected/empty/main.rs
@@ -1,0 +1,7 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// This test checks that zero checks are reported for an empty test
+
+#[kani::proof]
+fn check_nothing() {}


### PR DESCRIPTION
### Description of changes: 

For programs without any checks, Kani currently reports `0 of 1 failed` and doesn't display any checks. This PR fixes this issue so that Kani reports `0 of 0 failed` instead.

### Resolved issues:

Resolves #842 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Added one test

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X]  Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
