### PR TITLE
Enable `--list-harnesses` flag

### DIFF
--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -61,7 +61,9 @@ pub struct KaniArgs {
     /// Keep temporary files generated throughout Kani process
     #[structopt(long, hidden_short_help(true))]
     pub keep_temps: bool,
-
+    /// Return list of harnesses as a JSON String
+    #[structopt(long, hidden(true), requires("enable-unstable"))]
+    pub list_harnesses: bool,
     /// Produce full debug information
     #[structopt(long)]
     pub debug: bool,

--- a/kani-driver/src/main.rs
+++ b/kani-driver/src/main.rs
@@ -66,6 +66,11 @@ fn cargokani_main(input_args: Vec<OsString>) -> Result<()> {
 
     let mut failed_harnesses: Vec<&HarnessMetadata> = Vec::new();
 
+    if ctx.args.list_harnesses {
+        ctx.return_list_harnesses(&sorted_harnesses).unwrap();
+        return Ok(());
+    }
+
     for harness in &sorted_harnesses {
         let harness_filename = harness.pretty_name.replace("::", "-");
         let report_dir = report_base.join(format!("report-{}", harness_filename));
@@ -192,6 +197,14 @@ impl KaniSession {
             std::process::exit(1);
         }
 
+        Ok(())
+    }
+
+    fn return_list_harnesses(self, sorted_harnesses: &[HarnessMetadata]) -> Result<()> {
+        if !self.args.quiet && !self.args.visualize && sorted_harnesses.len() > 1 {
+            let v: String = serde_json::to_string_pretty(&sorted_harnesses)?;
+            println!("{}", v);
+        }
         Ok(())
     }
 }

--- a/tests/cargo-ui/list-harnesses/Cargo.toml
+++ b/tests/cargo-ui/list-harnesses/Cargo.toml
@@ -1,0 +1,11 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+[package]
+name = "list-harnesses"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.kani]
+flags = { list-harnesses=true, enable-unstable=true }

--- a/tests/cargo-ui/list-harnesses/expected
+++ b/tests/cargo-ui/list-harnesses/expected
@@ -1,0 +1,18 @@
+[
+  {
+    "pretty_name": "check_estimate_size_2",
+    "mangled_name": "check_estimate_size_2",
+    "original_file":
+    "original_start_line":
+    "original_end_line":
+    "unwind_value": null
+  },
+  {
+    "pretty_name": "check_estimate_size",
+    "mangled_name": "check_estimate_size",
+    "original_file":
+    "original_start_line":
+    "original_end_line":
+    "unwind_value": null
+  }
+]

--- a/tests/cargo-ui/list-harnesses/src/lib.rs
+++ b/tests/cargo-ui/list-harnesses/src/lib.rs
@@ -1,0 +1,41 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! The --list-harnesses flag is to return a consumable JSON.
+//! Can't test for exact output but this flag should not return anything but JSON
+
+fn estimate_size(x: u32) -> u32 {
+    if x < 256 {
+        if x < 128 {
+            return 1;
+        } else {
+            return 3;
+        }
+    } else if x < 1024 {
+        if x > 1022 {
+            panic!("Oh no, a failing corner case!");
+        } else {
+            return 5;
+        }
+    } else {
+        if x < 2048 {
+            return 7;
+        } else {
+            return 9;
+        }
+    }
+}
+
+// ANCHOR: kani
+#[cfg(kani)]
+#[kani::proof]
+fn check_estimate_size() {
+    let x: u32 = kani::any();
+    estimate_size(x);
+}
+
+#[kani::proof]
+fn check_estimate_size_2() {
+    let y: u32 = kani::any();
+    estimate_size(y);
+}


### PR DESCRIPTION
### Description of changes: 

Kani contains the harness metadata in a JSON file but it is only read temporarily before being deleted. The only way to retain this information was through the `--keep-temps` flag which stores these temporary files but is a bulky operation. The flag now however, does not start the verification process. The `--list-harnesses` flag returns a JSON string which can be consumed as an API by any receiver. 

The output with the flag looks like this - 
$cargo kani --enable-unstable --list-harnesses

``` JSON
[
  {
    "pretty_name": "check_estimate_size_2",
    "mangled_name": "check_estimate_size_2",
    "original_file": "../src/lib.rs",
    "original_start_line": 39,
    "original_end_line": 42,
    "unwind_value": null
  },
  {
    "pretty_name": "check_estimate_size",
    "mangled_name": "check_estimate_size",
    "original_file": "..src/lib.rs",
    "original_start_line": 30,
    "original_end_line": 33,
    "unwind_value": null
  }
]

```
### Resolved issues:

Resolves #1612 

### Call-outs:

The flag only runs with cargo kani and not the single script kani because the cargo kani output would always be a superset of the kani output. i.e running the flag with just kani - 

`kani --list-harnesses test.rs`

would return the regular verification output as if `kani test.rs` were run.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
