### PR TITLE
Detect VSCode Remote-SSH when using --visualize

### DIFF
--- a/docs/src/cheat-sheets.md
+++ b/docs/src/cheat-sheets.md
@@ -111,15 +111,6 @@ git submodule update --init
 ```
 
 ```bash
-# Done with that PR, time for a new one?
-git switch main
-git pull origin
-git submodule update --init
-cd src/kani-compiler
-cargo build --workspace
-```
-
-```bash
 # Need to update local branch (e.g. for an open pull request?)
 git fetch origin
 git merge origin/main
@@ -134,16 +125,20 @@ git switch pr/$ID
 ```
 
 ```bash
+# Push to someone else's pull request
+git origin add $USER $GIR_URL_FOR_THAT_USER
+git push $USER $LOCAL_BRANCH:$THEIR_PR_BRANCH_NAME
+```
+
+```bash
 # Search only git-tracked files
 git grep codegen_panic
 ```
 
 ```bash
-# See all commits that are part of Kani, not part of Rust
-git log --graph --oneline origin/upstream-rustc..origin/main
-```
-
-```bash
-# See all files modified by Kani (compared to upstream Rust)
-git diff --stat origin/upstream-rustc..origin/main
+# Accidentally commit to main?
+# "Move" commit to a branch:
+git checkout -b my_branch
+# Fix main:
+git branch --force main origin/main
 ```

--- a/kani-driver/src/call_cbmc_viewer.rs
+++ b/kani-driver/src/call_cbmc_viewer.rs
@@ -75,7 +75,7 @@ impl KaniSession {
                 && std::env::var("SSH_CONNECTION").is_ok()
             {
                 println!(
-                    "VSCode Remote-SSH port forwards for you. Try:  python3 -m http.server --directory {}/html",
+                    "VS Code automatically forwards ports for locally hosted servers. To view the report remotely,\nTry:  python3 -m http.server --directory {}/html",
                     report_dir.to_string_lossy()
                 );
             }

--- a/kani-driver/src/call_cbmc_viewer.rs
+++ b/kani-driver/src/call_cbmc_viewer.rs
@@ -70,6 +70,15 @@ impl KaniSession {
         // Let the user know
         if !self.args.quiet {
             println!("Report written to: {}/html/index.html", report_dir.to_string_lossy());
+            // If using VS Code with Remote-SSH, suggest an option for remote viewing:
+            if std::env::var("VSCODE_IPC_HOOK_CLI").is_ok()
+                && std::env::var("SSH_CONNECTION").is_ok()
+            {
+                println!(
+                    "VSCode Remote-SSH port forwards for you. Try:  python3 -m http.server --directory {}/html",
+                    report_dir.to_string_lossy()
+                );
+            }
         }
 
         Ok(())


### PR DESCRIPTION
### Description of changes: 

Add a quick suggestion for how to view a visualize report when using VS Code Remote-SSH.

* I also updated some of the cheat-sheets in docs. I:
  * Removed old cheat sheets that aren't relevant now that we're not a fork
  * Added a new one reminding how to fix "I committed to main"

### Resolved issues:

Resolves #1263


### Call-outs:

See it in action:

![Screen Shot 2022-06-20 at 5 18 40 PM](https://user-images.githubusercontent.com/1508333/174683965-886089b5-5e30-4763-bec6-2c9a27dd190f.png)


### Testing:

* How is this change tested? Manually - We could check for the appearance of this line, but it's not a meaningful test.

* Is this a refactor change? no

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
