### PR TITLE
More reliable property attributes extraction

### DIFF
--- a/kani-driver/src/cbmc_output_parser.rs
+++ b/kani-driver/src/cbmc_output_parser.rs
@@ -324,7 +324,11 @@ impl<'de> serde::Deserialize<'de> for PropertyId {
         // Return tuple after converting counter from string into number.
         // Safe to do because we've checked the format earlier.
         let class = String::from(attributes_tuple.1);
-        Ok(PropertyId { fn_name: attributes_tuple.0, class, id: attributes_tuple.2.parse().unwrap() })
+        Ok(PropertyId {
+            fn_name: attributes_tuple.0,
+            class,
+            id: attributes_tuple.2.parse().unwrap(),
+        })
     }
 }
 

--- a/kani-driver/src/cbmc_output_parser.rs
+++ b/kani-driver/src/cbmc_output_parser.rs
@@ -323,9 +323,8 @@ impl<'de> serde::Deserialize<'de> for PropertyId {
         );
         // Return tuple after converting counter from string into number.
         // Safe to do because we've checked the format earlier.
-        let fn_name = attributes_tuple.0.map(|x| String::from(x));
-        let class = attributes_tuple.1.map(|x| String::from(x));
-        Ok(PropertyId { fn_name, class, id: attributes_tuple.2.parse().unwrap() })
+        let class = String::from(attributes_tuple.1);
+        Ok(PropertyId { fn_name: attributes_tuple.0, class, id: attributes_tuple.2.parse().unwrap() })
     }
 }
 

--- a/kani-driver/src/cbmc_output_parser.rs
+++ b/kani-driver/src/cbmc_output_parser.rs
@@ -1144,96 +1144,134 @@ fn determine_verification_result(properties: &[Property]) -> bool {
     number_failed_properties == 0
 }
 
-#[test]
-fn check_property_id_deserialization_general() {
-    let prop_id_string = "\"alloc::raw_vec::RawVec::<u8>::allocate_in.sanity_check.1\"";
-    let prop_id_result: Result<PropertyId, serde_json::Error> =
-        serde_json::from_str(prop_id_string);
-    let prop_id = prop_id_result.unwrap();
-    assert_eq!(prop_id.fn_name, Some(String::from("alloc::raw_vec::RawVec::<u8>::allocate_in")));
-    assert_eq!(prop_id.class, Some(String::from("sanity_check")));
-    assert_eq!(prop_id.id, 1);
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn check_property_id_deserialization_general() {
+        let prop_id_string = "\"alloc::raw_vec::RawVec::<u8>::allocate_in.sanity_check.1\"";
+        let prop_id_result: Result<PropertyId, serde_json::Error> =
+            serde_json::from_str(prop_id_string);
+        let prop_id = prop_id_result.unwrap();
+        assert_eq!(
+            prop_id.fn_name,
+            Some(String::from("alloc::raw_vec::RawVec::<u8>::allocate_in"))
+        );
+        assert_eq!(prop_id.class, Some(String::from("sanity_check")));
+        assert_eq!(prop_id.id, 1);
 
-    let dummy_prop = Property {
-        description: "".to_string(),
-        property_id: prop_id,
-        source_location: SourceLocation { function: None, file: None, column: None, line: None },
-        status: CheckStatus::Success,
-        reach: None,
-        trace: None,
-    };
-    assert_eq!(dummy_prop.property_name().unwrap(), prop_id_string[1..prop_id_string.len() - 1]);
-}
+        let dummy_prop = Property {
+            description: "".to_string(),
+            property_id: prop_id,
+            source_location: SourceLocation {
+                function: None,
+                file: None,
+                column: None,
+                line: None,
+            },
+            status: CheckStatus::Success,
+            reach: None,
+            trace: None,
+        };
+        assert_eq!(
+            dummy_prop.property_name().unwrap(),
+            prop_id_string[1..prop_id_string.len() - 1]
+        );
+    }
 
