### PR TITLE
Cleanup rvalue_repeat: use statement_expression instead of generating unnecessary function

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -230,7 +230,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 Stmt::skip(loc),
                 idx.clone().lt(self.codegen_const(*sz, None)),
                 idx.clone().postincr().as_stmt(loc),
-                self.codegen_idx_array(res.clone(), idx.clone()).assign(val, loc),
+                self.codegen_idx_array(res.clone(), idx).assign(val, loc),
                 loc,
             ),
             res.as_stmt(loc),

--- a/tests/kani/Array/array_init.rs
+++ b/tests/kani/Array/array_init.rs
@@ -1,0 +1,18 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#[kani::proof]
+fn init_int() {
+    let a = [4u8; 6];
+    let i: usize = kani::any();
+    kani::assume(i < 6);
+    assert_eq!(a[i], 4);
+}
+
+#[kani::proof]
+fn init_option() {
+    let a = [Some(4u8); 6];
+    let i: usize = kani::any();
+    kani::assume(i < 6);
+    assert_eq!(a[i], Some(4));
+}

--- a/tests/output-files/check-output.sh
+++ b/tests/output-files/check-output.sh
@@ -49,7 +49,6 @@ declare -a PATTERNS=(
     'struct PrettyStruct pretty_function(struct PrettyStruct' # expected demangled struct and function name
     'monomorphize::<usize>(' # monomorphized function name
     'struct ()' # pretty-printed unit struct
-    'init_array_repeat<[bool; 2]>' # pretty-printed array initializer
     'struct &str' # pretty-printed reference type
     'TestEnum::Variant1' # pretty-printed variant
 )


### PR DESCRIPTION
### Description of changes: 

Currently, we generate a function to allow us to have a temporary variable in `Expr` contect.
But `StatementExpr` does the same thing, and is clearer and easier to debug.

### Resolved issues:

Resolves #1451 

### Call-outs:


### Testing:

* How is this change tested? Additional tests for gen-repeat

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
