### PR TITLE
Fix slow generator tests by adding kani::unwind annotation

### DIFF
--- a/tests/kani/Generator/rustc-generator-tests/niche-in-generator.rs
+++ b/tests/kani/Generator/rustc-generator-tests/niche-in-generator.rs
@@ -20,6 +20,7 @@ use std::mem::size_of_val;
 fn take<T>(_: T) {}
 
 #[kani::proof]
+#[kani::unwind(2)]
 fn main() {
     let x = false;
     let mut gen1 = || {
@@ -27,9 +28,6 @@ fn main() {
         take(x);
     };
 
-    // FIXME: for some reason, these asserts are very hard for CBMC to figure out
-    // Kani didn't terminate within 5 minutes.
-    // assert_eq!(Pin::new(&mut gen1).resume(()), GeneratorState::Yielded(()));
-    // assert_eq!(Pin::new(&mut gen1).resume(()), GeneratorState::Complete(()));
-    assert!(false); // to make the test fail without taking forever
+    assert_eq!(Pin::new(&mut gen1).resume(()), GeneratorState::Yielded(()));
+    assert_eq!(Pin::new(&mut gen1).resume(()), GeneratorState::Complete(()));
 }

--- a/tests/kani/Generator/rustc-generator-tests/size-moved-locals.rs
+++ b/tests/kani/Generator/rustc-generator-tests/size-moved-locals.rs
@@ -26,7 +26,7 @@
 use std::ops::{Generator, GeneratorState};
 use std::pin::Pin;
 
-const FOO_SIZE: usize = 1024;
+const FOO_SIZE: usize = 128;
 struct Foo([u8; FOO_SIZE]);
 
 impl Drop for Foo {
@@ -79,9 +79,9 @@ fn overlap_x_and_y() -> impl Generator<Yield = (), Return = ()> {
 }
 
 #[kani::proof]
+#[kani::unwind(129)]
 fn main() {
-    // FIXME: the following tests are very slow (did not terminate in a couple of minutes)
-    /* let mut generator = move_before_yield();
+    let mut generator = move_before_yield();
     assert_eq!(
         unsafe { Pin::new_unchecked(&mut generator) }.resume(()),
         GeneratorState::Yielded(())
@@ -131,6 +131,5 @@ fn main() {
     assert_eq!(
         unsafe { Pin::new_unchecked(&mut generator) }.resume(()),
         GeneratorState::Complete(())
-    ); */
-    assert!(false); // to make the test fail without taking forever
+    );
 }


### PR DESCRIPTION
### Description of changes: 

This fixes previously disabled generator tests by adding a `kani::unwind` annotation.

### Resolved issues:

Resolves #1406 

### Call-outs:

### Testing:

* How is this change tested? Existing regression tests that now work

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
