### PR TITLE
Removed redundant code

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -39,8 +39,4 @@ rustflags = [ # Global lints/warnings. Need to use underscore instead of -.
     "-Aclippy::upper_case_acronyms",
     "-Aclippy::useless_conversion",
     "-Aclippy::useless_format",
-
-    # Turned off to simplify merge: See #1608 for progress.
-    "-Adead_code",
-    "-Aunused_variables",
 ]

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -30,122 +30,6 @@ use crate::test_runner::FailurePersistence;
 #[cfg(feature = "std")]
 use crate::test_runner::FileFailurePersistence;
 
-#[cfg(feature = "std")]
-const CASES: &str = "PROPTEST_CASES";
-#[cfg(feature = "std")]
-const MAX_LOCAL_REJECTS: &str = "PROPTEST_MAX_LOCAL_REJECTS";
-#[cfg(feature = "std")]
-const MAX_GLOBAL_REJECTS: &str = "PROPTEST_MAX_GLOBAL_REJECTS";
-#[cfg(feature = "std")]
-const MAX_FLAT_MAP_REGENS: &str = "PROPTEST_MAX_FLAT_MAP_REGENS";
-#[cfg(feature = "std")]
-const MAX_SHRINK_TIME: &str = "PROPTEST_MAX_SHRINK_TIME";
-#[cfg(feature = "std")]
-const MAX_SHRINK_ITERS: &str = "PROPTEST_MAX_SHRINK_ITERS";
-#[cfg(feature = "fork")]
-const FORK: &str = "PROPTEST_FORK";
-#[cfg(feature = "timeout")]
-const TIMEOUT: &str = "PROPTEST_TIMEOUT";
-#[cfg(feature = "std")]
-const VERBOSE: &str = "PROPTEST_VERBOSE";
-const RNG_ALGORITHM: &str = "PROPTEST_RNG_ALGORITHM";
-
-#[cfg(feature = "std")]
-fn contextualize_config(mut result: Config) -> Config {
-    fn parse_or_warn<T: FromStr + fmt::Display>(
-        src: &OsString,
-        dst: &mut T,
-        typ: &str,
-        var: &str,
-    ) {
-        if let Some(src) = src.to_str() {
-            if let Ok(value) = src.parse() {
-                *dst = value;
-            } else {
-                eprintln!(
-                    "proptest: The env-var {}={} can't be parsed as {}, \
-                     using default of {}.",
-                    var, src, typ, *dst
-                );
-            }
-        } else {
-            eprintln!(
-                "proptest: The env-var {} is not valid, using \
-                 default of {}.",
-                var, *dst
-            );
-        }
-    }
-
-    result.failure_persistence =
-        Some(Box::new(FileFailurePersistence::default()));
-    for (var, value) in
-        env::vars_os().filter_map(|(k, v)| k.into_string().ok().map(|k| (k, v)))
-    {
-        match var.as_str() {
-            CASES => parse_or_warn(&value, &mut result.cases, "u32", CASES),
-            MAX_LOCAL_REJECTS => parse_or_warn(
-                &value,
-                &mut result.max_local_rejects,
-                "u32",
-                MAX_LOCAL_REJECTS,
-            ),
-            MAX_GLOBAL_REJECTS => parse_or_warn(
-                &value,
-                &mut result.max_global_rejects,
-                "u32",
-                MAX_GLOBAL_REJECTS,
-            ),
-            MAX_FLAT_MAP_REGENS => parse_or_warn(
-                &value,
-                &mut result.max_flat_map_regens,
-                "u32",
-                MAX_FLAT_MAP_REGENS,
-            ),
-            #[cfg(feature = "fork")]
-            FORK => parse_or_warn(&value, &mut result.fork, "bool", FORK),
-            #[cfg(feature = "timeout")]
-            TIMEOUT => {
-                parse_or_warn(&value, &mut result.timeout, "timeout", TIMEOUT)
-            }
-            MAX_SHRINK_TIME => parse_or_warn(
-                &value,
-                &mut result.max_shrink_time,
-                "u32",
-                MAX_SHRINK_TIME,
-            ),
-            MAX_SHRINK_ITERS => parse_or_warn(
-                &value,
-                &mut result.max_shrink_iters,
-                "u32",
-                MAX_SHRINK_ITERS,
-            ),
-            VERBOSE => {
-                parse_or_warn(&value, &mut result.verbose, "u32", VERBOSE)
-            }
-            RNG_ALGORITHM => parse_or_warn(
-                &value,
-                &mut result.rng_algorithm,
-                "RngAlgorithm",
-                RNG_ALGORITHM,
-            ),
-
-            _ => {
-                if var.starts_with("PROPTEST_") {
-                    eprintln!("proptest: Ignoring unknown env-var {}.", var);
-                }
-            }
-        }
-    }
-
-    result
-}
-
-#[cfg(not(feature = "std"))]
-fn contextualize_config(result: Config) -> Config {
-    result
-}
-
 fn default_default_config() -> Config {
     Config {
         cases: 256,
@@ -168,14 +52,6 @@ fn default_default_config() -> Config {
         rng_algorithm: RngAlgorithm::default(),
         _non_exhaustive: (),
     }
-}
-
-// The default config, computed by combining environment variables and
-// defaults.
-#[cfg(feature = "std")]
-lazy_static! {
-    static ref DEFAULT_CONFIG: Config =
-        contextualize_config(default_default_config());
 }
 
 /// Configuration for how a proptest test should be run.

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -402,19 +402,6 @@ impl TestRng {
         Self::from_seed_internal(self.new_rng_seed())
     }
 
-    /// Overwrite the given TestRng with the provided seed.
-    pub(crate) fn set_seed(&mut self, seed: Seed) {
-        *self = Self::from_seed_internal(seed);
-    }
-
-    /// Generate a new randomized seed, set it to this TestRng,
-    /// and return the seed.
-    pub(crate) fn gen_get_seed(&mut self) -> Seed {
-        let seed = self.new_rng_seed();
-        self.set_seed(seed.clone());
-        seed
-    }
-
     /// Randomize a perturbed randomized seed from the given TestRng.
     pub(crate) fn new_rng_seed(&mut self) -> Seed {
         Seed::XorShift([0; 16])

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -36,9 +36,6 @@ use crate::test_runner::replay;
 use crate::test_runner::result_cache::*;
 use crate::test_runner::rng::TestRng;
 
-#[cfg(feature = "fork")]
-const ENV_FORK_FILE: &'static str = "_PROPTEST_FORKFILE";
-
 const ALWAYS: u32 = 0;
 const SHOW_FALURES: u32 = 1;
 const TRACE: u32 = 2;
@@ -62,8 +59,6 @@ macro_rules! verbose_message {
         let _ = $level;
     };
 }
-
-type RejectionDetail = BTreeMap<Reason, u32>;
 
 /// State used when running a proptest test.
 #[derive(Clone)]
@@ -128,18 +123,8 @@ impl ForkOutput {
         }
     }
 
