### PR TITLE
Improve CI times

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -1,7 +1,16 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 name: Kani CI
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    # Not just any push, as that includes tags.
+    # We don't want to re-trigger this workflow when tagging an existing commit.
+    branches:
+      - main
+
+env:
+  RUST_BACKTRACE: 1
 
 jobs:
   regression:
@@ -19,9 +28,7 @@ jobs:
             os: ${{ matrix.os }}
 
       - name: Build Kani
-        run: |
-          export RUST_BACKTRACE=1
-          cargo build --workspace
+        run: cargo build --workspace
 
       - name: Execute Kani regression
         run: ./scripts/kani-regression.sh
@@ -38,9 +45,7 @@ jobs:
             os: ubuntu-20.04
 
       - name: Build Kani
-        run: |
-          export RUST_BACKTRACE=1
-          cargo build --workspace
+        run: cargo build --workspace
 
       - name: Execute Kani performance tests
         run: ./scripts/kani-perf.sh
@@ -59,9 +64,7 @@ jobs:
             os: ubuntu-20.04
 
       - name: Build Kani
-        run: |
-          export RUST_BACKTRACE=1
-          cargo build --workspace
+        run: cargo build --workspace
 
       - name: Install book runner dependencies
         run: ./scripts/setup/install_bookrunner_deps.sh

--- a/scripts/std-lib-regression.sh
+++ b/scripts/std-lib-regression.sh
@@ -13,6 +13,10 @@ then
   WRAPPER="env time -v"
 elif [[ $PLATFORM == "Darwin i386" ]]
 then
+  # Temporarily disabled (in CI) to keeps CI times down
+  # See https://github.com/model-checking/kani/issues/1578
+  exit 0
+
   TARGET="x86_64-apple-darwin"
   # mac 'time' doesn't have -v
   WRAPPER=""


### PR DESCRIPTION
### Description of changes: 

1. Do not needlessly re-trigger the standard regression suite on "tag". Only on push of commits to main. This eliminates some wait time in the release process from being throttled on too many CI tasks running at once.
2. (Minor change to setting `RUST_BACKTRACE`)
3. Disable the stdlib test on macos for the moment. When someone has time to speed this up, we should re-enable it. Tracked in #1578 

### Resolved issues:


### Call-outs:


### Testing:

* How is this change tested? ci

* Is this a refactor change? no

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
