### PR TITLE
[DRAFT] Support MMIO regions

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -405,16 +405,3 @@ fn extract_integer_argument(attr: &Attribute) -> Option<u128> {
         None
     }
 }
-
-// /// Extracts the integer value argument from the attribute provided
-// /// For example, `unwind(8)` return `Some(8)`
-// fn extract_integer_arguments(attr: &Attribute) -> Result<Vec<u128>, String> {
-//     // Vector of meta items , that contain the arguments given the attribute
-//     let attr_args = attr.meta_item_list().unwrap;
-//     Ok(attr_args.iter().map(|a| {
-//         match a.literal()?.kind {
-//             LitKind::Int(y, ..) => Some(y),
-//             _ => None,
-//         }
-//     }).collect())
-// }

--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -95,12 +95,18 @@ impl KaniSession {
             args.push(unwind_value.to_string().into());
         }
 
+        if !harness_metadata.mmio_regions.is_empty() {
+            for (start, len) in &harness_metadata.mmio_regions {
+                args.push("--mmio-regions".into());
+                args.push(format!("{}:{}", start, len).into());
+            }
+        }
+
         args.push("--slice-formula".into());
 
         args.extend(self.args.cbmc_args.iter().cloned());
 
         args.push(file.to_owned().into_os_string());
-
         Ok(args)
     }
 

--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -96,10 +96,14 @@ impl KaniSession {
         }
 
         if !harness_metadata.mmio_regions.is_empty() {
-            for (start, len) in &harness_metadata.mmio_regions {
-                args.push("--mmio-regions".into());
-                args.push(format!("{}:{}", start, len).into());
-            }
+            args.push("--mmio-regions".into());
+            let mmio_string = harness_metadata
+                .mmio_regions
+                .iter()
+                .map(|(s, l)| format!("{}:{}", s, l))
+                .collect::<Vec<String>>()
+                .join(",");
+            args.push(mmio_string.into());
         }
 
         args.push("--slice-formula".into());

--- a/kani-driver/src/metadata.rs
+++ b/kani-driver/src/metadata.rs
@@ -147,6 +147,7 @@ pub fn mock_proof_harness(name: &str, unwind_value: Option<u32>) -> HarnessMetad
         original_file: "<unknown>".into(),
         original_line: "<unknown>".into(),
         unwind_value,
+        mmio_regions: vec![],
     }
 }
 

--- a/kani_metadata/src/harness.rs
+++ b/kani_metadata/src/harness.rs
@@ -16,4 +16,6 @@ pub struct HarnessMetadata {
     pub original_line: String,
     /// Optional data to store unwind value
     pub unwind_value: Option<u32>,
+    /// Optional MMIO regions
+    pub mmio_regions: Vec<(u128, u128)>,
 }

--- a/library/kani_macros/src/lib.rs
+++ b/library/kani_macros/src/lib.rs
@@ -73,3 +73,26 @@ pub fn unwind(attr: TokenStream, item: TokenStream) -> TokenStream {
     result.extend(item);
     result
 }
+
+#[cfg(not(kani))]
+#[proc_macro_attribute]
+pub fn mmio_region(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    // When the config is not kani, we should leave the function alone
+    item
+}
+
+/// Set Loop unwind limit for proof harnesses
+/// The attribute '#[kani::unwind(arg)]' can only be called alongside '#[kani::proof]'.
+/// arg - Takes in a integer value (u32) that represents the unwind value for the harness.
+#[cfg(kani)]
+#[proc_macro_attribute]
+pub fn mmio_region(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut result = TokenStream::new();
+
+    // Translate #[kani::unwind(arg)] to #[kanitool::unwind(arg)]
+    let insert_string = "#[kanitool::mmio_region(".to_owned() + &attr.clone().to_string() + ")]";
+    result.extend(insert_string.parse::<TokenStream>().unwrap());
+
+    result.extend(item);
+    result
+}

