### PR TITLE
Fix performance regressions script

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -63,8 +63,8 @@ jobs:
         with:
           os: ubuntu-20.04
 
-      - name: Build Kani
-        run: cargo build
+      - name: Build Kani using release mode
+        run: cargo build --release
 
       - name: Execute Kani performance tests
         run: ./scripts/kani-perf.sh

--- a/scripts/kani-perf.sh
+++ b/scripts/kani-perf.sh
@@ -8,8 +8,8 @@ set -o nounset
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 KANI_DIR=$SCRIPT_DIR/..
 
-# Build Kani using release mode.
-cargo build --release
+# Build Kani
+cargo build
 
 PERF_DIR="${KANI_DIR}/tests/perf"
 
@@ -40,3 +40,4 @@ else
   echo "***Kani perf tests failed."
 fi
 echo
+exit $exit_code

--- a/scripts/kani-perf.sh
+++ b/scripts/kani-perf.sh
@@ -8,8 +8,8 @@ set -o nounset
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 KANI_DIR=$SCRIPT_DIR/..
 
-# Build Kani
-cargo build
+# Build Kani using release mode
+cargo build --release
 
 PERF_DIR="${KANI_DIR}/tests/perf"
 

--- a/scripts/kani-perf.sh
+++ b/scripts/kani-perf.sh
@@ -8,7 +8,7 @@ set -o nounset
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 KANI_DIR=$SCRIPT_DIR/..
 
-# Build Kani using release mode
+# Build Kani using release mode.
 cargo build --release
 
 PERF_DIR="${KANI_DIR}/tests/perf"


### PR DESCRIPTION
### Description of changes: 

Performance regressions are currently broken in two ways:
1. They build Kani using `cargo build --release`, which causes two `kani-driver` binaries to exist under the target directory:
```
target/debug/kani-driver
target/release/kani-driver
```
which in turn causes the kani/cargo-kani script to fail, since they explicitly check that only binary is found:
```bash
[ ${#KANI_CANDIDATES[@]} -ne 1 ]]
```
2. The `kani-perf.sh` script always exits with 0 status even if the regressions failed!

This PR fixes both issues.

### Resolved issues:

Resolves #1688 
Resolves #1689 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
