### PR TITLE
Added ability to figure out workspaces from cargo kani.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abb7553d5b9b8421c6de7cb02606ff15e0c6eea7d8eadd75ef013fd636bec36"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +316,7 @@ name = "kani-driver"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
  "clap",
  "glob",
  "kani_metadata",
@@ -646,6 +678,15 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 
 [dependencies]
 kani_metadata = { path = "../kani_metadata" }
+cargo_metadata = "0.15.0"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -22,6 +22,7 @@ pub struct CargoOutputs {
     pub metadata: Vec<PathBuf>,
 }
 
+/// Finds the "target" directory while considering workspaces,
 fn find_target_dir() -> PathBuf {
     fn maybe_get_target() -> Option<PathBuf> {
         let raw_metadata = Command::new("cargo").arg("metadata").output().ok()?;

--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use anyhow::{Context, Result};
-use serde_json::Value;
+use cargo_metadata::MetadataCommand;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -25,11 +25,7 @@ pub struct CargoOutputs {
 /// Finds the "target" directory while considering workspaces,
 fn find_target_dir() -> PathBuf {
     fn maybe_get_target() -> Option<PathBuf> {
-        let raw_metadata = Command::new("cargo").arg("metadata").output().ok()?;
-
-        let parsed_metadata: Value = serde_json::from_reader(&raw_metadata.stdout[..]).ok()?;
-
-        Some(parsed_metadata.as_object()?.get("target_directory")?.as_str()?.into())
+        Some(MetadataCommand::new().exec().ok()?.target_directory.into())
     }
 
     maybe_get_target().unwrap_or(PathBuf::from("target"))


### PR DESCRIPTION
### Description of changes:  

Made cargo-kani deal with work-spaces when finding `target`. This avoids `target` getting plopped down in middle of work-spaces when they should not be. Also helps if the library needs to link symtabs from neighboring work-spaces.

### Resolved issues: 

Resolves #1420 


### Call-outs:

The feature relies on parsing json from `cargo metadata`.

### Testing:

* How is this change tested? Make a project with workspaces and run tests on it.

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
