### PR TITLE
Remove the need to build Kani with --workspace

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -28,7 +28,7 @@ jobs:
             os: ${{ matrix.os }}
 
       - name: Build Kani
-        run: cargo build --workspace
+        run: cargo build
 
       - name: Execute Kani regression
         run: ./scripts/kani-regression.sh
@@ -45,7 +45,7 @@ jobs:
             os: ubuntu-20.04
 
       - name: Build Kani
-        run: cargo build --workspace
+        run: cargo build
 
       - name: Execute Kani performance tests
         run: ./scripts/kani-perf.sh
@@ -64,7 +64,7 @@ jobs:
             os: ubuntu-20.04
 
       - name: Build Kani
-        run: cargo build --workspace
+        run: cargo build
 
       - name: Install book runner dependencies
         run: ./scripts/setup/install_bookrunner_deps.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,13 @@ members = [
   "tools/bookrunner/librustdoc",
 ]
 
+# This indicates what package to e.g. build with 'cargo build' without --workspace
+default-members = [
+  ".",
+  "kani-driver",
+  "kani-compiler",
+]
+
 exclude = [
   "build",
   "target",

--- a/docs/src/build-from-source.md
+++ b/docs/src/build-from-source.md
@@ -57,7 +57,7 @@ source $HOME/.cargo/env
 Build the Kani package:
 
 ```
-cargo build --workspace
+cargo build
 ```
 
 Then, optionally, run the regression tests:

--- a/docs/src/cheat-sheets.md
+++ b/docs/src/cheat-sheets.md
@@ -9,11 +9,6 @@ development purposes.
 ### Build
 
 ```bash
-# Build all packages in the repository
-cargo build --workspace
-```
-
-```bash
 # Error "'rustc' panicked at 'failed to lookup `SourceFile` in new context'"
 # or similar error?
 # Clean `kani-compiler` and re-build:

--- a/docs/src/repo-crawl.md
+++ b/docs/src/repo-crawl.md
@@ -84,8 +84,7 @@ will refer to the name as `$CONTAINER_NAME` from now on.
 In this step we will download the list of repositories using a script
 [kani-run-on-repos.sh](../../scripts/exps/kani-run-on-repos.sh)
 
-Make sure to have Kani ready to run. If not, compile with `cargo build
---workspace`.
+Make sure to have Kani ready to run. If not, compile with `cargo build`.
 
 From the repository root, you can run the script with
 `./scripts/exps/kani-run-on-repos.sh $URL_LIST_FILE` where

--- a/scripts/kani-perf.sh
+++ b/scripts/kani-perf.sh
@@ -8,8 +8,8 @@ set -o nounset
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 KANI_DIR=$SCRIPT_DIR/..
 
-# Build all packages in the workspace using release mode.
-cargo build --workspace --release
+# Build Kani using release mode.
+cargo build --release
 
 PERF_DIR="${KANI_DIR}/tests/perf"
 

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -26,7 +26,7 @@ check-cbmc-viewer-version.py --major 3 --minor 5
 ${SCRIPT_DIR}/kani-fmt.sh --check
 
 # Build all packages in the workspace
-cargo build --workspace
+cargo build
 
 # Unit tests
 cargo test -p cprover_bindings

--- a/tools/make-kani-release/src/main.rs
+++ b/tools/make-kani-release/src/main.rs
@@ -62,7 +62,7 @@ fn prebundle(dir: &Path) -> Result<()> {
     }
 
     // Before we begin, ensure Kani is built successfully in release mode.
-    Command::new("cargo").args(&["build", "--release", "--workspace"]).run()?;
+    Command::new("cargo").args(&["build", "--release"]).run()?;
 
     Ok(())
 }


### PR DESCRIPTION
### Description of changes: 

1. This depends on a feature?/bug fix? that will land in stable Rust in 1.64 (released in a month on Sept 22). It works for us now because we're pinned against a nightly Rust that now includes the patch.
2. This might slightly reduce the over all "load" in CI, but I doubt it will decrease CI times by very much. The current critical path is macos-11 regression, and I believe that there we only save the build time of "bookrunner" and "make-kani-release" and nothing else. Hmm, maybe saving a "rebuild" of `library/kani` as well maybe.

### Resolved issues:


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? ci

* Is this a refactor change? sorta

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
