### PR TITLE
Support ThreadLocalRef (by treating it like a static variable)

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -12,12 +12,17 @@ use rustc_middle::ty::{Instance, InstanceDef};
 use rustc_span::Span;
 use tracing::{debug, warn};
 
+#[macro_export]
 macro_rules! emit_concurrency_warning {
     ($intrinsic: expr, $loc: expr) => {{
+        emit_concurrency_warning!($intrinsic, $loc, "a sequential operation");
+    }};
+    ($intrinsic: expr, $loc: expr, $treated_as: expr) => {{
         warn!(
-            "Kani does not support concurrency for now. `{}` in {} treated as a sequential operation.",
+            "Kani does not support concurrency for now. `{}` in {} treated as {}.",
             $intrinsic,
-            $loc.short_string()
+            $loc.short_string(),
+            $treated_as,
         );
     }};
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -368,7 +368,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 // here we have a function pointer
                 self.codegen_func_expr(instance, span).address_of()
             }
-            GlobalAlloc::Static(def_id) => self.codegen_static_pointer(def_id),
+            GlobalAlloc::Static(def_id) => self.codegen_static_pointer(def_id, false),
             GlobalAlloc::Memory(alloc) => {
                 // Full (mangled) crate name added so that allocations from different
                 // crates do not conflict. The name alone is insufficient because Rust
@@ -395,7 +395,7 @@ impl<'tcx> GotocCtx<'tcx> {
         }
     }
 
-    pub fn codegen_static_pointer(&mut self, def_id: DefId) -> Expr {
+    pub fn codegen_static_pointer(&mut self, def_id: DefId, is_thread_local: bool) -> Expr {
         // here we have a potentially unevaluated static
         let instance = Instance::mono(self.tcx, def_id);
 
@@ -421,6 +421,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 ctx.codegen_span(&span),
             )
             .with_is_extern(rlinkage.is_none())
+            .with_is_thread_local(is_thread_local)
         });
         sym.clone().to_expr().address_of()
     }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -395,6 +395,7 @@ impl<'tcx> GotocCtx<'tcx> {
         }
     }
 
