### PR TITLE
Added packages to release for ubuntu-20.04 only.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          registry: ghcr.io
           context: .
           file: scripts/ci/Dockerfile.bundle-release-20-04
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
       - name: 'Build release bundle'
         run: |
           cargo run -p make-kani-release -- ${{ needs.Release.outputs.version }}
+          cargo package -p kani-verifier
 
       - name: 'Login to GitHub Container Registry'
         uses: docker/login-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
             os: ${{ matrix.os }}
-      
+
       - name: Build release bundle
         run: |
           cargo run -p make-kani-release -- ${{ needs.Release.outputs.version }}
@@ -86,3 +86,44 @@ jobs:
           asset_path: kani-${{ needs.Release.outputs.version }}-${{ matrix.target }}.tar.gz
           asset_name: kani-${{ needs.Release.outputs.version }}-${{ matrix.target }}.tar.gz
           asset_content_type: application/gzip
+
+  Package-Docker:
+    name: 'Package Docker'
+    needs: Release
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    strategy:
+      os: ubuntu-20.04
+      target: x86_64-unknown-linux-gnu
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Kani Dependencies
+        uses: ./.github/actions/setup
+        with:
+          os: ubuntu-20.04
+
+      - name: 'Build release bundle'
+        run: |
+          cargo run -p make-kani-release -- ${{ needs.Release.outputs.version }}
+
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: model-checking
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          registry: ghcr.io
+          context: .
+          file: scripts/ci/Dockerfile.bundle-test-ubuntu-20-04
+          push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tags: |
+            ghcr.io/model-checking/kani-${{ matrix.target }}:${{ needs.Release.outputs.version }}
+            ghcr.io/model-checking/kani-${{ matrix.target }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,8 @@ jobs:
           push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ghcr.io/model-checking/kani-${{ env.os }}:${{ needs.Release.outputs.version }}
-            ghcr.io/model-checking/kani-${{ env.os }}:latest
+            ghcr.io/${{ github.repository_owner }}/kani-${{ env.os }}:${{ needs.Release.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/kani-${{ env.os }}:latest
           labels: |
             org.opencontainers.image.source=${{ github.repositoryUrl }}
             org.opencontainers.image.version=${{ needs.Release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       contents: write
-    strategy:
+    env:
       os: ubuntu-20.04
       target: x86_64-unknown-linux-gnu
     steps:
@@ -125,5 +125,5 @@ jobs:
           push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ghcr.io/model-checking/kani-${{ matrix.target }}:${{ needs.Release.outputs.version }}
-            ghcr.io/model-checking/kani-${{ matrix.target }}:latest
+            ghcr.io/model-checking/kani-${{ os }}:${{ needs.Release.outputs.version }}
+            ghcr.io/model-checking/kani-${{ os }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           registry: ghcr.io
           context: .
-          file: scripts/ci/Dockerfile.bundle-test-ubuntu-20-04
+          file: scripts/ci/Dockerfile.bundle-release-20-04
           push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       contents: write
+      packages: write
     env:
       os: ubuntu-20.04
       target: x86_64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: model-checking
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
@@ -127,3 +127,7 @@ jobs:
           tags: |
             ghcr.io/model-checking/kani-${{ env.os }}:${{ needs.Release.outputs.version }}
             ghcr.io/model-checking/kani-${{ env.os }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ needs.Release.outputs.version }}
+            org.opencontainers.image.licenses=Apache-2.0 OR MIT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 'Set lower case owner name. Needed for docker push.'
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
@@ -125,8 +131,8 @@ jobs:
           push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/kani-${{ env.os }}:${{ needs.Release.outputs.version }}
-            ghcr.io/${{ github.repository_owner }}/kani-${{ env.os }}:latest
+            ghcr.io/${{ env.OWNER_LC }}/kani-${{ env.os }}:${{ needs.Release.outputs.version }}
+            ghcr.io/${{ env.OWNER_LC }}/kani-${{ env.os }}:latest
           labels: |
             org.opencontainers.image.source=${{ github.repositoryUrl }}
             org.opencontainers.image.version=${{ needs.Release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,5 +125,5 @@ jobs:
           push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ghcr.io/model-checking/kani-${{ os }}:${{ needs.Release.outputs.version }}
-            ghcr.io/model-checking/kani-${{ os }}:latest
+            ghcr.io/model-checking/kani-${{ env.os }}:${{ needs.Release.outputs.version }}
+            ghcr.io/model-checking/kani-${{ env.os }}:latest

--- a/scripts/ci/Dockerfile.bundle-release-20-04
+++ b/scripts/ci/Dockerfile.bundle-release-20-04
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true \
     PATH="/root/.cargo/bin:${PATH}"
 WORKDIR /tmp/kani
-COPY ./kani-latest-x86_64-unknown-linux-gnu.tar.gz ./
+COPY ./kani-*-x86_64-unknown-linux-gnu.tar.gz ./kani-latest-x86_64-unknown-linux-gnu.tar.gz
 # Very awkward glob (not regex!) to get `kani-verifier-*` and not `kani-verifier-*.crate`
 COPY ./target/package/kani-verifier-*[^e] ./kani-verifier
 

--- a/scripts/ci/Dockerfile.bundle-release-20-04
+++ b/scripts/ci/Dockerfile.bundle-release-20-04
@@ -25,5 +25,3 @@ RUN apt-get update && \
     cargo-kani setup --use-local-bundle ./kani-latest-x86_64-unknown-linux-gnu.tar.gz && \
     apt-get clean && \
     rm -rf /tmp/kani/* /root/.rustup/toolchains/*/share
-
-LABEL org.opencontainers.image.source https://github.com/model-checking/kani

--- a/scripts/ci/Dockerfile.bundle-release-20-04
+++ b/scripts/ci/Dockerfile.bundle-release-20-04
@@ -1,0 +1,29 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# Docker image for Kani GitHub Package release ubuntu-20-04.
+
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive \
+    DEBCONF_NONINTERACTIVE_SEEN=true \
+    PATH="/root/.cargo/bin:${PATH}"
+WORKDIR /tmp/kani
+COPY ./kani-latest-x86_64-unknown-linux-gnu.tar.gz ./
+# Very awkward glob (not regex!) to get `kani-verifier-*` and not `kani-verifier-*.crate`
+COPY ./target/package/kani-verifier-*[^e] ./kani-verifier
+
+# Install Kani and dependencies. We will install the required
+# toolchain by running an empty cargo command inside kani release
+# directory. Rustup is purged for space.
+
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip curl ctags && \
+    curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none && \
+    (cd kani-verifier/; cargo) && \
+    rustup default $(rustup toolchain list | awk '{ print $1 }') && \
+    cargo install --path ./kani-verifier && \
+    cargo-kani setup --use-local-bundle ./kani-latest-x86_64-unknown-linux-gnu.tar.gz && \
+    apt-get clean && \
+    rm -rf /tmp/kani/* /root/.rustup/toolchains/*/share
+
+LABEL org.opencontainers.image.source https://github.com/model-checking/kani

--- a/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04
+++ b/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04
@@ -18,5 +18,3 @@ COPY ./kani-latest-x86_64-unknown-linux-gnu.tar.gz ./
 COPY ./target/package/kani-verifier-*[^e] ./kani-verifier
 RUN cargo install --path ./kani-verifier
 RUN cargo-kani setup --use-local-bundle ./kani-latest-x86_64-unknown-linux-gnu.tar.gz
-
-LABEL org.opencontainers.image.source https://github.com/model-checking/kani

--- a/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04
+++ b/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04
@@ -18,3 +18,5 @@ COPY ./kani-latest-x86_64-unknown-linux-gnu.tar.gz ./
 COPY ./target/package/kani-verifier-*[^e] ./kani-verifier
 RUN cargo install --path ./kani-verifier
 RUN cargo-kani setup --use-local-bundle ./kani-latest-x86_64-unknown-linux-gnu.tar.gz
+
+LABEL org.opencontainers.image.source https://github.com/model-checking/kani


### PR DESCRIPTION
### Description of changes: 

This PR modifies the release workflow to also push docker images to GHCR. By having these images up in GHCR, users can access kani without compiling it.

### Resolved issues:

Resolves #1587

### Call-outs:
- Since running docker images in CI is restricted to linux, I only implemented the image for ubuntu 20.04
- During testing, make sure to have the 

### Testing:

* How is this change tested? Fork the PR branch, then do a fake release to check that the image is uploaded correctly.

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
