### PR TITLE
Cleanup: add method that generates and declares a temporary variable

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -349,8 +349,8 @@ impl<'tcx> GotocCtx<'tcx> {
                 emit_concurrency_warning!(intrinsic, loc);
                 let var1_ref = fargs.remove(0);
                 let var1 = var1_ref.dereference();
-                let tmp = self.gen_temp_variable(var1.typ().clone(), loc).to_expr();
-                let decl_stmt = Stmt::decl(tmp.clone(), Some(var1.to_owned()), loc);
+                let (tmp, decl_stmt) =
+                    self.gen_and_decl_temp_variable(var1.typ().clone(), Some(var1.to_owned()), loc);
                 let var2 = fargs.remove(0);
                 let op_expr = (var1.clone()).$op(var2).with_location(loc);
                 let assign_stmt = (var1.clone()).assign(op_expr, loc);
@@ -837,8 +837,8 @@ impl<'tcx> GotocCtx<'tcx> {
         emit_concurrency_warning!(intrinsic, loc);
         let var1_ref = fargs.remove(0);
         let var1 = var1_ref.dereference().with_location(loc);
-        let tmp = self.gen_temp_variable(var1.typ().clone(), loc).to_expr();
-        let decl_stmt = Stmt::decl(tmp.clone(), Some(var1.to_owned()), loc);
+        let (tmp, decl_stmt) =
+            self.gen_and_decl_temp_variable(var1.typ().clone(), Some(var1.to_owned()), loc);
         let var2 = fargs.remove(0).with_location(loc);
         let var3 = fargs.remove(0).with_location(loc);
         let eq_expr = (var1.clone()).eq(var2);
@@ -873,8 +873,8 @@ impl<'tcx> GotocCtx<'tcx> {
         emit_concurrency_warning!(intrinsic, loc);
         let var1_ref = fargs.remove(0);
         let var1 = var1_ref.dereference().with_location(loc);
-        let tmp = self.gen_temp_variable(var1.typ().clone(), loc).to_expr();
-        let decl_stmt = Stmt::decl(tmp.clone(), Some(var1.to_owned()), loc);
+        let (tmp, decl_stmt) =
+            self.gen_and_decl_temp_variable(var1.typ().clone(), Some(var1.to_owned()), loc);
         let var2 = fargs.remove(0).with_location(loc);
         let assign_stmt = var1.assign(var2, loc);
         let res_stmt = self.codegen_expr_to_place(p, tmp);
@@ -1265,10 +1265,10 @@ impl<'tcx> GotocCtx<'tcx> {
         let newval = fargs.remove(0);
         // Type checker should have ensured it's a vector type
         let elem_ty = cbmc_ret_ty.base_type().unwrap().clone();
-        let tmp = self.gen_temp_variable(cbmc_ret_ty, loc).to_expr();
+        let (tmp, decl) = self.gen_and_decl_temp_variable(cbmc_ret_ty, Some(vec), loc);
         Stmt::block(
             vec![
-                Stmt::decl(tmp.clone(), Some(vec), loc),
+                decl,
                 tmp.clone().index_array(index).assign(newval.cast_to(elem_ty), loc),
                 self.codegen_expr_to_place(p, tmp),
             ],

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -350,7 +350,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 let var1_ref = fargs.remove(0);
                 let var1 = var1_ref.dereference();
                 let (tmp, decl_stmt) =
-                    self.gen_and_decl_temp_variable(var1.typ().clone(), Some(var1.to_owned()), loc);
+                    self.decl_temp_variable(var1.typ().clone(), Some(var1.to_owned()), loc);
                 let var2 = fargs.remove(0);
                 let op_expr = (var1.clone()).$op(var2).with_location(loc);
                 let assign_stmt = (var1.clone()).assign(op_expr, loc);
@@ -838,7 +838,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let var1_ref = fargs.remove(0);
         let var1 = var1_ref.dereference().with_location(loc);
         let (tmp, decl_stmt) =
-            self.gen_and_decl_temp_variable(var1.typ().clone(), Some(var1.to_owned()), loc);
+            self.decl_temp_variable(var1.typ().clone(), Some(var1.to_owned()), loc);
         let var2 = fargs.remove(0).with_location(loc);
         let var3 = fargs.remove(0).with_location(loc);
         let eq_expr = (var1.clone()).eq(var2);
@@ -874,7 +874,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let var1_ref = fargs.remove(0);
         let var1 = var1_ref.dereference().with_location(loc);
         let (tmp, decl_stmt) =
-            self.gen_and_decl_temp_variable(var1.typ().clone(), Some(var1.to_owned()), loc);
+            self.decl_temp_variable(var1.typ().clone(), Some(var1.to_owned()), loc);
         let var2 = fargs.remove(0).with_location(loc);
         let assign_stmt = var1.assign(var2, loc);
         let res_stmt = self.codegen_expr_to_place(p, tmp);
@@ -1265,7 +1265,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let newval = fargs.remove(0);
         // Type checker should have ensured it's a vector type
         let elem_ty = cbmc_ret_ty.base_type().unwrap().clone();
-        let (tmp, decl) = self.gen_and_decl_temp_variable(cbmc_ret_ty, Some(vec), loc);
+        let (tmp, decl) = self.decl_temp_variable(cbmc_ret_ty, Some(vec), loc);
         Stmt::block(
             vec![
                 decl,

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -915,8 +915,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // Insert a CBMC-time size check, roughly:
         //     <Ty> local_temp = nondet();
         //     assert(__CPROVER_OBJECT_SIZE(&local_temp) == vt_size);
-        let temp_var = self.gen_temp_variable(ty.clone(), Location::none()).to_expr();
-        let decl = Stmt::decl(temp_var.clone(), None, Location::none());
+        let (temp_var, decl) = self.gen_and_decl_temp_variable(ty.clone(), None, Location::none());
         let cbmc_size = if ty.is_empty() {
             // CBMC errors on passing a pointer to void to __CPROVER_OBJECT_SIZE.
             // In practice, we have seen this with the Never type, which has size 0:

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -915,7 +915,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // Insert a CBMC-time size check, roughly:
         //     <Ty> local_temp = nondet();
         //     assert(__CPROVER_OBJECT_SIZE(&local_temp) == vt_size);
-        let (temp_var, decl) = self.gen_and_decl_temp_variable(ty.clone(), None, Location::none());
+        let (temp_var, decl) = self.decl_temp_variable(ty.clone(), None, Location::none());
         let cbmc_size = if ty.is_empty() {
             // CBMC errors on passing a pointer to void to __CPROVER_OBJECT_SIZE.
             // In practice, we have seen this with the Never type, which has size 0:

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -519,11 +519,11 @@ impl<'tcx> GotocCtx<'tcx> {
             match fn_ptr.typ() {
                 Type::Pointer { typ: box Type::Code { parameters, .. } } => {
                     let param_typ = parameters.first().unwrap().typ();
-                    let tmp = self.gen_temp_variable(param_typ.clone(), loc).to_expr();
+                    let (tmp, decl) = self.gen_and_decl_temp_variable(param_typ.clone(), None, loc);
                     debug!(?tmp,
                         orig=?data_ptr.typ(),
                         "codegen_virtual_funcall");
-                    ret_stmts.push(Stmt::decl(tmp.clone(), None, loc));
+                    ret_stmts.push(decl);
                     ret_stmts.push(Stmt::assign(
                         self.extract_ptr(tmp.clone(), self_ty),
                         data_ptr,

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -519,7 +519,7 @@ impl<'tcx> GotocCtx<'tcx> {
             match fn_ptr.typ() {
                 Type::Pointer { typ: box Type::Code { parameters, .. } } => {
                     let param_typ = parameters.first().unwrap().typ();
-                    let (tmp, decl) = self.gen_and_decl_temp_variable(param_typ.clone(), None, loc);
+                    let (tmp, decl) = self.decl_temp_variable(param_typ.clone(), None, loc);
                     debug!(?tmp,
                         orig=?data_ptr.typ(),
                         "codegen_virtual_funcall");

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -144,21 +144,16 @@ impl<'tcx> GotocCtx<'tcx> {
         symbol
     }
 
-    /// Generate a new function local variable that can be used as a temporary in Kani expressions.
-    pub fn gen_temp_variable(&mut self, t: Type, loc: Location) -> Symbol {
-        let c = self.current_fn_mut().get_and_incr_counter();
-        self.gen_stack_variable(c, &self.current_fn().name(), "temp", t, loc)
-    }
-
     /// Generate a new function local variable that can be used as a temporary
     /// in Kani expressions and declare it with the specified (optional) value
-    pub fn gen_and_decl_temp_variable(
+    pub fn decl_temp_variable(
         &mut self,
         t: Type,
         value: Option<Expr>,
         loc: Location,
     ) -> (Expr, Stmt) {
-        let var = self.gen_temp_variable(t, loc).to_expr();
+        let c = self.current_fn_mut().get_and_incr_counter();
+        let var = self.gen_stack_variable(c, &self.current_fn().name(), "temp", t, loc).to_expr();
         let decl = Stmt::decl(var.clone(), value, loc);
         (var, decl)
     }

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -149,6 +149,19 @@ impl<'tcx> GotocCtx<'tcx> {
         let c = self.current_fn_mut().get_and_incr_counter();
         self.gen_stack_variable(c, &self.current_fn().name(), "temp", t, loc)
     }
+
+    /// Generate a new function local variable that can be used as a temporary
+    /// in Kani expressions and declare it with the specified (optional) value
+    pub fn gen_and_decl_temp_variable(
+        &mut self,
+        t: Type,
+        value: Option<Expr>,
+        loc: Location,
+    ) -> (Expr, Stmt) {
+        let var = self.gen_temp_variable(t, loc).to_expr();
+        let decl = Stmt::decl(var.clone(), value, loc);
+        (var, decl)
+    }
 }
 
 /// Symbol table related

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -163,11 +163,12 @@ impl<'tcx> GotocHook<'tcx> for Assert {
 
         // Since `cond` might have side effects, assign it to a temporary
         // variable so that it's evaluated once, then assert and assume it
-        let tmp = tcx.gen_temp_variable(cond.typ().clone(), caller_loc).to_expr();
+        let (tmp, decl) =
+            tcx.gen_and_decl_temp_variable(cond.typ().clone(), Some(cond), caller_loc);
         Stmt::block(
             vec![
                 reach_stmt,
-                Stmt::decl(tmp.clone(), Some(cond), caller_loc),
+                decl,
                 tcx.codegen_assert(tmp.clone(), PropertyClass::Assertion, &msg, caller_loc),
                 Stmt::assume(tmp, caller_loc),
                 Stmt::goto(tcx.current_fn().find_label(&target), caller_loc),

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -163,8 +163,7 @@ impl<'tcx> GotocHook<'tcx> for Assert {
 
         // Since `cond` might have side effects, assign it to a temporary
         // variable so that it's evaluated once, then assert and assume it
-        let (tmp, decl) =
-            tcx.gen_and_decl_temp_variable(cond.typ().clone(), Some(cond), caller_loc);
+        let (tmp, decl) = tcx.decl_temp_variable(cond.typ().clone(), Some(cond), caller_loc);
         Stmt::block(
             vec![
                 reach_stmt,


### PR DESCRIPTION
### Description of changes: 

The goto context (`GotocCtx`) has a method to generate a temporary variable, `gen_temp_variable`. A call to this method is always followed by a call to declare this variable. This PR adds a new method that is a wrapper for the combined generation/declaration: `gen_and_decl_temp_variable`. All usage of `gen_temp_variable` has been replaced with `gen_and_decl_temp_variable`.

### Resolved issues:


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regressions

* Is this a refactor change? Yes

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
