### PR TITLE
Enable CBMC's slicer

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -79,7 +79,10 @@ impl KaniSession {
         file: &Path,
         harness_metadata: &HarnessMetadata,
     ) -> Result<Vec<OsString>> {
-        let mut args = self.cbmc_check_flags();
+        let mut args = Vec::new();
+        if self.args.checks.unwinding_on() {
+            args.push("--unwinding-assertions".into());
+        }
 
         if let Some(object_bits) = self.args.cbmc_object_bits() {
             args.push("--object-bits".into());
@@ -122,10 +125,6 @@ impl KaniSession {
             // We might want to create a transformation pass instead of enabling CBMC since Kani
             // compiler sometimes rely on the bitwise conversion of signed <-> unsigned.
             // args.push("--conversion-check".into());
-        }
-
-        if self.args.checks.unwinding_on() {
-            args.push("--unwinding-assertions".into());
         }
 
         if self.args.extra_pointer_checks {

--- a/tests/expected/dry-run/expected
+++ b/tests/expected/dry-run/expected
@@ -3,4 +3,5 @@ symtab2gb
 goto-cc
 --function main
 goto-instrument
-cbmc --bounds-check --pointer-check --div-by-zero-check --float-overflow-check --nan-check --undefined-shift-check --unwinding-assertions --object-bits 16
+goto-instrument --bounds-check --pointer-check --div-by-zero-check --float-overflow-check --nan-check --undefined-shift-check
+cbmc --unwinding-assertions --object-bits 16

--- a/tests/expected/one-assert/expected
+++ b/tests/expected/one-assert/expected
@@ -1,1 +1,1 @@
-** 0 of 2 failed
+** 0 of 1 failed

--- a/tests/ui/cbmc_checks/signed-overflow/expected
+++ b/tests/ui/cbmc_checks/signed-overflow/expected
@@ -1,14 +1,8 @@
-Failed Checks: arithmetic overflow on signed addition
-Failed Checks: arithmetic overflow on signed subtraction
-Failed Checks: arithmetic overflow on signed multiplication
 Failed Checks: division by zero
-Failed Checks: arithmetic overflow on signed division
 Failed Checks: division by zero
 Failed Checks: result of signed mod is not representable
 Failed Checks: shift distance is negative
 Failed Checks: shift distance too large
 Failed Checks: shift operand is negative
-Failed Checks: arithmetic overflow on signed shl
 Failed Checks: shift distance is negative
 Failed Checks: shift distance too large
-Failed Checks: arithmetic overflow on signed unary minus


### PR DESCRIPTION
### Description of changes: 

Enable CBMC's slicer (`--reachability-slice`) to remove code that does not impact any of the checks from the goto binary. This change required moving all the check options (e.g. `--bounds-check`, `--pointer-check`, etc.) from the `cbmc` step to `goto-instrument` to make sure they're injected into the goto binary _before_ the slicer is applied (see discussion [here](https://github.com/diffblue/cbmc/issues/6730#issuecomment-1067800914)).

### Resolved issues:

Resolves #683 

Should help with standard library linking (e.g. #576)


### Call-outs:

This change breaks Kani's `--cbmc-args` option even further: specifying any check options, e.g. `--signed-overflow-check` may not have an impact since they will be applied after the possible removal of code relevant to those checks by the slicer.

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Current regressions

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