-    fn terminate(&mut self) {
-        if let Some(ref mut file) = self.file {
-            replay::terminate(file).expect("Failed to append to replay file");
-        }
-    }
-
     fn empty() -> Self {
         ForkOutput { file: None }
-    }
-
-    fn is_in_fork(&self) -> bool {
-        self.file.is_some()
     }
 }
 
@@ -383,131 +368,6 @@ impl TestRunner {
         Ok(())
     }
 
-    #[cfg(not(feature = "fork"))]
-    fn run_in_fork<S: Strategy>(
-        &mut self,
-        _: &S,
-        _: impl Fn(S::Value) -> TestCaseResult,
-    ) -> TestRunResult<S> {
-        unreachable!()
-    }
-
-    #[cfg(feature = "fork")]
-    fn run_in_fork<S: Strategy>(
-        &mut self,
-        _: &S,
-        _: impl Fn(S::Value) -> TestCaseResult,
-    ) -> TestRunResult<S> {
-        unreachable!()
-    }
-
-    fn run_in_process<S: Strategy>(
-        &mut self,
-        strategy: &S,
-        test: impl Fn(S::Value) -> TestCaseResult,
-    ) -> TestRunResult<S> {
-        let (replay_steps, fork_output) = init_replay(&mut self.rng);
-        self.run_in_process_with_replay(
-            strategy,
-            test,
-            replay_steps.into_iter(),
-            fork_output,
-        )
-    }
-
-    fn run_in_process_with_replay<S: Strategy>(
-        &mut self,
-        strategy: &S,
-        test: impl Fn(S::Value) -> TestCaseResult,
-        mut replay: impl Iterator<Item = TestCaseResult>,
-        mut fork_output: ForkOutput,
-    ) -> TestRunResult<S> {
-        let old_rng = self.rng.clone();
-
-        let persisted_failure_seeds: Vec<PersistedSeed> = self
-            .config
-            .failure_persistence
-            .as_ref()
-            .map(|f| f.load_persisted_failures2(self.config.source_file))
-            .unwrap_or_default();
-
-        let mut result_cache = self.new_cache();
-
-        for PersistedSeed(persisted_seed) in persisted_failure_seeds {
-            self.rng.set_seed(persisted_seed);
-            self.gen_and_run_case(
-                strategy,
-                &test,
-                &mut replay,
-                &mut *result_cache,
-                &mut fork_output,
-            )?;
-        }
-        self.rng = old_rng;
-
-        while self.successes < self.config.cases {
-            // Generate a new seed and make an RNG from that so that we know
-            // what seed to persist if this case fails.
-            let seed = self.rng.gen_get_seed();
-            let result = self.gen_and_run_case(
-                strategy,
-                &test,
-                &mut replay,
-                &mut *result_cache,
-                &mut fork_output,
-            );
-            if let Err(TestError::Fail(_, ref value)) = result {
-                if let Some(ref mut failure_persistence) =
-                    self.config.failure_persistence
-                {
-                    let source_file = &self.config.source_file;
-
-                    // Don't update the persistence file if we're a child
-                    // process. The parent relies on it remaining consistent
-                    // and will take care of updating it itself.
-                    if !fork_output.is_in_fork() {
-                        failure_persistence.save_persisted_failure2(
-                            *source_file,
-                            PersistedSeed(seed),
-                            value,
-                        );
-                    }
-                }
-            }
-
-            if let Err(e) = result {
-                fork_output.terminate();
-                return Err(e.into());
-            }
-        }
-
-        fork_output.terminate();
-        Ok(())
-    }
-
-    fn gen_and_run_case<S: Strategy>(
-        &mut self,
-        strategy: &S,
-        f: &impl Fn(S::Value) -> TestCaseResult,
-        replay: &mut impl Iterator<Item = TestCaseResult>,
-        result_cache: &mut dyn ResultCache,
-        fork_output: &mut ForkOutput,
-    ) -> TestRunResult<S> {
-        let case = unwrap_or!(strategy.new_tree(self), msg =>
-                return Err(TestError::Abort(msg)));
-
-        if self.run_one_with_replay(
-            case,
-            f,
-            replay,
-            result_cache,
-            fork_output,
-        )? {
-            self.successes += 1;
-        }
-        Ok(())
-    }
-
     /// Run one specific test case against this runner.
     ///
     /// If the test fails, finds the minimal failing test case. If the test
