### PR TITLE
Audit for `copysignf*`

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -491,8 +491,8 @@ impl<'tcx> GotocCtx<'tcx> {
             "copy_nonoverlapping" => unreachable!(
                 "Expected `core::intrinsics::unreachable` to be handled by `StatementKind::CopyNonOverlapping`"
             ),
-            "copysignf32" => unstable_codegen!(codegen_simple_intrinsic!(Copysignf)),
-            "copysignf64" => unstable_codegen!(codegen_simple_intrinsic!(Copysign)),
+            "copysignf32" => codegen_simple_intrinsic!(Copysignf),
+            "copysignf64" => codegen_simple_intrinsic!(Copysign),
             "cosf32" => codegen_simple_intrinsic!(Cosf),
             "cosf64" => codegen_simple_intrinsic!(Cos),
             "ctlz" => codegen_count_intrinsic!(ctlz, true),

--- a/tests/kani/Intrinsics/CopySign/copysignf32.rs
+++ b/tests/kani/Intrinsics/CopySign/copysignf32.rs
@@ -1,0 +1,59 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Checks that `copysignf32` returns a floating point value with the magnitude
+// of `mag` and the sign of `sgn`. There are two special cases to consider:
+//  * If `mag` is NaN, then NaN with the sign of `sgn` is returned.
+//  * If `sgn` is -0, the result is only negative if the implementation supports
+//    the signed zero consistenly in arithmetic operations.
+#![feature(core_intrinsics)]
+
+// NaN values in either `mag` or `sgn` can lead to spurious failures in these
+// harnesses, so they are excluded when needed.
+#[kani::proof]
+fn test_copysign() {
+    let mag: f32 = kani::any();
+    let sig: f32 = kani::any();
+    kani::assume(!mag.is_nan());
+    kani::assume(!sig.is_nan());
+
+    // Build the expected result
+    let abs_mag = mag.abs();
+    let expected_res = if sig.is_sign_positive() { abs_mag } else { -abs_mag };
+
+    let res = unsafe { std::intrinsics::copysignf32(mag, sig) };
+
+    // Compare against the expected result
+    assert!(expected_res == res);
+}
+
+#[kani::proof]
+fn test_copysign_mag_nan() {
+    let mag: f32 = kani::any();
+    let sig: f32 = kani::any();
+    kani::assume(mag.is_nan());
+    kani::assume(!sig.is_nan());
+
+    let res = unsafe { std::intrinsics::copysignf32(mag, sig) };
+
+    // Check the result is NaN with the expected sign
+    if sig.is_sign_positive() {
+        assert!(res.is_nan());
+        assert!(res.is_sign_positive());
+    } else {
+        assert!(res.is_nan());
+        assert!(res.is_sign_negative());
+    }
+}
+
+#[kani::proof]
+fn test_copysign_sig_neg_zero() {
+    let mag: f32 = kani::any();
+    let sig: f32 = -0.0;
+
+    let res = unsafe { std::intrinsics::copysignf32(mag, sig) };
+
+    // Check that the result is negative. This case is already included in the
+    // general case, but we provide it for clarity.
+    assert!(res.is_sign_negative());
+}

--- a/tests/kani/Intrinsics/CopySign/copysignf64.rs
+++ b/tests/kani/Intrinsics/CopySign/copysignf64.rs
@@ -1,0 +1,59 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Checks that `copysignf64` returns a floating point value with the magnitude
+// of `mag` and the sign of `sgn`. There are two special cases to consider:
+//  * If `mag` is NaN, then NaN with the sign of `sgn` is returned.
+//  * If `sgn` is -0, the result is only negative if the implementation supports
+//    the signed zero consistenly in arithmetic operations.
+#![feature(core_intrinsics)]
+
+// NaN values in either `mag` or `sgn` can lead to spurious failures in these
+// harnesses, so they are excluded when needed.
+#[kani::proof]
+fn test_copysign() {
+    let mag: f64 = kani::any();
+    let sig: f64 = kani::any();
+    kani::assume(!mag.is_nan());
+    kani::assume(!sig.is_nan());
+
+    // Build the expected result
+    let abs_mag = mag.abs();
+    let expected_res = if sig.is_sign_positive() { abs_mag } else { -abs_mag };
+
+    let res = unsafe { std::intrinsics::copysignf64(mag, sig) };
+
+    // Compare against the expected result
+    assert!(expected_res == res);
+}
+
+#[kani::proof]
+fn test_copysign_mag_nan() {
+    let mag: f64 = kani::any();
+    let sig: f64 = kani::any();
+    kani::assume(mag.is_nan());
+    kani::assume(!sig.is_nan());
+
+    let res = unsafe { std::intrinsics::copysignf64(mag, sig) };
+
+    // Check the result is NaN with the expected sign
+    if sig.is_sign_positive() {
+        assert!(res.is_nan());
+        assert!(res.is_sign_positive());
+    } else {
+        assert!(res.is_nan());
+        assert!(res.is_sign_negative());
+    }
+}
+
+#[kani::proof]
+fn test_copysign_sig_neg_zero() {
+    let mag: f64 = kani::any();
+    let sig: f64 = -0.0;
+
+    let res = unsafe { std::intrinsics::copysignf64(mag, sig) };
+
+    // Check that the result is negative. This case is already included in the
+    // general case, but we provide it for clarity.
+    assert!(res.is_sign_negative());
+}


### PR DESCRIPTION
### Description of changes: 

Restores and completes the audit for `copysignf32` (`copysignf`) and `copysignf64` (`copysign`) with one test for each intrinsic.

### Resolved issues:

Part of #1163 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Adds 2 tests.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
