### PR TITLE
Fix generator tests in bookrunner

### DIFF
--- a/tools/bookrunner/configs/books/The Unstable Book/Language Features/generators/165.props
+++ b/tools/bookrunner/configs/books/The Unstable Book/Language Features/generators/165.props
@@ -1,0 +1,1 @@
+// kani-flags: --enable-unstable --cbmc-args --unwind 3

--- a/tools/bookrunner/configs/books/The Unstable Book/Language Features/generators/28.props
+++ b/tools/bookrunner/configs/books/The Unstable Book/Language Features/generators/28.props
@@ -1,0 +1,1 @@
+// kani-flags: --enable-unstable --cbmc-args --unwind 5

--- a/tools/bookrunner/src/util.rs
+++ b/tools/bookrunner/src/util.rs
@@ -218,7 +218,7 @@ pub fn add_verification_job(litani: &mut Litani, test_props: &TestProps) {
         &kani,
         &[&phony_in],
         &[],
-        "Ca Kani reason about it?",
+        "Can Kani reason about it?",
         test_props.path.to_str().unwrap(),
         "verification",
         exit_status,


### PR DESCRIPTION
### Description of changes: 
Fix the bookrunner tests for generators by adding an `unwind` bound. 

### Testing:

* How is this change tested? existing bookrunner test (tested locally and will be run on CI)

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
