### PR TITLE
Refactor names: "operator" instead of "operand"

### DIFF
--- a/cprover_bindings/src/goto_program/mod.rs
+++ b/cprover_bindings/src/goto_program/mod.rs
@@ -18,7 +18,7 @@ mod typ;
 
 pub use builtin::BuiltinFn;
 pub use expr::{
-    ArithmeticOverflowResult, BinaryOperand, Expr, ExprValue, SelfOperand, UnaryOperand,
+    ArithmeticOverflowResult, BinaryOperator, Expr, ExprValue, SelfOperator, UnaryOperator,
 };
 pub use location::Location;
 pub use stmt::{Stmt, StmtBody, SwitchCase};

--- a/cprover_bindings/src/goto_program/symtab_transformer/gen_c_transformer/expr_transformer.rs
+++ b/cprover_bindings/src/goto_program/symtab_transformer/gen_c_transformer/expr_transformer.rs
@@ -5,7 +5,7 @@ use std::ops::{BitAnd, Shl, Shr};
 
 use super::super::Transformer;
 use crate::goto_program::{
-    BinaryOperand, CIntType, Expr, Location, Parameter, Stmt, Symbol, SymbolTable, SymbolValues,
+    BinaryOperator, CIntType, Expr, Location, Parameter, Stmt, Symbol, SymbolTable, SymbolValues,
     Type,
 };
 use crate::InternedString;