-#[test]
-fn check_property_id_deserialization_only_name() {
-    let prop_id_string = "\"alloc::raw_vec::RawVec::<u8>::allocate_in.1\"";
-    let prop_id_result: Result<PropertyId, serde_json::Error> =
-        serde_json::from_str(prop_id_string);
-    dbg!(&prop_id_result);
-    let prop_id = prop_id_result.unwrap();
-    assert_eq!(prop_id.fn_name, Some(String::from("alloc::raw_vec::RawVec::<u8>::allocate_in")));
-    assert_eq!(prop_id.class, None);
-    assert_eq!(prop_id.id, 1);
+    #[test]
+    fn check_property_id_deserialization_only_name() {
+        let prop_id_string = "\"alloc::raw_vec::RawVec::<u8>::allocate_in.1\"";
+        let prop_id_result: Result<PropertyId, serde_json::Error> =
+            serde_json::from_str(prop_id_string);
+        dbg!(&prop_id_result);
+        let prop_id = prop_id_result.unwrap();
+        assert_eq!(
+            prop_id.fn_name,
+            Some(String::from("alloc::raw_vec::RawVec::<u8>::allocate_in"))
+        );
+        assert_eq!(prop_id.class, None);
+        assert_eq!(prop_id.id, 1);
 
-    let dummy_prop = Property {
-        description: "".to_string(),
-        property_id: prop_id,
-        source_location: SourceLocation { function: None, file: None, column: None, line: None },
-        status: CheckStatus::Success,
-        reach: None,
-        trace: None,
-    };
-    assert_eq!(dummy_prop.property_name().unwrap(), prop_id_string[1..prop_id_string.len() - 1]);
-}
+        let dummy_prop = Property {
+            description: "".to_string(),
+            property_id: prop_id,
+            source_location: SourceLocation {
+                function: None,
+                file: None,
+                column: None,
+                line: None,
+            },
+            status: CheckStatus::Success,
+            reach: None,
+            trace: None,
+        };
+        assert_eq!(
+            dummy_prop.property_name().unwrap(),
+            prop_id_string[1..prop_id_string.len() - 1]
+        );
+    }
 
-#[test]
-fn check_property_id_deserialization_only_class() {
-    let prop_id_string = "\"assertion.1\"";
-    let prop_id_result: Result<PropertyId, serde_json::Error> =
-        serde_json::from_str(prop_id_string);
-    let prop_id = prop_id_result.unwrap();
-    assert_eq!(prop_id.fn_name, None);
-    assert_eq!(prop_id.class, Some(String::from("assertion")));
-    assert_eq!(prop_id.id, 1);
+    #[test]
+    fn check_property_id_deserialization_only_class() {
+        let prop_id_string = "\"assertion.1\"";
+        let prop_id_result: Result<PropertyId, serde_json::Error> =
+            serde_json::from_str(prop_id_string);
+        let prop_id = prop_id_result.unwrap();
+        assert_eq!(prop_id.fn_name, None);
+        assert_eq!(prop_id.class, Some(String::from("assertion")));
+        assert_eq!(prop_id.id, 1);
 
-    let dummy_prop = Property {
-        description: "".to_string(),
-        property_id: prop_id,
-        source_location: SourceLocation { function: None, file: None, column: None, line: None },
-        status: CheckStatus::Success,
-        reach: None,
-        trace: None,
-    };
-    assert_eq!(dummy_prop.property_name().unwrap(), prop_id_string[1..prop_id_string.len() - 1]);
-}
+        let dummy_prop = Property {
+            description: "".to_string(),
+            property_id: prop_id,
+            source_location: SourceLocation {
+                function: None,
+                file: None,
+                column: None,
+                line: None,
+            },
+            status: CheckStatus::Success,
+            reach: None,
+            trace: None,
+        };
+        assert_eq!(
+            dummy_prop.property_name().unwrap(),
+            prop_id_string[1..prop_id_string.len() - 1]
+        );
+    }
 
