### PR TITLE
Enabled constant prooftest.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -39,4 +39,8 @@ rustflags = [ # Global lints/warnings. Need to use underscore instead of -.
     "-Aclippy::upper_case_acronyms",
     "-Aclippy::useless_conversion",
     "-Aclippy::useless_format",
+
+    # Turned off to simplify merge: See #1608 for progress.
+    "-Adead_code",
+    "-Aunused_variables",
 ]

--- a/proptest/src/lib.rs
+++ b/proptest/src/lib.rs
@@ -108,14 +108,3 @@ pub mod sample;
 pub mod string;
 
 pub mod prelude;
-
-#[cfg(test)]
-mod test_kani {
-    #[kani::proof]
-    fn trivial() {
-        let vector = vec![0; 16];
-        let index = kani::any::<usize>() % vector.len();
-
-        assert_eq!(vector[index], 0);
-    }
-}

--- a/proptest/src/sugar.rs
+++ b/proptest/src/sugar.rs
@@ -262,6 +262,9 @@ macro_rules! proptest {
 /// message includes the point of invocation and the format message. `format`
 /// and `args` may be omitted to simply use the condition itself as the
 /// message.
+///
+/// Kani Adjustment: Use Kani::assume instead of rejecting randomly
+/// generated values.
 #[macro_export]
 macro_rules! prop_assume {
     ($expr:expr) => {
@@ -269,13 +272,7 @@ macro_rules! prop_assume {
     };
 
     ($expr:expr, $fmt:tt $(, $fmt_arg:expr),* $(,)?) => {
-        if !$expr {
-            return ::core::result::Result::Err(
-                $crate::test_runner::TestCaseError::reject(
-                    format!(concat!("{}:{}:{}: ", $fmt),
-                            file!(), line!(), column!()
-                            $(, $fmt_arg)*)));
-        }
+        kani::assume($expr)
     };
 }
 
@@ -732,6 +729,7 @@ macro_rules! prop_compose {
 /// #
 /// # fn main() { triangle_inequality(); }
 /// ```
+/// Kani Adjustment: Just use normal assert. No need to catch failure.
 #[macro_export]
 macro_rules! prop_assert {
     ($cond:expr) => {
@@ -739,12 +737,7 @@ macro_rules! prop_assert {
     };
 
     ($cond:expr, $($fmt:tt)*) => {
-        if !$cond {
-            let message = format!($($fmt)*);
-            let message = format!("{} at {}:{}", message, file!(), line!());
-            return ::core::result::Result::Err(
-                $crate::test_runner::TestCaseError::fail(message));
-        }
+        assert!($cond, $($fmt)*);
     };
 }
 
@@ -950,43 +943,34 @@ macro_rules! proptest_helper {
     };
     // build a property testing block that when executed, executes the full property test.
     (@_BODY $config:ident ($($parm:pat in $strategy:expr),+) [$($mod:tt)*] $body:expr) => {{
+        // Kani Adjustment: Since we don't need to match and print
+        // Error cases anymore, we just run and unwrap.
         $config.source_file = Some(file!());
         let mut runner = $crate::test_runner::TestRunner::new($config);
-        let names = $crate::proptest_helper!(@_WRAPSTR ($($parm),*));
-        match runner.run(
-            &$crate::strategy::Strategy::prop_map(
-                $crate::proptest_helper!(@_WRAP ($($strategy)*)),
-                |values| $crate::sugar::NamedArguments(names, values)),
-            $($mod)* |$crate::sugar::NamedArguments(
-                _, $crate::proptest_helper!(@_WRAPPAT ($($parm),*)))|
-            {
-                let _: () = $body;
+        runner.run(
+            &$crate::proptest_helper!(@_WRAP ($($strategy)*)),
+            |$crate::proptest_helper!(@_WRAPPAT ($($parm),*))| {
+                {
+                    $body
+                }
                 Ok(())
-            })
-        {
-            Ok(_) => (),
-            Err(e) => panic!("{}\n{}", e, runner),
-        }
+            }
+        ).unwrap();
     }};
     // build a property testing block that when executed, executes the full property test.
     (@_BODY2 $config:ident ($($arg:tt)+) [$($mod:tt)*] $body:expr) => {{
+        // Kani Adjustment: Same as @_BODY
         $config.source_file = Some(file!());
         let mut runner = $crate::test_runner::TestRunner::new($config);
-        let names = $crate::proptest_helper!(@_EXT _STR ($($arg)*));
-        match runner.run(
-            &$crate::strategy::Strategy::prop_map(
-                $crate::proptest_helper!(@_EXT _STRAT ($($arg)*)),
-                |values| $crate::sugar::NamedArguments(names, values)),
-            $($mod)* |$crate::sugar::NamedArguments(
-                _, $crate::proptest_helper!(@_EXT _PAT ($($arg)*)))|
-            {
-                let _: () = $body;
+        runner.run(
+            &$crate::proptest_helper!(@_EXT _STRAT ($($arg)*)),
+            |$crate::proptest_helper!(@_EXT _PAT ($($arg)*))| {
+                {
+                    $body
+                }
                 Ok(())
-            })
-        {
-            Ok(_) => (),
-            Err(e) => panic!("{}\n{}", e, runner),
-        }
+            }
+        ).unwrap();
     }};
 
     // The logic below helps support `pat: type` in the proptest! macro.

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -480,14 +480,6 @@ impl Config {
     }
 }
 
-#[cfg(feature = "std")]
-impl Default for Config {
-    fn default() -> Self {
-        DEFAULT_CONFIG.clone()
-    }
-}
-
-#[cfg(not(feature = "std"))]
 impl Default for Config {
     fn default() -> Self {
         default_default_config()

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -73,10 +73,6 @@ pub struct TestRunner {
     local_rejects: u32,
     global_rejects: u32,
     rng: TestRng,
-    flat_map_regens: Arc<AtomicUsize>,
-
-    local_reject_detail: RejectionDetail,
-    global_reject_detail: RejectionDetail,
 }
 
 impl fmt::Debug for TestRunner {
@@ -87,9 +83,6 @@ impl fmt::Debug for TestRunner {
             .field("local_rejects", &self.local_rejects)
             .field("global_rejects", &self.global_rejects)
             .field("rng", &"<TestRng>")
-            .field("flat_map_regens", &self.flat_map_regens)
-            .field("local_reject_detail", &self.local_reject_detail)
-            .field("global_reject_detail", &self.global_reject_detail)
             .finish()
     }
 }
@@ -102,13 +95,6 @@ impl fmt::Display for TestRunner {
              \tlocal rejects: {}\n",
             self.successes, self.local_rejects
         )?;
-        for (whence, count) in &self.local_reject_detail {
-            writeln!(f, "\t\t{} times at {}", count, whence)?;
-        }
-        writeln!(f, "\tglobal rejects: {}", self.global_rejects)?;
-        for (whence, count) in &self.global_reject_detail {
-            writeln!(f, "\t\t{} times at {}", count, whence)?;
-        }
 
         Ok(())
     }
@@ -334,9 +320,6 @@ impl TestRunner {
             local_rejects: 0,
             global_rejects: 0,
             rng: rng,
-            flat_map_regens: Arc::new(AtomicUsize::new(0)),
-            local_reject_detail: BTreeMap::new(),
-            global_reject_detail: BTreeMap::new(),
         }
     }
 
@@ -350,9 +333,6 @@ impl TestRunner {
             local_rejects: 0,
             global_rejects: 0,
             rng: self.new_rng(),
-            flat_map_regens: Arc::clone(&self.flat_map_regens),
-            local_reject_detail: BTreeMap::new(),
-            global_reject_detail: BTreeMap::new(),
         }
     }
 
@@ -398,11 +378,9 @@ impl TestRunner {
         strategy: &S,
         test: impl Fn(S::Value) -> TestCaseResult,
     ) -> TestRunResult<S> {
-        if self.config.fork() {
-            self.run_in_fork(strategy, test)
-        } else {
-            self.run_in_process(strategy, test)
-        }
+        let tree = strategy.new_tree(self).unwrap();
+        test(tree.current()).unwrap();
+        Ok(())
     }
 
     #[cfg(not(feature = "fork"))]
@@ -717,10 +695,6 @@ impl TestRunner {
             Err("Too many local rejects".into())
         } else {
             self.local_rejects += 1;
-            Self::insert_or_increment(
-                &mut self.local_reject_detail,
-                whence.into(),
-            );
             Ok(())
         }
     }
@@ -732,7 +706,6 @@ impl TestRunner {
             Err(TestError::Abort("Too many global rejects".into()))
         } else {
             self.global_rejects += 1;
-            Self::insert_or_increment(&mut self.global_reject_detail, whence);
             Ok(())
         }
     }
