### PR TITLE
Add doc section on debugging Kani in VS code

### DIFF
--- a/docs/src/rustc-hacks.md
+++ b/docs/src/rustc-hacks.md
@@ -33,6 +33,25 @@ You may also need to install the `rustc-dev` package using rustup
 rustup toolchain install nightly --component rustc-dev
 ```
 
+#### Debugging in VS code
+
+To debug Kani in VS code, first install the [CodeLLDB extension](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).
+Then add the following lines at the start of the `main` function (see [the CodeLLDB manual](https://github.com/vadimcn/vscode-lldb/blob/master/MANUAL.md#attaching-debugger-to-the-current-process-rust) for details):
+
+```rust
+{
+    let url = format!(
+        "vscode://vadimcn.vscode-lldb/launch/config?{{'request':'attach','sourceLanguages':['rust'],'waitFor':true,'pid':{}}}",
+        std::process::id()
+    );
+    std::process::Command::new("code").arg("--open-url").arg(url).output().unwrap();
+}
+```
+
+Note that pretty printing for the Rust nightly toolchain (which Kani uses) is not very good as of June 2022.
+For example, a vector may be displayed as `vec![{...}, {...}]` on nightly Rust, when it would be displayed as `vec![Some(0), None]` on stable Rust.
+Hopefully, this will be fixed soon.
+
 ### CLion / IntelliJ
 This is not a great solution, but it works for now (see <https://github.com/intellij-rust/intellij-rust/issues/1618>
 for more details).


### PR DESCRIPTION
### Description of changes: 

This adds documentation on how to use the VS code debugger on Kani.

### Call-outs:

It was not able to get to launch the executable at the same time as the debugger, hence I settled for adding the code to Kani, which calls the VS code debugger.

### Testing:

* How is this change tested? Manual test

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
