### PR TITLE
Add a `kani::futures` library containing `block_on`

### DIFF
--- a/library/kani/src/futures.rs
+++ b/library/kani/src/futures.rs
@@ -1,15 +1,20 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! This module contains functions to work with futures (and async/.await) in Kani.
+
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, RawWaker, RawWakerVTable, Waker},
 };
 
-/// Polls the future in a loop until completion (a very simple executor)
+/// A very simple executor: it polls the future in a busy loop until completion
 ///
 /// This is intended as a drop-in replacement for `futures::block_on`, which Kani cannot handle.
+/// Whereas a clever executor like `block_on` in `futures` or `tokio` would interact with the OS scheduler
+/// to be woken up when a resource becomes available, this is not supported by Kani.
+/// As a consequence, this function completely ignores the waker infrastructure and just polls the given future in a busy loop.
 pub fn block_on<T>(mut fut: impl Future<Output = T>) -> T {
     let waker = unsafe { Waker::from_raw(NOOP_RAW_WAKER) };
     let cx = &mut Context::from_waker(&waker);

--- a/library/kani/src/futures.rs
+++ b/library/kani/src/futures.rs
@@ -1,0 +1,36 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, RawWaker, RawWakerVTable, Waker},
+};
+
+/// Polls the future in a loop until completion (a very simple executor)
+///
+/// This is intended as a drop-in replacement for `futures::block_on`, which Kani cannot handle.
+pub fn block_on<F: Future>(mut fut: F) -> <F as Future>::Output {
+    let waker = unsafe { Waker::from_raw(NOOP_RAW_WAKER) };
+    let cx = &mut Context::from_waker(&waker);
+    loop {
+        let pinned = unsafe { Pin::new_unchecked(&mut fut) };
+        match pinned.poll(cx) {
+            std::task::Poll::Ready(res) => return res,
+            std::task::Poll::Pending => continue,
+        }
+    }
+}
+
+/// A dummy waker, which is needed to call [`Future::poll`]
+const NOOP_RAW_WAKER: RawWaker = {
+    #[inline]
+    unsafe fn clone_waker(_: *const ()) -> RawWaker {
+        NOOP_RAW_WAKER
+    }
+
+    #[inline]
+    unsafe fn noop(_: *const ()) {}
+
+    RawWaker::new(std::ptr::null(), &RawWakerVTable::new(clone_waker, noop, noop, noop))
+};

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -4,11 +4,13 @@
 #![feature(min_specialization)] // Used for default implementation of Arbitrary.
 
 pub mod arbitrary;
+pub mod futures;
 pub mod invariant;
 pub mod slice;
 pub mod vec;
 
 pub use arbitrary::Arbitrary;
+pub use futures::block_on;
 pub use invariant::Invariant;
 
 /// Creates an assumption that will be valid after this statement run. Note that the assumption

--- a/tests/kani/AsyncAwait/main.rs
+++ b/tests/kani/AsyncAwait/main.rs
@@ -40,12 +40,12 @@ pub async fn async_fn() -> i32 {
 }
 
 /// A very simple executor that just polls the future in a loop
-pub fn block_on<F: Future>(mut fut: F) -> <F as Future>::Output {
+pub fn block_on<T>(mut fut: impl Future<Output = T>) -> T {
     let waker = unsafe { Waker::from_raw(NOOP_RAW_WAKER) };
     let cx = &mut Context::from_waker(&waker);
+    let mut fut = unsafe { Pin::new_unchecked(&mut fut) };
     loop {
-        let pinned = unsafe { Pin::new_unchecked(&mut fut) };
-        match pinned.poll(cx) {
+        match fut.as_mut().poll(cx) {
             std::task::Poll::Ready(res) => return res,
             std::task::Poll::Pending => continue,
         }


### PR DESCRIPTION
### Description of changes: 

Following up on #1414, this adds a `kani::block_on` function to drive futures to completion in Kani. The `block_on` function from [`futures`](https://docs.rs/futures/latest/futures/executor/fn.block_on.html) or [`tokio`](https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.block_on) do not work because Kani does not understand the thread primitives these implementations use.

### Callouts:

I had to add `#[inline]` annotations to work around the linking issue #1425. But inlining makes sense for these functions anyway (they're small and do basically nothing), so this is not a problem.

### Testing:

* How is this change tested? Added  a test in `tests/kani/AsyncAwait/main.rs`

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
