### PR TITLE
Simplify drop logic

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -851,7 +851,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 // Function body
                 let unimplemented = ctx
                     .codegen_unimplemented(
-                        format!("drop_in_place for {}", drop_sym_name).as_str(),
+                        &format!("drop_in_place for missing type {}", ty),
                         Type::empty(),
                         Location::none(),
                         "https://github.com/model-checking/kani/issues/281",

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -372,24 +372,7 @@ impl<'tcx> GotocCtx<'tcx> {
                         // The only argument should be a self reference
                         let args = vec![arg];
 
-                        // We have a known issue where nested Arc and Mutex objects result in
-                        // drop_in_place call implementations that fail to typecheck. Skipping
-                        // drop entirely causes unsound verification results in common cases
-                        // like vector extend, so for now, add a sound special case workaround
-                        // for calls that fail the typecheck.
-                        // https://github.com/model-checking/kani/issues/426
-                        // Unblocks: https://github.com/model-checking/kani/issues/435
-                        if Expr::typecheck_call(&func, &args) {
-                            func.call(args)
-                        } else {
-                            self.codegen_unimplemented(
-                                format!("drop_in_place call for {:?}", func).as_str(),
-                                func.typ().return_type().unwrap().clone(),
-                                Location::none(),
-                                "https://github.com/model-checking/kani/issues/426",
-                            )
-                        }
-                        .as_stmt(Location::none())
+                        func.call(args).as_stmt(Location::none())
                     }
                 }
             }


### PR DESCRIPTION
### Description of changes: 

This removes a check from the `drop_in_place` code that has become unnecessary.

### Resolved issues:

Resolves #1434 

### Testing:

* How is this change tested? Regression tests and I manually tried compiling tokio with it.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
