### PR TITLE
Codegen function contracts from MIR to gotoc.

### DIFF
--- a/cprover_bindings/src/goto_program/symbol.rs
+++ b/cprover_bindings/src/goto_program/symbol.rs
@@ -131,15 +131,14 @@ impl Symbol {
 
     pub fn contract<T: Into<InternedString>, U: Into<InternedString>>(
         name: T,
-        base_name: U,
         typ: Type,
         contract: Contract,
         loc: Location,
     ) -> Symbol {
         let name = name.into();
-        // Both base name and pretty name contain the name of the function that the contract is written for.
-        let base_name: InternedString = base_name.into();
-        let pretty_name = base_name;
+        // Both base name and pretty name have the same name as the contract.
+        let base_name = name;
+        let pretty_name = name;
         Symbol::new(
             name,
             loc,

--- a/cprover_bindings/src/goto_program/symbol.rs
+++ b/cprover_bindings/src/goto_program/symbol.rs
@@ -129,7 +129,7 @@ impl Symbol {
         )
     }
 
-    pub fn contract<T: Into<InternedString>, U: Into<InternedString>>(
+    pub fn contract<T: Into<InternedString>>(
         name: T,
         typ: Type,
         contract: Contract,

--- a/cprover_bindings/src/goto_program/symbol.rs
+++ b/cprover_bindings/src/goto_program/symbol.rs
@@ -131,14 +131,15 @@ impl Symbol {
 
     pub fn contract<T: Into<InternedString>>(
         name: T,
+        base_name: U,
         typ: Type,
         contract: Contract,
         loc: Location,
     ) -> Symbol {
         let name = name.into();
-        // Both base name and pretty name have the same name as the contract.
-        let base_name = name;
-        let pretty_name = name;
+        // Both base name and pretty name contain the name of the function that the contract is written for.
+        let base_name: InternedString = base_name.into();
+        let pretty_name = base_name;
         Symbol::new(
             name,
             loc,

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
@@ -85,7 +85,7 @@ impl<'tcx> GotocCtx<'tcx> {
                         let expr = Expr::symbol_expression(sym.name.clone(), sym.typ.clone());
                         Some(Spec::new(bv, expr, loc))
                     }
-                    None => None, // ignore globals for now.
+                    None => panic!("Global variables are not supported inside modifies clauses."),
                 }
             })
             .collect();

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
@@ -86,9 +86,10 @@ impl<'tcx> GotocCtx<'tcx> {
                         Some(Spec::new(bv, expr, loc))
                     }
                     None => {
-                        self.tcx
-                            .sess
-                            .span_err(mir.span, "Symbol not supported inside modifies clauses.");
+                        self.tcx.sess.span_err(
+                            mir.span,
+                            format!("Symbol {} not supported inside modifies clauses.", basename),
+                        );
                         None
                     }
                 }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
@@ -1,0 +1,87 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This file contains functions related to codegenning code contracts from MIR into gotoc
+use crate::codegen_cprover_gotoc::GotocCtx;
+use cbmc::goto_program::{Contract, Expr, Spec, Symbol};
+use rustc_ast::NestedMetaItem;
+use rustc_middle::mir::Local;
+use rustc_middle::ty::{self, FnSig};
+
+impl<'tcx> GotocCtx<'tcx> {
+    /// Transforms current function's arguments into expressions
+    fn extract_function_arguments(&mut self, sig: FnSig<'tcx>) -> Vec<Expr> {
+        let args = sig.inputs();
+        args.iter()
+            .enumerate()
+            .map(|(i, t)| {
+                let lc = Local::from_usize(i + 1); // The zeroth index (local variable) is reserved for the return value of the function. Hence, function argument index starts from one.
+                let ident = self.codegen_var_name(&lc);
+                let typ = self.codegen_ty(*t);
+                Expr::symbol_expression(ident, typ)
+            })
+            .collect()
+    }
+
+    /// Transforms current function's return value into an expression
+    fn extract_function_return_value(&mut self, sig: FnSig<'tcx>) -> Expr {
+        let rt = sig.output();
+        let lc = Local::from_usize(0); // The zeroth index (local variable) is reserved for the return value of the function.
+        let ident = self.codegen_var_name(&lc);
+        let typ = self.codegen_ty(rt);
+        Expr::symbol_expression(ident, typ)
+    }
+
+    /// In order to keep the contract symbol self-contained, every function contract clause
+    /// such as `requires`, `ensures`, etc. is wrapped into a lambda expression.
+    /// The binding variables of these lambda expressions are -
+    ///  1) the return value of the function as the first variable, followed by,
+    ///  2) the list of function arguments (in order).
+    fn get_lambda_binding_variables(&mut self, sig: FnSig<'tcx>) -> Vec<Expr> {
+        let mut vars = vec![];
+        let ret = self.extract_function_return_value(sig);
+        vars.push(ret);
+        let args = self.extract_function_arguments(sig);
+        vars.extend(args);
+        return vars;
+    }
+
+    /// Generates a specification containing a lambda expression with "true" as its body
+    fn spec_true(&mut self, sig: FnSig<'tcx>) -> Spec {
+        let bv = self.get_lambda_binding_variables(sig);
+        let mir = self.current_fn().mir();
+        let loc = self.codegen_span(&mir.span);
+        Spec::new(bv, Expr::bool_true(), loc)
+    }
+
+    /// Generates a symbol for the function contract and adds it to the symbol table
+    pub fn codegen_assigns_clause(&mut self, args: Vec<NestedMetaItem>) {
+        let mir = self.current_fn().mir();
+        let loc = self.codegen_span(&mir.span);
+        let sig = self.current_fn().sig();
+        let sig =
+            self.tcx.normalize_erasing_late_bound_regions(ty::ParamEnv::reveal_all(), sig.unwrap());
+        let typ = self.fn_typ();
+
+        let name = format!("contract::{}", self.current_fn().name()); // name of the contract symbol
+
+        // Transform comma-separated "targets" (variables, references, etc.) from the assigns clause into specifications containing lambda expressions
+        let spec_args = args
+            .iter()
+            .map(|a| {
+                let bv = self.get_lambda_binding_variables(sig);
+                let ident = a.meta_item().unwrap().path.segments[0].ident;
+                let sym = self.lookup_local_decl_by_name(&ident.to_string()).unwrap(); // lookup the symbol for the argument in the symbol table
+                let expr = Expr::symbol_expression(sym.name.clone(), sym.typ.clone());
+                Spec::new(bv, expr, loc)
+            })
+            .collect();
+        let contract = Contract::function_contract(
+            vec![self.spec_true(sig)],
+            vec![self.spec_true(sig)],
+            spec_args,
+        );
+        let sym = Symbol::contract(name, typ, contract, loc);
+        self.symbol_table.insert(sym);
+    }
+}

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
@@ -55,7 +55,7 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     /// Generates a symbol for the function contract and adds it to the symbol table
-    pub fn codegen_assigns_clause(&mut self, args: Vec<NestedMetaItem>) {
+    pub fn codegen_modifies_clause(&mut self, args: Vec<NestedMetaItem>) {
         let mir = self.current_fn().mir();
         let loc = self.codegen_span(&mir.span);
         let sig = self.current_fn().sig();
@@ -65,7 +65,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
         let name = format!("contract::{}", self.current_fn().name()); // name of the contract symbol
 
-        // Transform comma-separated "targets" (variables, references, etc.) from the assigns clause into specifications containing lambda expressions
+        // Transform comma-separated "targets" (variables, references, etc.) from the modifies clause into specifications containing lambda expressions
         let spec_args = args
             .iter()
             .map(|a| {

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
@@ -57,10 +57,10 @@ impl<'tcx> GotocCtx<'tcx> {
     /// Generates a new contract symbol and adds it to the symbol table.
     /// See https://github.com/diffblue/cbmc/pull/6799 for further details about the contract symbol.
     /// The name of the contract symbol should be set to "contract::<function-name>".
-    /// The type field of the contract symbol contains the `#spec_requires`, `#spec_ensures`, and `#spec_assigns` fields 
+    /// The type field of the contract symbol contains the `#spec_requires`, `#spec_ensures`, and `#spec_assigns` fields
     ///     for specifying the preconditions, postconditions, and the modifies (assigns/write) set of the function respectively.
-    /// The contract symbol serves as the entry point for CBMC to check the contract. 
-    /// Since we want CBMC to only check the modifies clause, we set the other expected fields - 
+    /// The contract symbol serves as the entry point for CBMC to check the contract.
+    /// Since we want CBMC to only check the modifies clause, we set the other expected fields -
     ///     `#spec_requires` and `#spec_ensures` to "true".
     pub fn codegen_modifies_clause(&mut self, args: Vec<NestedMetaItem>) {
         let mir = self.current_fn().mir();

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
@@ -85,7 +85,13 @@ impl<'tcx> GotocCtx<'tcx> {
                         let expr = Expr::symbol_expression(sym.name.clone(), sym.typ.clone());
                         Some(Spec::new(bv, expr, loc))
                     }
-                    None => panic!("Global variables are not supported inside modifies clauses."),
+                    None => {
+                        self.tcx.sess.span_err(
+                            mir.span,
+                            "Global variables are not supported inside modifies clauses.",
+                        );
+                        None
+                    }
                 }
             })
             .collect();

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
@@ -86,10 +86,9 @@ impl<'tcx> GotocCtx<'tcx> {
                         Some(Spec::new(bv, expr, loc))
                     }
                     None => {
-                        self.tcx.sess.span_err(
-                            mir.span,
-                            "Global variables are not supported inside modifies clauses.",
-                        );
+                        self.tcx
+                            .sess
+                            .span_err(mir.span, "Symbol not supported inside modifies clauses.");
                         None
                     }
                 }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -304,7 +304,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// Generates a symbol for the function contract and adds it to the symbol table
     fn handle_kanitool_assigns(&mut self, attr: &Attribute) {
         let attr_args = attr.meta_item_list().unwrap();
-        self.codegen_assigns_clause(attr_args);
+        self.codegen_modifies_clause(attr_args);
     }
 
     /// Updates the proof harness with new unwind value

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -273,7 +273,7 @@ impl<'tcx> GotocCtx<'tcx> {
         for attr in other_attributes.iter() {
             match attr.0.as_str() {
                 "unwind" => self.handle_kanitool_unwind(attr.1, &mut harness),
-                "assigns" => self.handle_kanitool_assigns(attr.1),
+                "modifies" => self.handle_kanitool_modifies(attr.1),
                 _ => {
                     self.tcx.sess.span_err(
                         attr.1.span,
@@ -302,7 +302,7 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     /// Generates a symbol for the function contract and adds it to the symbol table
-    fn handle_kanitool_assigns(&mut self, attr: &Attribute) {
+    fn handle_kanitool_modifies(&mut self, attr: &Attribute) {
         let attr_args = attr.meta_item_list().unwrap();
         self.codegen_modifies_clause(attr_args);
     }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -273,6 +273,7 @@ impl<'tcx> GotocCtx<'tcx> {
         for attr in other_attributes.iter() {
             match attr.0.as_str() {
                 "unwind" => self.handle_kanitool_unwind(attr.1, &mut harness),
+                "assigns" => self.handle_kanitool_assigns(attr.1),
                 _ => {
                     self.tcx.sess.span_err(
                         attr.1.span,
@@ -298,6 +299,12 @@ impl<'tcx> GotocCtx<'tcx> {
             original_line: loc.line().unwrap().to_string(),
             unwind_value: None,
         }
+    }
+
+    /// Generates a symbol for the function contract and adds it to the symbol table
+    fn handle_kanitool_assigns(&mut self, attr: &Attribute) {
+        let attr_args = attr.meta_item_list().unwrap();
+        self.codegen_assigns_clause(attr_args);
     }
 
     /// Updates the proof harness with new unwind value

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/mod.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/mod.rs
@@ -6,6 +6,7 @@
 
 mod assert;
 mod block;
+mod contract;
 mod function;
 mod intrinsic;
 mod operand;

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
@@ -4,7 +4,7 @@ use super::super::codegen::TypeExt;
 use crate::codegen_cprover_gotoc::codegen::typ::{is_pointer, pointee_type};
 use crate::codegen_cprover_gotoc::codegen::PropertyClass;
 use crate::codegen_cprover_gotoc::GotocCtx;
-use cbmc::goto_program::{Expr, ExprValue, Location, Stmt, SymbolTable, Type};
+use cbmc::goto_program::{Expr, ExprValue, Location, Stmt, Symbol, SymbolTable, Type};
 use cbmc::{btree_string_map, InternedString};
 use rustc_errors::FatalError;
 use rustc_middle::ty::layout::LayoutOf;
@@ -237,5 +237,20 @@ impl<'tcx> GotocCtx<'tcx> {
         let component = components.first().unwrap();
         assert_eq!(component.name().to_string().as_str(), "pointer");
         assert!(component.typ().is_pointer() || component.typ().is_rust_fat_ptr(&self.symbol_table))
+    }
+}
+
+impl<'tcx> GotocCtx<'tcx> {
+    /// Iterates over the list of local declarations of the current function and
+    /// returns the corresponding symbol from the symbol table, if the base name matches the target.
+    pub fn lookup_local_decl_by_name(&mut self, target: &str) -> Option<&Symbol> {
+        let mir = self.current_fn().mir();
+        let ldecls = &mir.local_decls;
+        let sym_name = ldecls
+            .indices()
+            .into_iter()
+            .find(|lc| self.codegen_var_base_name(&lc) == target)
+            .map_or_else(|| None, |lc| Some(self.codegen_var_name(&lc)))?;
+        self.symbol_table.lookup(sym_name)
     }
 }


### PR DESCRIPTION
### Description of changes: 

Added support to codegen function contracts from MIR to gotoc. 

While handling Kani attributes during codegen, if a `#[kani::assigns(...)]` clause is present (macro yet to be implemented), a new symbol is created for the function contract (using the `Symbol::contract(..)` constructor) and added to the symbol table. 

### Resolved issues:

### Call-outs:

We are only checking the write-set with CBMC. The `[kani::ensures(...)]` and `[kani::requires(...)]` clauses will be inlined as `assert` or `assume` in the future, depending on whether the contract is being checked or replaced. However, CBMC expects all three fields - `#[spec_ensures]`, `#[spec_requires]` and `[spec_assigns]` to be populated while creating a contract symbol. Hence the `ensures` and `requires` are set to be `true` in the newly create contract symbol.


### Testing:

* How is this change tested?
By running Kani regression tests. Need to have end-to-end pipeline before adding additional test cases. Will not merge into main until we have these tests.

* Is this a refactor change?
No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
