### PR TITLE
Add hooks for handling pre and post conditions in function contracts.

### DIFF
--- a/kani-compiler/kani_queries/src/lib.rs
+++ b/kani-compiler/kani_queries/src/lib.rs
@@ -18,6 +18,12 @@ pub trait UserInput {
 
     fn set_ignore_global_asm(&mut self, global_asm: bool);
     fn get_ignore_global_asm(&self) -> bool;
+
+    fn set_enforce_contracts(&mut self, enforce_contracts: bool);
+    fn get_enforce_contracts(&self) -> bool;
+
+    fn set_replace_with_contracts(&mut self, replace_with_contracts: bool);
+    fn get_replace_with_contracts(&self) -> bool;
 }
 
 #[derive(Debug, Default)]
@@ -27,6 +33,8 @@ pub struct QueryDb {
     symbol_table_passes: Vec<String>,
     json_pretty_print: AtomicBool,
     ignore_global_asm: AtomicBool,
+    enforce_contracts: AtomicBool,
+    replace_with_contracts: AtomicBool,
 }
 
 impl UserInput for QueryDb {
@@ -68,5 +76,20 @@ impl UserInput for QueryDb {
 
     fn get_ignore_global_asm(&self) -> bool {
         self.ignore_global_asm.load(Ordering::Relaxed)
+    }
+
+    fn set_enforce_contracts(&mut self, enforce_contracts: bool) {
+        self.enforce_contracts.store(enforce_contracts, Ordering::Relaxed);
+    }
+    fn get_enforce_contracts(&self) -> bool {
+        self.enforce_contracts.load(Ordering::Relaxed)
+    }
+
+    fn set_replace_with_contracts(&mut self, replace_with_contracts: bool) {
+        self.replace_with_contracts.store(replace_with_contracts, Ordering::Relaxed);
+    }
+
+    fn get_replace_with_contracts(&self) -> bool {
+        self.replace_with_contracts.load(Ordering::Relaxed)
     }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -256,42 +256,25 @@ impl<'tcx> GotocHook<'tcx> for Postcondition {
     fn handle(
         &self,
         tcx: &mut GotocCtx<'tcx>,
-        _instance: Instance<'tcx>,
+        instance: Instance<'tcx>,
         mut fargs: Vec<Expr>,
-        _assign_to: Place<'tcx>,
+        assign_to: Place<'tcx>,
         target: Option<BasicBlock>,
         span: Option<Span>,
     ) -> Stmt {
         assert_eq!(fargs.len(), 1);
-        let cond = fargs.remove(0).cast_to(Type::bool());
-        let target = target.unwrap();
+        // let cond = fargs.remove(0).cast_to(Type::bool());
+        // let target = target.unwrap();
         let loc = tcx.codegen_span_option(span);
 
         if tcx.queries.get_enforce_contracts() {
-            // If function contract is being checked,
-            // convert "postcondition(x)" into "assert!(x)"
-            let tmp = tcx.gen_temp_variable(cond.typ().clone(), loc).to_expr();
-            Stmt::block(
-                vec![
-                    Stmt::decl(tmp.clone(), Some(cond), loc),
-                    tcx.codegen_assert(tmp.clone(), PropertyClass::Assertion, "postcondition", loc),
-                    Stmt::goto(tcx.current_fn().find_label(&target), loc),
-                ],
-                loc,
-            )
+            fargs.push(Expr::string_constant("Post-condition failed"));
+            Assert.handle(tcx, instance, fargs, assign_to, target, span)
         } else if tcx.queries.get_replace_with_contracts() {
-            // If function is being replace with contract,
-            // convert "postcondition(x)" into "assume!(x)"
-            Stmt::block(
-                vec![
-                    Stmt::assume(cond, loc),
-                    Stmt::goto(tcx.current_fn().find_label(&target), loc),
-                ],
-                loc,
-            )
+            Assume.handle(tcx, instance, fargs, assign_to, target, span)
         } else {
             // The function contract is being ignored in this case.
-            Stmt::block(vec![Stmt::goto(tcx.current_fn().find_label(&target), loc)], loc)
+            Stmt::block(vec![Stmt::goto(tcx.current_fn().find_label(&target.unwrap()), loc)], loc)
         }
     }
 }
@@ -307,42 +290,52 @@ impl<'tcx> GotocHook<'tcx> for Precondition {
     fn handle(
         &self,
         tcx: &mut GotocCtx<'tcx>,
-        _instance: Instance<'tcx>,
+        instance: Instance<'tcx>,
         mut fargs: Vec<Expr>,
-        _assign_to: Place<'tcx>,
+        assign_to: Place<'tcx>,
         target: Option<BasicBlock>,
         span: Option<Span>,
     ) -> Stmt {
         assert_eq!(fargs.len(), 1);
-        let cond = fargs.remove(0).cast_to(Type::bool());
-        let target = target.unwrap();
+        // let cond = fargs.remove(0).cast_to(Type::bool());
+        // let target = target.unwrap();
         let loc = tcx.codegen_span_option(span);
 
         if tcx.queries.get_enforce_contracts() {
-            // If function contract is being checked,
-            // convert "precondition(x)" into "assume!(x)"
-            Stmt::block(
-                vec![
-                    Stmt::assume(cond, loc),
-                    Stmt::goto(tcx.current_fn().find_label(&target), loc),
-                ],
-                loc,
-            )
+            Assume.handle(tcx, instance, fargs, assign_to, target, span)
         } else if tcx.queries.get_replace_with_contracts() {
-            // If function is being replace with contract,
-            // convert  "precondition(x)" into "assert!(x)"
-            let tmp = tcx.gen_temp_variable(cond.typ().clone(), loc).to_expr();
-            Stmt::block(
-                vec![
-                    Stmt::decl(tmp.clone(), Some(cond), loc),
-                    tcx.codegen_assert(tmp.clone(), PropertyClass::Assertion, "precondition", loc),
-                ],
-                loc,
-            )
+            fargs.push(Expr::string_constant("Post-condition failed"));
+            Assert.handle(tcx, instance, fargs, assign_to, target, span)
         } else {
             // The function contract is being ignored in this case.
-            Stmt::block(vec![Stmt::goto(tcx.current_fn().find_label(&target), loc)], loc)
+            Stmt::block(vec![Stmt::goto(tcx.current_fn().find_label(&target.unwrap()), loc)], loc)
         }
+
+        // if tcx.queries.get_enforce_contracts() {
+        //     // If function contract is being checked,
+        //     // convert "precondition(x)" into "assume!(x)"
+        //     Stmt::block(
+        //         vec![
+        //             Stmt::assume(cond, loc),
+        //             Stmt::goto(tcx.current_fn().find_label(&target), loc),
+        //         ],
+        //         loc,
+        //     )
+        // } else if tcx.queries.get_replace_with_contracts() {
+        //     // If function is being replace with contract,
+        //     // convert  "precondition(x)" into "assert!(x)"
+        //     let tmp = tcx.gen_temp_variable(cond.typ().clone(), loc).to_expr();
+        //     Stmt::block(
+        //         vec![
+        //             Stmt::decl(tmp.clone(), Some(cond), loc),
+        //             tcx.codegen_assert(tmp.clone(), PropertyClass::Assertion, "precondition", loc),
+        //         ],
+        //         loc,
+        //     )
+        // } else {
+        //     // The function contract is being ignored in this case.
+        //     Stmt::block(vec![Stmt::goto(tcx.current_fn().find_label(&target), loc)], loc)
+        // }
     }
 }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -402,24 +402,12 @@ impl<'tcx> GotocHook<'tcx> for ReplaceFunctionBody {
         let target = target.unwrap();
         let pe = unwrap_or_return_codegen_unimplemented_stmt!(tcx, tcx.codegen_place(&assign_to))
             .goto_expr;
-        if tcx.queries.get_replace_with_contracts() {
-            // function is being replace with contract
-            Stmt::block(
-                vec![
-                    pe.assign(Expr::c_true(), loc),
-                    Stmt::goto(tcx.current_fn().find_label(&target), loc),
-                ],
-                loc,
-            )
-        } else {
-            Stmt::block(
-                vec![
-                    pe.assign(Expr::c_false(), loc),
-                    Stmt::goto(tcx.current_fn().find_label(&target), loc),
-                ],
-                loc,
-            )
-        }
+        let value =
+            if tcx.queries.get_replace_with_contracts() { Expr::c_true() } else { Expr::c_false() };
+        Stmt::block(
+            vec![pe.assign(value, loc), Stmt::goto(tcx.current_fn().find_label(&target), loc)],
+            loc,
+        )
     }
 }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -263,8 +263,6 @@ impl<'tcx> GotocHook<'tcx> for Postcondition {
         span: Option<Span>,
     ) -> Stmt {
         assert_eq!(fargs.len(), 1);
-        // let cond = fargs.remove(0).cast_to(Type::bool());
-        // let target = target.unwrap();
         let loc = tcx.codegen_span_option(span);
 
         if tcx.queries.get_enforce_contracts() {
@@ -297,45 +295,17 @@ impl<'tcx> GotocHook<'tcx> for Precondition {
         span: Option<Span>,
     ) -> Stmt {
         assert_eq!(fargs.len(), 1);
-        // let cond = fargs.remove(0).cast_to(Type::bool());
-        // let target = target.unwrap();
         let loc = tcx.codegen_span_option(span);
 
         if tcx.queries.get_enforce_contracts() {
             Assume.handle(tcx, instance, fargs, assign_to, target, span)
         } else if tcx.queries.get_replace_with_contracts() {
-            fargs.push(Expr::string_constant("Post-condition failed"));
+            fargs.push(Expr::string_constant("Pre-condition failed"));
             Assert.handle(tcx, instance, fargs, assign_to, target, span)
         } else {
             // The function contract is being ignored in this case.
             Stmt::block(vec![Stmt::goto(tcx.current_fn().find_label(&target.unwrap()), loc)], loc)
         }
-
-        // if tcx.queries.get_enforce_contracts() {
-        //     // If function contract is being checked,
-        //     // convert "precondition(x)" into "assume!(x)"
-        //     Stmt::block(
-        //         vec![
-        //             Stmt::assume(cond, loc),
-        //             Stmt::goto(tcx.current_fn().find_label(&target), loc),
-        //         ],
-        //         loc,
-        //     )
-        // } else if tcx.queries.get_replace_with_contracts() {
-        //     // If function is being replace with contract,
-        //     // convert  "precondition(x)" into "assert!(x)"
-        //     let tmp = tcx.gen_temp_variable(cond.typ().clone(), loc).to_expr();
-        //     Stmt::block(
-        //         vec![
-        //             Stmt::decl(tmp.clone(), Some(cond), loc),
-        //             tcx.codegen_assert(tmp.clone(), PropertyClass::Assertion, "precondition", loc),
-        //         ],
-        //         loc,
-        //     )
-        // } else {
-        //     // The function contract is being ignored in this case.
-        //     Stmt::block(vec![Stmt::goto(tcx.current_fn().find_label(&target), loc)], loc)
-        // }
     }
 }
 

--- a/kani-compiler/src/main.rs
+++ b/kani-compiler/src/main.rs
@@ -90,6 +90,8 @@ fn main() -> Result<(), &'static str> {
     queries.set_check_assertion_reachability(matches.is_present(parser::ASSERTION_REACH_CHECKS));
     queries.set_output_pretty_json(matches.is_present(parser::PRETTY_OUTPUT_FILES));
     queries.set_ignore_global_asm(matches.is_present(parser::IGNORE_GLOBAL_ASM));
+    queries.set_enforce_contracts(matches.is_present(parser::ENFORCE_CONTRACTS));
+    queries.set_replace_with_contracts(matches.is_present(parser::REPLACE_WITH_CONTRACTS));
 
     // Generate rustc args.
     let rustc_args = generate_rustc_args(&matches);

--- a/kani-compiler/src/parser.rs
+++ b/kani-compiler/src/parser.rs
@@ -37,6 +37,12 @@ pub const PRETTY_OUTPUT_FILES: &str = "pretty-json-files";
 /// Option used for suppressing global ASM error.
 pub const IGNORE_GLOBAL_ASM: &str = "ignore-global-asm";
 
+/// Option used for checking function contracts.
+pub const ENFORCE_CONTRACTS: &str = "enforce-contracts";
+
+/// Option used for replacing function with its contract.
+pub const REPLACE_WITH_CONTRACTS: &str = "replace-with-contracts";
+
 /// Option name used to override the sysroot.
 pub const SYSROOT: &str = "sysroot";
 
@@ -142,6 +148,17 @@ pub fn parser<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name(IGNORE_GLOBAL_ASM)
                 .long("--ignore-global-asm")
                 .help("Suppress error due to the existence of global_asm in a crate"),
+        )
+        .arg(
+            Arg::with_name(ENFORCE_CONTRACTS)
+                .long("--enforce-contracts")
+                .help("Check if functions satisfy their contracts."),
+        )
+        .arg(
+            Arg::with_name(REPLACE_WITH_CONTRACTS)
+                .long("--replace-with-contracts")
+                .help("Replace functions with their contracts.")
+                .conflicts_with(ENFORCE_CONTRACTS),
         )
 }
 

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -148,6 +148,14 @@ pub struct KaniArgs {
     /// This option may impact the soundness of the analysis and may cause false proofs and/or counterexamples
     #[structopt(long, hidden_short_help(true), requires("enable-unstable"))]
     pub ignore_global_asm: bool,
+
+    /// Check if functions satisfy their contracts.
+    #[structopt(long, hidden_short_help(true), requires("enable-unstable"))]
+    pub enforce_contracts: bool,
+
+    /// Replace functions with their contracts.
+    #[structopt(long, hidden_short_help(true), requires("enable-unstable"))]
+    pub replace_with_contracts: bool,
     /*
     The below is a "TODO list" of things not yet implemented from the kani_flags.py script.
 

--- a/kani-driver/src/call_single_file.rs
+++ b/kani-driver/src/call_single_file.rs
@@ -120,6 +120,12 @@ impl KaniSession {
         if self.args.ignore_global_asm {
             flags.push("--ignore-global-asm".into());
         }
+        if self.args.enforce_contracts {
+            flags.push("--enforce-contracts".into());
+        }
+        if self.args.replace_with_contracts {
+            flags.push("--replace-with-contracts".into());
+        }
 
         // Stratification point!
         // Above are arguments that should be parsed by kani-compiler

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -125,5 +125,25 @@ pub fn panic(message: &'static str) -> ! {
     panic!("{}", message)
 }
 
+/// Function used to inline `#[kani::requires(...)]` function contract clauses as "precondition(..)"
+/// statements within the function body.
+#[inline(never)]
+#[rustc_diagnostic_item = "KaniPrecondition"]
+pub fn precondition(_cond: bool) {}
+
+/// Function used to inline `#[kani::ensures(...)]` function contract clauses as "postcondition(..)"
+/// statements within the function body.
+#[inline(never)]
+#[rustc_diagnostic_item = "KaniPostcondition"]
+pub fn postcondition(_cond: bool) {}
+
+/// Function used as a flag to nondet the body of a function when a function is being replaced
+/// by its contract.
+#[inline(never)]
+#[rustc_diagnostic_item = "KaniReplaceFunctionBody"]
+pub fn replace_function_body() -> bool {
+    unimplemented!("Kani replace_function_body")
+}
+
 /// Kani proc macros must be in a separate crate
 pub use kani_macros::*;


### PR DESCRIPTION
### Description of changes: 

Background: During macro expansion (yet to be implemented), `#[kani::requires(x)]` will get inlined as `kani::precondition(x)` in the function body before the actual function body begins. Similarly, `#[kani::ensures(x)]` will get inlined as `kani::postcondition(x)` at the end of the function body. The actual function body will get wrapped in an inner function that gets called and the corresponding return value is returned from the wrapper function. 

This change includes - 
1) Hooks for replacing `precondition(x)` calls into `assert` or `assume` statements depending on whether a function contract is being checked or if a function is being replaced by its contract.  
2) Similarly, add hooks for replacing `postcondition(x)` calls into `assert` or `assume` statements.
2) Add Kani flag `--enforce-contracts` to checks all function contracts.
3) Add Kani flag `--replace-with-contracts` for replacing functions with their contracts, if a contract exists.

### Resolved issues:

Resolves https://github.com/model-checking/kani/issues/1501


### Call-outs:


### Testing:

* How is this change tested?
By running Kani regression tests. Need to have end-to-end pipeline before adding additional test cases. Will not merge into main until we have these tests.

* Is this a refactor change?
No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
