### PR TITLE
Cleanup the way we test niche values

### DIFF
--- a/cprover_bindings/src/goto_program/expr.rs
+++ b/cprover_bindings/src/goto_program/expr.rs
@@ -1328,7 +1328,7 @@ impl Expr {
 
     /// `self == 0`
     pub fn is_zero(self) -> Self {
-        assert!(self.typ.is_numeric());
+        assert!(self.typ.is_numeric() || self.typ.is_pointer());
         let typ = self.typ.clone();
         self.eq(typ.zero())
     }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -608,7 +608,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
     /// fetch the niche value (as both left and right value)
     pub fn codegen_get_niche(&self, v: Expr, offset: Size, niche_ty: Type) -> Expr {
-        if offset.bytes() == 0 {
+        if offset == Size::ZERO {
             v.reinterpret_cast(niche_ty)
         } else {
             v // t: T

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -608,12 +608,16 @@ impl<'tcx> GotocCtx<'tcx> {
 
     /// fetch the niche value (as both left and right value)
     pub fn codegen_get_niche(&self, v: Expr, offset: Size, niche_ty: Type) -> Expr {
-        v // t: T
-            .address_of() // &t: T*
-            .cast_to(Type::unsigned_int(8).to_pointer()) // (u8 *)&t: u8 *
-            .plus(Expr::int_constant(offset.bytes_usize(), Type::size_t())) // ((u8 *)&t) + offset: u8 *
-            .cast_to(niche_ty.to_pointer()) // (N *)(((u8 *)&t) + offset): N *
-            .dereference() // *(N *)(((u8 *)&t) + offset): N
+        if offset.bytes() == 0 {
+            v.reinterpret_cast(niche_ty)
+        } else {
+            v // t: T
+                .address_of() // &t: T*
+                .cast_to(Type::unsigned_int(8).to_pointer()) // (u8 *)&t: u8 *
+                .plus(Expr::int_constant(offset.bytes(), Type::size_t())) // ((u8 *)&t) + offset: u8 *
+                .cast_to(niche_ty.to_pointer()) // (N *)(((u8 *)&t) + offset): N *
+                .dereference() // *(N *)(((u8 *)&t) + offset): N
+        }
     }
 
     /// Ensure that the given instance is in the symbol table, returning the symbol.

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -508,7 +508,9 @@ impl<'tcx> GotocCtx<'tcx> {
                     self.codegen_discriminant_field(e, ty).cast_to(self.codegen_ty(res_ty))
                 }
                 TagEncoding::Niche { dataful_variant, niche_variants, niche_start } => {
-                    // This code follows the logic in the cranelift codegen backend:
+                    // This code follows the logic in the ssa codegen backend:
+                    // https://github.com/rust-lang/rust/blob/fee75fbe11b1fad5d93c723234178b2a329a3c03/compiler/rustc_codegen_ssa/src/mir/place.rs#L247
+                    // See also the cranelift backend:
                     // https://github.com/rust-lang/rust/blob/05d22212e89588e7c443cc6b9bc0e4e02fdfbc8d/compiler/rustc_codegen_cranelift/src/discriminant.rs#L116
                     let offset = match &layout.fields {
                         FieldsShape::Arbitrary { offsets, .. } => offsets[0],
@@ -523,6 +525,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     // https://github.com/rust-lang/rust/blob/fee75fbe11b1fad5d93c723234178b2a329a3c03/compiler/rustc_codegen_ssa/src/mir/place.rs#L247
                     //
                     // Note: niche_variants can only represent values that fit in a u32.
+                    let result_type = self.codegen_ty(res_ty);
                     let discr_mir_ty = self.codegen_enum_discr_typ(ty);
                     let discr_type = self.codegen_ty(discr_mir_ty);
                     let niche_val = self.codegen_get_niche(e, offset, discr_type);
@@ -539,18 +542,18 @@ impl<'tcx> GotocCtx<'tcx> {
                     };
                     let niche_discr = {
                         let relative_discr = if relative_max == 0 {
-                            self.codegen_ty(res_ty).zero()
+                            result_type.zero()
                         } else {
-                            relative_discr.cast_to(self.codegen_ty(res_ty))
+                            relative_discr.cast_to(result_type.clone())
                         };
                         relative_discr.plus(Expr::int_constant(
                             niche_variants.start().as_u32(),
-                            self.codegen_ty(res_ty),
+                            result_type.clone(),
                         ))
                     };
                     is_niche.ternary(
                         niche_discr,
-                        Expr::int_constant(dataful_variant.as_u32(), self.codegen_ty(res_ty)),
+                        Expr::int_constant(dataful_variant.as_u32(), result_type),
                     )
                 }
             },

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -535,9 +535,13 @@ impl<'tcx> GotocCtx<'tcx> {
                         discr_type.null().eq(relative_discr.clone())
                     } else {
                         tracing::trace!(?tag, "Not Primitive::Pointer");
-                        relative_discr
-                            .clone()
-                            .le(Expr::int_constant(relative_max, relative_discr.typ().clone()))
+                        if relative_max == 0 {
+                            relative_discr.clone().is_zero()
+                        } else {
+                            relative_discr
+                                .clone()
+                                .le(Expr::int_constant(relative_max, relative_discr.typ().clone()))
+                        }
                     };
                     let niche_discr = {
                         let relative_discr = if relative_max == 0 {


### PR DESCRIPTION
### Description of changes: 

The current code for testing niche values is complicated and hard to understand.
Rewrite it so it more closely follows the pattern in `rustc`.
This allows removal of the "Pointer" special case.
It also removes verbiage in the output `goto` that was making debugging more annoying.

### Resolved issues:

Resolves #1540

### Call-outs:
* `is_zero` works on pointers. Remove the assert that prevented it from doing so.

### Testing:

* How is this change tested? Existing unit tests that cover niche optimization

* Is this a refactor change? Kinda?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