+    /// Generates a pointer to a static or thread-local variable.
     pub fn codegen_static_pointer(&mut self, def_id: DefId, is_thread_local: bool) -> Expr {
         // here we have a potentially unevaluated static
         let instance = Instance::mono(self.tcx, def_id);

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -4,7 +4,7 @@ use super::typ::{is_pointer, pointee_type, TypeExt};
 use crate::codegen_cprover_gotoc::codegen::PropertyClass;
 use crate::codegen_cprover_gotoc::utils::{dynamic_fat_ptr, slice_fat_ptr};
 use crate::codegen_cprover_gotoc::{GotocCtx, VtableCtx};
-use crate::unwrap_or_return_codegen_unimplemented;
+use crate::{emit_concurrency_warning, unwrap_or_return_codegen_unimplemented};
 use cbmc::goto_program::{Expr, Location, Stmt, Symbol, Type};
 use cbmc::utils::BUG_REPORT_URL;
 use cbmc::MachineModel;
@@ -487,6 +487,7 @@ impl<'tcx> GotocCtx<'tcx> {
             }
             Rvalue::ThreadLocalRef(def_id) => {
                 // Since Kani is single-threaded, we treat a thread local like a static variable:
+                emit_concurrency_warning!("thread local", loc, "a static variable");
                 self.codegen_static_pointer(*def_id, true)
             }
             // A CopyForDeref is equivalent to a read from a place at the codegen level.

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -487,7 +487,7 @@ impl<'tcx> GotocCtx<'tcx> {
             }
             Rvalue::ThreadLocalRef(def_id) => {
                 // Since Kani is single-threaded, we treat a thread local like a static variable:
-                self.codegen_static_pointer(*def_id)
+                self.codegen_static_pointer(*def_id, true)
             }
             // A CopyForDeref is equivalent to a read from a place at the codegen level.
             // https://github.com/rust-lang/rust/blob/1673f1450eeaf4a5452e086db0fe2ae274a0144f/compiler/rustc_middle/src/mir/syntax.rs#L1055

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -485,14 +485,9 @@ impl<'tcx> GotocCtx<'tcx> {
             Rvalue::Aggregate(ref k, operands) => {
                 self.codegen_rvalue_aggregate(k, operands, res_ty)
             }
-            Rvalue::ThreadLocalRef(_) => {
-                let typ = self.codegen_ty(res_ty);
-                self.codegen_unimplemented(
-                    "Rvalue::ThreadLocalRef",
-                    typ,
-                    Location::none(),
-                    "https://github.com/model-checking/kani/issues/541",
-                )
+            Rvalue::ThreadLocalRef(def_id) => {
+                // Since Kani is single-threaded, we treat a thread local like a static variable:
+                self.codegen_static_pointer(*def_id)
             }
             // A CopyForDeref is equivalent to a read from a place at the codegen level.
             // https://github.com/rust-lang/rust/blob/1673f1450eeaf4a5452e086db0fe2ae274a0144f/compiler/rustc_middle/src/mir/syntax.rs#L1055

--- a/tests/kani/ThreadLocalRef/main.rs
+++ b/tests/kani/ThreadLocalRef/main.rs
@@ -11,8 +11,6 @@ thread_local! {
     static COMPLEX_DATA: RefCell<&'static str> = RefCell::new("before");
 }
 
-pub fn main() {}
-
 #[kani::proof]
 fn test_bool() {
     COND.with(|&b| {

--- a/tests/kani/ThreadLocalRef/main.rs
+++ b/tests/kani/ThreadLocalRef/main.rs
@@ -1,15 +1,44 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
-// Checks for failures due to unsupported features related to threads.
+// Checks that thread locals work as intended.
+
+use std::cell::RefCell;
 
 thread_local! {
     static COND : bool = true;
+    static COUNTER: RefCell<i32> = RefCell::new(0);
+    static COMPLEX_DATA: RefCell<&'static str> = RefCell::new("before");
+}
+
+pub fn main() {}
+
+#[kani::proof]
+fn test_bool() {
+    COND.with(|&b| {
+        assert!(b);
+    });
 }
 
 #[kani::proof]
-fn main() {
-    COND.with(|&b| {
-        assert!(b);
+fn test_i32() {
+    COUNTER.with(|c| {
+        assert_eq!(*c.borrow(), 0);
+        *c.borrow_mut() += 1;
+    });
+    COUNTER.with(|c| {
+        assert_eq!(*c.borrow(), 1);
+    });
+}
+
+#[kani::proof]
+#[kani::unwind(7)]
+fn test_complex_data() {
+    COMPLEX_DATA.with(|c| {
+        assert_eq!(*c.borrow(), "before");
+        *c.borrow_mut() = "after"
+    });
+    COMPLEX_DATA.with(|c| {
+        assert_eq!(*c.borrow(), "after");
     });
 }

--- a/tests/kani/ThreadLocalRef/main.rs
+++ b/tests/kani/ThreadLocalRef/main.rs
@@ -4,13 +4,12 @@
 // Checks for failures due to unsupported features related to threads.
 
 thread_local! {
-    static COND : bool = kani::any();
+    static COND : bool = true;
 }
 
 #[kani::proof]
 fn main() {
     COND.with(|&b| {
-        kani::assume(b);
-        assert!(b, "This should fail because we do not support thread local");
+        assert!(b);
     });
 }

--- a/tests/kani/ThreadLocalRef/main.rs
+++ b/tests/kani/ThreadLocalRef/main.rs
@@ -9,9 +9,8 @@ thread_local! {
 
 #[kani::proof]
 fn main() {
-    COND.with(|&b|{
+    COND.with(|&b| {
         kani::assume(b);
         assert!(b, "This should fail because we do not support thread local");
     });
 }
-

--- a/tests/ui/unsupported-features/thread/expected
+++ b/tests/ui/unsupported-features/thread/expected
@@ -1,7 +1,0 @@
-warning: Found the following unsupported constructs:\
-Rvalue::ThreadLocalRef\
-\
-Verification will fail if one or more of these constructs is reachable.\
-See https://model-checking.github.io/kani/rust-feature-support.html for more details.
-
-Failed Checks: Rvalue::ThreadLocalRef is not currently supported by Kani.


### PR DESCRIPTION
### Description of changes: 

Kani did not support thread locals, in particular the MIR construct `ThreadLocalRef`. As discovered #1400, this is the most used feature that is currently unsupported in Kani. In particular it is needed to compile tokio.

Since Kani is single-threaded, thread locals are treated like static variables and translated in the same way.

### Resolved issues:

Resolves #1450
Resolves #541
Resolves #157


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? A previously failing regression test that now passes. It uses the same code as static variables, so the same code path is also tested in other tests using static variables.

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