@@ -120,7 +120,7 @@ impl Transformer for ExprTransformer {
     fn transform_expr_bin_op(
         &mut self,
         _typ: &Type,
-        op: &BinaryOperand,
+        op: &BinaryOperator,
         lhs: &Expr,
         rhs: &Expr,
     ) -> Expr {
@@ -128,7 +128,7 @@ impl Transformer for ExprTransformer {
         let rhs = self.transform_expr(rhs);
 
         match op {
-            BinaryOperand::Implies => lhs.not().bitor(rhs).cast_to(Type::bool()),
+            BinaryOperator::Implies => lhs.not().bitor(rhs).cast_to(Type::bool()),
             _ => lhs.binop(*op, rhs),
         }
     }

--- a/cprover_bindings/src/goto_program/symtab_transformer/transformer.rs
+++ b/cprover_bindings/src/goto_program/symtab_transformer/transformer.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::goto_program::{
-    BinaryOperand, CIntType, DatatypeComponent, Expr, ExprValue, Location, Parameter, SelfOperand,
-    Stmt, StmtBody, SwitchCase, Symbol, SymbolTable, SymbolValues, Type, UnaryOperand,
+    BinaryOperator, CIntType, DatatypeComponent, Expr, ExprValue, Location, Parameter,
+    SelfOperator, Stmt, StmtBody, SwitchCase, Symbol, SymbolTable, SymbolValues, Type,
+    UnaryOperator,
 };
 use crate::InternedString;
 use num::bigint::BigInt;
@@ -322,7 +323,7 @@ pub trait Transformer: Sized {
     fn transform_expr_bin_op(
         &mut self,
         _typ: &Type,
-        op: &BinaryOperand,
+        op: &BinaryOperator,
         lhs: &Expr,
         rhs: &Expr,
     ) -> Expr {
@@ -418,13 +419,13 @@ pub trait Transformer: Sized {
     }
 
     /// Transforms a self-op expr (`op++`, etc.)
-    fn transform_expr_self_op(&mut self, _typ: &Type, op: &SelfOperand, e: &Expr) -> Expr {
+    fn transform_expr_self_op(&mut self, _typ: &Type, op: &SelfOperator, e: &Expr) -> Expr {
         let transformed_e = self.transform_expr(e);
         match op {
-            SelfOperand::Postdecrement => transformed_e.postdecr(),
-            SelfOperand::Postincrement => transformed_e.postincr(),
-            SelfOperand::Predecrement => transformed_e.predecr(),
-            SelfOperand::Preincrement => transformed_e.preincr(),
+            SelfOperator::Postdecrement => transformed_e.postdecr(),
+            SelfOperator::Postincrement => transformed_e.postincr(),
+            SelfOperator::Predecrement => transformed_e.predecr(),
+            SelfOperator::Preincrement => transformed_e.preincr(),
         }
     }
 
@@ -479,22 +480,22 @@ pub trait Transformer: Sized {
     }
 
     /// Transforms a unary operator expr (`op self`)
-    fn transform_expr_un_op(&mut self, _typ: &Type, op: &UnaryOperand, e: &Expr) -> Expr {
+    fn transform_expr_un_op(&mut self, _typ: &Type, op: &UnaryOperator, e: &Expr) -> Expr {
         let transformed_e = self.transform_expr(e);
         match op {
-            UnaryOperand::Bitnot => transformed_e.bitnot(),
-            UnaryOperand::BitReverse => transformed_e.bitreverse(),
-            UnaryOperand::Bswap => transformed_e.bswap(),
-            UnaryOperand::IsDynamicObject => transformed_e.dynamic_object(),
-            UnaryOperand::IsFinite => transformed_e.is_finite(),
-            UnaryOperand::Not => transformed_e.not(),
-            UnaryOperand::ObjectSize => transformed_e.object_size(),
-            UnaryOperand::PointerObject => transformed_e.pointer_object(),
-            UnaryOperand::PointerOffset => transformed_e.pointer_offset(),
-            UnaryOperand::Popcount => transformed_e.popcount(),
-            UnaryOperand::CountTrailingZeros { allow_zero } => transformed_e.cttz(*allow_zero),
-            UnaryOperand::CountLeadingZeros { allow_zero } => transformed_e.ctlz(*allow_zero),
-            UnaryOperand::UnaryMinus => transformed_e.neg(),
+            UnaryOperator::Bitnot => transformed_e.bitnot(),
+            UnaryOperator::BitReverse => transformed_e.bitreverse(),
+            UnaryOperator::Bswap => transformed_e.bswap(),
+            UnaryOperator::IsDynamicObject => transformed_e.dynamic_object(),
+            UnaryOperator::IsFinite => transformed_e.is_finite(),
+            UnaryOperator::Not => transformed_e.not(),
+            UnaryOperator::ObjectSize => transformed_e.object_size(),
+            UnaryOperator::PointerObject => transformed_e.pointer_object(),
+            UnaryOperator::PointerOffset => transformed_e.pointer_offset(),
+            UnaryOperator::Popcount => transformed_e.popcount(),
+            UnaryOperator::CountTrailingZeros { allow_zero } => transformed_e.cttz(*allow_zero),
+            UnaryOperator::CountLeadingZeros { allow_zero } => transformed_e.ctlz(*allow_zero),
+            UnaryOperator::UnaryMinus => transformed_e.neg(),
         }
     }
 

--- a/cprover_bindings/src/irep/to_irep.rs
+++ b/cprover_bindings/src/irep/to_irep.rs
@@ -7,8 +7,8 @@ use super::super::MachineModel;
 use super::{Irep, IrepId};
 use crate::linear_map;
 use goto_program::{
-    BinaryOperand, CIntType, DatatypeComponent, Expr, ExprValue, Location, Parameter, SelfOperand,
-    Stmt, StmtBody, SwitchCase, SymbolValues, Type, UnaryOperand,
+    BinaryOperator, CIntType, DatatypeComponent, Expr, ExprValue, Location, Parameter,
+    SelfOperator, Stmt, StmtBody, SwitchCase, SymbolValues, Type, UnaryOperator,
 };
 
 pub trait ToIrep {
@@ -48,70 +48,70 @@ pub trait ToIrepId {
     fn to_irep_id(&self) -> IrepId;
 }
 
-impl ToIrepId for BinaryOperand {
+impl ToIrepId for BinaryOperator {
     fn to_irep_id(&self) -> IrepId {
         match self {
-            BinaryOperand::And => IrepId::And,
-            BinaryOperand::Ashr => IrepId::Ashr,
-            BinaryOperand::Bitand => IrepId::Bitand,
-            BinaryOperand::Bitnand => IrepId::Bitnand,
-            BinaryOperand::Bitor => IrepId::Bitor,
-            BinaryOperand::Bitxor => IrepId::Bitxor,
-            BinaryOperand::Div => IrepId::Div,
-            BinaryOperand::Equal => IrepId::Equal,
-            BinaryOperand::Ge => IrepId::Ge,
-            BinaryOperand::Gt => IrepId::Gt,
-            BinaryOperand::IeeeFloatEqual => IrepId::IeeeFloatEqual,
-            BinaryOperand::IeeeFloatNotequal => IrepId::IeeeFloatNotequal,
-            BinaryOperand::Implies => IrepId::Implies,
-            BinaryOperand::Le => IrepId::Le,
-            BinaryOperand::Lshr => IrepId::Lshr,
-            BinaryOperand::Lt => IrepId::Lt,
-            BinaryOperand::Minus => IrepId::Minus,
-            BinaryOperand::Mod => IrepId::Mod,
-            BinaryOperand::Mult => IrepId::Mult,
-            BinaryOperand::Notequal => IrepId::Notequal,
-            BinaryOperand::Or => IrepId::Or,
-            BinaryOperand::OverflowMinus => IrepId::OverflowMinus,
-            BinaryOperand::OverflowMult => IrepId::OverflowMult,
-            BinaryOperand::OverflowPlus => IrepId::OverflowPlus,
-            BinaryOperand::Plus => IrepId::Plus,
-            BinaryOperand::ROk => IrepId::ROk,
-            BinaryOperand::Rol => IrepId::Rol,
-            BinaryOperand::Ror => IrepId::Ror,
-            BinaryOperand::Shl => IrepId::Shl,
-            BinaryOperand::Xor => IrepId::Xor,
+            BinaryOperator::And => IrepId::And,
+            BinaryOperator::Ashr => IrepId::Ashr,
+            BinaryOperator::Bitand => IrepId::Bitand,
+            BinaryOperator::Bitnand => IrepId::Bitnand,
+            BinaryOperator::Bitor => IrepId::Bitor,
+            BinaryOperator::Bitxor => IrepId::Bitxor,
+            BinaryOperator::Div => IrepId::Div,
+            BinaryOperator::Equal => IrepId::Equal,
+            BinaryOperator::Ge => IrepId::Ge,
+            BinaryOperator::Gt => IrepId::Gt,
+            BinaryOperator::IeeeFloatEqual => IrepId::IeeeFloatEqual,
+            BinaryOperator::IeeeFloatNotequal => IrepId::IeeeFloatNotequal,
+            BinaryOperator::Implies => IrepId::Implies,
+            BinaryOperator::Le => IrepId::Le,
+            BinaryOperator::Lshr => IrepId::Lshr,
+            BinaryOperator::Lt => IrepId::Lt,
+            BinaryOperator::Minus => IrepId::Minus,
+            BinaryOperator::Mod => IrepId::Mod,
+            BinaryOperator::Mult => IrepId::Mult,
+            BinaryOperator::Notequal => IrepId::Notequal,
+            BinaryOperator::Or => IrepId::Or,
+            BinaryOperator::OverflowMinus => IrepId::OverflowMinus,
+            BinaryOperator::OverflowMult => IrepId::OverflowMult,
+            BinaryOperator::OverflowPlus => IrepId::OverflowPlus,
+            BinaryOperator::Plus => IrepId::Plus,
+            BinaryOperator::ROk => IrepId::ROk,
+            BinaryOperator::Rol => IrepId::Rol,
+            BinaryOperator::Ror => IrepId::Ror,
+            BinaryOperator::Shl => IrepId::Shl,
+            BinaryOperator::Xor => IrepId::Xor,
         }
     }
 }
 
-impl ToIrepId for SelfOperand {
+impl ToIrepId for SelfOperator {
     fn to_irep_id(&self) -> IrepId {
         match self {
-            SelfOperand::Postdecrement => IrepId::Postdecrement,
-            SelfOperand::Postincrement => IrepId::Postincrement,
-            SelfOperand::Predecrement => IrepId::Predecrement,
-            SelfOperand::Preincrement => IrepId::Preincrement,
+            SelfOperator::Postdecrement => IrepId::Postdecrement,
+            SelfOperator::Postincrement => IrepId::Postincrement,
+            SelfOperator::Predecrement => IrepId::Predecrement,
+            SelfOperator::Preincrement => IrepId::Preincrement,
         }
     }
 }
 
-impl ToIrepId for UnaryOperand {
+impl ToIrepId for UnaryOperator {
     fn to_irep_id(&self) -> IrepId {
         match self {
-            UnaryOperand::Bitnot => IrepId::Bitnot,
-            UnaryOperand::BitReverse => IrepId::BitReverse,
-            UnaryOperand::Bswap => IrepId::Bswap,
-            UnaryOperand::CountLeadingZeros { .. } => IrepId::CountLeadingZeros,
-            UnaryOperand::CountTrailingZeros { .. } => IrepId::CountTrailingZeros,
-            UnaryOperand::IsDynamicObject => IrepId::IsDynamicObject,
-            UnaryOperand::IsFinite => IrepId::IsFinite,
-            UnaryOperand::Not => IrepId::Not,
-            UnaryOperand::ObjectSize => IrepId::ObjectSize,
-            UnaryOperand::PointerObject => IrepId::PointerObject,
-            UnaryOperand::PointerOffset => IrepId::PointerOffset,
-            UnaryOperand::Popcount => IrepId::Popcount,
-            UnaryOperand::UnaryMinus => IrepId::UnaryMinus,
+            UnaryOperator::Bitnot => IrepId::Bitnot,
+            UnaryOperator::BitReverse => IrepId::BitReverse,
+            UnaryOperator::Bswap => IrepId::Bswap,
+            UnaryOperator::CountLeadingZeros { .. } => IrepId::CountLeadingZeros,
+            UnaryOperator::CountTrailingZeros { .. } => IrepId::CountTrailingZeros,
+            UnaryOperator::IsDynamicObject => IrepId::IsDynamicObject,
+            UnaryOperator::IsFinite => IrepId::IsFinite,
+            UnaryOperator::Not => IrepId::Not,
+            UnaryOperator::ObjectSize => IrepId::ObjectSize,
+            UnaryOperator::PointerObject => IrepId::PointerObject,
+            UnaryOperator::PointerOffset => IrepId::PointerOffset,
+            UnaryOperator::Popcount => IrepId::Popcount,
+            UnaryOperator::UnaryMinus => IrepId::UnaryMinus,
         }
     }
 }
@@ -300,15 +300,15 @@ impl ToIrep for ExprValue {
                     Irep::just_string_id(field.to_string()),
                 )],
             },
-            ExprValue::UnOp { op: UnaryOperand::Bswap, e } => Irep {
+            ExprValue::UnOp { op: UnaryOperator::Bswap, e } => Irep {
                 id: IrepId::Bswap,
                 sub: vec![e.to_irep(mm)],
                 named_sub: linear_map![(IrepId::BitsPerByte, Irep::just_int_id(8u8))],
             },
-            ExprValue::UnOp { op: UnaryOperand::BitReverse, e } => {
+            ExprValue::UnOp { op: UnaryOperator::BitReverse, e } => {
                 Irep { id: IrepId::BitReverse, sub: vec![e.to_irep(mm)], named_sub: linear_map![] }
             }
-            ExprValue::UnOp { op: UnaryOperand::CountLeadingZeros { allow_zero }, e } => Irep {
+            ExprValue::UnOp { op: UnaryOperator::CountLeadingZeros { allow_zero }, e } => Irep {
                 id: IrepId::CountLeadingZeros,
                 sub: vec![e.to_irep(mm)],
                 named_sub: linear_map![(
@@ -316,7 +316,7 @@ impl ToIrep for ExprValue {
                     if *allow_zero { Irep::zero() } else { Irep::one() }
                 )],
             },
-            ExprValue::UnOp { op: UnaryOperand::CountTrailingZeros { allow_zero }, e } => Irep {
+            ExprValue::UnOp { op: UnaryOperator::CountTrailingZeros { allow_zero }, e } => Irep {
                 id: IrepId::CountTrailingZeros,
                 sub: vec![e.to_irep(mm)],
                 named_sub: linear_map![(


### PR DESCRIPTION
### Description of changes: 

Just rename these types from "Operand" to "Operator", which is what they actually are.

### Resolved issues:

### Call-outs:

### Testing:

* How is this change tested? No testing needed.

* Is this a refactor change? Yes.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
