### PR TITLE
Change base_name and pretty_name fields in contract symbols to match the contract name. 

### DIFF
--- a/cprover_bindings/src/goto_program/symbol.rs
+++ b/cprover_bindings/src/goto_program/symbol.rs
@@ -131,15 +131,14 @@ impl Symbol {
 
     pub fn contract<T: Into<InternedString>, U: Into<InternedString>>(
         name: T,
-        base_name: U,
         typ: Type,
         contract: Contract,
         loc: Location,
     ) -> Symbol {
         let name = name.into();
-        // Both base name and pretty name contain the name of the function that the contract is written for.
-        let base_name: InternedString = base_name.into();
-        let pretty_name = base_name;
+        // Both base name and pretty name have the same name as the contract.
+        let base_name = name;
+        let pretty_name = name;
         Symbol::new(
             name,
             loc,

--- a/cprover_bindings/src/goto_program/symbol.rs
+++ b/cprover_bindings/src/goto_program/symbol.rs
@@ -129,7 +129,7 @@ impl Symbol {
         )
     }
 
-    pub fn contract<T: Into<InternedString>, U: Into<InternedString>>(
+    pub fn contract<T: Into<InternedString>>(
         name: T,
         typ: Type,
         contract: Contract,


### PR DESCRIPTION
### Description of changes: 

Changing `base_name` and `pretty_name` to match the `name` field in a contract symbol.  Hence, all three names will now be of the form `contract::<foo>`, where `<foo>` refers to the function name. 

The change is due to a corresponding change in CBMC for a bugfix. See https://github.com/diffblue/cbmc/pull/7063 for more details.

### Resolved issues:


### Call-outs:

### Testing:
The code won't be merged into main until we have test cases.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
