### PR TITLE
feat: POC for kani lib changes

### DIFF
--- a/library/kani/src/arbitrary.rs
+++ b/library/kani/src/arbitrary.rs
@@ -13,6 +13,7 @@ pub trait Arbitrary {
 impl<T> Arbitrary for T
 where
     T: Invariant,
+    [(); std::mem::size_of::<T>()]:,
 {
     default fn any() -> Self {
         let value = unsafe { any_raw::<T>() };

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![feature(rustc_attrs)] // Used for rustc_diagnostic_item.
 #![feature(min_specialization)] // Used for default implementation of Arbitrary.
+#![feature(generic_const_exprs)] // Used for getting size_of generic types
 
 pub mod arbitrary;
 pub mod invariant;
@@ -9,6 +10,10 @@ pub mod slice;
 
 pub use arbitrary::Arbitrary;
 pub use invariant::Invariant;
+
+use std::env;
+use std::fs;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Creates an assumption that will be valid after this statement run. Note that the assumption
 /// will only be applied for paths that follow the assumption. If the assumption doesn't hold, the
@@ -94,10 +99,36 @@ pub fn any<T: Arbitrary>() -> T {
 /// kani::assume(char::from_u32(c as u32).is_ok());
 /// ```
 ///
+#[inline(never)]
+pub unsafe fn any_raw<T>() -> T
+where
+    [(); std::mem::size_of::<T>()]:,
+{
+    let non_det_byte_arr = any_raw_inner::<{ std::mem::size_of::<T>() }>();
+    let non_det_var =
+        std::mem::transmute_copy::<[u8; std::mem::size_of::<T>()], T>(&non_det_byte_arr);
+    non_det_var
+}
+
+static RAW_COUNT: AtomicUsize = AtomicUsize::new(0);
+
 #[rustc_diagnostic_item = "KaniAnyRaw"]
 #[inline(never)]
-pub unsafe fn any_raw<T>() -> T {
-    unimplemented!("Kani any_raw")
+unsafe fn any_raw_inner<const T: usize>() -> [u8; T] {
+    let det_vals_file = env::var("DET_VALS_FILE").unwrap();
+    let contents_str = fs::read_to_string(det_vals_file).expect("Couldn't read det_vals.txt");
+    let contents_vec: Vec<&str> = contents_str.split("\n").collect();
+    let raw_count = RAW_COUNT.fetch_add(T, Ordering::SeqCst);
+    let mut bytes_t = [0; T];
+
+    for i in 0..T {
+        let a_byte_quotes = contents_vec[raw_count + i];
+        let a_byte_quotes_len = a_byte_quotes.len();
+        let a_byte_str = &a_byte_quotes[1..a_byte_quotes_len - 1];
+        let a_byte: u8 = a_byte_str.parse().unwrap();
+        bytes_t[i] = a_byte;
+    }
+    bytes_t
 }
 
 /// This function has been split into a safe and unsafe functions: `kani::any` and `kani::any_raw`.

--- a/library/kani/src/slice.rs
+++ b/library/kani/src/slice.rs
@@ -79,7 +79,10 @@ impl<T, const MAX_SLICE_LENGTH: usize> AnySlice<T, MAX_SLICE_LENGTH> {
         any_slice
     }
 
-    fn new_raw() -> Self {
+    fn new_raw() -> Self
+    where
+        [(); std::mem::size_of::<T>()]:,
+    {
         let any_slice = AnySlice::<T, MAX_SLICE_LENGTH>::alloc_slice();
         unsafe {
             let mut i = 0;
@@ -149,6 +152,9 @@ where
     AnySlice::<T, MAX_SLICE_LENGTH>::new()
 }
 
-pub unsafe fn any_raw_slice<T, const MAX_SLICE_LENGTH: usize>() -> AnySlice<T, MAX_SLICE_LENGTH> {
+pub unsafe fn any_raw_slice<T, const MAX_SLICE_LENGTH: usize>() -> AnySlice<T, MAX_SLICE_LENGTH>
+where
+    [(); std::mem::size_of::<T>()]:,
+{
     AnySlice::<T, MAX_SLICE_LENGTH>::new_raw()
 }

--- a/tests/cargo-kani/firecracker-block-example/src/main.rs
+++ b/tests/cargo-kani/firecracker-block-example/src/main.rs
@@ -4,6 +4,7 @@
 
 #![allow(dead_code)]
 #![allow(unused_variables)]
+#![feature(generic_const_exprs)]
 
 mod descriptor_permission_checker;
 use descriptor_permission_checker::*;
@@ -42,6 +43,7 @@ impl GuestMemoryMmap {
     fn read_obj<T>(&self, addr: GuestAddress) -> Result<T, Error>
     where
         T: ByteValued + kani::Invariant + ReadObjChecks<T>,
+        [(); std::mem::size_of::<T>()]:,
     {
         if kani::any() {
             let val = kani::any::<T>();

--- a/tests/expected/one-assert/expected
+++ b/tests/expected/one-assert/expected
@@ -1,1 +1,1 @@
-** 0 of 2 failed
+** 0 of 14 failed

--- a/tests/kani/FunctionAbstractions/mem_replace.rs
+++ b/tests/kani/FunctionAbstractions/mem_replace.rs
@@ -3,6 +3,8 @@
 
 //! Tests the `std::mem::replace` function using various function types.
 
+#![feature(generic_const_exprs)]
+
 use std::mem;
 
 #[derive(PartialEq, Copy, Clone)]
@@ -17,7 +19,10 @@ unsafe impl kani::Invariant for Pair {
     }
 }
 
-fn test<T: kani::Invariant + std::cmp::PartialEq + Clone>() {
+fn test<T: kani::Invariant + std::cmp::PartialEq + Clone>()
+where
+    [(); std::mem::size_of::<T>()]:,
+{
     let mut var1 = kani::any::<T>();
     let var2 = kani::any::<T>();
     let old_var1 = var1.clone();

--- a/tests/kani/FunctionAbstractions/mem_swap.rs
+++ b/tests/kani/FunctionAbstractions/mem_swap.rs
@@ -3,6 +3,8 @@
 
 //! Tests the `std::mem::swap` function using various function types.
 
+#![feature(generic_const_exprs)]
+
 use std::mem;
 
 #[derive(PartialEq, Copy, Clone)]
@@ -17,7 +19,10 @@ unsafe impl kani::Invariant for Pair {
     }
 }
 
-fn test<T: kani::Invariant + std::cmp::PartialEq + Clone>() {
+fn test<T: kani::Invariant + std::cmp::PartialEq + Clone>()
+where
+    [(); std::mem::size_of::<T>()]:,
+{
     let mut var1 = kani::any::<T>();
     let mut var2 = kani::any::<T>();
     let old_var1 = var1.clone();


### PR DESCRIPTION
### Description of changes: 

This PR modifies Kani any_raw to use byte arrays as the low-level unit of non-determinism. This enables us to use a different any_raw backend when we compile with LLVM that injects concrete values from a file.

### Testing:

1. None, as of yet.
2. I had to modify some of the existing regression tests to add support for generic constants.