-#[test]
-fn check_property_id_deserialization_special() {
-    let prop_id_string = "\".recursion\"";
-    let prop_id_result: Result<PropertyId, serde_json::Error> =
-        serde_json::from_str(prop_id_string);
-    let prop_id = prop_id_result.unwrap();
-    assert_eq!(prop_id.fn_name, None);
-    assert_eq!(prop_id.class, Some(String::from("recursion")));
-    assert_eq!(prop_id.id, 1);
+    #[test]
+    fn check_property_id_deserialization_special() {
+        let prop_id_string = "\".recursion\"";
+        let prop_id_result: Result<PropertyId, serde_json::Error> =
+            serde_json::from_str(prop_id_string);
+        let prop_id = prop_id_result.unwrap();
+        assert_eq!(prop_id.fn_name, None);
+        assert_eq!(prop_id.class, Some(String::from("recursion")));
+        assert_eq!(prop_id.id, 1);
 
-    let dummy_prop = Property {
-        description: "".to_string(),
-        property_id: prop_id,
-        source_location: SourceLocation { function: None, file: None, column: None, line: None },
-        status: CheckStatus::Success,
-        reach: None,
-        trace: None,
-    };
-    assert_eq!(dummy_prop.property_name().unwrap(), "recursion.1");
-}
+        let dummy_prop = Property {
+            description: "".to_string(),
+            property_id: prop_id,
+            source_location: SourceLocation {
+                function: None,
+                file: None,
+                column: None,
+                line: None,
+            },
+            status: CheckStatus::Success,
+            reach: None,
+            trace: None,
+        };
+        assert_eq!(dummy_prop.property_name().unwrap(), "recursion.1");
+    }
 
-#[test]
-#[should_panic]
-fn check_property_id_deserialization_panics() {
-    let prop_id_string = "\"not_a_property_ID\"";
-    let prop_id_result: Result<PropertyId, serde_json::Error> =
-        serde_json::from_str(prop_id_string);
-    let _prop_id = prop_id_result.unwrap();
+    #[test]
+    #[should_panic]
+    fn check_property_id_deserialization_panics() {
+        let prop_id_string = "\"not_a_property_ID\"";
+        let prop_id_result: Result<PropertyId, serde_json::Error> =
+            serde_json::from_str(prop_id_string);
+        let _prop_id = prop_id_result.unwrap();
+    }
 }

