### PR TITLE
Bump to CBMC 5.60

### DIFF
--- a/docs/src/build-from-source.md
+++ b/docs/src/build-from-source.md
@@ -11,8 +11,8 @@ In general, the following dependencies are required to build Kani from source.
 > below and don't need to be manually installed.
 
 1. Cargo installed via [rustup](https://rustup.rs/)
-2. [CBMC](https://github.com/diffblue/cbmc) (>= 5.59.0)
-3. [CBMC Viewer](https://github.com/awslabs/aws-viewer-for-cbmc) (>= 3.2)
+2. [CBMC](https://github.com/diffblue/cbmc) (latest release)
+3. [CBMC Viewer](https://github.com/awslabs/aws-viewer-for-cbmc) (latest release)
 
 Kani has been tested in [Ubuntu](#install-dependencies-on-ubuntu) and [macOS](##install-dependencies-on-macos) platforms.
 

--- a/scripts/setup/ubuntu/install_cbmc.sh
+++ b/scripts/setup/ubuntu/install_cbmc.sh
@@ -5,7 +5,7 @@
 set -eu
 
 UBUNTU_VERSION=$(lsb_release -rs)
-CBMC_VERSION=5.59.0
+CBMC_VERSION=5.60.0
 FILE="ubuntu-${UBUNTU_VERSION}-cbmc-${CBMC_VERSION}-Linux.deb"
 URL="https://github.com/diffblue/cbmc/releases/download/cbmc-${CBMC_VERSION}/$FILE"
 


### PR DESCRIPTION
### Description of changes: 

1. Bump
2. Deliberately did not bump the "minimum version check" - no observable changes to cbmc this week
3. "latest release" in build from source docs, instead of specific numbers
4. macos build was already picking up 5.60

### Resolved issues:



### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? ci

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
