### PR TITLE
Update blog examples to avoid using `Invariant`

### DIFF
--- a/tests/cargo-kani/firecracker-block-example/src/main.rs
+++ b/tests/cargo-kani/firecracker-block-example/src/main.rs
@@ -93,12 +93,7 @@ unsafe impl ByteValued for Descriptor {}
 
 impl kani::Arbitrary for Descriptor {
     fn any() -> Self {
-        Descriptor {
-            addr: kani::any(),
-            len: kani::any(),
-            flags: kani::any(),
-            next: kani::any(),
-        }
+        Descriptor { addr: kani::any(), len: kani::any(), flags: kani::any(), next: kani::any() }
     }
 }
 

--- a/tests/cargo-kani/firecracker-block-example/src/main.rs
+++ b/tests/cargo-kani/firecracker-block-example/src/main.rs
@@ -65,7 +65,7 @@ impl GuestMemoryMmap {
 pub struct GuestAddress(pub u64);
 
 impl kani::Arbitrary for GuestAddress {
-    fn any() -> GuestAddress {
+    fn any() -> Self {
         GuestAddress(kani::any())
     }
 }

--- a/tests/cargo-kani/vecdeque-cve/src/abstract_vecdeque.rs
+++ b/tests/cargo-kani/vecdeque-cve/src/abstract_vecdeque.rs
@@ -27,7 +27,7 @@ struct AbstractVecDeque {
 }
 
 impl kani::Arbitrary for AbstractVecDeque {
-    fn any() -> AbstractVecDeque {
+    fn any() -> Self {
         let value = AbstractVecDeque { tail: kani::any(), head: kani::any(), buf: kani::any() };
         kani::assume(value.is_valid());
         value
@@ -239,18 +239,12 @@ struct AbstractRawVec {
 }
 
 impl kani::Arbitrary for AbstractRawVec {
-    fn any() -> AbstractRawVec {
-        let value = AbstractRawVec { cap: kani::any() };
-        kani::assume(value.is_valid());
-        value
+    fn any() -> Self {
+        AbstractRawVec { cap: kani::any() };
     }
 }
 
 impl AbstractRawVec {
-    fn is_valid(&self) -> bool {
-        true
-    }
-
     pub fn capacity(&self) -> usize {
         self.cap
     }

--- a/tests/cargo-kani/vecdeque-cve/src/abstract_vecdeque.rs
+++ b/tests/cargo-kani/vecdeque-cve/src/abstract_vecdeque.rs
@@ -240,7 +240,7 @@ struct AbstractRawVec {
 
 impl kani::Arbitrary for AbstractRawVec {
     fn any() -> Self {
-        AbstractRawVec { cap: kani::any() };
+        AbstractRawVec { cap: kani::any() }
     }
 }
 


### PR DESCRIPTION
### Description of changes: 

Updates the blog example to avoid using the `Invariant` trait, which was deprecated in #1415. This is required for the publication of the next post in https://github.com/model-checking/kani-verifier-blog/pull/16, which will be updated to avoid the `Invariant` trait as well.

In general, we implement `Arbitrary` for all types that were using `Invariant`. `is_valid` methods have been defined as a standard methods (i.e., moved from `impl Invariant for Type` to `impl Type`), or simply removed if they were defined as `true`. If `is_valid` exists for a given type, it's used in the `any` implementation.

An update to the related posts will be submitted after merging this PR.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regression. In addition, I tested the vecdeque example following the instructions in the blog bost.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
