### PR TITLE
Update Rust Toolchain to 2022-06-09

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -787,7 +787,9 @@ impl<'tcx> GotocCtx<'tcx> {
 
         // Then we check if the type allows "raw" initialization for the cases
         // where memory is zero-initialized or entirely uninitialized
-        if intrinsic == "assert_zero_valid" && !layout.might_permit_raw_init(self, InitKind::Zero, false) {
+        if intrinsic == "assert_zero_valid"
+            && !layout.might_permit_raw_init(self, InitKind::Zero, false)
+        {
             return self.codegen_fatal_error(
                 PropertyClass::DefaultAssertion,
                 &format!("attempted to zero-initialize type `{}`, which is invalid", ty),
@@ -795,7 +797,9 @@ impl<'tcx> GotocCtx<'tcx> {
             );
         }
 
-        if intrinsic == "assert_uninit_valid" && !layout.might_permit_raw_init(self, InitKind::Uninit, false) {
+        if intrinsic == "assert_uninit_valid"
+            && !layout.might_permit_raw_init(self, InitKind::Uninit, false)
+        {
             return self.codegen_fatal_error(
                 PropertyClass::DefaultAssertion,
                 &format!("attempted to leave type `{}` uninitialized, which is invalid", ty),

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -10,6 +10,7 @@ use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{self, Ty};
 use rustc_middle::ty::{Instance, InstanceDef};
 use rustc_span::Span;
+use rustc_target::abi::InitKind;
 use tracing::{debug, warn};
 
 macro_rules! emit_concurrency_warning {
@@ -785,7 +786,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
         // Then we check if the type allows "raw" initialization for the cases
         // where memory is zero-initialized or entirely uninitialized
-        if intrinsic == "assert_zero_valid" && !layout.might_permit_raw_init(self, true) {
+        if intrinsic == "assert_zero_valid" && !layout.might_permit_raw_init(self, InitKind::Zero, false) {
             return self.codegen_fatal_error(
                 PropertyClass::DefaultAssertion,
                 &format!("attempted to zero-initialize type `{}`, which is invalid", ty),
@@ -793,7 +794,7 @@ impl<'tcx> GotocCtx<'tcx> {
             );
         }
 
-        if intrinsic == "assert_uninit_valid" && !layout.might_permit_raw_init(self, false) {
+        if intrinsic == "assert_uninit_valid" && !layout.might_permit_raw_init(self, InitKind::Uninit, false) {
             return self.codegen_fatal_error(
                 PropertyClass::DefaultAssertion,
                 &format!("attempted to leave type `{}` uninitialized, which is invalid", ty),

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -48,17 +48,18 @@ impl<'tcx> GotocCtx<'tcx> {
         &mut self,
         func: &Operand<'tcx>,
         args: &[Operand<'tcx>],
-        destination: &Option<(Place<'tcx>, BasicBlock)>,
+        destination: &Place<'tcx>,
+        target: &Option<BasicBlock>,
         span: Span,
     ) -> Stmt {
         let instance = self.get_intrinsic_instance(func).unwrap();
 
-        if let Some((assign_to, target)) = destination {
+        if let Some(target) = target {
             let loc = self.codegen_span(&span);
             let fargs = self.codegen_funcall_args(args);
             Stmt::block(
                 vec![
-                    self.codegen_intrinsic(instance, fargs, &assign_to, Some(span)),
+                    self.codegen_intrinsic(instance, fargs, &destination, Some(span)),
                     Stmt::goto(self.current_fn().find_label(&target), loc),
                 ],
                 loc,

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -424,7 +424,8 @@ impl<'tcx> GotocCtx<'tcx> {
             Rvalue::Repeat(op, sz) => self.codegen_rvalue_repeat(op, sz, res_ty),
             Rvalue::Ref(_, _, p) | Rvalue::AddressOf(_, p) => self.codegen_rvalue_ref(p, res_ty),
             Rvalue::Len(p) => self.codegen_rvalue_len(p),
-            // Rust has begun distinguishing "ptr -> num" and "num -> ptr" (providence-relevent casts) but we do not yet:
+            // Rust has begun distinguishing "ptr -> num" and "num -> ptr" (providence-relevant casts) but we do not yet:
+            // Should we? Tracking ticket: https://github.com/model-checking/kani/issues/1274
             Rvalue::Cast(
                 CastKind::Misc
                 | CastKind::PointerExposeAddress

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -14,7 +14,7 @@ use num::bigint::BigInt;
 use rustc_middle::mir::{AggregateKind, BinOp, CastKind, NullOp, Operand, Place, Rvalue, UnOp};
 use rustc_middle::ty::adjustment::PointerCast;
 use rustc_middle::ty::layout::LayoutOf;
-use rustc_middle::ty::{self, Instance, IntTy, Ty, UintTy, VtblEntry, COMMON_VTABLE_ENTRIES};
+use rustc_middle::ty::{self, Instance, IntTy, Ty, UintTy, VtblEntry, TyCtxt};
 use rustc_target::abi::{FieldsShape, Primitive, TagEncoding, Variants};
 use tracing::{debug, warn};
 
@@ -950,7 +950,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
                     ctx.tcx.vtable_entries(trait_ref_binder)
                 } else {
-                    COMMON_VTABLE_ENTRIES
+                    TyCtxt::COMMON_VTABLE_ENTRIES
                 };
 
                 let (vt_size, vt_align) = ctx.codegen_vtable_size_and_align(src_mir_type);

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -14,7 +14,7 @@ use num::bigint::BigInt;
 use rustc_middle::mir::{AggregateKind, BinOp, CastKind, NullOp, Operand, Place, Rvalue, UnOp};
 use rustc_middle::ty::adjustment::PointerCast;
 use rustc_middle::ty::layout::LayoutOf;
-use rustc_middle::ty::{self, Instance, IntTy, Ty, UintTy, VtblEntry, TyCtxt};
+use rustc_middle::ty::{self, Instance, IntTy, Ty, TyCtxt, UintTy, VtblEntry};
 use rustc_target::abi::{FieldsShape, Primitive, TagEncoding, Variants};
 use tracing::{debug, warn};
 
@@ -425,7 +425,13 @@ impl<'tcx> GotocCtx<'tcx> {
             Rvalue::Ref(_, _, p) | Rvalue::AddressOf(_, p) => self.codegen_rvalue_ref(p, res_ty),
             Rvalue::Len(p) => self.codegen_rvalue_len(p),
             // Rust has begun distinguishing "ptr -> num" and "num -> ptr" (providence-relevent casts) but we do not yet:
-            Rvalue::Cast(CastKind::Misc | CastKind::PointerExposeAddress | CastKind::PointerFromExposedAddress, e, t) => {
+            Rvalue::Cast(
+                CastKind::Misc
+                | CastKind::PointerExposeAddress
+                | CastKind::PointerFromExposedAddress,
+                e,
+                t,
+            ) => {
                 let t = self.monomorphize(*t);
                 self.codegen_misc_cast(e, t)
             }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -90,8 +90,8 @@ impl<'tcx> GotocCtx<'tcx> {
             TerminatorKind::DropAndReplace { .. } => {
                 unreachable!("this instruction is unreachable")
             }
-            TerminatorKind::Call { func, args, destination, .. } => {
-                self.codegen_funcall(func, args, destination, term.source_info.span)
+            TerminatorKind::Call { func, args, destination, target, .. } => {
+                self.codegen_funcall(func, args, destination, target, term.source_info.span)
             }
             TerminatorKind::Assert { cond, expected, msg, target, .. } => {
                 let cond = {
@@ -155,112 +155,106 @@ impl<'tcx> GotocCtx<'tcx> {
         let loc_ty = self.place_ty(location);
         debug!(?loc_ty, "codegen_drop");
         let drop_instance = Instance::resolve_drop_in_place(self.tcx, loc_ty);
-        if let Some(hk) = self.hooks.hook_applies(self.tcx, drop_instance) {
-            let le =
-                unwrap_or_return_codegen_unimplemented_stmt!(self, self.codegen_place(location))
-                    .goto_expr;
-            hk.handle(self, drop_instance, vec![le], None, Some(*target), None)
-        } else {
-            let drop_implementation = match drop_instance.def {
-                InstanceDef::DropGlue(_, None) => {
-                    // We can skip empty DropGlue functions
-                    Stmt::skip(Location::none())
-                }
-                _ => {
-                    match loc_ty.kind() {
-                        ty::Dynamic(..) => {
-                            // Virtual drop via a vtable lookup
-                            let trait_fat_ptr = unwrap_or_return_codegen_unimplemented_stmt!(
-                                self,
-                                self.codegen_place(location)
-                            )
-                            .fat_ptr_goto_expr
-                            .unwrap();
-                            debug!(?trait_fat_ptr, "codegen_drop: ");
+        // Once upon a time we did a `hook_applies` check here, but we no longer seem to hook drops
+        let drop_implementation = match drop_instance.def {
+            InstanceDef::DropGlue(_, None) => {
+                // We can skip empty DropGlue functions
+                Stmt::skip(Location::none())
+            }
+            _ => {
+                match loc_ty.kind() {
+                    ty::Dynamic(..) => {
+                        // Virtual drop via a vtable lookup
+                        let trait_fat_ptr = unwrap_or_return_codegen_unimplemented_stmt!(
+                            self,
+                            self.codegen_place(location)
+                        )
+                        .fat_ptr_goto_expr
+                        .unwrap();
+                        debug!(?trait_fat_ptr, "codegen_drop: ");
 
-                            // Pull the function off of the fat pointer's vtable pointer
-                            let vtable_ref =
-                                trait_fat_ptr.to_owned().member("vtable", &self.symbol_table);
+                        // Pull the function off of the fat pointer's vtable pointer
+                        let vtable_ref =
+                            trait_fat_ptr.to_owned().member("vtable", &self.symbol_table);
 
-                            let vtable = vtable_ref.dereference();
-                            let fn_ptr = vtable.member("drop", &self.symbol_table);
+                        let vtable = vtable_ref.dereference();
+                        let fn_ptr = vtable.member("drop", &self.symbol_table);
 
-                            // Pull the self argument off of the fat pointer's data pointer
-                            if let Some(typ) = pointee_type(self.local_ty(location.local)) {
-                                if !(typ.is_trait() || typ.is_box()) {
-                                    warn!(self_type=?typ, "Unsupported drop of unsized");
-                                    return self
-                                        .codegen_unimplemented(
-                                            format!("Unsupported drop unsized struct: {:?}", typ)
-                                                .as_str(),
-                                            Type::Empty,
-                                            Location::None,
-                                            "https://github.com/model-checking/kani/issues/1072",
-                                        )
-                                        .as_stmt(Location::None);
-                                }
-                            }
-                            let self_data =
-                                trait_fat_ptr.to_owned().member("data", &self.symbol_table);
-                            let self_ref =
-                                self_data.clone().cast_to(trait_fat_ptr.typ().clone().to_pointer());
-
-                            let call =
-                                fn_ptr.dereference().call(vec![self_ref]).as_stmt(Location::none());
-                            if self.vtable_ctx.emit_vtable_restrictions {
-                                self.virtual_call_with_restricted_fn_ptr(
-                                    trait_fat_ptr.typ().clone(),
-                                    VtableCtx::drop_index(),
-                                    call,
-                                )
-                            } else {
-                                call
+                        // Pull the self argument off of the fat pointer's data pointer
+                        if let Some(typ) = pointee_type(self.local_ty(location.local)) {
+                            if !(typ.is_trait() || typ.is_box()) {
+                                warn!(self_type=?typ, "Unsupported drop of unsized");
+                                return self
+                                    .codegen_unimplemented(
+                                        format!("Unsupported drop unsized struct: {:?}", typ)
+                                            .as_str(),
+                                        Type::Empty,
+                                        Location::None,
+                                        "https://github.com/model-checking/kani/issues/1072",
+                                    )
+                                    .as_stmt(Location::None);
                             }
                         }
-                        _ => {
-                            // Non-virtual, direct drop call
-                            assert!(!matches!(drop_instance.def, InstanceDef::Virtual(_, _)));
+                        let self_data =
+                            trait_fat_ptr.to_owned().member("data", &self.symbol_table);
+                        let self_ref =
+                            self_data.clone().cast_to(trait_fat_ptr.typ().clone().to_pointer());
 
-                            let func = self.codegen_func_expr(drop_instance, None);
-                            let place = unwrap_or_return_codegen_unimplemented_stmt!(
-                                self,
-                                self.codegen_place(location)
-                            );
-                            let arg = if let Some(fat_ptr) = place.fat_ptr_goto_expr {
-                                // Drop takes the fat pointer if it exists
-                                fat_ptr
-                            } else {
-                                place.goto_expr.address_of()
-                            };
-                            // The only argument should be a self reference
-                            let args = vec![arg];
-
-                            // We have a known issue where nested Arc and Mutex objects result in
-                            // drop_in_place call implementations that fail to typecheck. Skipping
-                            // drop entirely causes unsound verification results in common cases
-                            // like vector extend, so for now, add a sound special case workaround
-                            // for calls that fail the typecheck.
-                            // https://github.com/model-checking/kani/issues/426
-                            // Unblocks: https://github.com/model-checking/kani/issues/435
-                            if Expr::typecheck_call(&func, &args) {
-                                func.call(args)
-                            } else {
-                                self.codegen_unimplemented(
-                                    format!("drop_in_place call for {:?}", func).as_str(),
-                                    func.typ().return_type().unwrap().clone(),
-                                    Location::none(),
-                                    "https://github.com/model-checking/kani/issues/426",
-                                )
-                            }
-                            .as_stmt(Location::none())
+                        let call =
+                            fn_ptr.dereference().call(vec![self_ref]).as_stmt(Location::none());
+                        if self.vtable_ctx.emit_vtable_restrictions {
+                            self.virtual_call_with_restricted_fn_ptr(
+                                trait_fat_ptr.typ().clone(),
+                                VtableCtx::drop_index(),
+                                call,
+                            )
+                        } else {
+                            call
                         }
                     }
+                    _ => {
+                        // Non-virtual, direct drop call
+                        assert!(!matches!(drop_instance.def, InstanceDef::Virtual(_, _)));
+
+                        let func = self.codegen_func_expr(drop_instance, None);
+                        let place = unwrap_or_return_codegen_unimplemented_stmt!(
+                            self,
+                            self.codegen_place(location)
+                        );
+                        let arg = if let Some(fat_ptr) = place.fat_ptr_goto_expr {
+                            // Drop takes the fat pointer if it exists
+                            fat_ptr
+                        } else {
+                            place.goto_expr.address_of()
+                        };
+                        // The only argument should be a self reference
+                        let args = vec![arg];
+
+                        // We have a known issue where nested Arc and Mutex objects result in
+                        // drop_in_place call implementations that fail to typecheck. Skipping
+                        // drop entirely causes unsound verification results in common cases
+                        // like vector extend, so for now, add a sound special case workaround
+                        // for calls that fail the typecheck.
+                        // https://github.com/model-checking/kani/issues/426
+                        // Unblocks: https://github.com/model-checking/kani/issues/435
+                        if Expr::typecheck_call(&func, &args) {
+                            func.call(args)
+                        } else {
+                            self.codegen_unimplemented(
+                                format!("drop_in_place call for {:?}", func).as_str(),
+                                func.typ().return_type().unwrap().clone(),
+                                Location::none(),
+                                "https://github.com/model-checking/kani/issues/426",
+                            )
+                        }
+                        .as_stmt(Location::none())
+                    }
                 }
-            };
-            let goto_target = Stmt::goto(self.current_fn().find_label(target), Location::none());
-            let block = vec![drop_implementation, goto_target];
-            Stmt::block(block, Location::none())
-        }
+            }
+        };
+        let goto_target = Stmt::goto(self.current_fn().find_label(target), Location::none());
+        let block = vec![drop_implementation, goto_target];
+        Stmt::block(block, Location::none())
     }
 
     /// https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/terminator/enum.TerminatorKind.html#variant.SwitchInt
@@ -387,11 +381,12 @@ impl<'tcx> GotocCtx<'tcx> {
         &mut self,
         func: &Operand<'tcx>,
         args: &[Operand<'tcx>],
-        destination: &Option<(Place<'tcx>, BasicBlock)>,
+        destination: &Place<'tcx>,
+        target: &Option<BasicBlock>,
         span: Span,
     ) -> Stmt {
         if self.is_intrinsic(func) {
-            return self.codegen_funcall_of_intrinsic(func, args, destination, span);
+            return self.codegen_funcall_of_intrinsic(func, args, destination, target, span);
         }
 
         let loc = self.codegen_span(&span);
@@ -413,14 +408,11 @@ impl<'tcx> GotocCtx<'tcx> {
                         self,
                         instance,
                         fargs,
-                        destination.map(|t| t.0),
-                        destination.map(|t| t.1),
+                        *destination,
+                        *target,
                         Some(span),
                     );
                 }
-
-                let (place, target) =
-                    if let Some((p, t)) = destination { (Some(p), Some(t)) } else { (None, None) };
 
                 let mut stmts: Vec<Stmt> = match instance.def {
                     // Here an empty drop glue is invoked; we just ignore it.
@@ -447,7 +439,7 @@ impl<'tcx> GotocCtx<'tcx> {
                             trait_fat_ptr,
                             def_id,
                             idx,
-                            place,
+                            destination,
                             &mut fargs,
                             loc.clone(),
                         )
@@ -462,29 +454,24 @@ impl<'tcx> GotocCtx<'tcx> {
                     | InstanceDef::ClosureOnceShim { .. }
                     | InstanceDef::CloneShim(..) => {
                         let func_exp = self.codegen_operand(func);
-                        if let Some(dest_place) = place {
-                            vec![
-                                self.codegen_expr_to_place(&dest_place, func_exp.call(fargs))
-                                    .with_location(loc.clone()),
-                            ]
-                        } else {
-                            vec![func_exp.call(fargs).as_stmt(loc.clone())]
-                        }
+                        vec![
+                            self.codegen_expr_to_place(&destination, func_exp.call(fargs))
+                                .with_location(loc.clone()),
+                        ]
                     }
                 };
-                stmts.push(self.codegen_end_call(target, loc.clone()));
+                stmts.push(self.codegen_end_call(target.as_ref(), loc.clone()));
                 return Stmt::block(stmts, loc);
             }
             // Function call through a pointer
             ty::FnPtr(_) => {
-                let (p, target) = destination.unwrap();
                 let func_expr = self.codegen_operand(func).dereference();
                 // Actually generate the function call and return.
                 return Stmt::block(
                     vec![
-                        self.codegen_expr_to_place(&p, func_expr.call(fargs))
+                        self.codegen_expr_to_place(&destination, func_expr.call(fargs))
                             .with_location(loc.clone()),
-                        Stmt::goto(self.current_fn().find_label(&target), loc.clone()),
+                        Stmt::goto(self.current_fn().find_label(&target.unwrap()), loc.clone()),
                     ],
                     loc,
                 );
@@ -498,7 +485,7 @@ impl<'tcx> GotocCtx<'tcx> {
         trait_fat_ptr: Expr,
         def_id: DefId,
         idx: usize,
-        place: Option<&Place<'tcx>>,
+        place: &Place<'tcx>,
         fargs: &mut Vec<Expr>,
         loc: Location,
     ) -> Vec<Stmt> {
@@ -530,11 +517,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
         // Virtual function call and corresponding nonnull assertion.
         let call = fn_ptr.dereference().call(fargs.to_vec());
-        let call_stmt = if let Some(place) = place {
-            self.codegen_expr_to_place(place, call).with_location(loc.clone())
-        } else {
-            call.as_stmt(loc.clone())
-        };
+        let call_stmt = self.codegen_expr_to_place(place, call).with_location(loc.clone());
         let call_stmt = if self.vtable_ctx.emit_vtable_restrictions {
             self.virtual_call_with_restricted_fn_ptr(trait_fat_ptr.typ().clone(), idx, call_stmt)
         } else {

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -195,8 +195,7 @@ impl<'tcx> GotocCtx<'tcx> {
                                     .as_stmt(Location::None);
                             }
                         }
-                        let self_data =
-                            trait_fat_ptr.to_owned().member("data", &self.symbol_table);
+                        let self_data = trait_fat_ptr.to_owned().member("data", &self.symbol_table);
                         let self_ref =
                             self_data.clone().cast_to(trait_fat_ptr.typ().clone().to_pointer());
 
@@ -404,14 +403,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 }
 
                 if let Some(hk) = self.hooks.hook_applies(self.tcx, instance) {
-                    return hk.handle(
-                        self,
-                        instance,
-                        fargs,
-                        *destination,
-                        *target,
-                        Some(span),
-                    );
+                    return hk.handle(self, instance, fargs, *destination, *target, Some(span));
                 }
 
                 let mut stmts: Vec<Stmt> = match instance.def {

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -215,7 +215,8 @@ impl<'tcx> GotocHook<'tcx> for Nondet {
             Stmt::goto(tcx.current_fn().find_label(&target), loc)
         } else {
             let pe =
-                unwrap_or_return_codegen_unimplemented_stmt!(tcx, tcx.codegen_place(&assign_to)).goto_expr;
+                unwrap_or_return_codegen_unimplemented_stmt!(tcx, tcx.codegen_place(&assign_to))
+                    .goto_expr;
             Stmt::block(
                 vec![
                     pe.clone().assign(tcx.codegen_ty(pt).nondet(), loc.clone()),

--- a/kani-compiler/src/main.rs
+++ b/kani-compiler/src/main.rs
@@ -7,9 +7,7 @@
 //! Like miri, clippy, and other tools developed on the top of rustc, we rely on the
 //! rustc_private feature and a specific version of rustc.
 #![deny(warnings)]
-#![feature(crate_visibility_modifier)]
 #![feature(extern_types)]
-#![feature(nll)]
 #![recursion_limit = "256"]
 #![feature(box_patterns)]
 #![feature(once_cell)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2022-05-17"
+channel = "nightly-2022-06-09"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/ui/code-location/expected
+++ b/tests/ui/code-location/expected
@@ -1,7 +1,7 @@
 module/mod.rs:10:5 in function module::not_empty
 main.rs:13:5 in function same_file
 /toolchains/
-alloc/src/vec/mod.rs:2881:81 in function <std::vec::Vec<T, A> as std::ops::Drop>::drop
+alloc/src/vec/mod.rs:2888:81 in function <std::vec::Vec<T, A> as std::ops::Drop>::drop
 
 VERIFICATION:- SUCCESSFUL
 

--- a/tools/bookrunner/configs/books/The Rustonomicon/Concurrency/Atomics/198.props
+++ b/tools/bookrunner/configs/books/The Rustonomicon/Concurrency/Atomics/198.props
@@ -1,0 +1,1 @@
+// kani-flags: --enable-unstable --cbmc-args --unwind 0

--- a/tools/bookrunner/librustdoc/clean/cfg.rs
+++ b/tools/bookrunner/librustdoc/clean/cfg.rs
@@ -18,7 +18,7 @@ use rustc_span::symbol::{sym, Symbol};
 use rustc_span::Span;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-crate enum Cfg {
+pub(crate) enum Cfg {
     /// Accepts all configurations.
     True,
     /// Denies all configurations.
@@ -34,9 +34,9 @@ crate enum Cfg {
 }
 
 #[derive(PartialEq, Debug)]
-crate struct InvalidCfgError {
-    crate msg: &'static str,
-    crate span: Span,
+pub(crate) struct InvalidCfgError {
+    pub(crate) msg: &'static str,
+    pub(crate) span: Span,
 }
 
 impl Cfg {
@@ -57,7 +57,7 @@ impl Cfg {
     ///
     /// If the content is not properly formatted, it will return an error indicating what and where
     /// the error is.
-    crate fn parse(cfg: &MetaItem) -> Result<Cfg, InvalidCfgError> {
+    pub(crate) fn parse(cfg: &MetaItem) -> Result<Cfg, InvalidCfgError> {
         let name = match cfg.ident() {
             Some(ident) => ident.name,
             None => {
@@ -100,7 +100,7 @@ impl Cfg {
     ///
     /// Equivalent to `attr::cfg_matches`.
     // FIXME: Actually make use of `features`.
-    crate fn matches(&self, parse_sess: &ParseSess, features: Option<&Features>) -> bool {
+    pub(crate) fn matches(&self, parse_sess: &ParseSess, features: Option<&Features>) -> bool {
         match *self {
             Cfg::False => false,
             Cfg::True => true,

--- a/tools/bookrunner/librustdoc/clean/inline.rs
+++ b/tools/bookrunner/librustdoc/clean/inline.rs
@@ -42,7 +42,7 @@ type Attrs<'hir> = &'hir [ast::Attribute];
 /// and `Some` of a vector of items if it was successfully expanded.
 ///
 /// `parent_module` refers to the parent of the *re-export*, not the original item.
-crate fn try_inline(
+pub(crate) fn try_inline(
     cx: &mut DocContext<'_>,
     parent_module: DefId,
     import_def_id: Option<DefId>,
@@ -138,7 +138,7 @@ crate fn try_inline(
     Some(ret)
 }
 
-crate fn try_inline_glob(
+pub(crate) fn try_inline_glob(
     cx: &mut DocContext<'_>,
     res: Res,
     visited: &mut FxHashSet<DefId>,
@@ -166,7 +166,7 @@ fn load_attrs<'hir>(cx: &DocContext<'hir>, did: DefId) -> Attrs<'hir> {
 ///
 /// These names are used later on by HTML rendering to generate things like
 /// source links back to the original item.
-crate fn record_extern_fqn(cx: &mut DocContext<'_>, did: DefId, kind: ItemType) {
+pub(crate) fn record_extern_fqn(cx: &mut DocContext<'_>, did: DefId, kind: ItemType) {
     let crate_name = cx.tcx.crate_name(did.krate);
 
     let relative =
@@ -285,7 +285,7 @@ fn build_type_alias(cx: &mut DocContext<'_>, did: DefId) -> clean::Typedef {
 }
 
 /// Builds all inherent implementations of an ADT (struct/union/enum) or Trait item/path/reexport.
-crate fn build_impls(
+pub(crate) fn build_impls(
     cx: &mut DocContext<'_>,
     parent_module: Option<DefId>,
     did: DefId,
@@ -329,7 +329,7 @@ fn merge_attrs(
 }
 
 /// Inline an `impl`, inherent or of a trait. The `did` must be for an `impl`.
-crate fn build_impl(
+pub(crate) fn build_impl(
     cx: &mut DocContext<'_>,
     parent_module: impl Into<Option<DefId>>,
     did: DefId,
@@ -560,7 +560,7 @@ fn build_module(
     clean::Module { items, span }
 }
 
-crate fn print_inlined_const(tcx: TyCtxt<'_>, did: DefId) -> String {
+pub(crate) fn print_inlined_const(tcx: TyCtxt<'_>, did: DefId) -> String {
     if let Some(did) = did.as_local() {
         let hir_id = tcx.hir().local_def_id_to_hir_id(did);
         rustc_hir_pretty::id_to_string(&tcx.hir(), hir_id)
@@ -664,7 +664,7 @@ fn separate_supertrait_bounds(
     (g, ty_bounds)
 }
 
-crate fn record_extern_trait(cx: &mut DocContext<'_>, did: DefId) {
+pub(crate) fn record_extern_trait(cx: &mut DocContext<'_>, did: DefId) {
     if did.is_local() {
         return;
     }

--- a/tools/bookrunner/librustdoc/clean/simplify.rs
+++ b/tools/bookrunner/librustdoc/clean/simplify.rs
@@ -25,7 +25,7 @@ use crate::clean::GenericArgs as PP;
 use crate::clean::WherePredicate as WP;
 use crate::core::DocContext;
 
-crate fn where_clauses(cx: &DocContext<'_>, clauses: Vec<WP>) -> Vec<WP> {
+pub(crate) fn where_clauses(cx: &DocContext<'_>, clauses: Vec<WP>) -> Vec<WP> {
     // First, partition the where clause into its separate components.
     //
     // We use `FxIndexMap` so that the insertion order is preserved to prevent messing up to
@@ -91,7 +91,7 @@ crate fn where_clauses(cx: &DocContext<'_>, clauses: Vec<WP>) -> Vec<WP> {
     clauses
 }
 
-crate fn merge_bounds(
+pub(crate) fn merge_bounds(
     cx: &clean::DocContext<'_>,
     bounds: &mut Vec<clean::GenericBound>,
     trait_did: DefId,

--- a/tools/bookrunner/librustdoc/clean/types.rs
+++ b/tools/bookrunner/librustdoc/clean/types.rs
@@ -1360,7 +1360,11 @@ pub(crate) struct Import {
 }
 
 impl Import {
-    pub(crate) fn new_simple(name: Symbol, source: ImportSource, should_be_displayed: bool) -> Self {
+    pub(crate) fn new_simple(
+        name: Symbol,
+        source: ImportSource,
+        should_be_displayed: bool,
+    ) -> Self {
         Self { kind: ImportKind::Simple(name), source, should_be_displayed }
     }
 

--- a/tools/bookrunner/librustdoc/clean/types.rs
+++ b/tools/bookrunner/librustdoc/clean/types.rs
@@ -39,16 +39,16 @@ use crate::core::DocContext;
 use crate::formats::cache::Cache;
 use crate::formats::item_type::ItemType;
 
-crate use self::FnRetTy::*;
-crate use self::ItemKind::*;
-crate use self::Type::{
+pub(crate) use self::FnRetTy::*;
+pub(crate) use self::ItemKind::*;
+pub(crate) use self::Type::{
     Array, BareFunction, BorrowedRef, DynTrait, Generic, ImplTrait, Infer, Primitive, QPath,
     RawPointer, Slice, Tuple,
 };
-crate use self::Visibility::{Inherited, Public};
+pub(crate) use self::Visibility::{Inherited, Public};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
-crate enum ItemId {
+pub(crate) enum ItemId {
     /// A "normal" item that uses a [`DefId`] for identification.
     DefId(DefId),
     /// Identifier that is used for auto traits.
@@ -61,7 +61,7 @@ crate enum ItemId {
 
 impl ItemId {
     #[inline]
-    crate fn is_local(self) -> bool {
+    pub(crate) fn is_local(self) -> bool {
         match self {
             ItemId::Auto { for_: id, .. }
             | ItemId::Blanket { for_: id, .. }
@@ -72,13 +72,13 @@ impl ItemId {
 
     #[inline]
     #[track_caller]
-    crate fn expect_def_id(self) -> DefId {
+    pub(crate) fn expect_def_id(self) -> DefId {
         self.as_def_id()
             .unwrap_or_else(|| panic!("ItemId::expect_def_id: `{:?}` isn't a DefId", self))
     }
 
     #[inline]
-    crate fn as_def_id(self) -> Option<DefId> {
+    pub(crate) fn as_def_id(self) -> Option<DefId> {
         match self {
             ItemId::DefId(id) => Some(id),
             _ => None,
@@ -86,7 +86,7 @@ impl ItemId {
     }
 
     #[inline]
-    crate fn krate(self) -> CrateNum {
+    pub(crate) fn krate(self) -> CrateNum {
         match self {
             ItemId::Auto { for_: id, .. }
             | ItemId::Blanket { for_: id, .. }
@@ -96,7 +96,7 @@ impl ItemId {
     }
 
     #[inline]
-    crate fn index(self) -> Option<DefIndex> {
+    pub(crate) fn index(self) -> Option<DefIndex> {
         match self {
             ItemId::DefId(id) => Some(id.index),
             _ => None,
@@ -112,14 +112,14 @@ impl From<DefId> for ItemId {
 
 /// This struct is used to wrap additional information added by rustdoc on a `trait` item.
 #[derive(Clone, Debug)]
-crate struct TraitWithExtraInfo {
-    crate trait_: Trait,
-    crate is_notable: bool,
+pub(crate) struct TraitWithExtraInfo {
+    pub(crate) trait_: Trait,
+    pub(crate) is_notable: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
-crate struct ExternalCrate {
-    crate crate_num: CrateNum,
+pub(crate) struct ExternalCrate {
+    pub(crate) crate_num: CrateNum,
 }
 
 impl ExternalCrate {}
@@ -128,23 +128,23 @@ impl ExternalCrate {}
 /// name. That is, anything that can be documented. This doesn't correspond
 /// directly to the AST's concept of an item; it's a strict superset.
 #[derive(Clone, Debug)]
-crate struct Item {
+pub(crate) struct Item {
     /// The name of this item.
     /// Optional because not every item has a name, e.g. impls.
-    crate name: Option<Symbol>,
-    crate attrs: Box<Attributes>,
-    crate visibility: Visibility,
+    pub(crate) name: Option<Symbol>,
+    pub(crate) attrs: Box<Attributes>,
+    pub(crate) visibility: Visibility,
     /// Information about this item that is specific to what kind of item it is.
     /// E.g., struct vs enum vs function.
-    crate kind: Box<ItemKind>,
-    crate def_id: ItemId,
+    pub(crate) kind: Box<ItemKind>,
+    pub(crate) def_id: ItemId,
 }
 
 // `Item` is used a lot. Make sure it doesn't unintentionally get bigger.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 rustc_data_structures::static_assert_size!(Item, 48);
 
-crate fn rustc_span(def_id: DefId, tcx: TyCtxt<'_>) -> Span {
+pub(crate) fn rustc_span(def_id: DefId, tcx: TyCtxt<'_>) -> Span {
     Span::new(def_id.as_local().map_or_else(
         || tcx.def_span(def_id),
         |local| {
@@ -155,7 +155,7 @@ crate fn rustc_span(def_id: DefId, tcx: TyCtxt<'_>) -> Span {
 }
 
 impl Item {
-    crate fn span(&self, tcx: TyCtxt<'_>) -> Span {
+    pub(crate) fn span(&self, tcx: TyCtxt<'_>) -> Span {
         let kind = match &*self.kind {
             ItemKind::StrippedItem(k) => k,
             _ => &*self.kind,
@@ -176,7 +176,7 @@ impl Item {
         }
     }
 
-    crate fn attr_span(&self, tcx: TyCtxt<'_>) -> rustc_span::Span {
+    pub(crate) fn attr_span(&self, tcx: TyCtxt<'_>) -> rustc_span::Span {
         crate::passes::span_of_attrs(&self.attrs).unwrap_or_else(|| self.span(tcx).inner())
     }
 
@@ -220,7 +220,7 @@ impl Item {
         }
     }
 
-    crate fn is_stripped(&self) -> bool {
+    pub(crate) fn is_stripped(&self) -> bool {
         match *self.kind {
             StrippedItem(..) => true,
             ImportItem(ref i) => !i.should_be_displayed,
@@ -229,13 +229,13 @@ impl Item {
     }
 
     /// Returns a documentation-level item type from the item.
-    crate fn type_(&self) -> ItemType {
+    pub(crate) fn type_(&self) -> ItemType {
         ItemType::from(self)
     }
 }
 
 #[derive(Clone, Debug)]
-crate enum ItemKind {
+pub(crate) enum ItemKind {
     ExternCrateItem {
         /// The crate's name, *not* the name it's imported as.
         src: Option<Symbol>,
@@ -281,12 +281,12 @@ crate enum ItemKind {
 impl ItemKind {}
 
 #[derive(Clone, Debug)]
-crate struct Module {
-    crate items: Vec<Item>,
-    crate span: Span,
+pub(crate) struct Module {
+    pub(crate) items: Vec<Item>,
+    pub(crate) span: Span,
 }
 
-crate struct ListAttributesIter<'a> {
+pub(crate) struct ListAttributesIter<'a> {
     attrs: slice::Iter<'a, ast::Attribute>,
     current_list: vec::IntoIter<ast::NestedMetaItem>,
     name: Symbol,
@@ -320,7 +320,7 @@ impl<'a> Iterator for ListAttributesIter<'a> {
     }
 }
 
-crate trait AttributesExt {
+pub(crate) trait AttributesExt {
     /// Finds an attribute as List and returns the list of attributes nested inside.
     fn lists(&self, name: Symbol) -> ListAttributesIter<'_>;
 
@@ -442,7 +442,7 @@ impl AttributesExt for [ast::Attribute] {
     }
 }
 
-crate trait NestedAttributesExt {
+pub(crate) trait NestedAttributesExt {
     /// Returns `true` if the attribute list contains a specific `word`
     fn has_word(self, word: Symbol) -> bool
     where
@@ -474,16 +474,16 @@ where
 /// information can be given when a doctest fails. Sugared doc comments and "raw" doc comments are
 /// kept separate because of issue #42760.
 #[derive(Clone, PartialEq, Eq, Debug)]
-crate struct DocFragment {
-    crate span: rustc_span::Span,
+pub(crate) struct DocFragment {
+    pub(crate) span: rustc_span::Span,
     /// The module this doc-comment came from.
     ///
     /// This allows distinguishing between the original documentation and a pub re-export.
     /// If it is `None`, the item was not re-exported.
-    crate parent_module: Option<DefId>,
-    crate doc: Symbol,
-    crate kind: DocFragmentKind,
-    crate indent: usize,
+    pub(crate) parent_module: Option<DefId>,
+    pub(crate) doc: Symbol,
+    pub(crate) kind: DocFragmentKind,
+    pub(crate) indent: usize,
 }
 
 // `DocFragment` is used a lot. Make sure it doesn't unintentionally get bigger.
@@ -491,7 +491,7 @@ crate struct DocFragment {
 rustc_data_structures::static_assert_size!(DocFragment, 32);
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
-crate enum DocFragmentKind {
+pub(crate) enum DocFragmentKind {
     /// A doc fragment created from a `///` or `//!` doc comment.
     SugaredDoc,
     /// A doc fragment created from a "raw" `#[doc=""]` attribute.
@@ -523,7 +523,7 @@ fn add_doc_fragment(out: &mut String, frag: &DocFragment) {
 
 /// Collapse a collection of [`DocFragment`]s into one string,
 /// handling indentation and newlines as needed.
-crate fn collapse_doc_fragments(doc_strings: &[DocFragment]) -> String {
+pub(crate) fn collapse_doc_fragments(doc_strings: &[DocFragment]) -> String {
     let mut acc = String::new();
     for frag in doc_strings {
         add_doc_fragment(&mut acc, frag);
@@ -536,7 +536,7 @@ crate fn collapse_doc_fragments(doc_strings: &[DocFragment]) -> String {
 ///
 /// This link will be turned into a rendered link by [`Item::links`].
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-crate struct ItemLink {
+pub(crate) struct ItemLink {
     /// The original link written in the markdown
     pub(crate) link: String,
     /// The link text displayed in the HTML.
@@ -561,13 +561,13 @@ pub(crate) struct RenderedLink {
 /// The attributes on an [`Item`], including attributes like `#[derive(...)]` and `#[inline]`,
 /// as well as doc comments.
 #[derive(Clone, Debug, Default)]
-crate struct Attributes {
-    crate doc_strings: Vec<DocFragment>,
-    crate other_attrs: Vec<ast::Attribute>,
+pub(crate) struct Attributes {
+    pub(crate) doc_strings: Vec<DocFragment>,
+    pub(crate) other_attrs: Vec<ast::Attribute>,
 }
 
 impl Attributes {
-    crate fn has_doc_flag(&self, flag: Symbol) -> bool {
+    pub(crate) fn has_doc_flag(&self, flag: Symbol) -> bool {
         for attr in &self.other_attrs {
             if !attr.has_name(sym::doc) {
                 continue;
@@ -583,7 +583,7 @@ impl Attributes {
         false
     }
 
-    crate fn from_ast(
+    pub(crate) fn from_ast(
         attrs: &[ast::Attribute],
         additional_attrs: Option<(&[ast::Attribute], DefId)>,
     ) -> Attributes {
@@ -622,7 +622,7 @@ impl Attributes {
     }
     /// Finds all `doc` attributes as NameValues and returns their corresponding values, joined
     /// with newlines.
-    crate fn collapsed_doc_value(&self) -> Option<String> {
+    pub(crate) fn collapsed_doc_value(&self) -> Option<String> {
         if self.doc_strings.is_empty() {
             None
         } else {
@@ -645,13 +645,13 @@ impl PartialEq for Attributes {
 impl Eq for Attributes {}
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate enum GenericBound {
+pub(crate) enum GenericBound {
     TraitBound(PolyTrait, hir::TraitBoundModifier),
     Outlives(Lifetime),
 }
 
 impl GenericBound {
-    crate fn maybe_sized(cx: &mut DocContext<'_>) -> GenericBound {
+    pub(crate) fn maybe_sized(cx: &mut DocContext<'_>) -> GenericBound {
         let did = cx.tcx.require_lang_item(LangItem::Sized, None);
         let empty = cx.tcx.intern_substs(&[]);
         let path = external_path(cx, did, false, vec![], empty);
@@ -662,7 +662,7 @@ impl GenericBound {
         )
     }
 
-    crate fn is_sized_bound(&self, cx: &DocContext<'_>) -> bool {
+    pub(crate) fn is_sized_bound(&self, cx: &DocContext<'_>) -> bool {
         use rustc_hir::TraitBoundModifier as TBM;
         if let GenericBound::TraitBound(PolyTrait { ref trait_, .. }, TBM::None) = *self {
             if Some(trait_.def_id()) == cx.tcx.lang_items().sized_trait() {
@@ -674,27 +674,27 @@ impl GenericBound {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate struct Lifetime(pub(crate) Symbol);
+pub(crate) struct Lifetime(pub(crate) Symbol);
 
 impl Lifetime {
-    crate fn statik() -> Lifetime {
+    pub(crate) fn statik() -> Lifetime {
         Lifetime(kw::StaticLifetime)
     }
 
-    crate fn elided() -> Lifetime {
+    pub(crate) fn elided() -> Lifetime {
         Lifetime(kw::UnderscoreLifetime)
     }
 }
 
 #[derive(Clone, Debug)]
-crate enum WherePredicate {
+pub(crate) enum WherePredicate {
     BoundPredicate { ty: Type, bounds: Vec<GenericBound>, bound_params: Vec<Lifetime> },
     RegionPredicate { lifetime: Lifetime, bounds: Vec<GenericBound> },
     EqPredicate { lhs: Type, rhs: Term },
 }
 
 impl WherePredicate {
-    crate fn get_bounds(&self) -> Option<&[GenericBound]> {
+    pub(crate) fn get_bounds(&self) -> Option<&[GenericBound]> {
         match *self {
             WherePredicate::BoundPredicate { ref bounds, .. } => Some(bounds),
             WherePredicate::RegionPredicate { ref bounds, .. } => Some(bounds),
@@ -704,16 +704,16 @@ impl WherePredicate {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate enum GenericParamDefKind {
+pub(crate) enum GenericParamDefKind {
     Lifetime { outlives: Vec<Lifetime> },
     Type { did: DefId, bounds: Vec<GenericBound>, default: Option<Box<Type>>, synthetic: bool },
     Const { did: DefId, ty: Box<Type>, default: Option<Box<String>> },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate struct GenericParamDef {
-    crate name: Symbol,
-    crate kind: GenericParamDefKind,
+pub(crate) struct GenericParamDef {
+    pub(crate) name: Symbol,
+    pub(crate) kind: GenericParamDefKind,
 }
 
 // `GenericParamDef` is used in many places. Make sure it doesn't unintentionally get bigger.
@@ -722,70 +722,70 @@ rustc_data_structures::static_assert_size!(GenericParamDef, 56);
 
 // maybe use a Generic enum and use Vec<Generic>?
 #[derive(Clone, Debug, Default)]
-crate struct Generics {
-    crate params: Vec<GenericParamDef>,
-    crate where_predicates: Vec<WherePredicate>,
+pub(crate) struct Generics {
+    pub(crate) params: Vec<GenericParamDef>,
+    pub(crate) where_predicates: Vec<WherePredicate>,
 }
 
 #[derive(Clone, Debug)]
-crate struct Function {
-    crate decl: FnDecl,
-    crate generics: Generics,
-    crate header: hir::FnHeader,
+pub(crate) struct Function {
+    pub(crate) decl: FnDecl,
+    pub(crate) generics: Generics,
+    pub(crate) header: hir::FnHeader,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate struct FnDecl {
-    crate inputs: Arguments,
-    crate output: FnRetTy,
-    crate c_variadic: bool,
+pub(crate) struct FnDecl {
+    pub(crate) inputs: Arguments,
+    pub(crate) output: FnRetTy,
+    pub(crate) c_variadic: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate struct Arguments {
-    crate values: Vec<Argument>,
+pub(crate) struct Arguments {
+    pub(crate) values: Vec<Argument>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate struct Argument {
-    crate type_: Type,
-    crate name: Symbol,
+pub(crate) struct Argument {
+    pub(crate) type_: Type,
+    pub(crate) name: Symbol,
     /// This field is used to represent "const" arguments from the `rustc_legacy_const_generics`
     /// feature. More information in <https://github.com/rust-lang/rust/issues/83167>.
-    crate is_const: bool,
+    pub(crate) is_const: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate enum FnRetTy {
+pub(crate) enum FnRetTy {
     Return(Type),
     DefaultReturn,
 }
 
 #[derive(Clone, Debug)]
-crate struct Trait {
-    crate unsafety: hir::Unsafety,
-    crate items: Vec<Item>,
-    crate generics: Generics,
-    crate bounds: Vec<GenericBound>,
-    crate is_auto: bool,
+pub(crate) struct Trait {
+    pub(crate) unsafety: hir::Unsafety,
+    pub(crate) items: Vec<Item>,
+    pub(crate) generics: Generics,
+    pub(crate) bounds: Vec<GenericBound>,
+    pub(crate) is_auto: bool,
 }
 
 #[derive(Clone, Debug)]
-crate struct TraitAlias {
-    crate generics: Generics,
-    crate bounds: Vec<GenericBound>,
+pub(crate) struct TraitAlias {
+    pub(crate) generics: Generics,
+    pub(crate) bounds: Vec<GenericBound>,
 }
 
 /// A trait reference, which may have higher ranked lifetimes.
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate struct PolyTrait {
-    crate trait_: Path,
-    crate generic_params: Vec<GenericParamDef>,
+pub(crate) struct PolyTrait {
+    pub(crate) trait_: Path,
+    pub(crate) generic_params: Vec<GenericParamDef>,
 }
 
 /// Rustdoc's representation of types, mostly based on the [`hir::Ty`].
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate enum Type {
+pub(crate) enum Type {
     /// A named type, which could be a trait.
     ///
     /// This is mostly Rustdoc's version of [`hir::Path`].
@@ -835,7 +835,7 @@ crate enum Type {
 rustc_data_structures::static_assert_size!(Type, 72);
 
 impl Type {
-    crate fn primitive_type(&self) -> Option<PrimitiveType> {
+    pub(crate) fn primitive_type(&self) -> Option<PrimitiveType> {
         match *self {
             Primitive(p) | BorrowedRef { type_: box Primitive(p), .. } => Some(p),
             Slice(..) | BorrowedRef { type_: box Slice(..), .. } => Some(PrimitiveType::Slice),
@@ -853,14 +853,14 @@ impl Type {
         }
     }
 
-    crate fn generics(&self) -> Option<Vec<&Type>> {
+    pub(crate) fn generics(&self) -> Option<Vec<&Type>> {
         match self {
             Type::Path { path, .. } => path.generics(),
             _ => None,
         }
     }
 
-    crate fn projection(&self) -> Option<(&Type, DefId, Symbol)> {
+    pub(crate) fn projection(&self) -> Option<(&Type, DefId, Symbol)> {
         let (self_, trait_, name) = match self {
             QPath { self_type, trait_, name, .. } => (self_type, trait_, name),
             _ => return None,
@@ -897,7 +897,7 @@ impl Type {
     /// See [`Self::def_id_no_primitives`] for more.
     ///
     /// [clean]: crate::clean
-    crate fn def_id(&self, cache: &Cache) -> Option<DefId> {
+    pub(crate) fn def_id(&self, cache: &Cache) -> Option<DefId> {
         self.inner_def_id(Some(cache))
     }
 }
@@ -909,7 +909,7 @@ impl Type {
 /// N.B. This has to be different from [`hir::PrimTy`] because it also includes types that aren't
 /// paths, like [`Self::Unit`].
 #[derive(Clone, PartialEq, Eq, Hash, Copy, Debug)]
-crate enum PrimitiveType {
+pub(crate) enum PrimitiveType {
     Isize,
     I8,
     I16,
@@ -939,7 +939,7 @@ crate enum PrimitiveType {
 
 type SimplifiedTypes = FxHashMap<PrimitiveType, ArrayVec<SimplifiedType, 2>>;
 impl PrimitiveType {
-    crate fn simplified_types() -> &'static SimplifiedTypes {
+    pub(crate) fn simplified_types() -> &'static SimplifiedTypes {
         use ty::fast_reject::SimplifiedTypeGen::*;
         use ty::{FloatTy, IntTy, UintTy};
         use PrimitiveType::*;
@@ -984,7 +984,7 @@ impl PrimitiveType {
         })
     }
 
-    crate fn impls<'tcx>(&self, tcx: TyCtxt<'tcx>) -> impl Iterator<Item = DefId> + 'tcx {
+    pub(crate) fn impls<'tcx>(&self, tcx: TyCtxt<'tcx>) -> impl Iterator<Item = DefId> + 'tcx {
         Self::simplified_types()
             .get(self)
             .into_iter()
@@ -993,7 +993,7 @@ impl PrimitiveType {
             .copied()
     }
 
-    crate fn all_impls(tcx: TyCtxt<'_>) -> impl Iterator<Item = DefId> + '_ {
+    pub(crate) fn all_impls(tcx: TyCtxt<'_>) -> impl Iterator<Item = DefId> + '_ {
         Self::simplified_types()
             .values()
             .flatten()
@@ -1001,7 +1001,7 @@ impl PrimitiveType {
             .copied()
     }
 
-    crate fn as_sym(&self) -> Symbol {
+    pub(crate) fn as_sym(&self) -> Symbol {
         use PrimitiveType::*;
         match self {
             Isize => sym::isize,
@@ -1117,7 +1117,7 @@ impl From<hir::PrimTy> for PrimitiveType {
 }
 
 #[derive(Copy, Clone, Debug)]
-crate enum Visibility {
+pub(crate) enum Visibility {
     /// `pub`
     Public,
     /// Visibility inherited from parent.
@@ -1129,39 +1129,39 @@ crate enum Visibility {
 }
 
 #[derive(Clone, Debug)]
-crate struct Struct {
-    crate struct_type: CtorKind,
-    crate generics: Generics,
-    crate fields: Vec<Item>,
-    crate fields_stripped: bool,
+pub(crate) struct Struct {
+    pub(crate) struct_type: CtorKind,
+    pub(crate) generics: Generics,
+    pub(crate) fields: Vec<Item>,
+    pub(crate) fields_stripped: bool,
 }
 
 #[derive(Clone, Debug)]
-crate struct Union {
-    crate generics: Generics,
-    crate fields: Vec<Item>,
-    crate fields_stripped: bool,
+pub(crate) struct Union {
+    pub(crate) generics: Generics,
+    pub(crate) fields: Vec<Item>,
+    pub(crate) fields_stripped: bool,
 }
 
 /// This is a more limited form of the standard Struct, different in that
 /// it lacks the things most items have (name, id, parameterization). Found
 /// only as a variant in an enum.
 #[derive(Clone, Debug)]
-crate struct VariantStruct {
-    crate struct_type: CtorKind,
-    crate fields: Vec<Item>,
-    crate fields_stripped: bool,
+pub(crate) struct VariantStruct {
+    pub(crate) struct_type: CtorKind,
+    pub(crate) fields: Vec<Item>,
+    pub(crate) fields_stripped: bool,
 }
 
 #[derive(Clone, Debug)]
-crate struct Enum {
-    crate variants: IndexVec<VariantIdx, Item>,
-    crate generics: Generics,
-    crate variants_stripped: bool,
+pub(crate) struct Enum {
+    pub(crate) variants: IndexVec<VariantIdx, Item>,
+    pub(crate) generics: Generics,
+    pub(crate) variants_stripped: bool,
 }
 
 #[derive(Clone, Debug)]
-crate enum Variant {
+pub(crate) enum Variant {
     CLike,
     Tuple(Vec<Item>),
     Struct(VariantStruct),
@@ -1170,38 +1170,38 @@ crate enum Variant {
 /// Small wrapper around [`rustc_span::Span`] that adds helper methods
 /// and enforces calling [`rustc_span::Span::source_callsite()`].
 #[derive(Copy, Clone, Debug)]
-crate struct Span(rustc_span::Span);
+pub(crate) struct Span(rustc_span::Span);
 
 impl Span {
     /// Wraps a [`rustc_span::Span`]. In case this span is the result of a macro expansion, the
     /// span will be updated to point to the macro invocation instead of the macro definition.
     ///
     /// (See rust-lang/rust#39726)
-    crate fn new(sp: rustc_span::Span) -> Self {
+    pub(crate) fn new(sp: rustc_span::Span) -> Self {
         Self(sp.source_callsite())
     }
 
-    crate fn inner(&self) -> rustc_span::Span {
+    pub(crate) fn inner(&self) -> rustc_span::Span {
         self.0
     }
 
-    crate fn dummy() -> Self {
+    pub(crate) fn dummy() -> Self {
         Self(rustc_span::DUMMY_SP)
     }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate struct Path {
-    crate res: Res,
-    crate segments: Vec<PathSegment>,
+pub(crate) struct Path {
+    pub(crate) res: Res,
+    pub(crate) segments: Vec<PathSegment>,
 }
 
 impl Path {
-    crate fn def_id(&self) -> DefId {
+    pub(crate) fn def_id(&self) -> DefId {
         self.res.def_id()
     }
 
-    crate fn generics(&self) -> Option<Vec<&Type>> {
+    pub(crate) fn generics(&self) -> Option<Vec<&Type>> {
         self.segments.last().and_then(|seg| {
             if let GenericArgs::AngleBracketed { ref args, .. } = seg.args {
                 Some(
@@ -1220,7 +1220,7 @@ impl Path {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate enum GenericArg {
+pub(crate) enum GenericArg {
     Lifetime(Lifetime),
     Type(Type),
     Const(Box<Constant>),
@@ -1233,7 +1233,7 @@ crate enum GenericArg {
 rustc_data_structures::static_assert_size!(GenericArg, 80);
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate enum GenericArgs {
+pub(crate) enum GenericArgs {
     AngleBracketed { args: Vec<GenericArg>, bindings: ThinVec<TypeBinding> },
     Parenthesized { inputs: Vec<Type>, output: Option<Box<Type>> },
 }
@@ -1244,9 +1244,9 @@ crate enum GenericArgs {
 rustc_data_structures::static_assert_size!(GenericArgs, 40);
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate struct PathSegment {
-    crate name: Symbol,
-    crate args: GenericArgs,
+pub(crate) struct PathSegment {
+    pub(crate) name: Symbol,
+    pub(crate) args: GenericArgs,
 }
 
 // `PathSegment` usually occurs multiple times in every `Path`, so its size can
@@ -1255,52 +1255,52 @@ crate struct PathSegment {
 rustc_data_structures::static_assert_size!(PathSegment, 48);
 
 #[derive(Clone, Debug)]
-crate struct Typedef {
-    crate type_: Type,
-    crate generics: Generics,
+pub(crate) struct Typedef {
+    pub(crate) type_: Type,
+    pub(crate) generics: Generics,
     /// `type_` can come from either the HIR or from metadata. If it comes from HIR, it may be a type
     /// alias instead of the final type. This will always have the final type, regardless of whether
     /// `type_` came from HIR or from metadata.
     ///
     /// If `item_type.is_none()`, `type_` is guarenteed to come from metadata (and therefore hold the
     /// final type).
-    crate item_type: Option<Type>,
+    pub(crate) item_type: Option<Type>,
 }
 
 #[derive(Clone, Debug)]
-crate struct OpaqueTy {
-    crate bounds: Vec<GenericBound>,
-    crate generics: Generics,
+pub(crate) struct OpaqueTy {
+    pub(crate) bounds: Vec<GenericBound>,
+    pub(crate) generics: Generics,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate struct BareFunctionDecl {
-    crate unsafety: hir::Unsafety,
-    crate generic_params: Vec<GenericParamDef>,
-    crate decl: FnDecl,
-    crate abi: Abi,
+pub(crate) struct BareFunctionDecl {
+    pub(crate) unsafety: hir::Unsafety,
+    pub(crate) generic_params: Vec<GenericParamDef>,
+    pub(crate) decl: FnDecl,
+    pub(crate) abi: Abi,
 }
 
 #[derive(Clone, Debug)]
-crate struct Static {
-    crate type_: Type,
-    crate mutability: Mutability,
+pub(crate) struct Static {
+    pub(crate) type_: Type,
+    pub(crate) mutability: Mutability,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-crate struct Constant {
-    crate type_: Type,
-    crate kind: ConstantKind,
+pub(crate) struct Constant {
+    pub(crate) type_: Type,
+    pub(crate) kind: ConstantKind,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-crate enum Term {
+pub(crate) enum Term {
     Type(Type),
     Constant(Constant),
 }
 
 impl Term {
-    crate fn ty(&self) -> Option<&Type> {
+    pub(crate) fn ty(&self) -> Option<&Type> {
         if let Term::Type(ty) = self { Some(ty) } else { None }
     }
 }
@@ -1312,7 +1312,7 @@ impl From<Type> for Term {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-crate enum ConstantKind {
+pub(crate) enum ConstantKind {
     /// This is the wrapper around `ty::Const` for a non-local constant. Because it doesn't have a
     /// `BodyId`, we need to handle it on its own.
     ///
@@ -1330,47 +1330,47 @@ crate enum ConstantKind {
 }
 
 #[derive(Clone, Debug)]
-crate struct Impl {
-    crate generics: Generics,
-    crate trait_: Option<Path>,
-    crate for_: Type,
-    crate items: Vec<Item>,
-    crate polarity: ty::ImplPolarity,
-    crate kind: ImplKind,
+pub(crate) struct Impl {
+    pub(crate) generics: Generics,
+    pub(crate) trait_: Option<Path>,
+    pub(crate) for_: Type,
+    pub(crate) items: Vec<Item>,
+    pub(crate) polarity: ty::ImplPolarity,
+    pub(crate) kind: ImplKind,
 }
 
 #[derive(Clone, Debug)]
-crate enum ImplKind {
+pub(crate) enum ImplKind {
     Normal,
     Auto,
     Blanket(Box<Type>),
 }
 
 impl ImplKind {
-    crate fn is_blanket(&self) -> bool {
+    pub(crate) fn is_blanket(&self) -> bool {
         matches!(self, ImplKind::Blanket(_))
     }
 }
 
 #[derive(Clone, Debug)]
-crate struct Import {
-    crate kind: ImportKind,
-    crate source: ImportSource,
-    crate should_be_displayed: bool,
+pub(crate) struct Import {
+    pub(crate) kind: ImportKind,
+    pub(crate) source: ImportSource,
+    pub(crate) should_be_displayed: bool,
 }
 
 impl Import {
-    crate fn new_simple(name: Symbol, source: ImportSource, should_be_displayed: bool) -> Self {
+    pub(crate) fn new_simple(name: Symbol, source: ImportSource, should_be_displayed: bool) -> Self {
         Self { kind: ImportKind::Simple(name), source, should_be_displayed }
     }
 
-    crate fn new_glob(source: ImportSource, should_be_displayed: bool) -> Self {
+    pub(crate) fn new_glob(source: ImportSource, should_be_displayed: bool) -> Self {
         Self { kind: ImportKind::Glob, source, should_be_displayed }
     }
 }
 
 #[derive(Clone, Debug)]
-crate enum ImportKind {
+pub(crate) enum ImportKind {
     // use source as str;
     Simple(Symbol),
     // use source::*;
@@ -1378,32 +1378,32 @@ crate enum ImportKind {
 }
 
 #[derive(Clone, Debug)]
-crate struct ImportSource {
-    crate path: Path,
-    crate did: Option<DefId>,
+pub(crate) struct ImportSource {
+    pub(crate) path: Path,
+    pub(crate) did: Option<DefId>,
 }
 
 #[derive(Clone, Debug)]
-crate struct Macro {
-    crate source: String,
+pub(crate) struct Macro {
+    pub(crate) source: String,
 }
 
 #[derive(Clone, Debug)]
-crate struct ProcMacro {
-    crate kind: MacroKind,
-    crate helpers: Vec<Symbol>,
+pub(crate) struct ProcMacro {
+    pub(crate) kind: MacroKind,
+    pub(crate) helpers: Vec<Symbol>,
 }
 
 /// An type binding on an associated type (e.g., `A = Bar` in `Foo<A = Bar>` or
 /// `A: Send + Sync` in `Foo<A: Send + Sync>`).
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate struct TypeBinding {
-    crate name: Symbol,
-    crate kind: TypeBindingKind,
+pub(crate) struct TypeBinding {
+    pub(crate) name: Symbol,
+    pub(crate) kind: TypeBindingKind,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-crate enum TypeBindingKind {
+pub(crate) enum TypeBindingKind {
     Equality { term: Term },
     Constraint { bounds: Vec<GenericBound> },
 }
@@ -1421,18 +1421,18 @@ crate enum TypeBindingKind {
 ///
 /// `public_fn`'s docs will show it as returning `Vec<i32>`, since `PrivAlias` is private.
 /// [`SubstParam`] is used to record that `T` should be mapped to `i32`.
-crate enum SubstParam {
+pub(crate) enum SubstParam {
     Type(Type),
     Lifetime(Lifetime),
     Constant(Constant),
 }
 
 impl SubstParam {
-    crate fn as_ty(&self) -> Option<&Type> {
+    pub(crate) fn as_ty(&self) -> Option<&Type> {
         if let Self::Type(ty) = self { Some(ty) } else { None }
     }
 
-    crate fn as_lt(&self) -> Option<&Lifetime> {
+    pub(crate) fn as_lt(&self) -> Option<&Lifetime> {
         if let Self::Lifetime(lt) = self { Some(lt) } else { None }
     }
 }

--- a/tools/bookrunner/librustdoc/clean/utils.rs
+++ b/tools/bookrunner/librustdoc/clean/utils.rs
@@ -102,7 +102,11 @@ pub(crate) fn qpath_to_string(p: &hir::QPath<'_>) -> String {
     s
 }
 
-pub(crate) fn build_deref_target_impls(cx: &mut DocContext<'_>, items: &[Item], ret: &mut Vec<Item>) {
+pub(crate) fn build_deref_target_impls(
+    cx: &mut DocContext<'_>,
+    items: &[Item],
+    ret: &mut Vec<Item>,
+) {
     let tcx = cx.tcx;
 
     for item in items {

--- a/tools/bookrunner/librustdoc/clean/utils.rs
+++ b/tools/bookrunner/librustdoc/clean/utils.rs
@@ -83,7 +83,7 @@ pub(super) fn external_path(
     }
 }
 
-crate fn qpath_to_string(p: &hir::QPath<'_>) -> String {
+pub(crate) fn qpath_to_string(p: &hir::QPath<'_>) -> String {
     let segments = match *p {
         hir::QPath::Resolved(_, path) => &path.segments,
         hir::QPath::TypeRelative(_, segment) => return segment.ident.to_string(),
@@ -102,7 +102,7 @@ crate fn qpath_to_string(p: &hir::QPath<'_>) -> String {
     s
 }
 
-crate fn build_deref_target_impls(cx: &mut DocContext<'_>, items: &[Item], ret: &mut Vec<Item>) {
+pub(crate) fn build_deref_target_impls(cx: &mut DocContext<'_>, items: &[Item], ret: &mut Vec<Item>) {
     let tcx = cx.tcx;
 
     for item in items {
@@ -125,7 +125,7 @@ crate fn build_deref_target_impls(cx: &mut DocContext<'_>, items: &[Item], ret: 
     }
 }
 
-crate fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
+pub(crate) fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
     use rustc_hir::*;
     debug!("trying to get a name from pattern: {:?}", p);
 
@@ -158,7 +158,7 @@ crate fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
     })
 }
 
-crate fn print_const(cx: &DocContext<'_>, n: &ty::Const<'_>) -> String {
+pub(crate) fn print_const(cx: &DocContext<'_>, n: &ty::Const<'_>) -> String {
     match n.val() {
         ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs: _, promoted }) => {
             let mut s = if let Some(def) = def.as_local() {
@@ -188,7 +188,7 @@ crate fn print_const(cx: &DocContext<'_>, n: &ty::Const<'_>) -> String {
     }
 }
 
-crate fn print_const_expr(tcx: TyCtxt<'_>, body: hir::BodyId) -> String {
+pub(crate) fn print_const_expr(tcx: TyCtxt<'_>, body: hir::BodyId) -> String {
     let hir = tcx.hir();
     let value = &hir.body(body).value;
 
@@ -202,7 +202,7 @@ crate fn print_const_expr(tcx: TyCtxt<'_>, body: hir::BodyId) -> String {
 }
 
 /// Given a type Path, resolve it to a Type using the TyCtxt
-crate fn resolve_type(cx: &mut DocContext<'_>, path: Path) -> Type {
+pub(crate) fn resolve_type(cx: &mut DocContext<'_>, path: Path) -> Type {
     debug!("resolve_type({:?})", path);
 
     match path.res {
@@ -221,7 +221,7 @@ crate fn resolve_type(cx: &mut DocContext<'_>, path: Path) -> Type {
 /// This is later used by [`href()`] to determine the HTML link for the item.
 ///
 /// [`href()`]: crate::html::format::href
-crate fn register_res(cx: &mut DocContext<'_>, res: Res) -> DefId {
+pub(crate) fn register_res(cx: &mut DocContext<'_>, res: Res) -> DefId {
     use DefKind::*;
     debug!("register_res({:?})", res);
 
@@ -260,14 +260,14 @@ crate fn register_res(cx: &mut DocContext<'_>, res: Res) -> DefId {
     did
 }
 
-crate fn resolve_use_source(cx: &mut DocContext<'_>, path: Path) -> ImportSource {
+pub(crate) fn resolve_use_source(cx: &mut DocContext<'_>, path: Path) -> ImportSource {
     ImportSource {
         did: if path.res.opt_def_id().is_none() { None } else { Some(register_res(cx, path.res)) },
         path,
     }
 }
 
-crate fn enter_impl_trait<F, R>(cx: &mut DocContext<'_>, f: F) -> R
+pub(crate) fn enter_impl_trait<F, R>(cx: &mut DocContext<'_>, f: F) -> R
 where
     F: FnOnce(&mut DocContext<'_>) -> R,
 {
@@ -287,7 +287,7 @@ where
 ///
 /// This function exists because it runs on `hir::Attributes` whereas the other is a
 /// `clean::Attributes` method.
-crate fn has_doc_flag(tcx: TyCtxt<'_>, did: DefId, flag: Symbol) -> bool {
+pub(crate) fn has_doc_flag(tcx: TyCtxt<'_>, did: DefId, flag: Symbol) -> bool {
     tcx.get_attrs(did, sym::doc).any(|attr| {
         attr.meta_item_list().map_or(false, |l| rustc_attr::list_contains_name(&l, flag))
     })

--- a/tools/bookrunner/librustdoc/config.rs
+++ b/tools/bookrunner/librustdoc/config.rs
@@ -14,7 +14,7 @@ use rustc_span::edition::Edition;
 use rustc_target::spec::TargetTriple;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-crate enum OutputFormat {
+pub(crate) enum OutputFormat {
     Json,
     Html,
 }
@@ -41,86 +41,86 @@ impl TryFrom<&str> for OutputFormat {
 
 /// Configuration options for rustdoc.
 #[derive(Clone)]
-crate struct Options {
+pub(crate) struct Options {
     // Basic options / Options passed directly to rustc
     /// The crate root or Markdown file to load.
-    crate input: PathBuf,
+    pub(crate) input: PathBuf,
     /// The name of the crate being documented.
-    crate crate_name: Option<String>,
+    pub(crate) crate_name: Option<String>,
     /// Whether or not this is a proc-macro crate
-    crate proc_macro_crate: bool,
+    pub(crate) proc_macro_crate: bool,
     /// How to format errors and warnings.
-    crate error_format: ErrorOutputType,
+    pub(crate) error_format: ErrorOutputType,
     /// Library search paths to hand to the compiler.
-    crate libs: Vec<SearchPath>,
+    pub(crate) libs: Vec<SearchPath>,
     /// Library search paths strings to hand to the compiler.
-    crate lib_strs: Vec<String>,
+    pub(crate) lib_strs: Vec<String>,
     /// The list of external crates to link against.
-    crate externs: Externs,
+    pub(crate) externs: Externs,
     /// The list of external crates strings to link against.
-    crate extern_strs: Vec<String>,
+    pub(crate) extern_strs: Vec<String>,
     /// List of `cfg` flags to hand to the compiler. Always includes `rustdoc`.
-    crate cfgs: Vec<String>,
+    pub(crate) cfgs: Vec<String>,
     /// Codegen options strings to hand to the compiler.
-    crate codegen_options_strs: Vec<String>,
+    pub(crate) codegen_options_strs: Vec<String>,
     /// Debugging (`-Z`) options strings to pass to the compiler.
-    crate debugging_opts_strs: Vec<String>,
+    pub(crate) debugging_opts_strs: Vec<String>,
     /// The target used to compile the crate against.
-    crate target: TargetTriple,
+    pub(crate) target: TargetTriple,
     /// Edition used when reading the crate. Defaults to "2015". Also used by default when
     /// compiling doctests from the crate.
-    crate edition: Edition,
+    pub(crate) edition: Edition,
     /// The path to the sysroot. Used during the compilation process.
-    crate maybe_sysroot: Option<PathBuf>,
+    pub(crate) maybe_sysroot: Option<PathBuf>,
     /// Lint information passed over the command-line.
-    crate lint_opts: Vec<(String, Level)>,
+    pub(crate) lint_opts: Vec<(String, Level)>,
     /// Whether to ask rustc to describe the lints it knows.
-    crate describe_lints: bool,
+    pub(crate) describe_lints: bool,
     /// What level to cap lints at.
-    crate lint_cap: Option<Level>,
+    pub(crate) lint_cap: Option<Level>,
 
     // Options specific to running doctests
     /// Whether we should run doctests instead of generating docs.
-    crate should_test: bool,
+    pub(crate) should_test: bool,
     /// List of arguments to pass to the test harness, if running tests.
-    crate test_args: Vec<String>,
+    pub(crate) test_args: Vec<String>,
     /// The working directory in which to run tests.
-    crate test_run_directory: Option<PathBuf>,
+    pub(crate) test_run_directory: Option<PathBuf>,
     /// Optional path to persist the doctest executables to, defaults to a
     /// temporary directory if not set.
-    crate persist_doctests: Option<PathBuf>,
+    pub(crate) persist_doctests: Option<PathBuf>,
     /// Runtool to run doctests with
-    crate runtool: Option<String>,
+    pub(crate) runtool: Option<String>,
     /// Arguments to pass to the runtool
-    crate runtool_args: Vec<String>,
+    pub(crate) runtool_args: Vec<String>,
     /// Whether to allow ignoring doctests on a per-target basis
     /// For example, using ignore-foo to ignore running the doctest on any target that
     /// contains "foo" as a substring
-    crate enable_per_target_ignores: bool,
+    pub(crate) enable_per_target_ignores: bool,
     /// Do not run doctests, compile them if should_test is active.
-    crate no_run: bool,
+    pub(crate) no_run: bool,
 
     /// The path to a rustc-like binary to build tests with. If not set, we
     /// default to loading from `$sysroot/bin/rustc`.
-    crate test_builder: Option<PathBuf>,
+    pub(crate) test_builder: Option<PathBuf>,
 
     // Options that affect the documentation process
     /// Whether to run the `calculate-doc-coverage` pass, which counts the number of public items
     /// with and without documentation.
-    crate show_coverage: bool,
+    pub(crate) show_coverage: bool,
 
     // Options that alter generated documentation pages
     /// Crate version to note on the sidebar of generated docs.
-    crate crate_version: Option<String>,
+    pub(crate) crate_version: Option<String>,
     /// Collected options specific to outputting final pages.
-    crate render_options: RenderOptions,
+    pub(crate) render_options: RenderOptions,
     /// If this option is set to `true`, rustdoc will only run checks and not generate
     /// documentation.
-    crate run_check: bool,
+    pub(crate) run_check: bool,
     /// Whether doctests should emit unused externs
-    crate json_unused_externs: bool,
+    pub(crate) json_unused_externs: bool,
     /// Whether to skip capturing stdout and stderr of tests.
-    crate nocapture: bool,
+    pub(crate) nocapture: bool,
 }
 
 impl fmt::Debug for Options {
@@ -168,15 +168,15 @@ impl fmt::Debug for Options {
 
 /// Configuration options for the HTML page-creation process.
 #[derive(Clone, Debug)]
-crate struct RenderOptions {
+pub(crate) struct RenderOptions {
     /// Document items that have lower than `pub` visibility.
-    crate document_private: bool,
+    pub(crate) document_private: bool,
     /// Document items that have `doc(hidden)`.
-    crate document_hidden: bool,
+    pub(crate) document_hidden: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-crate enum EmitType {
+pub(crate) enum EmitType {
     Unversioned,
     Toolchain,
     InvocationSpecific,

--- a/tools/bookrunner/librustdoc/core.rs
+++ b/tools/bookrunner/librustdoc/core.rs
@@ -49,7 +49,11 @@ impl<'tcx> DocContext<'tcx> {
         self.tcx.sess
     }
 
-    pub(crate) fn with_param_env<T, F: FnOnce(&mut Self) -> T>(&mut self, def_id: DefId, f: F) -> T {
+    pub(crate) fn with_param_env<T, F: FnOnce(&mut Self) -> T>(
+        &mut self,
+        def_id: DefId,
+        f: F,
+    ) -> T {
         let old_param_env = mem::replace(&mut self.param_env, self.tcx.param_env(def_id));
         let ret = f(self);
         self.param_env = old_param_env;
@@ -58,7 +62,11 @@ impl<'tcx> DocContext<'tcx> {
 
     /// Call the closure with the given parameters set as
     /// the substitutions for a type alias' RHS.
-    pub(crate) fn enter_alias<F, R>(&mut self, substs: FxHashMap<DefId, clean::SubstParam>, f: F) -> R
+    pub(crate) fn enter_alias<F, R>(
+        &mut self,
+        substs: FxHashMap<DefId, clean::SubstParam>,
+        f: F,
+    ) -> R
     where
         F: FnOnce(&mut Self) -> R,
     {

--- a/tools/bookrunner/librustdoc/core.rs
+++ b/tools/bookrunner/librustdoc/core.rs
@@ -19,37 +19,37 @@ use crate::clean::{self, ItemId};
 use crate::config::RenderOptions;
 use crate::formats::cache::Cache;
 
-crate struct DocContext<'tcx> {
-    crate tcx: TyCtxt<'tcx>,
+pub(crate) struct DocContext<'tcx> {
+    pub(crate) tcx: TyCtxt<'tcx>,
     /// Used for normalization.
     ///
     /// Most of this logic is copied from rustc_lint::late.
-    crate param_env: ParamEnv<'tcx>,
+    pub(crate) param_env: ParamEnv<'tcx>,
     /// Later on moved through `clean::Crate` into `cache`
-    crate external_traits: Rc<RefCell<FxHashMap<DefId, clean::TraitWithExtraInfo>>>,
+    pub(crate) external_traits: Rc<RefCell<FxHashMap<DefId, clean::TraitWithExtraInfo>>>,
     /// Used while populating `external_traits` to ensure we don't process the same trait twice at
     /// the same time.
-    crate active_extern_traits: FxHashSet<DefId>,
+    pub(crate) active_extern_traits: FxHashSet<DefId>,
     // The current set of parameter substitutions,
     // for expanding type aliases at the HIR level:
     /// Table `DefId` of type, lifetime, or const parameter -> substituted type, lifetime, or const
-    crate substs: FxHashMap<DefId, clean::SubstParam>,
+    pub(crate) substs: FxHashMap<DefId, clean::SubstParam>,
     /// Table synthetic type parameter for `impl Trait` in argument position -> bounds
-    crate impl_trait_bounds: FxHashMap<ImplTraitParam, Vec<clean::GenericBound>>,
+    pub(crate) impl_trait_bounds: FxHashMap<ImplTraitParam, Vec<clean::GenericBound>>,
     /// The options given to rustdoc that could be relevant to a pass.
-    crate render_options: RenderOptions,
+    pub(crate) render_options: RenderOptions,
     /// This same cache is used throughout rustdoc, including in [`crate::html::render`].
-    crate cache: Cache,
+    pub(crate) cache: Cache,
     /// Used by [`clean::inline`] to tell if an item has already been inlined.
-    crate inlined: FxHashSet<ItemId>,
+    pub(crate) inlined: FxHashSet<ItemId>,
 }
 
 impl<'tcx> DocContext<'tcx> {
-    crate fn sess(&self) -> &'tcx Session {
+    pub(crate) fn sess(&self) -> &'tcx Session {
         self.tcx.sess
     }
 
-    crate fn with_param_env<T, F: FnOnce(&mut Self) -> T>(&mut self, def_id: DefId, f: F) -> T {
+    pub(crate) fn with_param_env<T, F: FnOnce(&mut Self) -> T>(&mut self, def_id: DefId, f: F) -> T {
         let old_param_env = mem::replace(&mut self.param_env, self.tcx.param_env(def_id));
         let ret = f(self);
         self.param_env = old_param_env;
@@ -58,7 +58,7 @@ impl<'tcx> DocContext<'tcx> {
 
     /// Call the closure with the given parameters set as
     /// the substitutions for a type alias' RHS.
-    crate fn enter_alias<F, R>(&mut self, substs: FxHashMap<DefId, clean::SubstParam>, f: F) -> R
+    pub(crate) fn enter_alias<F, R>(&mut self, substs: FxHashMap<DefId, clean::SubstParam>, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,
     {
@@ -70,7 +70,7 @@ impl<'tcx> DocContext<'tcx> {
 
     /// Like `hir().local_def_id_to_hir_id()`, but skips calling it on fake DefIds.
     /// (This avoids a slice-index-out-of-bounds panic.)
-    crate fn as_local_hir_id(tcx: TyCtxt<'_>, def_id: ItemId) -> Option<HirId> {
+    pub(crate) fn as_local_hir_id(tcx: TyCtxt<'_>, def_id: ItemId) -> Option<HirId> {
         match def_id {
             ItemId::DefId(real_id) => {
                 real_id.as_local().map(|def_id| tcx.hir().local_def_id_to_hir_id(def_id))
@@ -136,7 +136,7 @@ impl<'tcx> Visitor<'tcx> for EmitIgnoredResolutionErrors<'tcx> {
 /// `DefId` or parameter index (`ty::ParamTy.index`) of a synthetic type parameter
 /// for `impl Trait` in argument position.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-crate enum ImplTraitParam {
+pub(crate) enum ImplTraitParam {
     DefId(DefId),
     ParamIndex(u32),
 }

--- a/tools/bookrunner/librustdoc/doctest.rs
+++ b/tools/bookrunner/librustdoc/doctest.rs
@@ -40,9 +40,9 @@ use crate::passes::span_of_attrs;
 #[derive(Clone, Default)]
 pub struct GlobalTestOptions {
     /// Whether to disable the default `extern crate my_crate;` when creating doctests.
-    crate no_crate_inject: bool,
+    pub(crate) no_crate_inject: bool,
     /// Additional crate-level attributes to add to doctests.
-    crate attrs: Vec<String>,
+    pub(crate) attrs: Vec<String>,
 }
 
 /// Documentation test failure modes.
@@ -594,8 +594,8 @@ pub trait Tester {
     fn register_header(&mut self, _name: &str, _level: u32) {}
 }
 
-crate struct Collector {
-    crate tests: Vec<test::TestDescAndFn>,
+pub(crate) struct Collector {
+    pub(crate) tests: Vec<test::TestDescAndFn>,
 
     // The name of the test displayed to the user, separated by `::`.
     //
@@ -642,7 +642,7 @@ impl Collector {
         format!("{} - {}(line {})", filename.prefer_local(), item_path, line)
     }
 
-    crate fn set_position(&mut self, position: Span) {
+    pub(crate) fn set_position(&mut self, position: Span) {
         self.position = position;
     }
 

--- a/tools/bookrunner/librustdoc/externalfiles.rs
+++ b/tools/bookrunner/librustdoc/externalfiles.rs
@@ -5,16 +5,16 @@
 use serde::Serialize;
 
 #[derive(Clone, Debug, Serialize)]
-crate struct ExternalHtml {
+pub(crate) struct ExternalHtml {
     /// Content that will be included inline in the `<head>` section of a
     /// rendered Markdown file or generated documentation
-    crate in_header: String,
+    pub(crate) in_header: String,
     /// Content that will be included inline between `<body>` and the content of
     /// a rendered Markdown file or generated documentation
-    crate before_content: String,
+    pub(crate) before_content: String,
     /// Content that will be included inline between the content and `</body>` of
     /// a rendered Markdown file or generated documentation
-    crate after_content: String,
+    pub(crate) after_content: String,
 }
 
 impl ExternalHtml {}

--- a/tools/bookrunner/librustdoc/fold.rs
+++ b/tools/bookrunner/librustdoc/fold.rs
@@ -4,7 +4,7 @@
 // See GitHub history for details.
 use crate::clean::*;
 
-crate trait DocFolder: Sized {
+pub(crate) trait DocFolder: Sized {
     fn fold_item(&mut self, item: Item) -> Option<Item> {
         Some(self.fold_item_recur(item))
     }

--- a/tools/bookrunner/librustdoc/formats/cache.rs
+++ b/tools/bookrunner/librustdoc/formats/cache.rs
@@ -24,25 +24,25 @@ use crate::formats::Impl;
 /// to `Send` so it may be stored in an `Arc` instance and shared among the various
 /// rendering threads.
 #[derive(Default)]
-crate struct Cache {
+pub(crate) struct Cache {
     /// Maps a type ID to all known implementations for that type. This is only
     /// recognized for intra-crate [`clean::Type::Path`]s, and is used to print
     /// out extra documentation on the page of an enum/struct.
     ///
     /// The values of the map are a list of implementations and documentation
     /// found on that implementation.
-    crate impls: FxHashMap<DefId, Vec<Impl>>,
+    pub(crate) impls: FxHashMap<DefId, Vec<Impl>>,
 
     /// Maintains a mapping of local crate `DefId`s to the fully qualified name
     /// and "short type description" of that node. This is used when generating
     /// URLs when a type is being linked to. External paths are not located in
     /// this map because the `External` type itself has all the information
     /// necessary.
-    crate paths: FxHashMap<DefId, (Vec<Symbol>, ItemType)>,
+    pub(crate) paths: FxHashMap<DefId, (Vec<Symbol>, ItemType)>,
 
     /// Similar to `paths`, but only holds external paths. This is only used for
     /// generating explicit hyperlinks to other crates.
-    crate external_paths: FxHashMap<DefId, (Vec<Symbol>, ItemType)>,
+    pub(crate) external_paths: FxHashMap<DefId, (Vec<Symbol>, ItemType)>,
 
     /// Maps local `DefId`s of exported types to fully qualified paths.
     /// Unlike 'paths', this mapping ignores any renames that occur
@@ -54,31 +54,31 @@ crate struct Cache {
     /// to the path used if the corresponding type is inlined. By
     /// doing this, we can detect duplicate impls on a trait page, and only display
     /// the impl for the inlined type.
-    crate exact_paths: FxHashMap<DefId, Vec<Symbol>>,
+    pub(crate) exact_paths: FxHashMap<DefId, Vec<Symbol>>,
 
     /// This map contains information about all known traits of this crate.
     /// Implementations of a crate should inherit the documentation of the
     /// parent trait if no extra documentation is specified, and default methods
     /// should show up in documentation about trait implementations.
-    crate traits: FxHashMap<DefId, clean::TraitWithExtraInfo>,
+    pub(crate) traits: FxHashMap<DefId, clean::TraitWithExtraInfo>,
 
     /// When rendering traits, it's often useful to be able to list all
     /// implementors of the trait, and this mapping is exactly, that: a mapping
     /// of trait ids to the list of known implementors of the trait
-    crate implementors: FxHashMap<DefId, Vec<Impl>>,
+    pub(crate) implementors: FxHashMap<DefId, Vec<Impl>>,
 
     /// Cache of where documentation for primitives can be found.
-    crate primitive_locations: FxHashMap<clean::PrimitiveType, DefId>,
+    pub(crate) primitive_locations: FxHashMap<clean::PrimitiveType, DefId>,
 
     // Note that external items for which `doc(hidden)` applies to are shown as
     // non-reachable while local items aren't. This is because we're reusing
     // the access levels from the privacy check pass.
-    crate access_levels: AccessLevels<DefId>,
+    pub(crate) access_levels: AccessLevels<DefId>,
 
     /// Crates marked with [`#[doc(masked)]`][doc_masked].
     ///
     /// [doc_masked]: https://doc.rust-lang.org/nightly/unstable-book/language-features/doc-masked.html
-    crate masked_crates: FxHashSet<CrateNum>,
+    pub(crate) masked_crates: FxHashSet<CrateNum>,
 
     // Private fields only used when initially crawling a crate to build a cache
     stack: Vec<Symbol>,
@@ -91,7 +91,7 @@ crate struct Cache {
     // then the fully qualified name of the structure isn't presented in `paths`
     // yet when its implementation methods are being indexed. Caches such methods
     // and their parent id here and indexes them at the end of crate parsing.
-    crate orphan_impl_items: Vec<(DefId, clean::Item)>,
+    pub(crate) orphan_impl_items: Vec<(DefId, clean::Item)>,
 
     // Similarly to `orphan_impl_items`, sometimes trait impls are picked up
     // even though the trait itself is not exported. This can happen if a trait
@@ -103,7 +103,7 @@ crate struct Cache {
     orphan_trait_impls: Vec<(DefId, FxHashSet<DefId>, Impl)>,
 
     /// Cfg that have been hidden via #![doc(cfg_hide(...))]
-    crate hidden_cfg: FxHashSet<clean::cfg::Cfg>,
+    pub(crate) hidden_cfg: FxHashSet<clean::cfg::Cfg>,
 }
 
 /// This struct is used to wrap the `cache` and `tcx` in order to run `DocFolder`.

--- a/tools/bookrunner/librustdoc/formats/item_type.rs
+++ b/tools/bookrunner/librustdoc/formats/item_type.rs
@@ -25,7 +25,7 @@ use crate::clean;
 /// a heading, edit the listing in `html/render.rs`, function `sidebar_module`. This uses an
 /// ordering based on a helper function inside `item_module`, in the same file.
 #[derive(Copy, PartialEq, Eq, Hash, Clone, Debug, PartialOrd, Ord)]
-crate enum ItemType {
+pub(crate) enum ItemType {
     Module = 0,
     ExternCrate = 1,
     Import = 2,
@@ -152,7 +152,7 @@ impl From<DefKind> for ItemType {
 }
 
 impl ItemType {
-    crate fn as_str(&self) -> &'static str {
+    pub(crate) fn as_str(&self) -> &'static str {
         match *self {
             ItemType::Module => "mod",
             ItemType::ExternCrate => "externcrate",

--- a/tools/bookrunner/librustdoc/formats/mod.rs
+++ b/tools/bookrunner/librustdoc/formats/mod.rs
@@ -2,8 +2,8 @@
 //
 // Modifications Copyright Kani Contributors
 // See GitHub history for details.
-crate mod cache;
-crate mod item_type;
+pub(crate) mod cache;
+pub(crate) mod item_type;
 
 use rustc_hir::def_id::DefId;
 
@@ -11,19 +11,19 @@ use crate::clean;
 
 /// Metadata about implementations for a type or trait.
 #[derive(Clone, Debug)]
-crate struct Impl {
-    crate impl_item: clean::Item,
+pub(crate) struct Impl {
+    pub(crate) impl_item: clean::Item,
 }
 
 impl Impl {
-    crate fn inner_impl(&self) -> &clean::Impl {
+    pub(crate) fn inner_impl(&self) -> &clean::Impl {
         match *self.impl_item.kind {
             clean::ImplItem(ref impl_) => impl_,
             _ => panic!("non-impl item found in impl"),
         }
     }
 
-    crate fn trait_did(&self) -> Option<DefId> {
+    pub(crate) fn trait_did(&self) -> Option<DefId> {
         self.inner_impl().trait_.as_ref().map(|t| t.def_id())
     }
 }

--- a/tools/bookrunner/librustdoc/html/markdown.rs
+++ b/tools/bookrunner/librustdoc/html/markdown.rs
@@ -27,7 +27,7 @@ pub enum ErrorCodes {
 }
 
 impl ErrorCodes {
-    crate fn as_bool(self) -> bool {
+    pub(crate) fn as_bool(self) -> bool {
         match self {
             ErrorCodes::Yes => true,
             ErrorCodes::No => false,
@@ -253,7 +253,7 @@ enum ExtraInfoId {
 }
 
 impl<'tcx> ExtraInfo<'tcx> {
-    crate fn new(tcx: TyCtxt<'tcx>, hir_id: HirId, sp: Span) -> ExtraInfo<'tcx> {
+    pub(crate) fn new(tcx: TyCtxt<'tcx>, hir_id: HirId, sp: Span) -> ExtraInfo<'tcx> {
         ExtraInfo { id: ExtraInfoId::Hir(hir_id), sp, tcx }
     }
 
@@ -287,13 +287,13 @@ impl<'tcx> ExtraInfo<'tcx> {
 pub struct LangString {
     original: String,
     pub should_panic: bool,
-    crate no_run: bool,
+    pub(crate) no_run: bool,
     pub ignore: Ignore,
-    crate rust: bool,
-    crate test_harness: bool,
+    pub(crate) rust: bool,
+    pub(crate) test_harness: bool,
     pub compile_fail: bool,
-    crate error_codes: Vec<String>,
-    crate allow_fail: bool,
+    pub(crate) error_codes: Vec<String>,
+    pub(crate) allow_fail: bool,
     pub edition: Option<Edition>,
 }
 

--- a/tools/bookrunner/librustdoc/lib.rs
+++ b/tools/bookrunner/librustdoc/lib.rs
@@ -13,9 +13,7 @@
 #![feature(control_flow_enum)]
 #![feature(box_syntax)]
 #![feature(let_else)]
-#![feature(nll)]
 #![feature(test)]
-#![feature(crate_visibility_modifier)]
 #![feature(never_type)]
 #![feature(once_cell)]
 #![feature(type_ascription)]
@@ -94,7 +92,7 @@ mod fold;
 mod formats;
 // used by the error-index generator, so it needs to be public
 pub mod html;
-crate mod lint;
+pub(crate) mod lint;
 mod passes;
 mod scrape_examples;
 mod visit;

--- a/tools/bookrunner/librustdoc/passes/check_doc_test_visibility.rs
+++ b/tools/bookrunner/librustdoc/passes/check_doc_test_visibility.rs
@@ -46,7 +46,7 @@ impl crate::doctest::Tester for Tests {
     }
 }
 
-crate fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> bool {
+pub(crate) fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> bool {
     if !cx.cache.access_levels.is_public(item.def_id.expect_def_id())
         || matches!(
             *item.kind,
@@ -95,7 +95,7 @@ crate fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> boo
     level != lint::Level::Allow || matches!(source, LintLevelSource::Default)
 }
 
-crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
+pub(crate) fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
     let hir_id = match DocContext::as_local_hir_id(cx.tcx, item.def_id) {
         Some(hir_id) => hir_id,
         None => {

--- a/tools/bookrunner/librustdoc/passes/mod.rs
+++ b/tools/bookrunner/librustdoc/passes/mod.rs
@@ -12,7 +12,7 @@ use crate::clean::{self};
 mod check_doc_test_visibility;
 
 /// Returns a span encompassing all the given attributes.
-crate fn span_of_attrs(attrs: &clean::Attributes) -> Option<Span> {
+pub(crate) fn span_of_attrs(attrs: &clean::Attributes) -> Option<Span> {
     if attrs.doc_strings.is_empty() {
         return None;
     }

--- a/tools/bookrunner/librustdoc/scrape_examples.rs
+++ b/tools/bookrunner/librustdoc/scrape_examples.rs
@@ -8,21 +8,21 @@ use rustc_macros::{Decodable, Encodable};
 use rustc_span::edition::Edition;
 
 #[derive(Encodable, Decodable, Debug, Clone)]
-crate struct SyntaxRange {
-    crate byte_span: (u32, u32),
-    crate line_span: (usize, usize),
+pub(crate) struct SyntaxRange {
+    pub(crate) byte_span: (u32, u32),
+    pub(crate) line_span: (usize, usize),
 }
 
 #[derive(Encodable, Decodable, Debug, Clone)]
-crate struct CallLocation {
-    crate call_expr: SyntaxRange,
-    crate enclosing_item: SyntaxRange,
+pub(crate) struct CallLocation {
+    pub(crate) call_expr: SyntaxRange,
+    pub(crate) enclosing_item: SyntaxRange,
 }
 
 #[derive(Encodable, Decodable, Debug, Clone)]
-crate struct CallData {
-    crate locations: Vec<CallLocation>,
-    crate url: String,
-    crate display_name: String,
-    crate edition: Edition,
+pub(crate) struct CallData {
+    pub(crate) locations: Vec<CallLocation>,
+    pub(crate) url: String,
+    pub(crate) display_name: String,
+    pub(crate) edition: Edition,
 }

--- a/tools/bookrunner/librustdoc/visit.rs
+++ b/tools/bookrunner/librustdoc/visit.rs
@@ -4,7 +4,7 @@
 // See GitHub history for details.
 use crate::clean::*;
 
-crate trait DocVisitor: Sized {
+pub(crate) trait DocVisitor: Sized {
     fn visit_item(&mut self, item: &Item) {
         self.visit_item_recur(item)
     }

--- a/tools/bookrunner/librustdoc/visit_ast.rs
+++ b/tools/bookrunner/librustdoc/visit_ast.rs
@@ -15,23 +15,23 @@ use crate::clean::{AttributesExt, NestedAttributesExt};
 /// This module is used to store stuff from Rust's AST in a more convenient
 /// manner (and with prettier names) before cleaning.
 #[derive(Debug)]
-crate struct Module<'hir> {
-    crate name: Symbol,
-    crate where_inner: Span,
-    crate mods: Vec<Module<'hir>>,
-    crate id: hir::HirId,
+pub(crate) struct Module<'hir> {
+    pub(crate) name: Symbol,
+    pub(crate) where_inner: Span,
+    pub(crate) mods: Vec<Module<'hir>>,
+    pub(crate) id: hir::HirId,
     // (item, renamed)
-    crate items: Vec<(&'hir hir::Item<'hir>, Option<Symbol>)>,
-    crate foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Symbol>)>,
+    pub(crate) items: Vec<(&'hir hir::Item<'hir>, Option<Symbol>)>,
+    pub(crate) foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Symbol>)>,
 }
 
 impl Module<'_> {
-    crate fn where_outer(&self, tcx: TyCtxt<'_>) -> Span {
+    pub(crate) fn where_outer(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.hir().span(self.id)
     }
 }
 
-crate fn inherits_doc_hidden(tcx: TyCtxt<'_>, mut node: hir::HirId) -> bool {
+pub(crate) fn inherits_doc_hidden(tcx: TyCtxt<'_>, mut node: hir::HirId) -> bool {
     while let Some(id) = tcx.hir().get_enclosing_scope(node) {
         node = id;
         if tcx.hir().attrs(node).lists(sym::doc).has_word(sym::hidden) {


### PR DESCRIPTION
### Description of changes: 

Sync

### Resolved issues:

Resolves #1254 

### Call-outs:

1. Rustdoc changes were annoying us again.
2. Instead of fixing something in rustdoc I replaced it with `unreachable!()`
3. `layout.might_permit_raw_init` developed a `strict` flag that does additional checking. I'm not sure if we want to use it or not. Not using it preserves the old behavior, so is "safe" but maybe it's something we want to take advantage of.
4. `TerminatorKind::Call` went from having a `Option<Place, BasicBlock>` to a `(Place, Option<BasicBlock>)`. In other words: we always have a `Place` to store the results of a function call (and only optionally, for terminating functions, have a "next basic block" after the call). This is a nice clean up of a lot of code, but:
  * In `codegen_drop` we called our hooks with `None` as the `Place` and now we need to always have one.
  * But this code was apparently dead, since we no longer hook drops! So, I removed that code to solve that problem.
  * But in the future we'd probably just need to make up a temporary somehow, if we wanted to restore that hook. I wasn't sure how, so I preferred to remove the code.
5. There are new sub-categories of pointer casts that got factored out of "misc" casts. These are "ptr -> int" and "int -> ptr". It might be interesting for us to codegen/instrument these differently?

### Testing:

* How is this change tested? existing regression suite

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
