### PR TITLE
Use double braces in assert macro

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -40,7 +40,7 @@ macro_rules! assert {
     ($cond:expr $(,)?) => {
         kani::assert($cond, concat!("assertion failed: ", stringify!($cond)));
     };
-    ($cond:expr, $($arg:tt)+) => {
+    ($cond:expr, $($arg:tt)+) => {{
         kani::assert($cond, concat!(stringify!($($arg)+)));
         // Process the arguments of the assert inside an unreachable block. This
         // is to make sure errors in the arguments (e.g. an unknown variable or
@@ -56,7 +56,7 @@ macro_rules! assert {
         if false {
             let _ = format_args!($($arg)+);
         }
-    };
+    }};
 }
 
 // Override the assert_eq and assert_ne macros to

--- a/tests/kani/Assert/in_match.rs
+++ b/tests/kani/Assert/in_match.rs
@@ -1,0 +1,18 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test verifies that using the assert macro inside a match arm works
+
+enum Foo {
+    A,
+    B,
+}
+
+#[kani::proof]
+fn check_assert_in_match() {
+    let f = Foo::A;
+    match f {
+        Foo::A => assert!(1 + 1 == 2, "Message"),
+        Foo::B => panic!("Failed"),
+    }
+}


### PR DESCRIPTION
### Description of changes: 

PR #1561 introduced a bug that caused an error if an `assert` is used in a `match` arm. This PR fixes this bug through wrapping the `assert` definition in double braces to introduce an extra scope to allow using an `if` block in the macro definition.

### Resolved issues:

Resolves #1572 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Added one test

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
