### PR TITLE
docs: add uninit mem to UB list

### DIFF
--- a/docs/src/undefined-behaviour.md
+++ b/docs/src/undefined-behaviour.md
@@ -38,6 +38,8 @@ A non-exhaustive list of these, based on the non-exhaustive list from the [Rust 
     * Kani provides a [mechanism](./tutorial-nondeterministic-variables.md#safe-nondeterministic-variables-for-custom-types) `is_valid()` which users can use to check validity of objects, but it does not currently apply to all types.
 * Incorrect use of inline assembly.
     * Kani does not support inline assembly.
+* Using uninitialized memory.
+    * See the corresponding section in our [Rust feature support](./rust-feature-support.md#uninitialized-memory).
 
 Kani makes a best-effort attempt to detect some cases of UB:
 * Evaluating a dereference expression (`*expr`) on a raw pointer that is dangling or unaligned.


### PR DESCRIPTION
The Kani docs for undefined behavior previously did not mention [uninitialized memory](https://doc.rust-lang.org/nomicon/uninitialized.html). This change adds it.

### Testing:
I built the docs and tested that the link works.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix