### PR TITLE
Add support to compiletest's cargo-kani mode for tests with multi-level directories

### DIFF
--- a/tests/cargo-kani/nested-dirs/Cargo.toml
+++ b/tests/cargo-kani/nested-dirs/Cargo.toml
@@ -1,0 +1,7 @@
+[workspace]
+
+members = [
+   "crate1",
+   "crate2",
+   "crate2/nested_crate",
+]

--- a/tests/cargo-kani/nested-dirs/crate1/Cargo.toml
+++ b/tests/cargo-kani/nested-dirs/crate1/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "crate1"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/cargo-kani/nested-dirs/crate1/a_check.expected
+++ b/tests/cargo-kani/nested-dirs/crate1/a_check.expected
@@ -1,0 +1,3 @@
+Status: SUCCESS\
+Description: "assertion failed: v.len() == 3"
+VERIFICATION:- SUCCESSFUL

--- a/tests/cargo-kani/nested-dirs/crate1/src/lib.rs
+++ b/tests/cargo-kani/nested-dirs/crate1/src/lib.rs
@@ -1,0 +1,5 @@
+#[kani::proof]
+fn a_check() {
+    let v = vec![1, 2, 3];
+    assert_eq!(v.len(), 3);
+}

--- a/tests/cargo-kani/nested-dirs/crate2/Cargo.toml
+++ b/tests/cargo-kani/nested-dirs/crate2/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "crate2"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/cargo-kani/nested-dirs/crate2/another_check.expected
+++ b/tests/cargo-kani/nested-dirs/crate2/another_check.expected
@@ -1,0 +1,3 @@
+Status: SUCCESS\
+Description: "assertion failed: result == 4"
+VERIFICATION:- SUCCESSFUL

--- a/tests/cargo-kani/nested-dirs/crate2/nested_crate/Cargo.toml
+++ b/tests/cargo-kani/nested-dirs/crate2/nested_crate/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nested_crate"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/cargo-kani/nested-dirs/crate2/nested_crate/src/lib.rs
+++ b/tests/cargo-kani/nested-dirs/crate2/nested_crate/src/lib.rs
@@ -1,0 +1,6 @@
+#[kani::proof]
+fn yet_another_check() {
+    let x: u16 = kani::any();
+    let y = x;
+    assert_eq!(y - x, 0);
+}

--- a/tests/cargo-kani/nested-dirs/crate2/nested_crate/yet_another_check.expected
+++ b/tests/cargo-kani/nested-dirs/crate2/nested_crate/yet_another_check.expected
@@ -1,0 +1,4 @@
+Status: SUCCESS\
+Description: "assertion failed: y - x == 0"
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/cargo-kani/nested-dirs/crate2/src/lib.rs
+++ b/tests/cargo-kani/nested-dirs/crate2/src/lib.rs
@@ -1,0 +1,5 @@
+#[kani::proof]
+fn another_check() {
+    let result = 2 + 2;
+    assert_eq!(result, 4);
+}

--- a/tools/compiletest/src/main.rs
+++ b/tools/compiletest/src/main.rs
@@ -387,16 +387,24 @@ fn collect_tests_from_dir(
     // output directory corresponding to each to avoid race conditions during
     // the testing phase. We immediately return after adding the tests to avoid
     // treating `*.rs` files as tests.
-    if config.mode == Mode::CargoKani && dir.join("Cargo.toml").exists() {
+    if config.mode == Mode::CargoKani {
+        let has_cargo_toml = dir.join("Cargo.toml").exists();
         for file in fs::read_dir(dir)? {
-            let file_path = file?.path();
-            if file_path.to_str().unwrap().ends_with(".expected")
-                || "expected" == file_path.file_name().unwrap()
+            let file = file?;
+            let file_path = file.path();
+            if has_cargo_toml
+                && (file_path.to_str().unwrap().ends_with(".expected")
+                    || "expected" == file_path.file_name().unwrap())
             {
                 fs::create_dir_all(&build_dir.join(file_path.file_stem().unwrap())).unwrap();
                 let paths =
                     TestPaths { file: file_path, relative_dir: relative_dir_path.to_path_buf() };
                 tests.extend(make_test(config, &paths, inputs));
+            } else if file_path.is_dir() {
+                // recurse on subdirectory
+                let relative_file_path = relative_dir_path.join(file.file_name());
+                debug!("found directory: {:?}", file_path.display());
+                collect_tests_from_dir(config, &file_path, &relative_file_path, inputs, tests)?;
             }
         }
         return Ok(());


### PR DESCRIPTION
### Description of changes: 

Currently, `compiletest`'s `cargo-kani` mode looks for files of the form `<harness-name>.expected` and executes `cargo kani --harness <harness-name>` for each. However, if it finds a `Cargo.toml` in a directory, it does not recurse in its subdirectories. This makes it unable to handle cargo workspaces, where it's common to have a `Cargo.toml` file at the root directory of the package.

This PR fixes this issue by allowing `compiletest` to continue recursing into subdirectories looking for `*.expected` files, even if it finds a `Cargo.toml` in the parent directory.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Added a new test

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
