### PR TITLE
Fix static variable malformed symbol

### DIFF
--- a/cprover_bindings/src/goto_program/symbol.rs
+++ b/cprover_bindings/src/goto_program/symbol.rs
@@ -71,6 +71,13 @@ impl Symbol {
         let name = name.into();
         let base_name = base_name.intern();
         let pretty_name = pretty_name.intern();
+        // See https://github.com/model-checking/kani/issues/1361#issuecomment-1181499683
+        assert!(
+            name.to_string().ends_with(&base_name.map_or(String::new(), |s| s.to_string())),
+            "Symbol's base_name must be the suffix of its name.\nName: {:?}\nBase name: {:?}",
+            name,
+            base_name
+        );
         Symbol {
             name,
             location,

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/static_var.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/static_var.rs
@@ -10,9 +10,6 @@ use rustc_middle::mir::mono::MonoItem;
 use rustc_middle::ty::{subst::InternalSubsts, Instance};
 use tracing::debug;
 
-/// Separator used to generate function static variable names (<function_name>::<variable_name>).
-const SEPARATOR: &str = "::";
-
 impl<'tcx> GotocCtx<'tcx> {
     pub fn codegen_static(&mut self, def_id: DefId, item: MonoItem<'tcx>) {
         debug!("codegen_static");
@@ -26,15 +23,12 @@ impl<'tcx> GotocCtx<'tcx> {
         let symbol_name = item.symbol_name(self.tcx).to_string();
         // Pretty name which may include function name.
         let pretty_name = Instance::new(def_id, InternalSubsts::empty()).to_string();
-        // Name of the variable in the local context.
-        let base_name =
-            pretty_name.rsplit_once(SEPARATOR).map(|names| names.1).unwrap_or(pretty_name.as_str());
-        debug!(?symbol_name, ?pretty_name, ?base_name, "declare_static {}", item);
+        debug!(?symbol_name, ?pretty_name, "declare_static {}", item);
 
         let typ = self.codegen_ty(self.tcx.type_of(def_id));
         let span = self.tcx.def_span(def_id);
         let location = self.codegen_span(&span);
-        let symbol = Symbol::static_variable(symbol_name, base_name, typ, location)
+        let symbol = Symbol::static_variable(symbol_name.clone(), symbol_name, typ, location)
             .with_is_hidden(false) // Static items are always user defined.
             .with_pretty_name(pretty_name);
         self.symbol_table.insert(symbol);

--- a/scripts/std-lib-regression.sh
+++ b/scripts/std-lib-regression.sh
@@ -61,6 +61,7 @@ kani = {path=\"${KANI_DIR}/library/kani\"}
 cp ${KANI_DIR}/rust-toolchain.toml .
 
 echo "Starting cargo build with Kani"
+export RUST_BACKTRACE=1
 export RUSTC_LOG=error
 export KANIFLAGS="--goto-c --ignore-global-asm"
 export RUSTFLAGS="--kani-flags"


### PR DESCRIPTION
### Description of changes: 

A symbol's `base_name` has to be a suffix of its `name` otherwise it is considered a malformed symbol. For static variables, Kani was using the `pretty_name` to generate the `base_name` which was generating invalid iRep as a result. This was caught while trying to run symtab2gb after the std compilation.

### Resolved issues:

Fixes #1361

### Call-outs:

I couldn't figure out a good way of testing this. I also cannot enable `symtab2gb` on the std regression because I am now facing a new problem. I created #1379 to track the entire work of getting `symtab2gb` command working.

### Testing:

* How is this change tested? The assert I added to `Symbol::new()` would fail without the actual fix.

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