--- a/tests/expected/mmio/expected
+++ b/tests/expected/mmio/expected
@@ -1,0 +1,26 @@
+Status: SUCCESS\
+Description: "offset: attempt to compute number in bytes which would overflow"
+
+Status: SUCCESS\
+Description: "attempt to compute offset which would overflow"
+
+Status: FAILURE\
+Description: "dereference failure: pointer NULL"
+
+Status: SUCCESS
+Description: "dereference failure: pointer invalid"
+
+Status: FAILURE\
+Description: "dereference failure: deallocated dynamic object"
+
+Status: FAILURE\
+Description: "dereference failure: dead object"
+
+Status: FAILURE\
+Description: "dereference failure: pointer outside object bounds"
+
+Status: FAILURE\
+Description: "dereference failure: invalid integer address"
+
+Status: FAILURE\
+Description: "dereference failure: invalid integer address"

--- a/tests/expected/mmio/main.rs
+++ b/tests/expected/mmio/main.rs
@@ -1,0 +1,19 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+const BUFFER: *mut u32 = 0x8000 as *mut u32;
+const BUFFER2: *mut u32 = 0x1000 as *mut u32;
+
+#[cfg(kani)]
+#[kani::proof]
+#[kani::mmio_region(0x8000, 8)]
+fn test_write() {
+    let val = 12;
+    unsafe {
+        //BUFFER+2 is not in the MMIO region. Expect pointer check failures.
+        *(BUFFER.offset(2)) = val;
+        //BUFFER2 is not in the MMIO region. Expect pointer check failures.
+        *BUFFER2 = val;
+
+    }
+}

--- a/tests/expected/mmio/main.rs
+++ b/tests/expected/mmio/main.rs
@@ -14,6 +14,5 @@ fn test_write() {
         *(BUFFER.offset(2)) = val;
         //BUFFER2 is not in the MMIO region. Expect pointer check failures.
         *BUFFER2 = val;
-
     }
 }

--- a/tests/kani/MMIO/semantics.rs
+++ b/tests/kani/MMIO/semantics.rs
@@ -1,0 +1,63 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+const BUFFER: *mut u32 = 0x8000 as *mut u32;
+
+#[cfg(kani)]
+#[kani::proof]
+#[kani::mmio_region(0x8000, 4)]
+fn test_read_after_write_doesnt_havoc() {
+    let val = 12;
+    unsafe {
+        core::ptr::write_volatile(BUFFER, val);
+        let new_val = core::ptr::read_volatile(BUFFER);
+        assert_eq!(new_val, val);
+    }
+}
+
+#[cfg(kani)]
+#[kani::proof]
+#[kani::mmio_region(0x8000, 4)]
+fn test_read_is_stable() {
+    unsafe {
+        let val1 = core::ptr::read_volatile(BUFFER);
+        let val2 = core::ptr::read_volatile(BUFFER);
+        assert_eq!(val1, val2);
+    }
+}
+
+//TODO Weirdly, these fail even tho the other tests pass???
+#[cfg(kani)]
+#[kani::proof]
+#[kani::mmio_region(0x8000, 16)]
+fn test_writes_dont_alias() {
+    let val1 = 42;
+    let val2 = 314;
+    unsafe {
+        let p1 = BUFFER;
+        let p2 = BUFFER.offset(2);
+        core::ptr::write_volatile(p1, val1);
+        core::ptr::write_volatile(p2, val2);
+        assert_eq!(core::ptr::read_volatile(p1), val1);
+        assert_eq!(core::ptr::read_volatile(p2), val2);
+    }
+}
+
+//TODO Weirdly, these fail even tho the other tests pass???
+#[cfg(kani)]
+#[kani::proof]
+#[kani::mmio_region(0x8000, 16)]
+fn test_writes_dont_alias2() {
+    let val1 = 42;
+    let val2 = 314;
+    unsafe {
+        let p1 = BUFFER;
+        let p2 = BUFFER.offset(2);
+        *p1 = val1;
+        *p2 = val2;
+        assert_eq!(*p1, val1);
+        assert_eq!(*p2, val2);
+        assert_eq!(*p2, val1);
+        assert_eq!(*p1, val2);
+    }
+}

