### PR TITLE
Update rustc to nightly-2022-08-30

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -112,7 +112,7 @@ impl<'tcx> GotocCtx<'tcx> {
             self.codegen_function_prelude();
             self.codegen_declare_variables();
 
-            mir.basic_blocks().iter_enumerated().for_each(|(bb, bbd)| self.codegen_block(bb, bbd));
+            mir.basic_blocks.iter_enumerated().for_each(|(bb, bbd)| self.codegen_block(bb, bbd));
 
             let loc = self.codegen_span(&mir.span);
             let stmts = self.current_fn_mut().extract_block();
@@ -354,10 +354,13 @@ impl<'tcx> GotocCtx<'tcx> {
 /// If the attribute is named `kanitool::name`, this extracts `name`
 fn kanitool_attr_name(attr: &ast::Attribute) -> Option<String> {
     match &attr.kind {
-        ast::AttrKind::Normal(ast::AttrItem { path: ast::Path { segments, .. }, .. }, _)
-            if (!segments.is_empty()) && segments[0].ident.as_str() == "kanitool" =>
-        {
-            Some(segments[1].ident.as_str().to_string())
+        ast::AttrKind::Normal(normal) => {
+            let segments = &normal.item.path.segments;
+            if (!segments.is_empty()) && segments[0].ident.as_str() == "kanitool" {
+                Some(segments[1].ident.as_str().to_string())
+            } else {
+                None
+            }
         }
         _ => None,
     }

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -296,7 +296,7 @@ impl<'tcx> GotocCtx<'tcx> {
             self,
             self.tcx
                 .instance_mir(instance.def)
-                .basic_blocks()
+                .basic_blocks
                 .indices()
                 .map(|bb| format!("{:?}", bb))
                 .collect(),

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/debug.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/debug.rs
@@ -81,7 +81,7 @@ impl<'tcx> GotocCtx<'tcx> {
             for l in mir.args_iter().chain(mir.vars_and_temps_iter()) {
                 debug!("let {:?}: {:?}", l, self.local_ty(l));
             }
-            for (bb, bbd) in mir.basic_blocks().iter_enumerated() {
+            for (bb, bbd) in mir.basic_blocks.iter_enumerated() {
                 debug!("block {:?}", bb);
                 for stmt in &bbd.statements {
                     debug!("{:?}", stmt);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2022-08-16"
+channel = "nightly-2022-08-30"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/kani/Iterator/flat_map.rs
+++ b/tests/kani/Iterator/flat_map.rs
@@ -13,11 +13,3 @@ pub fn check_flat_map_char() {
     assert_eq!(hi_flat.next(), Some('i'));
     assert_eq!(hi_flat.next(), None);
 }
-
-#[kani::proof]
-#[kani::unwind(4)]
-fn check_flat_map_len() {
-    let hello = ["Hi", "!"];
-    let length = hello.iter().flat_map(|s| s.chars()).count();
-    assert_eq!(length, 3);
-}

--- a/tests/kani/Iterator/flat_map_count_fixme.rs
+++ b/tests/kani/Iterator/flat_map_count_fixme.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// This test checks the result of using Iterator::flat_map. We had some projection
+// issues with this in the past.
+// This currently fails due to missing core::str::count::char_count_general_case
+// std function:
+// https://github.com/model-checking/kani/issues/1213
+
+#[kani::proof]
+#[kani::unwind(4)]
+fn check_flat_map_len() {
+    let hello = ["Hi", "!"];
+    let length = hello.iter().flat_map(|s| s.chars()).count();
+    assert_eq!(length, 3);
+}

--- a/tests/ui/code-location/expected
+++ b/tests/ui/code-location/expected
@@ -1,7 +1,6 @@
 module/mod.rs:10:5 in function module::not_empty
 main.rs:13:5 in function same_file
 /toolchains/
-alloc/src/vec/mod.rs:2920:81 in function <std::vec::Vec<i32> as std::ops::Drop>::drop
+alloc/src/vec/mod.rs:2921:81 in function <std::vec::Vec<i32> as std::ops::Drop>::drop
 
 VERIFICATION:- SUCCESSFUL
-


### PR DESCRIPTION
### Description of changes: 

This update required a couple of minor changes:

1. `rustc_middle::mir::Body` no longer has a `basic_blocks` method. This has been replaced by accessing the public `basic_blocks` field directly.
2. The data for the `rustc_ast::ast::AttrKind` enum value is now wrapped in an owned smart pointer (`rustc_ast::ptr::P`), so the match statement that extracts the attribute segments was updated accordingly.


### Resolved issues:

Resolves #1614 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

One of the two harnesses in `tests/kani/Iterator/flat_map.rs` is now failing because of a missing `std` function. I moved that harness into a separate `fixme` test.

### Testing:

* How is this change tested? Regressions

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
