### PR TITLE
Better type checks for compound types

### DIFF
--- a/cprover_bindings/src/goto_program/typ.rs
+++ b/cprover_bindings/src/goto_program/typ.rs
@@ -184,7 +184,13 @@ impl DatatypeComponent {
     }
 
     pub fn field<T: Into<InternedString>>(name: T, typ: Type) -> Self {
-        assert!(Self::typecheck_datatype_field(&typ), "Illegal field type {:?}", typ);
+        // TODO https://github.com/model-checking/kani/issues/1243
+        // assert!(
+        //     Self::typecheck_datatype_field(&typ),
+        //     "Illegal field.\n\tName: {}\n\tType: {:?}",
+        //     name.into(),
+        //     typ
+        // );
         let name = name.into();
         Field { name, typ }
     }
@@ -966,19 +972,6 @@ impl Type {
 
     pub fn constructor() -> Self {
         Constructor
-    }
-
-    /// A component of a datatype (e.g. a field of a struct or union)
-    pub fn datatype_component<T: Into<InternedString>>(name: T, typ: Type) -> DatatypeComponent {
-        let name = name.into();
-        Field { name, typ }
-    }
-
-    // `__CPROVER_bitvector[bits] $pad<n>`
-    pub fn datatype_padding<T: Into<InternedString>>(name: T, bits: u64) -> DatatypeComponent {
-        let name = name.into();
-
-        Padding { name, bits }
     }
 
     pub fn double() -> Self {

--- a/cprover_bindings/src/goto_program/typ.rs
+++ b/cprover_bindings/src/goto_program/typ.rs
@@ -152,9 +152,39 @@ impl DatatypeComponent {
     }
 }
 
-//Constructors
+/// Constructors
 impl DatatypeComponent {
+    fn typecheck_datatype_field(typ: &Type) -> bool {
+        match typ.unwrap_typedef() {
+            Array { .. }
+            | Bool
+            | CBitField { .. }
+            | CInteger(_)
+            | Double
+            | FlexibleArray { .. }
+            | Float
+            | Pointer { .. }
+            | Signedbv { .. }
+            | Struct { .. }
+            | StructTag(_)
+            | TypeDef { .. }
+            | Union { .. }
+            | UnionTag(_)
+            | Unsignedbv { .. }
+            | Vector { .. } => true,
+
+            Code { .. }
+            | Constructor
+            | Empty
+            | IncompleteStruct { .. }
+            | IncompleteUnion { .. }
+            | InfiniteArray { .. }
+            | VariadicCode { .. } => false,
+        }
+    }
+
     pub fn field<T: Into<InternedString>>(name: T, typ: Type) -> Self {
+        assert!(Self::typecheck_datatype_field(&typ), "Illegal field type {:?}", typ);
         let name = name.into();
         Field { name, typ }
     }
@@ -831,12 +861,42 @@ impl Type {
 
 /// Constructors
 impl Type {
+    fn typecheck_array_elem(&self) -> bool {
+        match self.unwrap_typedef() {
+            Array { .. }
+            | Bool
+            | CBitField { .. }
+            | CInteger(_)
+            | Double
+            | Float
+            | Pointer { .. }
+            | Signedbv { .. }
+            | Struct { .. }
+            | StructTag(_)
+            | TypeDef { .. }
+            | Union { .. }
+            | UnionTag(_)
+            | Unsignedbv { .. }
+            | Vector { .. } => true,
+
+            Code { .. }
+            | Constructor
+            | Empty
+            | FlexibleArray { .. }
+            | IncompleteStruct { .. }
+            | IncompleteUnion { .. }
+            | InfiniteArray { .. }
+            | VariadicCode { .. } => false,
+        }
+    }
+
     /// elem_t[size]
     pub fn array_of<T>(self, size: T) -> Self
     where
         T: TryInto<u64>,
         T::Error: Debug,
     {
+        assert!(self.typecheck_array_elem(), "Can't make array of type {:?}", self);
         let size: u64 = size.try_into().unwrap();
         Array { typ: Box::new(self), size }
     }
@@ -965,6 +1025,7 @@ impl Type {
     }
 
     pub fn infinite_array_of(self) -> Self {
+        assert!(self.typecheck_array_elem(), "Can't make infinite array of type {:?}", self);
         InfiniteArray { typ: Box::new(self) }
     }
 
@@ -1013,11 +1074,25 @@ impl Type {
         StructTag(name)
     }
 
-    pub fn components_are_unique(components: &[DatatypeComponent]) -> bool {
+    fn components_are_unique(components: &[DatatypeComponent]) -> bool {
         let mut names: Vec<_> = components.iter().map(|x| x.name()).collect();
         names.sort();
         names.dedup();
         names.len() == components.len()
+    }
+
+    fn components_are_not_flexible_array(components: &[DatatypeComponent]) -> bool {
+        components.iter().all(|x| !x.typ().is_flexible_array())
+    }
+
+    /// A struct can only contain a flexible array as its last element
+    /// Check this
+    fn components_in_valid_order_for_struct(components: &[DatatypeComponent]) -> bool {
+        if let Some((_, cs)) = components.split_last() {
+            Type::components_are_not_flexible_array(cs)
+        } else {
+            true
+        }
     }
 
     /// struct name {
@@ -1032,6 +1107,12 @@ impl Type {
             "Components contain duplicates: {:?}",
             components
         );
+        assert!(
+            Type::components_in_valid_order_for_struct(&components),
+            "Components are not in valid order for struct: {:?}",
+            components
+        );
+
         let tag = tag.into();
         Struct { tag, components }
     }
@@ -1059,6 +1140,11 @@ impl Type {
         assert!(
             Type::components_are_unique(&components),
             "Components contain duplicates: {:?}",
+            components
+        );
+        assert!(
+            Type::components_are_not_flexible_array(&components),
+            "Unions cannot contain flexible arrays: {:?}",
             components
         );
         Union { tag, components }

--- a/cprover_bindings/src/goto_program/typ.rs
+++ b/cprover_bindings/src/goto_program/typ.rs
@@ -167,7 +167,6 @@ impl DatatypeComponent {
             | Signedbv { .. }
             | Struct { .. }
             | StructTag(_)
-            | TypeDef { .. }
             | Union { .. }
             | UnionTag(_)
             | Unsignedbv { .. }
@@ -180,6 +179,8 @@ impl DatatypeComponent {
             | IncompleteUnion { .. }
             | InfiniteArray { .. }
             | VariadicCode { .. } => false,
+
+            TypeDef { .. } => unreachable!("typedefs should have been unwrapped"),
         }
     }
 
@@ -879,7 +880,6 @@ impl Type {
             | Signedbv { .. }
             | Struct { .. }
             | StructTag(_)
-            | TypeDef { .. }
             | Union { .. }
             | UnionTag(_)
             | Unsignedbv { .. }
@@ -893,6 +893,8 @@ impl Type {
             | IncompleteUnion { .. }
             | InfiniteArray { .. }
             | VariadicCode { .. } => false,
+
+            TypeDef { .. } => unreachable!("typedefs should have been unwrapped"),
         }
     }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -3,7 +3,7 @@
 use crate::codegen_cprover_gotoc::utils::slice_fat_ptr;
 use crate::codegen_cprover_gotoc::GotocCtx;
 use crate::unwrap_or_return_codegen_unimplemented;
-use cbmc::goto_program::{Expr, Location, Stmt, Symbol, Type};
+use cbmc::goto_program::{DatatypeComponent, Expr, Location, Stmt, Symbol, Type};
 use cbmc::NO_PRETTY_NAME;
 use rustc_ast::ast::Mutability;
 use rustc_middle::mir::interpret::{
@@ -503,12 +503,12 @@ impl<'tcx> GotocCtx<'tcx> {
                     .iter()
                     .enumerate()
                     .map(|(i, d)| match d {
-                        AllocData::Bytes(bytes) => Type::datatype_component(
+                        AllocData::Bytes(bytes) => DatatypeComponent::field(
                             &i.to_string(),
                             Type::unsigned_int(8).array_of(bytes.len()),
                         ),
                         AllocData::Expr(e) => {
-                            Type::datatype_component(&i.to_string(), e.typ().clone())
+                            DatatypeComponent::field(&i.to_string(), e.typ().clone())
                         }
                     })
                     .collect()


### PR DESCRIPTION
### Description of changes: 
Only some types are legal in compound types (e.g. you can't have a struct whose field is of type `IncompleteStruct`. 
Currently, we don't check for this.
This PR adds checks.

### Resolved issues:

Resolves #1244 

### Call-outs:

Detected a situation where we are creating `Code` type elements in closures, instead of the expected `Code*`.
#1243 to track

### Testing:

* How is this change tested? Existing tests. 

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
