### PR TITLE
Remove MemReplace hook

### DIFF
--- a/tests/kani/FunctionAbstractions/mem_replace.rs
+++ b/tests/kani/FunctionAbstractions/mem_replace.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Tests the `std::mem::swap` function using various function types.
+//! Tests the `std::mem::replace` function using various function types.
 
 use std::mem;
 
@@ -21,7 +21,9 @@ fn test<T: kani::Invariant + std::cmp::PartialEq + Clone>() {
     let mut var1 = kani::any::<T>();
     let var2 = kani::any::<T>();
     let old_var1 = var1.clone();
+    let old_var2 = var2.clone();
     assert_eq!(mem::replace(&mut var1, var2), old_var1);
+    assert_eq!(var1, old_var2);
 }
 
 #[kani::proof]

--- a/tests/kani/FunctionAbstractions/mem_replace.rs
+++ b/tests/kani/FunctionAbstractions/mem_replace.rs
@@ -1,15 +1,36 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! Tests the `std::mem::swap` function using various function types.
+
 use std::mem;
 
-#[kani::proof]
-fn main() {
-    let mut var1 = kani::any::<i32>();
-    let mut var2 = kani::any::<i32>();
-    let old_var1 = var1;
-    unsafe {
-        assert_eq!(mem::replace(&mut var1, var2), old_var1);
+#[derive(PartialEq, Copy, Clone)]
+pub struct Pair {
+    value: u8,
+    key: u16,
+}
+
+unsafe impl kani::Invariant for Pair {
+    fn is_valid(&self) -> bool {
+        true
     }
-    assert_eq!(var1, var2);
+}
+
+fn test<T: kani::Invariant + std::cmp::PartialEq + Clone>() {
+    let mut var1 = kani::any::<T>();
+    let var2 = kani::any::<T>();
+    let old_var1 = var1.clone();
+    assert_eq!(mem::replace(&mut var1, var2), old_var1);
+}
+
+#[kani::proof]
+#[kani::unwind(9)]
+fn main() {
+    test::<i32>();
+    test::<char>();
+    test::<u32>();
+    test::<[u8; 4]>();
+    test::<[u16; 4]>();
+    test::<Pair>();
 }


### PR DESCRIPTION

### Description of changes: 

Currently, Kani uses a "hook" to override `mem::replace`.
We now support the intrinsics used here, so no need to override the function.

### Resolved issues:

Resolves #1223


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing tests

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
