### PR TITLE
Use #[kani::proof] for both sync and async functions (instead of #[kani::async_proof] for async)

### DIFF
--- a/library/kani_macros/src/lib.rs
+++ b/library/kani_macros/src/lib.rs
@@ -19,7 +19,7 @@ use {
 #[cfg(all(not(kani), not(test)))]
 #[proc_macro_attribute]
 pub fn proof(_attr: TokenStream, _item: TokenStream) -> TokenStream {
-    // Not-Kani, Not-Test means this code shouldn't exist, return nothing.
+    // Not-Kani, not-test means this code shouldn't exist, return nothing.
     TokenStream::new()
 }
 
@@ -39,37 +39,14 @@ pub fn proof(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // )
 }
 
-#[cfg(kani)]
-#[proc_macro_attribute]
-pub fn proof(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let mut result = TokenStream::new();
-
-    assert!(attr.is_empty(), "#[kani::proof] does not take any arguments");
-    result.extend("#[kanitool::proof]".parse::<TokenStream>().unwrap());
-    // no_mangle is a temporary hack to make the function "public" so it gets codegen'd
-    result.extend("#[no_mangle]".parse::<TokenStream>().unwrap());
-    result.extend(item);
-    result
-    // quote!(
-    //     #[kanitool::proof]
-    //     $item
-    // )
-}
-
-#[cfg(not(kani))]
-#[proc_macro_attribute]
-/// Treats #[kani::async_proof] like a normal #[kani::proof] if Kani is not active
-pub fn async_proof(attr: TokenStream, item: TokenStream) -> TokenStream {
-    proof(attr, item)
-}
-
-#[cfg(kani)]
-#[proc_macro_attribute]
-/// Translates #[kani::async_proof] to a #[kani::proof] harness that calls `kani::block_on`, if Kani is active
+/// Handles #[kani::proof] if #[cfg(kani)] is active
 ///
+/// For synchronous functions, it becomes a Kani-internal attribute.
+///
+/// For async functions, it translates to a synchronous function that calls `kani::block_on`.
 /// Specifically, it translates
 /// ```ignore
-/// #[kani::async_proof]
+/// #[kani::proof]
 /// #[attribute]
 /// pub async fn harness() { ... }
 /// ```
@@ -82,30 +59,44 @@ pub fn async_proof(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///   kani::block_on(harness())
 /// }
 /// ```
-pub fn async_proof(attr: TokenStream, item: TokenStream) -> TokenStream {
-    assert!(attr.is_empty(), "#[kani::async_proof] does not take any arguments for now");
+/// which is then translated again as a asynchronous function.
+#[cfg(kani)]
+#[proc_macro_attribute]
+pub fn proof(attr: TokenStream, item: TokenStream) -> TokenStream {
     let fn_item = parse_macro_input!(item as ItemFn);
     let attrs = fn_item.attrs;
     let vis = fn_item.vis;
     let sig = fn_item.sig;
-    assert!(sig.asyncness.is_some(), "#[kani::async_proof] can only be applied to async functions");
-    assert!(
-        sig.inputs.is_empty(),
-        "#[kani::async_proof] can only be applied to functions without inputs"
-    );
-    let mut modified_sig = sig.clone();
-    modified_sig.asyncness = None;
     let body = fn_item.block;
-    let fn_name = &sig.ident;
-    quote!(
-        #[kani::proof]
-        #(#attrs)*
-        #vis #modified_sig {
-            #sig #body
-            kani::block_on(#fn_name())
-        }
-    )
-    .into()
+
+    assert!(attr.is_empty(), "#[kani::proof] does not take any arguments for now");
+
+    if sig.asyncness.is_none() {
+        quote!(
+            #[kanitool::proof]
+            #[no_mangle]
+            #(#attrs)*
+            #vis #sig #body
+        )
+        .into()
+    } else {
+        assert!(
+            sig.inputs.is_empty(),
+            "#[kani::proof] cannot be applied to async functions that take inputs for now"
+        );
+        let mut modified_sig = sig.clone();
+        modified_sig.asyncness = None;
+        let fn_name = &sig.ident;
+        quote!(
+            #[kani::proof]
+            #(#attrs)*
+            #vis #modified_sig {
+                #sig #body
+                kani::block_on(#fn_name())
+            }
+        )
+        .into()
+    }
 }
 
 #[cfg(not(kani))]

--- a/tests/expected/async_proof/expected
+++ b/tests/expected/async_proof/expected
@@ -1,8 +1,5 @@
 error: custom attribute panicked
-#[kani::async_proof] does not take any arguments for now
+#[kani::proof] does not take any arguments for now
 
 error: custom attribute panicked
-#[kani::async_proof] can only be applied to async functions
-
-error: custom attribute panicked
-#[kani::async_proof] can only be applied to functions without inputs
+#[kani::proof] cannot be applied to async functions that take inputs for now

--- a/tests/expected/async_proof/main.rs
+++ b/tests/expected/async_proof/main.rs
@@ -3,15 +3,12 @@
 //
 // compile-flags: --edition 2018
 
-// Tests that the #[kani::async_proof] attribute works correctly
+// Tests that the #[kani::proof] attribute works correctly for async functions
 
 fn main() {}
 
-#[kani::async_proof(foo)]
+#[kani::proof(foo)]
 async fn test_async_proof_with_arguments() {}
 
-#[kani::async_proof]
-fn test_async_proof_on_sync_function() {}
-
-#[kani::async_proof]
+#[kani::proof]
 async fn test_async_proof_on_function_with_inputs(_: ()) {}

--- a/tests/kani/AsyncAwait/main.rs
+++ b/tests/kani/AsyncAwait/main.rs
@@ -13,7 +13,7 @@ use std::{
 
 fn main() {}
 
-#[kani::async_proof]
+#[kani::proof]
 #[kani::unwind(2)]
 async fn test_async_proof_harness() {
     let async_block_result = async { 42 }.await;
@@ -21,7 +21,7 @@ async fn test_async_proof_harness() {
     assert_eq!(async_block_result, async_fn_result);
 }
 
-#[kani::async_proof]
+#[kani::proof]
 #[kani::unwind(2)]
 pub async fn test_async_proof_harness_pub() {
     let async_block_result = async { 42 }.await;


### PR DESCRIPTION
### Description of changes: 

Previously, we had `#[kani::proof]` for synchronous and `#[kani::async_proof]` for asynchroonus harnesses. This PR unifies the two attributes, allowing `#[kani::proof]` to be used for both kinds of functions.

### Resolved issues:

Resolves #1464 

### Call-outs:

This now uses the syn and quote crates also for normal `#[kani::proof]` annotations for consistency. Previously this attributes modified `TokenStream`s manually.

### Testing:

* How is this change tested? Existing regression tests

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
