### PR TITLE
Switch to using cargo-deny

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,9 +1,8 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-# A temporary, non-required workflow to notify us when cargo-audit has things to say.
-# TODO: Remove this, and make cargo-audit part of release automation (when we have it) instead.
-# And maybe also figure out why dependabot wasn't notifying us. :(
+# 1. Checks licenses for allowed license.
+# 2. Checks Rust-Sec registry for security advisories.
 
 name: Cargo Audit
 on: [pull_request]
@@ -13,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/audit-check@v1
+      - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          arguments: --all-features --workspace
+          command-arguments: -s

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,54 @@
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "deny"
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+default = "deny"
+unlicensed = "deny"
+copyleft = "deny"
+allow = [
+    "MIT",
+    "Apache-2.0",
+]
+allow-osi-fsf-free = "neither"
+confidence-threshold = 0.8
+
+# All these exceptions should probably appear in: tools/make-kani-release/license-notes.txt
+exceptions = [
+    { name = "instant", allow=["BSD-3-Clause"] },
+    { name = "Inflector", allow=["BSD-2-Clause"] },
+]
+
+[licenses.private]
+ignore = false
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,6 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html

--- a/tools/bookrunner/Cargo.toml
+++ b/tools/bookrunner/Cargo.toml
@@ -5,6 +5,7 @@
 name = "bookrunner"
 version = "0.1.0"
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 Inflector = "0.11.4"

--- a/tools/bookrunner/librustdoc/Cargo.toml
+++ b/tools/bookrunner/librustdoc/Cargo.toml
@@ -6,6 +6,13 @@
 name = "rustdoc"
 version = "0.0.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
+# From upstream librustdoc:
+# https://github.com/rust-lang/rust/tree/master/src/librustdoc
+# Upstream crate does not list license but Rust statues:
+#   Rust is primarily distributed under the terms of both the MIT
+#   license and the Apache License (Version 2.0), with portions
+#   covered by various BSD-like licenses.
 
 [lib]
 path = "lib.rs"

--- a/tools/compiletest/Cargo.toml
+++ b/tools/compiletest/Cargo.toml
@@ -7,6 +7,13 @@
 name = "compiletest"
 version = "0.0.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
+# From upstream compiletest:
+# https://github.com/rust-lang/rust/tree/master/src/tools/compiletest
+# Upstream crate does not list license but Rust statues:
+#   Rust is primarily distributed under the terms of both the MIT
+#   license and the Apache License (Version 2.0), with portions
+#   covered by various BSD-like licenses.
 
 [dependencies]
 getopts = "0.2"

--- a/tools/make-kani-release/license-notes.txt
+++ b/tools/make-kani-release/license-notes.txt
@@ -20,6 +20,8 @@ Acknowledgement:
 cbmc-viewer: https://github.com/model-checking/cbmc-viewer
 License: Apache-2.0
 
+## Notable Python dependencies
+
 colorama: https://github.com/tartley/colorama
 License: BSD-3-Clause
 
@@ -29,8 +31,13 @@ License: BSD-3-Clause
 jinja2: https://github.com/pallets/jinja
 License: BSD-3-Clause
 
-setuptools: https://github.com/pypa/setuptools
-License: MIT
-
 MarkupSafe: https://github.com/pallets/markupsafe
 License: BSD-3-Clause
+
+## Notable Rust crate dependencies
+
+instant: https://github.com/sebcrozet/instant
+License: BSD-3-Clause
+
+Inflector: https://github.com/whatisinternet/inflector
+License: BSD-2-Clause


### PR DESCRIPTION
### Description of changes: 

1. Switch to using `cargo-deny` instead of `cargo-audit`. It can do the same role and more.
2. Add an explicit allow-list for licenses we use in our Rust code.
3. Add 2 crates to our license note file.
4. Organize and clean up the license note file a bit.
5. Add `license` field to crates in our repo.

### Resolved issues:

Resolves #1237 

### Call-outs:

* This rather nicely allows us to audit licenses for our whole workspace, so we can remove `cargo-license` from our release runbook.
* I'm going to separately write up a doc about scancode, as I think with this we can remove that from our regular release runbook as well.

### Testing:

* How is this change tested? ci

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