--- a/tests/kani/MMIO/test.rs
+++ b/tests/kani/MMIO/test.rs
@@ -26,3 +26,15 @@ fn test_write2() {
 
     }
 }
+
+#[cfg(kani)]
+#[kani::proof]
+#[kani::mmio_region(0x8000, 8)]
+/// Check that larger MMIO regions also work
+fn test_write3() {
+    let val = 12;
+    unsafe {
+        *BUFFER = val;
+        *(BUFFER.offset(1)) = val;
+    }
+}

--- a/tests/kani/MMIO/test.rs
+++ b/tests/kani/MMIO/test.rs
@@ -23,7 +23,6 @@ fn test_write2() {
     unsafe {
         core::ptr::write_volatile(BUFFER, val);
         core::ptr::write_volatile(BUFFER2, val);
-
     }
 }
 

--- a/tests/kani/MMIO/test.rs
+++ b/tests/kani/MMIO/test.rs
@@ -1,11 +1,12 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#[cfg(kani)]
-const BUFFER: *mut u32 = 0xb8000 as *mut u32;
+const BUFFER: *mut u32 = 0x8000 as *mut u32;
+const BUFFER2: *mut u32 = 0x1000 as *mut u32;
 
+#[cfg(kani)]
 #[kani::proof]
-#[kani::mmio_region(0xb8000, 4)]
+#[kani::mmio_region(0x8000, 4)]
 fn test_write() {
     let val = 12;
     unsafe {
@@ -13,15 +14,15 @@ fn test_write() {
     }
 }
 
-// #[cfg(kani)]
-// #[kani::proof]
-// #[kani::mmio_region(0xb8000, 4)]
-// #[kani::mmio_region(0xbF000, 4)]
-// fn test_write2() {
-//     let val = 12;
-//     unsafe {
-//         core::ptr::write_volatile(BUFFER, val);
-//         core::ptr::write_volatile(BUFFER2, val);
+#[cfg(kani)]
+#[kani::proof]
+#[kani::mmio_region(0x8000, 4)]
+#[kani::mmio_region(0x1000, 4)]
+fn test_write2() {
+    let val = 12;
+    unsafe {
+        core::ptr::write_volatile(BUFFER, val);
+        core::ptr::write_volatile(BUFFER2, val);
 
-//     }
-// }
+    }
+}

--- a/tests/kani/MMIO/test.rs
+++ b/tests/kani/MMIO/test.rs
@@ -1,0 +1,27 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#[cfg(kani)]
+const BUFFER: *mut u32 = 0xb8000 as *mut u32;
+
+#[kani::proof]
+#[kani::mmio_region(0xb8000, 4)]
+fn test_write() {
+    let val = 12;
+    unsafe {
+        core::ptr::write_volatile(BUFFER, val);
+    }
+}
+
+// #[cfg(kani)]
+// #[kani::proof]
+// #[kani::mmio_region(0xb8000, 4)]
+// #[kani::mmio_region(0xbF000, 4)]
+// fn test_write2() {
+//     let val = 12;
+//     unsafe {
+//         core::ptr::write_volatile(BUFFER, val);
+//         core::ptr::write_volatile(BUFFER2, val);
+
+//     }
+// }


### PR DESCRIPTION
### Description of changes: 

Adds support for MMIO regions to kani proof harnesses.

### Resolved issues:

Resolves #1304 

### Call-outs:

- [ ] This is dependent on https://github.com/diffblue/cbmc/pull/6747. It will not work until that is released. I tested against a locally built copy.
- [ ] We need documentation for this feature
- [x] Should probably add some negative tests too
- [ ] Should test that it behaves like MMIO: writes don't need to be the same as is read back, two reads can get different values

### Testing:

* How is this change tested? New regression tests.

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
