### PR TITLE
Make panic and assert const functions

### DIFF
--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -134,7 +134,7 @@ pub fn expect_fail(_cond: bool, _message: &'static str) {
 #[inline(never)]
 #[rustc_diagnostic_item = "KaniPanic"]
 #[doc(hidden)]
-pub fn panic(message: &'static str) -> ! {
+pub const fn panic(message: &'static str) -> ! {
     panic!("{}", message)
 }
 

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -58,7 +58,7 @@ pub fn assume(_cond: bool) {
 /// ```
 #[inline(never)]
 #[rustc_diagnostic_item = "KaniAssert"]
-pub fn assert(_cond: bool, _msg: &'static str) {
+pub const fn assert(_cond: bool, _msg: &'static str) {
     if cfg!(feature = "concrete_playback") {
         assert!(_cond, "{}", _msg);
     }

--- a/tests/kani/Assert/in_const_fn.rs
+++ b/tests/kani/Assert/in_const_fn.rs
@@ -1,0 +1,15 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test checks that `assert!` can be used in a const fn
+
+const fn const_add(x: i32, y: i32) {
+    assert!(x + y == x);
+}
+
+#[kani::proof]
+fn check() {
+    let x = kani::any();
+    let y = 0;
+    const_add(x, y);
+}

--- a/tests/kani/Panic/const.rs
+++ b/tests/kani/Panic/const.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test checks that `panic!` can be used in a const fn
+
+const fn my_const_fn() {
+    panic!()
+}
+
+#[kani::proof]
+pub fn check_something() {
+    let x: u8 = if kani::any() { 3 } else { 95 };
+    if x > 100 {
+        my_const_fn();
+    }
+}


### PR DESCRIPTION
### Description of changes: 

Rust allows `panic!`, `assert!`, and `assert_eq!` to be used in `const` functions. Kani's override of the `panic` and `assert` macros is implemented via a `panic` and an `assert` function that are not marked as constant, which causes an error when those macros are used in a const function. This PR fixes the issue by adding `const` to the `panic` and `assert` functions.

### Resolved issues:

Resolves #1586 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Added two tests

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
