### PR TITLE
Include `symtab2gb` conversion in `--only-codegen`

### DIFF
--- a/kani-driver/src/main.rs
+++ b/kani-driver/src/main.rs
@@ -40,12 +40,14 @@ fn cargokani_main(input_args: Vec<OsString>) -> Result<()> {
     let ctx = session::KaniSession::new(args.common_opts)?;
 
     let outputs = ctx.cargo_build()?;
-    if ctx.args.only_codegen {
-        return Ok(());
-    }
+
     let mut goto_objs: Vec<PathBuf> = Vec::new();
     for symtab in &outputs.symtabs {
         goto_objs.push(ctx.symbol_table_to_gotoc(symtab)?);
+    }
+
+    if ctx.args.only_codegen {
+        return Ok(());
     }
 
     let linked_obj = outputs.outdir.join("cbmc-linked.out");
@@ -86,10 +88,12 @@ fn standalone_main() -> Result<()> {
     let ctx = session::KaniSession::new(args.common_opts)?;
 
     let outputs = ctx.compile_single_rust_file(&args.input)?;
+
+    let goto_obj = ctx.symbol_table_to_gotoc(&outputs.symtab)?;
+
     if ctx.args.only_codegen {
         return Ok(());
     }
-    let goto_obj = ctx.symbol_table_to_gotoc(&outputs.symtab)?;
 
     let linked_obj = util::alter_extension(&args.input, "out");
     {


### PR DESCRIPTION
### Description of changes: 

#957 will need more fixes and discussions to be enabled. In the meantime, this PR includes the `symtab2gb` conversion step in `--only-codegen` runs, so that Kani fails if the conversion from Kani-generated symbol tables to GotoC program is invalid.

### Resolved issues:

Resolves #1584 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regression. Run locally the top 100 crates experiment, but it doesn't affect results.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
