### PR TITLE
feat: make byte arr the lowest level non-det interface

### DIFF
--- a/library/kani/src/arbitrary.rs
+++ b/library/kani/src/arbitrary.rs
@@ -13,6 +13,7 @@ pub trait Arbitrary {
 impl<T> Arbitrary for T
 where
     T: Invariant,
+    [(); std::mem::size_of::<T>()]:,
 {
     default fn any() -> Self {
         let value = unsafe { any_raw::<T>() };

--- a/library/kani/src/slice.rs
+++ b/library/kani/src/slice.rs
@@ -79,7 +79,10 @@ impl<T, const MAX_SLICE_LENGTH: usize> AnySlice<T, MAX_SLICE_LENGTH> {
         any_slice
     }
 
-    fn new_raw() -> Self {
+    fn new_raw() -> Self
+    where
+        [(); std::mem::size_of::<T>()]:,
+    {
         let any_slice = AnySlice::<T, MAX_SLICE_LENGTH>::alloc_slice();
         unsafe {
             let mut i = 0;
@@ -149,6 +152,9 @@ where
     AnySlice::<T, MAX_SLICE_LENGTH>::new()
 }
 
-pub unsafe fn any_raw_slice<T, const MAX_SLICE_LENGTH: usize>() -> AnySlice<T, MAX_SLICE_LENGTH> {
+pub unsafe fn any_raw_slice<T, const MAX_SLICE_LENGTH: usize>() -> AnySlice<T, MAX_SLICE_LENGTH>
+where
+    [(); std::mem::size_of::<T>()]:,
+{
     AnySlice::<T, MAX_SLICE_LENGTH>::new_raw()
 }

--- a/library/kani/src/vec.rs
+++ b/library/kani/src/vec.rs
@@ -6,6 +6,7 @@ use crate::{any, assume, Invariant};
 pub fn any_vec<T, const MAX_LENGTH: usize>() -> Vec<T>
 where
     T: Invariant,
+    [(); std::mem::size_of::<[T; MAX_LENGTH]>()]:,
 {
     let mut v = exact_vec::<T, MAX_LENGTH>();
     let real_length: usize = any();
@@ -19,6 +20,7 @@ where
 pub fn exact_vec<T, const EXACT_LENGTH: usize>() -> Vec<T>
 where
     T: Invariant,
+    [(); std::mem::size_of::<[T; EXACT_LENGTH]>()]:,
 {
     let boxed_array: Box<[T; EXACT_LENGTH]> = Box::new(any());
     <[T]>::into_vec(boxed_array)

--- a/tests/cargo-kani/firecracker-block-example/src/main.rs
+++ b/tests/cargo-kani/firecracker-block-example/src/main.rs
@@ -4,6 +4,7 @@
 
 #![allow(dead_code)]
 #![allow(unused_variables)]
+#![feature(generic_const_exprs)]
 
 mod descriptor_permission_checker;
 use descriptor_permission_checker::*;
@@ -42,6 +43,7 @@ impl GuestMemoryMmap {
     fn read_obj<T>(&self, addr: GuestAddress) -> Result<T, Error>
     where
         T: ByteValued + kani::Invariant + ReadObjChecks<T>,
+        [(); std::mem::size_of::<T>()]:,
     {
         if kani::any() {
             let val = kani::any::<T>();

--- a/tests/expected/one-assert/expected
+++ b/tests/expected/one-assert/expected
@@ -1,1 +1,1 @@
-** 0 of 2 failed
+** 0 of 16 failed

--- a/tests/kani/FunctionAbstractions/mem_replace.rs
+++ b/tests/kani/FunctionAbstractions/mem_replace.rs
@@ -3,6 +3,8 @@
 
 //! Tests the `std::mem::replace` function using various function types.
 
+#![feature(generic_const_exprs)]
+
 use std::mem;
 
 #[derive(PartialEq, Copy, Clone)]
@@ -17,7 +19,10 @@ unsafe impl kani::Invariant for Pair {
     }
 }
 
-fn test<T: kani::Invariant + std::cmp::PartialEq + Clone>() {
+fn test<T: kani::Invariant + std::cmp::PartialEq + Clone>()
+where
+    [(); std::mem::size_of::<T>()]:,
+{
     let mut var1 = kani::any::<T>();
     let var2 = kani::any::<T>();
     let old_var1 = var1.clone();

--- a/tests/kani/FunctionAbstractions/mem_swap.rs
+++ b/tests/kani/FunctionAbstractions/mem_swap.rs
@@ -3,6 +3,8 @@
 
 //! Tests the `std::mem::swap` function using various function types.
 
+#![feature(generic_const_exprs)]
+
 use std::mem;
 
 #[derive(PartialEq, Copy, Clone)]
@@ -17,7 +19,10 @@ unsafe impl kani::Invariant for Pair {
     }
 }
 
-fn test<T: kani::Invariant + std::cmp::PartialEq + Clone>() {
+fn test<T: kani::Invariant + std::cmp::PartialEq + Clone>()
+where
+    [(); std::mem::size_of::<T>()]:,
+{
     let mut var1 = kani::any::<T>();
     let mut var2 = kani::any::<T>();
     let old_var1 = var1.clone();


### PR DESCRIPTION
### Description of changes: 

This PR is a self-contained chunk of the executable trace feature. Since the rest of the executable trace feature requires the full UX to be working, I will save those PRs for later.

This PR modifies `any_raw` to get its non-deterministic bytes from the function `any_raw_inner`. This inner function returns only constant-length (parameterized by a const type) non-det byte arrays, which makes serializing / deserializing non-det variables easier.

### Call-outs:

#### Increased number of checks

As a result of using `transmute_copy` inside `any_raw`, this change introduces more (useless) checks that Kani has to verify. In particular, the expected output for the `expected/one-assert` test grew from 2 to 16 checks. Only checks 1 and 5 were present before (see output below). I didn't run a performance analysis, but it looks like even with these checks, all the existing regressions are running in time. I tried increasing the number of non-det vars in `expected/one-assert`, and the number of additional checks stays the same, so I think they're only being added once per harness.

If we didn't use this PR, we would only have to use `transmute_copy` in the alternate implementation of `any_raw_inner` that sticks concrete values into a type. Since that implementation isn't codegen'd for verification, it would get rid of these checks. However, this approach would significantly increase the difficulty of parsing  concrete values from the CBMC trace.

```
RESULTS:
Check 1: check_assert.assertion.1
	 - Status: SUCCESS
	 - Description: "assertion failed: x == y"
	 - Location: tests/expected/one-assert/test.rs:8:5 in function check_assert

Check 2: std::mem::transmute_copy.safety_check.1
	 - Status: SUCCESS
	 - Description: "`src` must be properly aligned"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:1107:9 in function std::mem::transmute_copy

Check 3: std::mem::transmute_copy.safety_check.2
	 - Status: SUCCESS
	 - Description: "`dst` must be properly aligned"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:1107:9 in function std::mem::transmute_copy

Check 4: std::mem::transmute_copy.arithmetic_overflow.1
	 - Status: SUCCESS
	 - Description: "copy_nonoverlapping: attempt to compute number in bytes which would overflow"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:1107:9 in function std::mem::transmute_copy

Check 5: <T as kani::Arbitrary>::any.unsupported_construct.1
	 - Status: SUCCESS
	 - Description: "resume instruction"
	 - Location: library/kani/src/arbitrary.rs:18:5 in function <T as kani::Arbitrary>::any

Check 6: std::mem::transmute_copy.pointer_dereference.1
	 - Status: SUCCESS
	 - Description: "dereference failure: pointer NULL"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/mod.rs:1047:18 in function std::mem::transmute_copy

Check 7: std::mem::transmute_copy.pointer_dereference.2
	 - Status: SUCCESS
	 - Description: "dereference failure: pointer invalid"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/mod.rs:1047:18 in function std::mem::transmute_copy

Check 8: std::mem::transmute_copy.pointer_dereference.3
	 - Status: SUCCESS
	 - Description: "dereference failure: deallocated dynamic object"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/mod.rs:1047:18 in function std::mem::transmute_copy

Check 9: std::mem::transmute_copy.pointer_dereference.4
	 - Status: SUCCESS
	 - Description: "dereference failure: dead object"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/mod.rs:1047:18 in function std::mem::transmute_copy

Check 10: std::mem::transmute_copy.pointer_dereference.5
	 - Status: SUCCESS
	 - Description: "dereference failure: pointer outside object bounds"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/mod.rs:1047:18 in function std::mem::transmute_copy

Check 11: std::mem::transmute_copy.pointer_dereference.6
	 - Status: SUCCESS
	 - Description: "dereference failure: invalid integer address"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/mod.rs:1047:18 in function std::mem::transmute_copy

Check 12: memcpy.pointer.1
	 - Status: SUCCESS
	 - Description: "same object violation"
	 - Location: <builtin-library-memcpy>:33 in function memcpy

Check 13: memcpy.pointer.2
	 - Status: SUCCESS
	 - Description: "same object violation"
	 - Location: <builtin-library-memcpy>:34 in function memcpy

Check 14: std::mem::transmute_copy.precondition_instance.1
	 - Status: SUCCESS
	 - Description: "memcpy src/dst overlap"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:1107:9 in function std::mem::transmute_copy

Check 15: std::mem::transmute_copy.precondition_instance.2
	 - Status: SUCCESS
	 - Description: "memcpy source region readable"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:1107:9 in function std::mem::transmute_copy

Check 16: std::mem::transmute_copy.precondition_instance.3
	 - Status: SUCCESS
	 - Description: "memcpy destination region writeable"
	 - Location: ~/.rustup/toolchains/nightly-2022-07-05-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:1107:9 in function std::mem::transmute_copy
```

#### Weird bug with `expected/trait-receiver` test (@celinval)

When running this test, `compiletest` reports that the line `Checking harness check_arc...` is not present in the output. Indeed, it isn't present when `compiletest` runs that test, but when I run it manually, I see that line, along with all the other lines for the `check_arc` harness. I'm confused why I'm seeing this behavior.

Note: see PR comment that addresses this bug.

### Testing:

* How is this change tested?

There aren't any explicit tests here, but we assume that if the existing tests pass, then the change to using non-det byte arrays didn't fundamentally change the semantics of generating non-det types.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
