### PR TITLE
Audit for `maxnumf*` and `minnumf*` intrinsics

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -548,12 +548,12 @@ impl<'tcx> GotocCtx<'tcx> {
             "log2f64" => unstable_codegen!(codegen_simple_intrinsic!(Log2)),
             "logf32" => unstable_codegen!(codegen_simple_intrinsic!(Logf)),
             "logf64" => unstable_codegen!(codegen_simple_intrinsic!(Log)),
-            "maxnumf32" => unstable_codegen!(codegen_simple_intrinsic!(Fmaxf)),
-            "maxnumf64" => unstable_codegen!(codegen_simple_intrinsic!(Fmax)),
+            "maxnumf32" => codegen_simple_intrinsic!(Fmaxf),
+            "maxnumf64" => codegen_simple_intrinsic!(Fmax),
             "min_align_of" => codegen_intrinsic_const!(),
             "min_align_of_val" => codegen_size_align!(align),
-            "minnumf32" => unstable_codegen!(codegen_simple_intrinsic!(Fminf)),
-            "minnumf64" => unstable_codegen!(codegen_simple_intrinsic!(Fmin)),
+            "minnumf32" => codegen_simple_intrinsic!(Fminf),
+            "minnumf64" => codegen_simple_intrinsic!(Fmin),
             "mul_with_overflow" => codegen_op_with_overflow!(mul_overflow),
             "nearbyintf32" => codegen_unimplemented_intrinsic!(
                 "https://github.com/model-checking/kani/issues/1025"

--- a/tests/kani/Intrinsics/MaxNum/maxnumf32_fixme.rs
+++ b/tests/kani/Intrinsics/MaxNum/maxnumf32_fixme.rs
@@ -38,7 +38,11 @@ fn test_one_nan() {
     let y: f32 = kani::any();
     kani::assume((x.is_nan() && !y.is_nan()) || (!x.is_nan() && y.is_nan()));
     let res = std::intrinsics::maxnumf32(x, y);
-    assert!(!res.is_nan());
+    if x.is_nan() {
+        assert!(res == y);
+    } else {
+        assert!(res == x);
+    }
 }
 
 #[kani::proof]

--- a/tests/kani/Intrinsics/MaxNum/maxnumf32_fixme.rs
+++ b/tests/kani/Intrinsics/MaxNum/maxnumf32_fixme.rs
@@ -1,0 +1,51 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `maxnumf32` returns the minimum of two values, except in the
+// following cases:
+//  * If one of the arguments is NaN, the other arguments is returned.
+//  * If both arguments are NaN, NaN is returned.
+#![feature(core_intrinsics)]
+
+// Note: All test cases are failing with the following error:
+// ```
+// Check X: fmaxf.assertion.1
+//          - Status: FAILURE
+//          - Description: "Function with missing definition is unreachable"
+//          - Location: <builtin-library-fmaxf> in function fmaxf
+// ```
+// This is because the `fmaxf` definition is not being found, either because
+// Kani does not produce the right expression (which is strange, because it's
+// doing the same for similar expressions and they work) or CBMC is not picking
+// it for some reason.
+// Tracked in https://github.com/model-checking/kani/issues/1025
+#[kani::proof]
+fn test_general() {
+    let x: f32 = kani::any();
+    let y: f32 = kani::any();
+    kani::assume(!x.is_nan() && !y.is_nan());
+    let res = std::intrinsics::maxnumf32(x, y);
+    if x > y {
+        assert!(res == x);
+    } else {
+        assert!(res == y);
+    }
+}
+
+#[kani::proof]
+fn test_one_nan() {
+    let x: f32 = kani::any();
+    let y: f32 = kani::any();
+    kani::assume((x.is_nan() && !y.is_nan()) || (!x.is_nan() && y.is_nan()));
+    let res = std::intrinsics::maxnumf32(x, y);
+    assert!(!res.is_nan());
+}
+
+#[kani::proof]
+fn test_both_nan() {
+    let x: f32 = kani::any();
+    let y: f32 = kani::any();
+    kani::assume(x.is_nan() && y.is_nan());
+    let res = std::intrinsics::maxnumf32(x, y);
+    assert!(res.is_nan());
+}

--- a/tests/kani/Intrinsics/MaxNum/maxnumf64.rs
+++ b/tests/kani/Intrinsics/MaxNum/maxnumf64.rs
@@ -1,0 +1,39 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `maxnumf64` returns the minimum of two values, except in the
+// following cases:
+//  * If one of the arguments is NaN, the other arguments is returned.
+//  * If both arguments are NaN, NaN is returned.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn test_general() {
+    let x: f64 = kani::any();
+    let y: f64 = kani::any();
+    kani::assume(!x.is_nan() && !y.is_nan());
+    let res = std::intrinsics::maxnumf64(x, y);
+    if x > y {
+        assert!(res == x);
+    } else {
+        assert!(res == y);
+    }
+}
+
+#[kani::proof]
+fn test_one_nan() {
+    let x: f64 = kani::any();
+    let y: f64 = kani::any();
+    kani::assume((x.is_nan() && !y.is_nan()) || (!x.is_nan() && y.is_nan()));
+    let res = std::intrinsics::maxnumf64(x, y);
+    assert!(!res.is_nan());
+}
+
+#[kani::proof]
+fn test_both_nan() {
+    let x: f64 = kani::any();
+    let y: f64 = kani::any();
+    kani::assume(x.is_nan() && y.is_nan());
+    let res = std::intrinsics::maxnumf64(x, y);
+    assert!(res.is_nan());
+}

--- a/tests/kani/Intrinsics/MaxNum/maxnumf64.rs
+++ b/tests/kani/Intrinsics/MaxNum/maxnumf64.rs
@@ -26,7 +26,11 @@ fn test_one_nan() {
     let y: f64 = kani::any();
     kani::assume((x.is_nan() && !y.is_nan()) || (!x.is_nan() && y.is_nan()));
     let res = std::intrinsics::maxnumf64(x, y);
-    assert!(!res.is_nan());
+    if x.is_nan() {
+        assert!(res == y);
+    } else {
+        assert!(res == x);
+    }
 }
 
 #[kani::proof]

--- a/tests/kani/Intrinsics/MinNum/minnumf32.rs
+++ b/tests/kani/Intrinsics/MinNum/minnumf32.rs
@@ -1,0 +1,39 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `minnumf32` returns the minimum of two values, except in the
+// following cases:
+//  * If one of the arguments is NaN, the other arguments is returned.
+//  * If both arguments are NaN, NaN is returned.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn test_general() {
+    let x: f32 = kani::any();
+    let y: f32 = kani::any();
+    kani::assume(!x.is_nan() && !y.is_nan());
+    let res = std::intrinsics::minnumf32(x, y);
+    if x < y {
+        assert!(res == x);
+    } else {
+        assert!(res == y);
+    }
+}
+
+#[kani::proof]
+fn test_one_nan() {
+    let x: f32 = kani::any();
+    let y: f32 = kani::any();
+    kani::assume((x.is_nan() && !y.is_nan()) || (!x.is_nan() && y.is_nan()));
+    let res = std::intrinsics::minnumf32(x, y);
+    assert!(!res.is_nan());
+}
+
+#[kani::proof]
+fn test_both_nan() {
+    let x: f32 = kani::any();
+    let y: f32 = kani::any();
+    kani::assume(x.is_nan() && y.is_nan());
+    let res = std::intrinsics::minnumf32(x, y);
+    assert!(res.is_nan());
+}