--- a/kani-driver/src/cbmc_output_parser.rs
+++ b/kani-driver/src/cbmc_output_parser.rs
@@ -1136,6 +1136,8 @@ fn determine_verification_result(properties: &[Property]) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn check_property_id_deserialization_general() {
         let prop_id_string = "\"alloc::raw_vec::RawVec::<u8>::allocate_in.sanity_check.1\"";

--- a/kani-driver/src/cbmc_output_parser.rs
+++ b/kani-driver/src/cbmc_output_parser.rs
@@ -315,13 +315,6 @@ impl<'de> serde::Deserialize<'de> for PropertyId {
             _ => unreachable!("Found property which doesn't have 2 or 3 attributes"),
         };
         // Do more sanity checks, just in case.
-        if let Some(prop_class) = attributes_tuple.1 {
-            assert!(
-                prop_class.chars().all(|c| c.is_ascii_lowercase() || c == '_' || c == '-')
-                    || prop_class == "NaN",
-                "Found property class `{prop_class}` that doesn't match class format `{id_str}`",
-            );
-        }
         assert!(
             attributes_tuple.2.chars().all(|c| c.is_ascii_digit()),
             "Found property counter that doesn't match number format"

--- a/kani-driver/src/concrete_playback.rs
+++ b/kani-driver/src/concrete_playback.rs
@@ -290,9 +290,7 @@ struct UnitTest {
 ///     ..., ] }
 /// ```
 mod concrete_vals_extractor {
-    use crate::cbmc_output_parser::{
-        get_property_class, get_property_name, CheckStatus, ParserItem, Property, TraceItem,
-    };
+    use crate::cbmc_output_parser::{CheckStatus, ParserItem, Property, TraceItem};
     use anyhow::{bail, ensure, Context, Result};
 
     pub struct ConcreteVal {
@@ -336,7 +334,7 @@ mod concrete_vals_extractor {
     ) -> Result<Vec<ConcreteVal>> {
         let mut concrete_vals: Vec<ConcreteVal> = Vec::new();
         let property_class =
-            get_property_class(property).context("Incorrectly formatted property class.")?;
+            property.property_class().context("Incorrectly formatted property class.")?;
         let property_is_assert = property_class == "assertion";
         let status_is_failure = property.status == CheckStatus::Failure;
 
@@ -344,14 +342,14 @@ mod concrete_vals_extractor {
             if *extracted_assert_fail {
                 println!(
                     "WARNING: Unable to extract concrete values from multiple failing assertions. Skipping property `{}` with description `{}`.",
-                    get_property_name(property).unwrap(),
+                    property.property_name().unwrap(),
                     property.description,
                 );
             } else {
                 *extracted_assert_fail = true;
                 println!(
                     "INFO: Parsing concrete values from property `{}` with description `{}`.",
-                    get_property_name(property).unwrap(),
+                    property.property_name().unwrap(),
                     property.description,
                 );
                 if let Some(trace) = &property.trace {
@@ -367,7 +365,7 @@ mod concrete_vals_extractor {
         } else if !property_is_assert && status_is_failure {
             println!(
                 "WARNING: Unable to extract concrete values from failing non-assertion checks. Skipping property `{}` with description `{}`.",
-                get_property_name(property).unwrap(),
+                property.property_name().unwrap(),
                 property.description,
             );
         }

--- a/kani-driver/src/concrete_playback.rs
+++ b/kani-driver/src/concrete_playback.rs
@@ -291,7 +291,7 @@ struct UnitTest {
 /// ```
 mod concrete_vals_extractor {
     use crate::cbmc_output_parser::{
-        extract_property_class, CheckStatus, ParserItem, Property, TraceItem,
+        get_property_class, get_property_name, CheckStatus, ParserItem, Property, TraceItem,
     };
     use anyhow::{bail, ensure, Context, Result};
 
@@ -336,7 +336,7 @@ mod concrete_vals_extractor {
     ) -> Result<Vec<ConcreteVal>> {
         let mut concrete_vals: Vec<ConcreteVal> = Vec::new();
         let property_class =
-            extract_property_class(property).context("Incorrectly formatted property class.")?;
+            get_property_class(property).context("Incorrectly formatted property class.")?;
         let property_is_assert = property_class == "assertion";
         let status_is_failure = property.status == CheckStatus::Failure;
 
@@ -344,13 +344,15 @@ mod concrete_vals_extractor {
             if *extracted_assert_fail {
                 println!(
                     "WARNING: Unable to extract concrete values from multiple failing assertions. Skipping property `{}` with description `{}`.",
-                    property.property, property.description,
+                    get_property_name(property).unwrap(),
+                    property.description,
                 );
             } else {
                 *extracted_assert_fail = true;
                 println!(
                     "INFO: Parsing concrete values from property `{}` with description `{}`.",
-                    property.property, property.description,
+                    get_property_name(property).unwrap(),
+                    property.description,
                 );
                 if let Some(trace) = &property.trace {
                     for trace_item in trace {
@@ -365,7 +367,8 @@ mod concrete_vals_extractor {
         } else if !property_is_assert && status_is_failure {
             println!(
                 "WARNING: Unable to extract concrete values from failing non-assertion checks. Skipping property `{}` with description `{}`.",
-                property.property, property.description,
+                get_property_name(property).unwrap(),
+                property.description,
             );
         }
         Ok(concrete_vals)

--- a/kani-driver/src/concrete_playback.rs
+++ b/kani-driver/src/concrete_playback.rs
@@ -333,8 +333,7 @@ mod concrete_vals_extractor {
         extracted_assert_fail: &mut bool,
     ) -> Result<Vec<ConcreteVal>> {
         let mut concrete_vals: Vec<ConcreteVal> = Vec::new();
-        let property_class =
-            property.property_class().context("Incorrectly formatted property class.")?;
+        let property_class = property.property_class();
         let property_is_assert = property_class == "assertion";
         let status_is_failure = property.status == CheckStatus::Failure;
 


### PR DESCRIPTION
### Description of changes: 

Improves how we extract property attributes, such as property classes. This work was done while working on #1513 but it turns we don't have to use the property class there, so I opened this PR. Also, opened https://github.com/diffblue/cbmc/issues/7069 to discuss the possibility of adding these attributes separately in the JSON output.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regression.

* Is this a refactor change? Yes.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
