### PR TITLE
Update kani's std library to use rust 2021

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,9 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 [[package]]
 name = "std"
 version = "0.5.0"
+dependencies = [
+ "kani",
+]
 
 [[package]]
 name = "string-interner"

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -229,6 +229,7 @@ impl<'tcx> GotocHook<'tcx> for Panic {
             || Some(def_id) == tcx.lang_items().panic_display()
             || Some(def_id) == tcx.lang_items().panic_fmt()
             || Some(def_id) == tcx.lang_items().begin_panic_fn()
+            || matches_function(tcx, instance, "KaniPanic")
     }
 
     fn handle(

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "kani"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -115,6 +115,10 @@ pub fn expect_fail(_cond: bool, _message: &'static str) {}
 
 /// Function used to generate panic with a static message as this is the only one currently
 /// supported by Kani display.
+///
+/// During verification this will get replaced by `assert(false)`. For concrete executions, we just
+/// invoke the regular `std::panic!()` function. This function is used by our standard library
+/// overrides, but not the other way around.
 #[inline(never)]
 #[rustc_diagnostic_item = "KaniPanic"]
 pub fn panic(message: &'static str) -> ! {

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -113,5 +113,13 @@ pub fn nondet<T: Arbitrary>() -> T {
 #[rustc_diagnostic_item = "KaniExpectFail"]
 pub fn expect_fail(_cond: bool, _message: &'static str) {}
 
+/// Function used to generate panic with a static message as this is the only one currently
+/// supported by Kani display.
+#[inline(never)]
+#[rustc_diagnostic_item = "KaniPanic"]
+pub fn panic(message: &'static str) -> ! {
+    panic!("{}", message)
+}
+
 /// Kani proc macros must be in a separate crate
 pub use kani_macros::*;

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "kani_macros"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -6,7 +6,8 @@
 # standard library symbols are preserved
 name = "std"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+kani = {path="../kani"}

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -140,8 +140,25 @@ macro_rules! eprintln {
 
 #[macro_export]
 macro_rules! unreachable {
-    ($($arg:tt)*) => ({
-        kani::panic(concat!("internal error: entered unreachable code: ", stringify!($($arg)
-        *)));
+    ($($msg:literal)? $(,)?) => (
+        kani::panic(concat!("internal error: entered unreachable code: ", $($msg)?))
+    );
+    ($fmt:expr, $($arg:tt)*) => (
+        kani::panic(concat!("internal error: entered unreachable code: ", $fmt), stringify!($($arg)*)));
+}
+
+#[macro_export]
+macro_rules! panic {
+    () => (
+        kani::panic("explicit panic")
+    );
+    ($msg:literal $(,)?) => ({
+        kani::panic(concat!($msg));
+    });
+    ($msg:expr $(,)?) => ({
+        kani::panic(stringify!($msg));
+    });
+    ($msg:expr, $($arg:tt)*) => ({
+        kani::panic(stringify!($msg, $($arg)*));
     });
 }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -141,7 +141,7 @@ macro_rules! eprintln {
 #[macro_export]
 macro_rules! unreachable {
     ($($arg:tt)*) => ({
-        panic!(concat!("internal error: entered unreachable code: ",
-        stringify!($($arg)*)));
+        kani::panic(concat!("internal error: entered unreachable code: ", stringify!($($arg)
+        *)));
     });
 }

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -8,10 +8,10 @@ pub use std::process::*;
 
 #[inline(always)]
 pub fn abort() -> ! {
-    panic!("Function abort() was invoked")
+    kani::panic("Function abort() was invoked")
 }
 
 #[inline(always)]
 pub fn exit(_code: i32) -> ! {
-    panic!("Function exit() was invoked")
+    kani::panic("Function exit() was invoked")
 }

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -89,7 +89,7 @@ time "$SCRIPT_DIR"/codegen-firecracker.sh
 time "$KANI_DIR"/tests/kani-dependency-test/diamond-dependency/run-dependency-test.sh
 
 # Check that documentation compiles.
-cargo doc --workspace --no-deps
+cargo doc --workspace --no-deps --exclude std
 
 echo
 echo "All Kani regression tests completed successfully."

--- a/tests/expected/arith_checks/expected
+++ b/tests/expected/arith_checks/expected
@@ -1,2 +1,2 @@
 Failed Checks: attempt to subtract with overflow
-Failed Checks: internal error: entered unreachable code: "Previous statement should fail"
+Failed Checks: internal error: entered unreachable code: Previous statement should fail

--- a/tests/expected/panic/panic-2018/expected
+++ b/tests/expected/panic/panic-2018/expected
@@ -1,0 +1,5 @@
+Failed Checks: msg
+Failed Checks: explicit panic
+Failed Checks: Panic message
+Failed Checks: "Panic message with arg {}", "str"
+Failed Checks: "{}", msg

--- a/tests/expected/panic/panic-2018/messages.rs
+++ b/tests/expected/panic/panic-2018/messages.rs
@@ -1,0 +1,13 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// compile-flags: --edition 2018
+
+//! Test that we can properly handle panic messages with rust 2018.
+
+include! {"../test.rs"}
+
+#[kani::proof]
+fn check_panic_2018() {
+    check_panic();
+}

--- a/tests/expected/panic/panic-2021/expected
+++ b/tests/expected/panic/panic-2021/expected
@@ -1,0 +1,5 @@
+Failed Checks: msg
+Failed Checks: explicit panic
+Failed Checks: Panic message
+Failed Checks: "Panic message with arg {}", "str"
+Failed Checks: "{}", msg

--- a/tests/expected/panic/panic-2021/messages.rs
+++ b/tests/expected/panic/panic-2021/messages.rs
@@ -1,0 +1,13 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// compile-flags: --edition 2021
+
+//! Test that we can properly handle panic messages with rust 2021.
+
+include! {"../test.rs"}
+
+#[kani::proof]
+fn check_panic_2021() {
+    check_panic();
+}

--- a/tests/expected/panic/test.rs
+++ b/tests/expected/panic/test.rs
@@ -1,0 +1,13 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+fn check_panic() {
+    let msg = "Panic message";
+    match kani::any::<u8>() {
+        0 => panic!(),
+        1 => panic!("Panic message"),
+        2 => panic!("Panic message with arg {}", "str"),
+        3 => panic!("{}", msg),
+        _ => panic!(msg),
+    }
+}


### PR DESCRIPTION
### Description of changes: 

For that, we needed to change how we handle panic messages. In rust 2021, the panic implementation will invoke `panic_fmt()` (except when no argument is given), which we cannot handle really well. Create our own panic function and use that instead.

### Resolved issues:

Resolves #1308 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? New tests

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