@@ -687,10 +547,7 @@ impl TestRunner {
 
     /// Update the state to account for a local rejection from `whence`, and
     /// return `Ok` if the caller should keep going or `Err` to abort.
-    pub fn reject_local(
-        &mut self,
-        whence: impl Into<Reason>,
-    ) -> Result<(), Reason> {
+    pub fn reject_local(&mut self, _: impl Into<Reason>) -> Result<(), Reason> {
         if self.local_rejects >= self.config.max_local_rejects {
             Err("Too many local rejects".into())
         } else {
@@ -701,20 +558,13 @@ impl TestRunner {
 
     /// Update the state to account for a global rejection from `whence`, and
     /// return `Ok` if the caller should keep going or `Err` to abort.
-    fn reject_global<T>(&mut self, whence: Reason) -> Result<(), TestError<T>> {
+    fn reject_global<T>(&mut self, _: Reason) -> Result<(), TestError<T>> {
         if self.global_rejects >= self.config.max_global_rejects {
             Err(TestError::Abort("Too many global rejects".into()))
         } else {
             self.global_rejects += 1;
             Ok(())
         }
-    }
-
-    /// Insert 1 or increment the rejection detail at key for whence.
-    fn insert_or_increment(into: &mut RejectionDetail, whence: Reason) {
-        into.entry(whence)
-            .and_modify(|count| *count += 1)
-            .or_insert(1);
     }
 
     /// Increment the counter of flat map regenerations and return whether it
@@ -728,38 +578,6 @@ impl TestRunner {
     }
 }
 
-#[cfg(feature = "fork")]
-fn init_replay(rng: &mut TestRng) -> (Vec<TestCaseResult>, ForkOutput) {
-    use crate::test_runner::replay::{open_file, Replay, ReplayFileStatus::*};
-
-    if let Some(path) = env::var_os(ENV_FORK_FILE) {
-        let mut file = open_file(&path).expect("Failed to open replay file");
-        let loaded =
-            Replay::parse_from(&mut file).expect("Failed to read replay file");
-        match loaded {
-            InProgress(replay) => {
-                rng.set_seed(replay.seed);
-                (replay.steps, ForkOutput { file: Some(file) })
-            }
-
-            Terminated(_) => {
-                panic!("Replay file for child process is terminated?")
-            }
-
-            Corrupt => panic!("Replay file for child process is corrupt"),
-        }
-    } else {
-        (vec![], ForkOutput::empty())
-    }
-}
-
-#[cfg(not(feature = "fork"))]
-fn init_replay(
-    _rng: &mut TestRng,
-) -> (iter::Empty<TestCaseResult>, ForkOutput) {
-    (iter::empty(), ForkOutput::empty())
-}
-
 #[cfg(test)]
 mod test {
     use crate::strategy::{Just, Strategy};
@@ -769,7 +587,7 @@ mod test {
         #[cfg_attr(kani, kani::proof)]
         fn successfully_linked_proptest(_ in &Just(()) ) {
             let config = Config::default();
-            prop_assert_eq!(
+            assert_eq!(
                 config.cases,
                 256,
                 "Default .cases should be 256. Check: src/test_runner/config.rs"


### PR DESCRIPTION
### Description of changes: 

Removed redundant code

### Resolved issues:

Towards #16098

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

- https://github.com/model-checking/kani/commit/22c276a4806173155e575ec8c72bb877cb9967bf is redundant b/c of #1660 

### Testing:

* How is this change tested? Same as #1660 

* Is this a refactor change? Yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