--- a/tests/kani/Intrinsics/MinNum/minnumf32.rs
+++ b/tests/kani/Intrinsics/MinNum/minnumf32.rs
@@ -26,7 +26,11 @@ fn test_one_nan() {
     let y: f32 = kani::any();
     kani::assume((x.is_nan() && !y.is_nan()) || (!x.is_nan() && y.is_nan()));
     let res = std::intrinsics::minnumf32(x, y);
-    assert!(!res.is_nan());
+    if x.is_nan() {
+        assert!(res == y);
+    } else {
+        assert!(res == x);
+    }
 }
 
 #[kani::proof]

--- a/tests/kani/Intrinsics/MinNum/minnumf64.rs
+++ b/tests/kani/Intrinsics/MinNum/minnumf64.rs
@@ -35,5 +35,9 @@ fn test_both_nan() {
     let y: f64 = kani::any();
     kani::assume(x.is_nan() && y.is_nan());
     let res = std::intrinsics::minnumf64(x, y);
-    assert!(res.is_nan());
+    if x.is_nan() {
+        assert!(res == y);
+    } else {
+        assert!(res == x);
+    }
 }

--- a/tests/kani/Intrinsics/MinNum/minnumf64.rs
+++ b/tests/kani/Intrinsics/MinNum/minnumf64.rs
@@ -26,7 +26,11 @@ fn test_one_nan() {
     let y: f64 = kani::any();
     kani::assume((x.is_nan() && !y.is_nan()) || (!x.is_nan() && y.is_nan()));
     let res = std::intrinsics::minnumf64(x, y);
-    assert!(!res.is_nan());
+    if x.is_nan() {
+        assert!(res == y);
+    } else {
+        assert!(res == x);
+    }
 }
 
 #[kani::proof]
