### PR TITLE
Fix gen-c display (#1241)

### DIFF
--- a/kani-driver/src/call_goto_instrument.rs
+++ b/kani-driver/src/call_goto_instrument.rs
@@ -27,7 +27,10 @@ impl KaniSession {
 
         if self.args.gen_c {
             if !self.args.quiet {
-                println!("Generated C code written to {}", output.to_string_lossy());
+                println!(
+                    "Generated C code written to {}",
+                    alter_extension(output, "c").to_string_lossy()
+                );
             }
             self.gen_c(output)?;
         }


### PR DESCRIPTION
Now gen-c display the c file instead of the goto binnary.


### Description of changes: 

When generating the c code with `cargo kani --enable-unstable --gen-c` , kani will display the goto file instead of C file.

### Resolved issues:

Resolves #1241 

### Checklist
- [X ] Each commit message has a non-empty body, explaining why the change was made
- [ X] Methods or procedures are documented
- [ X] Regression or unit tests are included, or existing tests cover the modified code
- [ X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
