### PR TITLE
Add cache to codegen_ty

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -139,7 +139,7 @@ impl CodegenBackend for GotocCodegenBackend {
 
         // Map MIR types to GotoC types
         let type_map: BTreeMap<InternedString, InternedString> =
-            BTreeMap::from_iter(c.type_map.into_iter().map(|(k, v)| (k, v.to_string().into())));
+            BTreeMap::from_iter(c.tag_map.into_iter().map(|(k, v)| (k, v.to_string().into())));
 
         // Get the vtable function pointer restrictions if requested
         let vtable_restrictions = if c.vtable_ctx.emit_vtable_restrictions {

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -57,7 +57,10 @@ pub struct GotocCtx<'tcx> {
     /// map (trait, method) pairs to possible implementations
     pub vtable_ctx: VtableCtx,
     pub current_fn: Option<CurrentFnCtx<'tcx>>,
-    pub type_map: FxHashMap<InternedString, Ty<'tcx>>,
+    /// Store the goto-c tag generated while generating a given type.
+    pub tag_map: FxHashMap<InternedString, Ty<'tcx>>,
+    /// Reverse map from `type_map` which allow us to cache the codegen type result.
+    pub type_map: FxHashMap<Ty<'tcx>, Type>,
     pub proof_harnesses: Vec<HarnessMetadata>,
     /// a global counter for generating unique IDs for checks
     pub global_checks_count: u64,
@@ -82,6 +85,7 @@ impl<'tcx> GotocCtx<'tcx> {
             alloc_map: FxHashMap::default(),
             vtable_ctx: VtableCtx::new(emit_vtable_restrictions),
             current_fn: None,
+            tag_map: FxHashMap::default(),
             type_map: FxHashMap::default(),
             proof_harnesses: vec![],
             global_checks_count: 0,

--- a/kani-compiler/src/codegen_cprover_gotoc/context/vtable_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/vtable_ctx.rs
@@ -120,7 +120,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // We only have the Gotoc type, we need to normalize to match the MIR type.
         // Retrieve the MIR for `&dyn T` and normalize the name.
         assert!(trait_ref.is_struct_tag());
-        let trait_ref_mir_type = self.type_map.get(&trait_ref.tag().unwrap()).unwrap();
+        let trait_ref_mir_type = self.tag_map.get(&trait_ref.tag().unwrap()).unwrap();
         let trait_name = self.normalized_trait_name(pointee_type(*trait_ref_mir_type).unwrap());
 
         // Label


### PR DESCRIPTION
### Description of changes: 

Avoid codegening the same types over and over again by adding a simple cache.

### Resolved issues:

N/A

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing tests

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
