### PR TITLE
Refactor: use `Size` type for offsets and sizes

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -273,9 +273,7 @@ impl<'tcx> GotocCtx<'tcx> {
                         Variants::Multiple { tag_encoding, .. } => match tag_encoding {
                             TagEncoding::Niche { .. } => {
                                 let offset = match &layout.fields {
-                                    FieldsShape::Arbitrary { offsets, .. } => {
-                                        offsets[0].bytes_usize()
-                                    }
+                                    FieldsShape::Arbitrary { offsets, .. } => offsets[0],
                                     _ => unreachable!("niche encoding must have arbitrary fields"),
                                 };
                                 let discr_ty = self.codegen_enum_discr_typ(ty);
@@ -454,19 +452,20 @@ impl<'tcx> GotocCtx<'tcx> {
 
     fn codegen_allocation_data(&mut self, alloc: &'tcx Allocation) -> Vec<AllocData<'tcx>> {
         let mut alloc_vals = Vec::with_capacity(alloc.relocations().len() + 1);
-        let pointer_size = self.symbol_table.machine_model().pointer_width_in_bytes();
+        let pointer_size =
+            Size::from_bytes(self.symbol_table.machine_model().pointer_width_in_bytes());
 
-        let mut next_offset = 0;
+        let mut next_offset = Size::ZERO;
         for &(offset, alloc_id) in alloc.relocations().iter() {
-            let offset = offset.bytes_usize();
             if offset > next_offset {
-                let bytes =
-                    alloc.inspect_with_uninit_and_ptr_outside_interpreter(next_offset..offset);
+                let bytes = alloc.inspect_with_uninit_and_ptr_outside_interpreter(
+                    next_offset.bytes_usize()..offset.bytes_usize(),
+                );
                 alloc_vals.push(AllocData::Bytes(bytes));
             }
             let ptr_offset = {
                 let bytes = alloc.inspect_with_uninit_and_ptr_outside_interpreter(
-                    offset..(offset + pointer_size),
+                    offset.bytes_usize()..(offset + pointer_size).bytes_usize(),
                 );
                 read_target_uint(self.tcx.sess.target.options.endian, bytes)
             }
@@ -480,8 +479,8 @@ impl<'tcx> GotocCtx<'tcx> {
 
             next_offset = offset + pointer_size;
         }
-        if alloc.len() >= next_offset {
-            let range = next_offset..alloc.len();
+        if alloc.len() >= next_offset.bytes_usize() {
+            let range = next_offset.bytes_usize()..alloc.len();
             let bytes = alloc.inspect_with_uninit_and_ptr_outside_interpreter(range);
             alloc_vals.push(AllocData::Bytes(bytes));
         }
@@ -598,16 +597,16 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     /// fetch the niche value (as both left and right value)
-    pub fn codegen_get_niche(&self, v: Expr, offset: usize, niche_ty: Type) -> Expr {
+    pub fn codegen_get_niche(&self, v: Expr, offset: Size, niche_ty: Type) -> Expr {
         v // t: T
             .address_of() // &t: T*
             .cast_to(Type::unsigned_int(8).to_pointer()) // (u8 *)&t: u8 *
-            .plus(Expr::int_constant(offset, Type::size_t())) // ((u8 *)&t) + offset: u8 *
+            .plus(Expr::int_constant(offset.bytes_usize(), Type::size_t())) // ((u8 *)&t) + offset: u8 *
             .cast_to(niche_ty.to_pointer()) // (N *)(((u8 *)&t) + offset): N *
             .dereference() // *(N *)(((u8 *)&t) + offset): N
     }
 
-    fn codegen_niche_literal(&mut self, ty: Ty<'tcx>, offset: usize, init: Expr) -> Expr {
+    fn codegen_niche_literal(&mut self, ty: Ty<'tcx>, offset: Size, init: Expr) -> Expr {
         let cgt = self.codegen_ty(ty);
         let fname = self.codegen_niche_init_name(ty);
         let pretty_name = format!("init_niche<{}>", self.ty_pretty_name(ty));

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -541,7 +541,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     // This code follows the logic in the cranelift codegen backend:
                     // https://github.com/rust-lang/rust/blob/05d22212e89588e7c443cc6b9bc0e4e02fdfbc8d/compiler/rustc_codegen_cranelift/src/discriminant.rs#L116
                     let offset = match &layout.fields {
-                        FieldsShape::Arbitrary { offsets, .. } => offsets[0].bytes_usize(),
+                        FieldsShape::Arbitrary { offsets, .. } => offsets[0],
                         _ => unreachable!("niche encoding must have arbitrary fields"),
                     };
 

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -107,9 +107,7 @@ impl<'tcx> GotocCtx<'tcx> {
                         TagEncoding::Niche { dataful_variant, niche_variants, niche_start } => {
                             if dataful_variant != variant_index {
                                 let offset = match &layout.fields {
-                                    FieldsShape::Arbitrary { offsets, .. } => {
-                                        offsets[0].bytes_usize()
-                                    }
+                                    FieldsShape::Arbitrary { offsets, .. } => offsets[0],
                                     _ => unreachable!("niche encoding must have arbitrary fields"),
                                 };
                                 let discr_ty = self.codegen_enum_discr_typ(pt);


### PR DESCRIPTION
### Description of changes: 

We sometimes use offsets in bits and sometimes in bytes. The `Size` type provides additional type safety for this and is just the cleaner solution. It also an overall reduction in code size. :)

### Testing:

* How is this change tested? Existing tests

* Is this a refactor change? Refactor

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
