### PR TITLE
feat: POC for kani compiler changes

### DIFF
--- a/kani-compiler/build.rs
+++ b/kani-compiler/build.rs
@@ -18,7 +18,7 @@ macro_rules! path_str {
 }
 
 /// Build the target library, and setup cargo to rerun them if the source has changed.
-fn setup_lib(out_dir: &str, lib_out: &str, lib: &str) {
+fn setup_lib(target_dir: &str, out_dir: &str, lib: &str) {
     let kani_lib = vec!["..", "library", lib];
     println!("cargo:rerun-if-changed={}", path_str!(kani_lib));
 
@@ -30,9 +30,11 @@ fn setup_lib(out_dir: &str, lib_out: &str, lib: &str) {
         &path_str!(kani_lib_toml),
         "-Z",
         "unstable-options",
-        "--out-dir",
-        lib_out,
+        // Generated artifacts go here
         "--target-dir",
+        &target_dir,
+        // Copy final artifacts here
+        "--out-dir",
         out_dir,
     ];
     let result = Command::new("cargo")
@@ -60,10 +62,12 @@ pub fn main() {
     println!("cargo:rustc-link-arg-bin=kani-compiler=-Wl,-rpath,{}/../toolchain/lib", origin);
 
     // Compile kani library and export KANI_LIB_PATH variable with its relative location.
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let lib_out = path_str!([&out_dir, "lib"]);
-    setup_lib(&out_dir, &lib_out, "kani");
-    setup_lib(&out_dir, &lib_out, "kani_macros");
-    setup_lib(&out_dir, &lib_out, "std");
-    println!("cargo:rustc-env=KANI_LIB_PATH={}", lib_out);
+    let target_dir = env::var("OUT_DIR").unwrap();
+    let out_dir = path_str!([&target_dir, "lib"]);
+    let out_dir_kani = path_str!([&out_dir, "kani"]);
+    let out_dir_std = path_str!([&out_dir, "std"]);
+    setup_lib(&target_dir, &out_dir_kani, "kani");
+    setup_lib(&target_dir, &out_dir_kani, "kani_macros");
+    setup_lib(&target_dir, &out_dir_std, "std");
+    println!("cargo:rustc-env=KANI_LIB_PATH={}", out_dir);
 }

--- a/kani-compiler/src/main.rs
+++ b/kani-compiler/src/main.rs
@@ -39,14 +39,9 @@ use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::rc::Rc;
 
-/// This function generates all rustc configurations required by our goto-c codegen.
-fn rustc_gotoc_flags(lib_path: &str) -> Vec<String> {
-    // The option below provides a mechanism by which definitions in the
-    // standard library can be overriden. See
-    // https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20Globally.20override.20an.20std.20macro/near/268873354
-    // for more details.
-    let kani_std_rlib = PathBuf::from(lib_path).join("libstd.rlib");
-    let kani_std_wrapper = format!("noprelude:std={}", kani_std_rlib.to_str().unwrap());
+/// This function generates all baseline args for running Kani code.
+fn base_kani_args() -> Vec<String> {
+    // TODO: We might not need all these flags for exec_trace
     let args = vec![
         "-C",
         "overflow-checks=on",
@@ -65,14 +60,41 @@ fn rustc_gotoc_flags(lib_path: &str) -> Vec<String> {
         "crate-attr=feature(register_tool)",
         "-Z",
         "crate-attr=register_tool(kanitool)",
+    ];
+    args.iter().map(|s| s.to_string()).collect()
+}
+
+/// This function adds Kani library args.
+fn kani_library_args(lib_path: &str) -> Vec<String> {
+    // The option below provides a mechanism by which definitions in the
+    // standard library can be overriden. See
+    // https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20Globally.20override.20an.20std.20macro/near/268873354
+    // for more details.
+    let mut base_args = base_kani_args();
+    let lib_path_kani: PathBuf = [lib_path, "kani"].iter().collect();
+    let kani_std_rlib: PathBuf = [lib_path, "std", "libstd.rlib"].iter().collect();
+    let kani_std_wrapper = format!("noprelude:std={}", kani_std_rlib.to_str().unwrap());
+    let args = vec![
         "-L",
-        lib_path,
+        lib_path_kani.to_str().unwrap(),
         "--extern",
         "kani",
         "--extern",
         kani_std_wrapper.as_str(),
     ];
-    args.iter().map(|s| s.to_string()).collect()
+    let mut all_args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    all_args.append(&mut base_args);
+    all_args
+}
+
+/// This function adds args for the Kani lib, but not the Kani std macros.
+fn exec_trace_args(lib_path: &str) -> Vec<String> {
+    let mut base_args = base_kani_args();
+    let lib_path_kani: PathBuf = [lib_path, "kani"].iter().collect();
+    let args = vec!["-L", lib_path_kani.to_str().unwrap(), "--extern", "kani"];
+    let mut all_args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    all_args.append(&mut base_args);
+    all_args
 }
 
 /// Main function. Configure arguments and run the compiler.
@@ -118,10 +140,14 @@ impl Callbacks for KaniCallbacks {}
 
 /// Generate the arguments to pass to rustc_driver.
 fn generate_rustc_args(args: &ArgMatches) -> Vec<String> {
-    let mut gotoc_args =
-        rustc_gotoc_flags(args.value_of(parser::KANI_LIB).unwrap_or(std::env!("KANI_LIB_PATH")));
+    // TODO: Re-order funcs inside this file
     let mut rustc_args = vec![String::from("rustc")];
+    let kani_lib_path = &args.value_of(parser::KANI_LIB).unwrap_or(std::env!("KANI_LIB_PATH"));
     if args.is_present(parser::GOTO_C) {
+        let mut gotoc_args = kani_library_args(kani_lib_path);
+        rustc_args.append(&mut gotoc_args);
+    } else if args.is_present(parser::EXEC_TRACE) {
+        let mut gotoc_args = exec_trace_args(kani_lib_path);
         rustc_args.append(&mut gotoc_args);
     }
 

--- a/kani-compiler/src/parser.rs
+++ b/kani-compiler/src/parser.rs
@@ -13,6 +13,9 @@ pub const LOG_LEVEL: &str = "log-level";
 /// Option name used to enable goto-c compilation.
 pub const GOTO_C: &str = "goto-c";
 
+/// Option name to use exec trace version of libs
+pub const EXEC_TRACE: &'static str = "exec-trace";
+
 /// Option name used to override Kani library path.
 pub const KANI_LIB: &str = "kani-lib";
 
@@ -68,6 +71,11 @@ pub fn parser<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name(GOTO_C)
                 .long("--goto-c")
                 .help("Enables compilation to goto-c intermediate representation."),
+        )
+        .arg(
+            Arg::with_name(EXEC_TRACE)
+                .long("--exec-trace")
+                .help("Compile with exec trace version of libs."),
         )
         .arg(
             Arg::with_name(SYM_TABLE_PASSES)
@@ -185,9 +193,11 @@ mod parser_test {
 
     #[test]
     fn test_kani_flags() {
-        let args = vec!["kani-compiler", "--goto-c", "--kani-lib", "some/path"];
+        let args = vec!["kani-compiler", "--goto-c", "--exec-trace", "--kani-lib", "some/path"];
         let matches = parser().get_matches_from(args);
         assert!(matches.is_present("goto-c"));
+        // TODO: Move to using global variables to test those.
+        assert!(matches.is_present("exec-trace"));
         assert_eq!(matches.value_of("kani-lib"), Some("some/path"));
     }
 


### PR DESCRIPTION
### Description of changes: 

This PR adds the executable trace flag to the Kani compiler that, if run with, calls the standard LLVM backend, linking in the Kani lib (but not the Kani std lib).

### Testing

None yet.