### PR TITLE
Implement `#[kani::async_proof]` attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,10 @@ dependencies = [
 [[package]]
 name = "kani_macros"
 version = "0.7.0"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "kani_metadata"

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -12,3 +12,5 @@ publish = false
 proc-macro = true
 
 [dependencies]
+quote = "1.0.20"
+syn = { version = "1.0.98", features = ["full"] }

--- a/library/kani_macros/src/lib.rs
+++ b/library/kani_macros/src/lib.rs
@@ -10,8 +10,11 @@
 
 // proc_macro::quote is nightly-only, so we'll cobble things together instead
 use proc_macro::TokenStream;
-use quote::quote;
-use syn::{parse_macro_input, ItemFn};
+#[cfg(kani)]
+use {
+    quote::quote,
+    syn::{parse_macro_input, ItemFn},
+};
 
 #[cfg(all(not(kani), not(test)))]
 #[proc_macro_attribute]

--- a/tests/expected/async_proof/expected
+++ b/tests/expected/async_proof/expected
@@ -1,0 +1,8 @@
+error: custom attribute panicked
+#[kani::async_proof] does not take any arguments for now
+
+error: custom attribute panicked
+#[kani::async_proof] can only be applied to async functions
+
+error: custom attribute panicked
+#[kani::async_proof] can only be applied to functions without inputs

--- a/tests/expected/async_proof/main.rs
+++ b/tests/expected/async_proof/main.rs
@@ -1,0 +1,17 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// compile-flags: --edition 2018
+
+// Tests that the #[kani::async_proof] attribute works correctly
+
+fn main() {}
+
+#[kani::async_proof(foo)]
+async fn test_async_proof_with_arguments() {}
+
+#[kani::async_proof]
+fn test_async_proof_on_sync_function() {}
+
+#[kani::async_proof]
+async fn test_async_proof_on_function_with_inputs(_: ()) {}

--- a/tests/kani/AsyncAwait/main.rs
+++ b/tests/kani/AsyncAwait/main.rs
@@ -21,6 +21,14 @@ async fn test_async_proof_harness() {
     assert_eq!(async_block_result, async_fn_result);
 }
 
+#[kani::async_proof]
+#[kani::unwind(2)]
+pub async fn test_async_proof_harness_pub() {
+    let async_block_result = async { 42 }.await;
+    let async_fn_result = async_fn().await;
+    assert_eq!(async_block_result, async_fn_result);
+}
+
 #[kani::proof]
 #[kani::unwind(2)]
 fn test_async_await() {

--- a/tests/kani/AsyncAwait/main.rs
+++ b/tests/kani/AsyncAwait/main.rs
@@ -3,7 +3,7 @@
 //
 // compile-flags: --edition 2018
 
-// Tests that the language constructs `async { .. .}` blocks, `async fn`, and `.await` work correctly.
+// Tests that the language constructs `async { ... }` blocks, `async fn`, and `.await` work correctly.
 
 use std::{
     future::Future,
@@ -12,6 +12,14 @@ use std::{
 };
 
 fn main() {}
+
+#[kani::async_proof]
+#[kani::unwind(2)]
+async fn test_async_proof_harness() {
+    let async_block_result = async { 42 }.await;
+    let async_fn_result = async_fn().await;
+    assert_eq!(async_block_result, async_fn_result);
+}
 
 #[kani::proof]
 #[kani::unwind(2)]


### PR DESCRIPTION
### Description of changes: 

This adds an attribute `#[kani::async_proof]` to make model-checking `async` functions more ergonomic. Before, one had to manually call `kani::block_on` on an `async` function.

### Call-outs:

This adds the dependencies `syn` and `quote` to `kani_macros`.

### Testing:

* How is this change tested? Added a regression test.

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
