### PR TITLE
Add `--mir-linker` flag and wire it up to the compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,8 @@ dependencies = [
 name = "kani_queries"
 version = "0.10.0"
 dependencies = [
+ "strum",
+ "strum_macros",
  "tracing",
 ]
 

--- a/kani-compiler/kani_queries/Cargo.toml
+++ b/kani-compiler/kani_queries/Cargo.toml
@@ -13,3 +13,6 @@ unsound_experiments = []
 
 [dependencies]
 tracing = {version = "0.1"}
+strum = {version = "0.24.0"}
+strum_macros = {version = "0.24.0"}
+

--- a/kani-compiler/kani_queries/src/lib.rs
+++ b/kani-compiler/kani_queries/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(not(feature = "unsound_experiments"))]
 use std::sync::Mutex;
 use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
 

--- a/kani-compiler/kani_queries/src/lib.rs
+++ b/kani-compiler/kani_queries/src/lib.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
 
 #[cfg(feature = "unsound_experiments")]
 mod unsound_experiments;
@@ -11,6 +13,25 @@ use {
     crate::unsound_experiments::UnsoundExperiments,
     std::sync::{Arc, Mutex},
 };
+
+#[derive(Debug, Clone, Copy, AsRefStr, EnumString, EnumVariantNames, PartialEq, Eq)]
+#[strum(serialize_all = "snake_case")]
+pub enum ReachabilityType {
+    /// Start the cross-crate reachability analysis from all harnesses in the local crate.
+    Harnesses,
+    /// Use standard rustc monomorphizer algorithm.
+    Legacy,
+    /// Don't perform any reachability analysis. This will skip codegen for this crate.
+    None,
+    /// Start the cross-crate reachability analysis from all public functions in the local crate.
+    PubFns,
+}
+
+impl Default for ReachabilityType {
+    fn default() -> Self {
+        ReachabilityType::None
+    }
+}
 
 pub trait UserInput {
     fn set_symbol_table_passes(&mut self, passes: Vec<String>);
@@ -28,6 +49,9 @@ pub trait UserInput {
     fn set_ignore_global_asm(&mut self, global_asm: bool);
     fn get_ignore_global_asm(&self) -> bool;
 
+    fn set_reachability_analysis(&mut self, reachability: ReachabilityType);
+    fn get_reachability_analysis(&self) -> ReachabilityType;
+
     #[cfg(feature = "unsound_experiments")]
     fn get_unsound_experiments(&self) -> Arc<Mutex<UnsoundExperiments>>;
 }
@@ -39,6 +63,7 @@ pub struct QueryDb {
     symbol_table_passes: Vec<String>,
     json_pretty_print: AtomicBool,
     ignore_global_asm: AtomicBool,
+    reachability_analysis: Mutex<ReachabilityType>,
     #[cfg(feature = "unsound_experiments")]
     unsound_experiments: Arc<Mutex<UnsoundExperiments>>,
 }
@@ -82,6 +107,14 @@ impl UserInput for QueryDb {
 
     fn get_ignore_global_asm(&self) -> bool {
         self.ignore_global_asm.load(Ordering::Relaxed)
+    }
+
+    fn set_reachability_analysis(&mut self, reachability: ReachabilityType) {
+        *self.reachability_analysis.get_mut().unwrap() = reachability;
+    }
+
+    fn get_reachability_analysis(&self) -> ReachabilityType {
+        *self.reachability_analysis.lock().unwrap()
     }
 
     #[cfg(feature = "unsound_experiments")]

--- a/kani-compiler/src/main.rs
+++ b/kani-compiler/src/main.rs
@@ -33,12 +33,13 @@ mod unsound_experiments;
 
 use crate::session::init_session;
 use clap::ArgMatches;
-use kani_queries::{QueryDb, UserInput};
+use kani_queries::{QueryDb, ReachabilityType, UserInput};
 use rustc_driver::{Callbacks, RunCompiler};
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::str::FromStr as _;
 
 /// This function generates all rustc configurations required by our goto-c codegen.
 fn rustc_gotoc_flags(lib_path: &str) -> Vec<String> {
@@ -91,6 +92,9 @@ fn main() -> Result<(), &'static str> {
     queries.set_check_assertion_reachability(matches.is_present(parser::ASSERTION_REACH_CHECKS));
     queries.set_output_pretty_json(matches.is_present(parser::PRETTY_OUTPUT_FILES));
     queries.set_ignore_global_asm(matches.is_present(parser::IGNORE_GLOBAL_ASM));
+    queries.set_reachability_analysis(
+        ReachabilityType::from_str(matches.value_of(parser::REACHABILITY).unwrap()).unwrap(),
+    );
     #[cfg(feature = "unsound_experiments")]
     crate::unsound_experiments::arg_parser::add_unsound_experiment_args_to_queries(
         &mut queries,

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -121,6 +121,11 @@ pub struct KaniArgs {
     /// Kani will only compile the crate. No verification will be performed
     #[structopt(long, hidden_short_help(true))]
     pub only_codegen: bool,
+    /// Enables experimental MIR Linker. This option will affect how Kani prunes the code to be
+    /// analyzed. Please report any missing function issue found here:
+    /// <https://github.com/model-checking/kani/issues/new/choose>
+    #[structopt(long, hidden = true, requires("enable-unstable"))]
+    pub mir_linker: bool,
     /// Compiles Kani harnesses in all features of all packages selected on the command-line.
     #[structopt(long)]
     pub all_features: bool,
@@ -128,7 +133,7 @@ pub struct KaniArgs {
     #[structopt(long)]
     pub workspace: bool,
     /// Run Kani on the specified packages.
-    #[structopt(long, short)]
+    #[structopt(long, short, conflicts_with("workspace"))]
     pub package: Vec<String>,
 
     /// Specify the value used for loop unwinding in CBMC

--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -36,7 +36,7 @@ impl KaniSession {
         let outdir = target_dir.join(build_target).join("debug/deps");
 
         let mut kani_args = self.kani_specific_flags();
-        let mut rustc_args = self.kani_rustc_flags();
+        let rustc_args = self.kani_rustc_flags();
 
         let mut cargo_args: Vec<OsString> = vec!["rustc".into()];
         if self.args.tests {
@@ -69,7 +69,7 @@ impl KaniSession {
         }
 
         // Only joing them at the end. All kani flags must come first.
-        kani_args.append(&mut rustc_args);
+        kani_args.extend_from_slice(&rustc_args);
 
         let members = project_members(&self.args, &metadata);
         for member in members {

--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -1,13 +1,13 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::args::KaniArgs;
+use crate::session::KaniSession;
 use anyhow::{Context, Result};
-use cargo_metadata::MetadataCommand;
+use cargo_metadata::{Metadata, MetadataCommand};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-use crate::session::KaniSession;
 
 /// The outputs of kani-compiler being invoked via cargo on a project.
 pub struct CargoOutputs {
@@ -22,66 +22,67 @@ pub struct CargoOutputs {
     pub metadata: Vec<PathBuf>,
 }
 
-/// Finds the "target" directory while considering workspaces,
-fn find_target_dir() -> PathBuf {
-    fn maybe_get_target() -> Option<PathBuf> {
-        Some(MetadataCommand::new().exec().ok()?.target_directory.into())
-    }
-
-    maybe_get_target().unwrap_or(PathBuf::from("target"))
-}
-
 impl KaniSession {
     /// Calls `cargo_build` to generate `*.symtab.json` files in `target_dir`
     pub fn cargo_build(&self) -> Result<CargoOutputs> {
         let build_target = env!("TARGET"); // see build.rs
-        let target_dir = self.args.target_dir.as_ref().unwrap_or(&find_target_dir()).clone();
+        let metadata = MetadataCommand::new().exec().expect("Failed to get cargo metadata.");
+        let target_dir = self
+            .args
+            .target_dir
+            .as_ref()
+            .unwrap_or(&metadata.target_directory.clone().into())
+            .clone();
         let outdir = target_dir.join(build_target).join("debug/deps");
 
-        let flag_env = {
-            let rustc_args = self.kani_rustc_flags();
-            crate::util::join_osstring(&rustc_args, " ")
-        };
+        let mut kani_args = self.kani_specific_flags();
+        let mut rustc_args = self.kani_rustc_flags();
 
-        let mut args: Vec<OsString> = Vec::new();
-
+        let mut cargo_args: Vec<OsString> = vec!["rustc".into()];
         if self.args.tests {
-            args.push("test".into());
-            args.push("--no-run".into());
-        } else {
-            args.push("build".into());
-        }
-
-        for package in self.args.package.iter() {
-            args.push("--package".into());
-            args.push(package.into());
+            cargo_args.push("--tests".into());
         }
 
         if self.args.all_features {
-            args.push("--all-features".into());
+            cargo_args.push("--all-features".into());
         }
 
-        if self.args.workspace {
-            args.push("--workspace".into());
-        }
+        cargo_args.push("--target".into());
+        cargo_args.push(build_target.into());
 
-        args.push("--target".into());
-        args.push(build_target.into());
-
-        args.push("--target-dir".into());
-        args.push(target_dir.into());
+        cargo_args.push("--target-dir".into());
+        cargo_args.push(target_dir.into());
 
         if self.args.verbose {
-            args.push("-v".into());
+            cargo_args.push("-v".into());
         }
 
-        let mut cmd = Command::new("cargo");
-        cmd.args(args)
-            .env("RUSTC", &self.kani_compiler)
-            .env("RUSTFLAGS", "--kani-flags")
-            .env("KANIFLAGS", flag_env);
+        // Arguments that will only be passed to the target package.
+        let mut pkg_args: Vec<OsString> = vec![];
+        if self.args.mir_linker {
+            // Only provide reachability flag to the target package.
+            pkg_args.push("--".into());
+            pkg_args.push("--reachability=harnesses".into());
+        } else {
+            // Pass legacy reachability to the target package and its dependencies.
+            kani_args.push("--reachability=legacy".into());
+        }
 
-        self.run_terminal(cmd)?;
+        // Only joing them at the end. All kani flags must come first.
+        kani_args.append(&mut rustc_args);
+
+        let members = project_members(&self.args, &metadata);
+        for member in members {
+            let mut cmd = Command::new("cargo");
+            cmd.args(&cargo_args)
+                .args(vec!["-p", &member])
+                .args(&pkg_args)
+                .env("RUSTC", &self.kani_compiler)
+                .env("RUSTFLAGS", "--kani-flags")
+                .env("KANIFLAGS", &crate::util::join_osstring(&kani_args, " "));
+
+            self.run_terminal(cmd)?;
+        }
 
         if self.args.dry_run {
             // mock an answer: mostly the same except we don't/can't expand the globs
@@ -109,4 +110,24 @@ fn glob(path: &Path) -> Result<Vec<PathBuf>> {
     // with anyhow, so a type annotation is required
     let v: core::result::Result<Vec<PathBuf>, glob::GlobError> = results.collect();
     Ok(v?)
+}
+
+/// Extract the packages that should be verified.
+/// If --package <pkg> is given, return the list of packages selected.
+/// If --workspace is given, return the list of workspace members.
+/// If no argument provided, return the root package if there's one or all members.
+///   - I.e.: Do whatever cargo does when there's no default_members.
+///   - This is because `default_members` is not available in cargo metadata.
+///     See <https://github.com/rust-lang/cargo/issues/8033>.
+fn project_members(args: &KaniArgs, metadata: &Metadata) -> Vec<String> {
+    if !args.package.is_empty() {
+        args.package.clone()
+    } else {
+        match (args.workspace, metadata.root_package()) {
+            (true, _) | (_, None) => {
+                metadata.workspace_members.iter().map(|id| metadata[id].name.clone()).collect()
+            }
+            (_, Some(root_pkg)) => vec![root_pkg.name.clone()],
+        }
+    }
 }

--- a/kani-driver/src/call_single_file.rs
+++ b/kani-driver/src/call_single_file.rs
@@ -44,19 +44,25 @@ impl KaniSession {
             }
         }
 
-        let mut args = self.kani_rustc_flags();
+        let mut kani_args = self.kani_specific_flags();
+        if self.args.mir_linker {
+            kani_args.push("--reachability=harnesses".into());
+        } else {
+            kani_args.push("--reachability=legacy".into());
+        }
 
+        let mut rustc_args = self.kani_rustc_flags();
         // kani-compiler workaround part 1/2: *.symtab.json gets generated in the local
         // directory, instead of based on file name like we expect.
         // So let we'll `cd` to that directory and here we only pass filename.
-        args.push(file.file_name().unwrap().into());
+        rustc_args.push(file.file_name().unwrap().into());
 
         if self.args.tests {
             // e.g. `tests/kani/Options/check_tests.rs` will fail because it already has it
             // so this is a hacky workaround
             let t = "--test".into();
-            if !args.contains(&t) {
-                args.push(t);
+            if !rustc_args.contains(&t) {
+                rustc_args.push(t);
             }
         } else {
             // If we specifically request "--function main" then don't override crate type
@@ -64,13 +70,15 @@ impl KaniSession {
                 // We only run against proof harnesses normally, and this change
                 // 1. Means we do not require a `fn main` to exist
                 // 2. Don't forget it also changes visibility rules.
-                args.push("--crate-type".into());
-                args.push("lib".into());
+                rustc_args.push("--crate-type".into());
+                rustc_args.push("lib".into());
             }
         }
 
+        // Note that the order of arguments is important. Kani specific flags should precede
+        // rustc ones.
         let mut cmd = Command::new(&self.kani_compiler);
-        cmd.args(args);
+        cmd.args(kani_args).args(rustc_args);
 
         // kani-compiler workaround: part 2/2: change directory for the subcommand
         cmd.current_dir(&outdir);
@@ -93,9 +101,9 @@ impl KaniSession {
         })
     }
 
-    /// These arguments are passed directly here for single file runs,
-    /// but are also used by call_cargo to pass as the env var KANIFLAGS.
-    pub fn kani_rustc_flags(&self) -> Vec<OsString> {
+    /// These arguments are arguments passed to kani-compiler that are `kani` specific.
+    /// These are also used by call_cargo to pass as the env var KANIFLAGS.
+    pub fn kani_specific_flags(&self) -> Vec<OsString> {
         let mut flags = vec![OsString::from("--goto-c")];
 
         if let Some(rlib) = &self.kani_rlib {
@@ -124,11 +132,13 @@ impl KaniSession {
         #[cfg(feature = "unsound_experiments")]
         flags.extend(self.args.unsound_experiments.process_args());
 
-        // Stratification point!
-        // Above are arguments that should be parsed by kani-compiler
-        // Below are arguments that should be parsed by the rustc call
-        // We need to ensure these are in-order due to the way kani-compiler parses arguments. :(
+        flags
+    }
 
+    /// These arguments are arguments passed to kani-compiler that are `rustc` specific.
+    /// These are also used by call_cargo to pass as the env var KANIFLAGS.
+    pub fn kani_rustc_flags(&self) -> Vec<OsString> {
+        let mut flags = Vec::<OsString>::new();
         if self.args.use_abs {
             flags.push("-Z".into());
             flags.push("force-unstable-if-unmarked=yes".into()); // ??

--- a/rfc/src/rfcs/0001-mir-linker.md
+++ b/rfc/src/rfcs/0001-mir-linker.md
@@ -1,8 +1,8 @@
 - **Feature Name:** MIR Linker (mir_linker)
 - **RFC Tracking Issue**: <https://github.com/model-checking/kani/issues/1588>
 - **RFC PR:** <https://github.com/model-checking/kani/pull/1600>
-- **Status:** Under Review
-- **Version:** 0
+- **Status:** In Progress
+- **Version:** 1
 
 -------------------
 
@@ -235,12 +235,9 @@ These results were obtained by looking at the artifacts generated during the sam
 - Should we codegen all static items no matter what? Static objects can only be initialized via constant function.
   Thus, it shouldn't have any side effect.
   That relies on all constant initializers being evaluated during compilation.
-- What's the best way to handle `cargo kani --tests`?
-  We still want to restrict the reachability and codegen to the last compilation step.
-  Possible solutions that we considered so far:
-  1. Add a new value to `--reachability`, maybe "on-tests" or something like that.
-     This would behave as either "harness" or "none" depending whether RUSTFLAGS has `--tests`.
-  2. Change how we handle not having `--reachability` argument to also take into account the existence of `--tests`.
+- ~~What's the best way to handle `cargo kani --tests`?~~
+  We will use similar mechanism to regular Kani runs:
+  - `cargo rustc --tests -- --reachability=harnesses`
 
 
 ## Future possibilities

--- a/scripts/std-lib-regression.sh
+++ b/scripts/std-lib-regression.sh
@@ -67,7 +67,7 @@ cp ${KANI_DIR}/rust-toolchain.toml .
 echo "Starting cargo build with Kani"
 export RUST_BACKTRACE=1
 export RUSTC_LOG=error
-export KANIFLAGS="--goto-c --ignore-global-asm"
+export KANIFLAGS="--goto-c --ignore-global-asm --reachability=legacy"
 export RUSTFLAGS="--kani-flags"
 export RUSTC="$KANI_DIR/target/debug/kani-compiler"
 # Compile rust to iRep

--- a/tests/cargo-ui/dry-run/expected
+++ b/tests/cargo-ui/dry-run/expected
@@ -1,5 +1,5 @@
-KANIFLAGS="--goto-c --log-level=warn --assertion-reach-checks -C symbol-mangling-version=v0" RUSTC=
-RUSTFLAGS="--kani-flags" cargo build
+KANIFLAGS="--goto-c --log-level=warn --assertion-reach-checks --reachability=legacy -C symbol-mangling-version=v0" RUSTC=
+RUSTFLAGS="--kani-flags" cargo rustc
 symtab2gb 
 goto-cc 
 goto-cc

--- a/tests/cargo-ui/mir-linker/Cargo.toml
+++ b/tests/cargo-ui/mir-linker/Cargo.toml
@@ -1,0 +1,12 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+[package]
+name = "mir-linker"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = "0.8.4"
+
+[package.metadata.kani]
+flags = { mir-linker=true, enable-unstable=true }

--- a/tests/cargo-ui/mir-linker/expected
+++ b/tests/cargo-ui/mir-linker/expected
@@ -1,0 +1,1 @@
+error: Using none reachability mode is still unsupported.

--- a/tests/cargo-ui/mir-linker/src/lib.rs
+++ b/tests/cargo-ui/mir-linker/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Dummy test to check --mir-linker runs on a cargo project.
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[kani::proof]
+fn check_add() {
+    let result = add(2, 2);
+    assert_eq!(result, 4);
+}

--- a/tests/ui/mir-linker/any_str.rs
+++ b/tests/ui/mir-linker/any_str.rs
@@ -1,0 +1,18 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// kani-flags: --enable-unstable --mir-linker
+//
+//! This test is to check MIR linker state of the art.
+//! I.e.: Currently, this should fail with missing function definition.
+
+#[kani::proof]
+#[kani::unwind(12)]
+fn check_abs() {
+    let data: [u8; 8] = kani::any();
+    let mut string = String::from_utf8_lossy(&data).to_string();
+    let new_len = kani::any();
+    kani::assume(new_len <= 2);
+    string.truncate(new_len);
+    assert!(string.len() <= 2);
+}

--- a/tests/ui/mir-linker/expected
+++ b/tests/ui/mir-linker/expected
@@ -1,0 +1,1 @@
+error: Using harnesses reachability mode is still unsupported.


### PR DESCRIPTION
### Description of changes: 

This change adds the `--mir-linker` option to `kani-driver` and `--reachability=[none | legacy | harnesses]` to the compiler. I also changed `cargo kani` to invoke `cargo rustc` instead of `cargo [build | tests]` so the reachability flag is passed at the right moment.

### Resolved issues:

Resolves #1617

### Related RFC:

#1600

### Call-outs:

1. Since the MIR linker hasn't been hooked up yet, the compiler will fail if this option is selected as shown by the new tests.
2. `cargo rustc -- --reachability=harnesses` will inject the argument `--reachability=harness` in the middle of the compiler flags. Thus, it has to be extracted from rustc args. :(

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
