### PR TITLE
Enable 2021 edition globally for rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 # Run rustfmt with this config (it should be picked up automatically).
+edition = "2021"
 version = "Two"
 use_small_heuristics = "Max"
 merge_derives = false

--- a/tests/kani/AsyncAwait/rustfmt.toml
+++ b/tests/kani/AsyncAwait/rustfmt.toml
@@ -1,4 +1,0 @@
-# Copyright Kani Contributors
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-
-edition = "2021"


### PR DESCRIPTION
### Description of changes: 

Following an internal discussion with @adpaco-aws, we decided to prefer to set the edition for rustfmt to 2021 globally.

### Testing:

* How is this change tested? only formatting configuration change -> not needed

* Is this a refactor change? yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
