### PR TITLE
Clean up codegen_niche_literal

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -271,10 +271,6 @@ impl<'tcx> GotocCtx<'tcx> {
         Type::union_tag(union_name)
     }
 
-    pub fn find_function<T: Into<InternedString>>(&mut self, fname: T) -> Option<Expr> {
-        self.symbol_table.lookup(fname).map(|s| s.to_expr())
-    }
-
     /// Makes a __attribute__((constructor)) fnname() {body} initalizer function
     pub fn register_initializer(&mut self, var_name: &str, body: Stmt) -> &Symbol {
         let fn_name = Self::initializer_fn_name(var_name);


### PR DESCRIPTION
### Description of changes: 

Clean up `codegen_niche_literal`: this does not require generating a separate function, similarly to #1457. I believe (and added assertions to that effect) that this code is only called when the whole type is the same size as the discriminant type and the offset of the discriminant is 0. Hence we can simply transmute the given scalar to the result type.

### Resolved issues:

Resolves #1485

### Call-outs

This adds a byte extract instruction. I vaguely remember CBMC struggling with this sometimes. But it seems better than casting to a pointer, adding an offset and dereferencing, which is what we used to do.

### Testing:

* How is this change tested? Existing regression tests

* Is this a refactor change? yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
