### PR TITLE
Fix codegen of skipped functions

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -81,6 +81,8 @@ impl<'tcx> GotocCtx<'tcx> {
             tracing::info!("Double codegen of {:?}", old_sym);
         } else if self.should_skip_current_fn() {
             debug!("Skipping function {}", self.current_fn().readable_name());
+            self.codegen_function_prelude();
+            self.codegen_declare_variables();
             let body = self.codegen_fatal_error(
                 PropertyClass::UnsupportedConstruct,
                 &GotocCtx::unsupported_msg(

--- a/scripts/std-lib-regression.sh
+++ b/scripts/std-lib-regression.sh
@@ -66,7 +66,15 @@ export RUSTC_LOG=error
 export KANIFLAGS="--goto-c --ignore-global-asm"
 export RUSTFLAGS="--kani-flags"
 export RUSTC="$KANI_DIR/target/debug/kani-compiler"
+# Compile rust to iRep
 $WRAPPER cargo build --verbose -Z build-std --lib --target $TARGET
+
+# Generate goto-program. This will make sure the representation is well formed.
+cd target/${TARGET}/debug/deps
+for symtab in *.symtab.json; do
+    echo "======== File: $symtab"
+    symtab2gb ${symtab} --out ${symtab}.out
+done
 
 echo
 echo "Finished Kani codegen for the Rust standard library successfully..."


### PR DESCRIPTION
### Description of changes: 
We currently skip code generation of a few functions like ArgumentV1::as_usize(). We generate an unsuppported check instead.
However, we still need to declare the parameters otherwise we end up with invalid symbol tables where the parameters are missing.

### Resolved issues:

Fixes #1379

### Call-outs:

I have added a step to run `symtab2gb` in the std regression script; however, I'm worried that github worker machines will end up without memory. :(

### Testing:

* How is this change tested? new check

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
