### PR TITLE
Only generate tests if the failure is reproducible

### DIFF
--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -210,7 +210,7 @@ impl KaniArgs {
 }
 
 arg_enum! {
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub enum ConcretePlaybackMode {
         Print,
         InPlace,
@@ -331,6 +331,10 @@ impl CargoKaniArgs {
 }
 impl KaniArgs {
     pub fn validate(&self) {
+        self.validate_inner().or_else(|e| -> Result<(), ()> { e.exit() }).unwrap()
+    }
+
+    fn validate_inner(&self) -> Result<(), Error> {
         let extra_unwind =
             self.cbmc_args.iter().any(|s| s.to_str().unwrap().starts_with("--unwind"));
         let natives_unwind = self.default_unwind.is_some() || self.unwind.is_some();
@@ -338,19 +342,28 @@ impl KaniArgs {
         // TODO: these conflicting flags reflect what's necessary to pass current tests unmodified.
         // We should consider improving the error messages slightly in a later pull request.
         if natives_unwind && extra_unwind {
-            Error::with_description(
+            Err(Error::with_description(
                 "Conflicting flags: unwind flags provided to kani and in --cbmc-args.",
                 ErrorKind::ArgumentConflict,
-            )
-            .exit();
-        }
-
-        if self.cbmc_args.contains(&OsString::from("--function")) {
-            Error::with_description(
+            ))
+        } else if self.cbmc_args.contains(&OsString::from("--function")) {
+            Err(Error::with_description(
                 "Invalid flag: --function should be provided to Kani directly, not via --cbmc-args.",
                 ErrorKind::ArgumentConflict,
-            )
-            .exit();
+            ))
+        } else if self.quiet && self.concrete_playback == Some(ConcretePlaybackMode::Print) {
+            Err(Error::with_description(
+                "Conflicting options: --concrete-playback=print and --quiet.",
+                ErrorKind::ArgumentConflict,
+            ))
+        } else if self.concrete_playback.is_some() && self.output_format == OutputFormat::Old {
+            Err(Error::with_description(
+                "Conflicting options: --concrete-playback isn't compatible with \
+                --output-format=old.",
+                ErrorKind::ArgumentConflict,
+            ))
+        } else {
+            Ok(())
         }
     }
 }
@@ -449,5 +462,29 @@ mod tests {
     #[test]
     fn check_disable_slicing_unstable() {
         check_unstable_flag("--no-slice-formula")
+    }
+
+    #[test]
+    fn check_concrete_playback_unstable() {
+        check_unstable_flag("--concrete-playback inplace");
+        check_unstable_flag("--concrete-playback print");
+    }
+
+    /// Check if parsing the given argument string results in the given error.
+    fn expect_validation_error(arg: &str, err: ErrorKind) {
+        let args = StandaloneArgs::from_iter(arg.split_whitespace());
+        assert_eq!(args.common_opts.validate_inner().unwrap_err().kind, err);
+    }
+
+    #[test]
+    fn check_concrete_playback_conflicts() {
+        expect_validation_error(
+            "kani --concrete-playback=print --quiet --enable-unstable test.rs",
+            ErrorKind::ArgumentConflict,
+        );
+        expect_validation_error(
+            "kani --concrete-playback=inplace --output-format=old --enable-unstable test.rs",
+            ErrorKind::ArgumentConflict,
+        );
     }
 }

--- a/tests/ui/concrete-playback/unsupported/expected
+++ b/tests/ui/concrete-playback/unsupported/expected
@@ -1,2 +1,2 @@
 Failed Checks: unwinding assertion loop 0
-WARNING: `check_unwind_fail` failure cannot be reproduced by the concrete playback. Only assertion failures are currently reproducible.
+WARNING: Kani could not produce a concrete playback for `check_unwind_fail` because there were no failing panic checks.

--- a/tests/ui/concrete-playback/unsupported/expected
+++ b/tests/ui/concrete-playback/unsupported/expected
@@ -1,0 +1,2 @@
+Failed Checks: unwinding assertion loop 0
+WARNING: `check_unwind_fail` failure cannot be reproduced by the concrete playback. Only assertion failures are currently reproducible.

--- a/tests/ui/concrete-playback/unsupported/loop.rs
+++ b/tests/ui/concrete-playback/unsupported/loop.rs
@@ -1,0 +1,14 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags: --enable-unstable --concrete-playback=print
+
+#[kani::proof]
+#[kani::unwind(2)]
+fn check_unwind_fail() {
+    let mut cnt = 0;
+    while kani::any() {
+        cnt += 1;
+        assert!(cnt < 10);
+    }
+}


### PR DESCRIPTION
### Description of changes: 

The concrete playback feature was generating an empty test for cases where the verification failed due to some non-reproducible error. For example, unwind loop assertion failure.

Instead, we print a warning if the verification failure doesn't include any reproducible trace.

### Resolved issues:

Resolves #1626 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->

### Call-outs:

I did a bit of refactoring to simplify the code. I replaced the bubbling up error logic and fail fast instead. I thought the code was getting a bit harder to read. I also modified the extraction value logic to do the following:

1. Find an assertion failure.
2. Parse the trace.
3. Iterate over leftover failures and print warnings about them not being handled today.

@sanjit-bhat let me know if you have any strong preference here and I can revert back.

### Testing:

* How is this change tested? New test

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