@@ -35,9 +39,5 @@ fn test_both_nan() {
     let y: f64 = kani::any();
     kani::assume(x.is_nan() && y.is_nan());
     let res = std::intrinsics::minnumf64(x, y);
-    if x.is_nan() {
-        assert!(res == y);
-    } else {
-        assert!(res == x);
-    }
+    assert!(res.is_nan());
 }

--- a/tests/kani/Intrinsics/MinNum/minnumf64.rs
+++ b/tests/kani/Intrinsics/MinNum/minnumf64.rs
@@ -1,0 +1,39 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `minnumf64` returns the minimum of two values, except in the
+// following cases:
+//  * If one of the arguments is NaN, the other arguments is returned.
+//  * If both arguments are NaN, NaN is returned.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn test_general() {
+    let x: f64 = kani::any();
+    let y: f64 = kani::any();
+    kani::assume(!x.is_nan() && !y.is_nan());
+    let res = std::intrinsics::minnumf64(x, y);
+    if x < y {
+        assert!(res == x);
+    } else {
+        assert!(res == y);
+    }
+}
+
+#[kani::proof]
+fn test_one_nan() {
+    let x: f64 = kani::any();
+    let y: f64 = kani::any();
+    kani::assume((x.is_nan() && !y.is_nan()) || (!x.is_nan() && y.is_nan()));
+    let res = std::intrinsics::minnumf64(x, y);
+    assert!(!res.is_nan());
+}
+
+#[kani::proof]
+fn test_both_nan() {
+    let x: f64 = kani::any();
+    let y: f64 = kani::any();
+    kani::assume(x.is_nan() && y.is_nan());
+    let res = std::intrinsics::minnumf64(x, y);
+    assert!(res.is_nan());
+}


### PR DESCRIPTION
### Description of changes: 

Restores and completes the audit for `maxnumf32`, `maxnumf64`, `minnumf32` and `minnumf64`. These depend on a set of CBMC builtins (`fmaxf`, `fmax`, `fminf` and `fmin`) that handle NaN arguments in a specific way.

### Resolved issues:

Part of #1163 
Part of #1025 

### Call-outs:

`fmaxf` is not working for an unknown reason, but I think we should restore it in order to ease debugging. The "fixme" test I added for it should work once the issue gets fixed in CBMC (if that's the reason) without needing any changes from Kani.
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Adds 4 tests (1 of them is a "fixme").

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
