### PR TITLE
Enable CBMC's equation-level slicer

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -91,6 +91,8 @@ impl KaniSession {
             args.push(unwind_value.to_string().into());
         }
 
+        args.push("--slice-formula".into());
+
         args.extend(self.args.cbmc_args.iter().cloned());
 
         args.push(file.to_owned().into_os_string());


### PR DESCRIPTION
### Description of changes: 

Use CBMC's equation-level slicer (`--slice-formula`). This results in a nice performance boost in some cases (e.g. s2n-quic's vectored_copy_u8) as well as some memory reduction.

  | Default | | With `--slice-formula` | |
-- | -- | -- | -- | -- |
Benchmark | Time (s) | Memory (MB) | Time (s) | Memory (MB) |
s2n-quic vectored_copy_u8 | 125.8 | 2658 | 23.13 | 1768 |
Firecracker block example | 4.75 | 213 | 3.2 | 127 |
Rectangle example | 6.28 | 106 | 7.53 | 127 |
VecDeque CVE | 0.57 | 191 | 0.26 | 190 |

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

The known side effect of using `--slice-formula` is that the trace generated by CBMC might exclude assignments to variables that are irrelevant to the check. This might actually be useful in since it could result in a smaller trace.

### Testing:

* How is this change tested? Existing regressions

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
