### PR TITLE
Add script to replace tags in GotoC output with type names

### DIFF
--- a/docs/src/cheat-sheets.md
+++ b/docs/src/cheat-sheets.md
@@ -72,7 +72,12 @@ kani --keep-temps file.rs
 # Generate "C code" from CBMC IR (.c)
 kani --gen-c file.rs
 ```
-
+```bash
+# "Demangle" the tags in the "C code" (file.out.c) with the Rust type names (file.type_map.json).
+# The result is written to file.out.demangled.c
+# This makes reading the generated C code much easier.
+demangle.py file
+```
 ## CBMC
 
 ```bash

--- a/scripts/demangle.py
+++ b/scripts/demangle.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+"""This small script replaces the tags in GotoC code with the proper Rust type names.
+
+This makes understanding the C code much easier and can help with debugging.
+"""
+
+import json
+import sys
+
+if __name__ == "__main__":
+    if len(sys.argv) < 1 or sys.argv[1] in ["-h", "--help"]:
+        print("Usage: demangle.py file")
+        print("This will replace the tags in `file.out.c` with the type names from `file.type_map.json`.")
+        print("The output will be written to `file.out.demangled.c`.")
+        sys.exit(0)
+    name = sys.argv[1]
+    if name.endswith(".rs"):
+        name = name[:-3]
+    with open(f"{name}.type_map.json") as tyfile:
+        typemap = json.load(tyfile)
+    with open(f"{name}.out.c") as cfile:
+        code = cfile.read()
+    for tag, typename in typemap.items():
+        if tag.startswith("tag-"):
+            tag = tag[4:]
+            code = code.replace(tag, typename)
+        else:
+            print(f"Unexpected tag: {tag} does not start with 'tag-'.", file=sys.stderr)
+    with open(f"{name}.out.demangled.c", "w") as outfile:
+        outfile.write(code)
+        print(f"Demangled output written to `{outfile.name}`.")


### PR DESCRIPTION
### Description of changes: 

This adds a Python script to replace the tags in the GotoC output file `file.out.c` with the Rust type names from `file.type_map.json` and writes the result to `file.demangled.c`.
The resulting "demangled" file is much easier to read and helps with debugging.
I also added documentation in the command cheat sheets.

### Call-outs:

Do we need to update the docs anywhere else? I think this was the only place that GotoC output was mentioned.

### Testing:

* How is this change tested? Manually. Since this is only a convenience script for developers, no automated testing seems necessary.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