@@ -747,8 +720,7 @@ impl TestRunner {
     /// Increment the counter of flat map regenerations and return whether it
     /// is still under the configured limit.
     pub fn flat_map_regen(&self) -> bool {
-        self.flat_map_regens.fetch_add(1, SeqCst)
-            < self.config.max_flat_map_regens as usize
+        false
     }
 
     fn new_cache(&self) -> Box<dyn ResultCache> {
@@ -788,7 +760,24 @@ fn init_replay(
     (iter::empty(), ForkOutput::empty())
 }
 
-#[cfg(TBD)]
+#[cfg(test)]
+mod test {
+    use crate::strategy::{Just, Strategy};
+    use crate::test_runner::Config;
+
+    proptest! {
+        #[cfg_attr(kani, kani::proof)]
+        fn successfully_linked_proptest(_ in &Just(()) ) {
+            let config = Config::default();
+            prop_assert_eq!(
+                config.cases,
+                256,
+                "Default .cases should be 256. Check: src/test_runner/config.rs"
+            );
+        }
+    }
+}
+
 #[cfg(all(test, not(kani)))]
 mod test {
     use std::cell::Cell;


### PR DESCRIPTION
### Description of changes: 

Changed behavior of the `proptest!` macro to enable proofs. Symbolics are not injected, so only constant proptests will work with kani.

### Resolved issues:

Works towards #1608 

### Call-outs:

- BTreeMap was removed from TestRunner b/c `BTreeMap::new()` required unwinding bounds that were not needed if that was removed. 

### Testing:

* How is this change tested? Trivial proptest under 

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
