### PR TITLE
RFC for Function and Method Stubbing

### DIFF
--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -1,0 +1,99 @@
+- **Feature Name:** Function stubbing (`function_stubbing`)
+- **Feature Request Issue:** [model-checking#1695](https://github.com/model-checking/kani/issues/1695)
+- **RFC PR:** *Link to original PR*
+- **Status:** Under Review
+- **Version:** 0
+- **Proof-of-concept:** *Optional field. If you have implemented a proof of concept, add a link here*
+
+## Summary
+
+This will feature will allow users to specify that certain functions should be replaced with mock functions (stubs) during verification.
+
+## User Impact
+
+We anticipate that stubbing will have a substantial positive impact on the usability of Kani. There are two main motivations for stubbing:
+
+
+1. Users might need to stub functions containing features that Kani does not support, such as inline assembly.
+2. Users might need to stub functions containing code that Kani supports in principle, but which in practice leads to bad verification performance.
+
+In both cases, stubbing would enable users to verify code that cannot currently be verified by Kani (or at least not within a reasonable resource bound).
+
+As an example, consider verifying the following assertion (which can fail):
+
+```rust
+assert!(rand::random::<u32>() != 0);
+```
+
+Currently, running Kani on this leads to 1503 checks: one is a failure because of a missing definition, and the other 1502 are undetermined. That is, Kani is currently unable to prove that this assertion can fail. Verification time is 0.52 seconds.
+
+Using stubbing, we can specify that the function `rand::random` should be replaced with the function `mock_random`, which we can define as
+
+```rust
+#[cfg(kani)]
+fn mock_random<T: kani::Arbitrary>() -> T {
+    kani::any()
+}
+```
+
+Under this substitution, Kani has a single check, which proves that the assertion can fail. Verification time is 0.03 seconds.
+
+## User Experience
+
+This feature is currently limited to stubbing functions; however, the hope is that the basic ideas and mechanisms will carry over to stubbing other features in the future (such as methods and types).
+
+Stubs will be specified per harness; that is, different harnesses can use different stubs (the reasoning being that users might want to mock different behavior for different harnesses).
+Users will specify stubs by attaching the `#[kani::stub_by(original, replacement)]` attribute to each harness function.
+The attribute may be specified multiple times per harness, so that multiple (non-conflicting) stub pairings are supported.
+The arguments `original` and `replacement` give the names of functions, relative to the crate of the harness (*not* relative to the module of the harness).
+
+For example, this code specifies that the function `mock_random` should be used in place of the function `rand::random` for the harness `check_random`:
+
+```rust
+#[cfg(kani)]
+fn mock_random<T: kani::Arbitrary>() -> T {
+    kani::any()
+}
+
+mod my_mod {
+
+    #[cfg(kani)]
+    #[kani::proof]
+    #[kani::stub_by(rand::random, mock_random)]
+    fn check_random() {
+        assert!(rand::random::<u32>() != 0);
+    }
+
+}
+```
+
+Kani will exit with an error if a specified `replacement` stub does not exist or if the user specifies conflicting stubs for the same harness (i.e., if the same `original` function is mapped to multiple `replacement` functions).
+
+To teach this feature, we will update the documentation with a section on function stubbing, including simple examples showing how stubbing can help Kani handle code that currently cannot be verified.
+
+## Detailed Design
+
+This is the technical portion of the RFC. Please provide high level details of the implementation you have in mind:
+
+- What are the main components that will be modified? (E.g.: changes to `kani-compiler`, `kani-driver`, metadata,
+  installation...)
+- How will they be modified? Any changes to how these components communicate?
+- Will this require any new dependency?
+- What corner cases do you anticipate?
+
+## Rationale and alternatives
+
+- What are the pros and cons of this design?
+- What is the impact of not doing this?
+- What other designs have you considered? Why didn't you choose them?
+
+## Open questions
+
+- Is there any part of the design that you expect to resolve through the RFC process?
+- What kind of user feedback do you expect to gather before stabilization? How will this impact your design?
+- Would there ever be the need to stub particular monomorphizations of functions, as opposed to the generic function?
+
+## Future possibilities
+
+What are natural extensions and possible improvements that you predict for this feature that is out of the
+scope of this RFC? Feel free to brainstorm here.

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -11,15 +11,17 @@ This will feature will allow users to specify that certain functions and methods
 
 ## User Impact
 
-We anticipate that stubbing will have a substantial positive impact on the usability of Kani. There are two main motivations for stubbing:
+We anticipate that stubbing will have a substantial positive impact on the usability of Kani:
 
 1. Users might need to stub functions/methods containing features that Kani does not support, such as inline assembly.
-2. Users might need to stub functions/methods containing code that Kani supports in principle, but which in practice leads to bad verification performance.
+2. Users might need to stub functions/methods containing code that Kani supports in principle, but which in practice leads to bad verification performance (for example, if it contains loops).
+3. Users could use stubbing to perform compositional reasoning: prove the behavior of a function/method `f`, and then in other proofs use a stub of `f` that mocks that behavior but is less complex.
 
-In both cases, stubbing would enable users to verify code that cannot currently be verified by Kani (or at least not within a reasonable resource bound).
+In all cases, stubbing would enable users to verify code that cannot currently be verified by Kani (or at least not within a reasonable resource bound).
+Stubbing might also be helpful in the development of Kani, as it would make it possible to run experiments like "Will Kani get better performance if we replace all instances of `Vec::new` in the codebase with `Vec::with_capacity?`" (following [Issue 1673](https://github.com/model-checking/kani/issues/1673)).
 
-In what follows, we give three examples of stubbing being put to work.
-Each of these examples runs on a prototype version of the stubbing mechanism we propose (except that the prototype does not support stub-related annotations; instead, it reads the stub mapping from a file).
+In what follows, we give XXX examples of stubbing being put to work, using the annotations we propose in this RFC.
+We are able to run each of these examples on a modified version of Kani using a proof-of-concept MIR-to-MIR transformation implementing stubbing (the prototype does not support stub-related annotations; instead, it reads the stub mapping from a file).
 
 ### Mocking Randomization
 
@@ -249,7 +251,8 @@ Stubbing is a *de facto* necessity for verification tools, and the lack of stubb
 - Because stubs are specified by annotating the harness, the user is able to specify stubs for functions they do not have source access to (like library functions).
 This contrasts with annotating the function to be replaced (such as with function contracts).
 - The current design provides the user with flexibility, as they can specify different sets of stubs to use for different harnesses.
-- The stub mappings are all located right by the harness, which makes it easy to understand which replacements are going to happen for each harness.
+This is important if users are trying to perform compositional reasoning using stubbing, since in some harnesses a function/method should be verified, in in other harnesses its behavior should be assumed.
+- The stub selections are located adjacent to the harness, which makes it easy to understand which replacements are going to happen for each harness.
 
 ### Risks
 
@@ -262,6 +265,7 @@ This is similar to other specification bugs.
 
 - In many cases, stubs are more user-friendly than contracts. With contracts, it is necessary to explicitly provide information that is automatically captured in Rust (such as which memory is written).
 - The [currently proposed function contract mechanism](https://github.com/model-checking/kani/tree/features/function-contracts) does not provide a way to put contracts on external functions.
+This is one of the key motivations for stubbing.
 
 ### Alternative #1: Annotate stubbed functions
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -9,7 +9,7 @@
 
 Allow users to specify that certain functions and methods should be replaced with mock functions (stubs) during verification.
 
-## User Impact
+## User impact
 
 We anticipate that stubbing will have a substantial positive impact on the usability of Kani:
 
@@ -26,7 +26,7 @@ We are able to run each of these examples on a modified version of Kani using a 
 These examples---involving randomization and deserialization---are the types of functions/methods that are commonly stubbed in other verification and program analysis projects.
 Other common examples that we should be able to handle include system calls and timer functions.
 
-### Mocking Randomization
+### Mocking randomization
 
 The crate [`rand`](https://crates.io/crates/rand) is widely used (150M downloads).
 However, Kani cannot currently handle code that uses it (Kani users have run into this; see <https://github.com/model-checking/kani/issues/1727>).
@@ -60,7 +60,7 @@ fn random_cannot_be_zero() {
 
 Under this substitution, Kani has a single check, which proves that the assertion can fail. Verification time is 0.02 seconds.
 
-### Mocking Deserialization
+### Mocking deserialization
 
 In this example, we mock a [serde_json](https://crates.io/crates/serde_json) (96M downloads) deserialization method so that we can prove a property about the following [Firecracker function](https://github.com/firecracker-microvm/firecracker/blob/01eba51ded2f5439da91a2d73280f579651b067c/src/api_server/src/request/vsock.rs#L11) that parses a configuration from some raw data:
 
@@ -157,7 +157,7 @@ fn mock_deserialize(_data: &[u8]) -> serde_json::Result<VsockDeviceConfig> {
 
 The proof takes 170 seconds to complete (using Kissat as the backend SAT solver for CBMC).
 
-## User Experience
+## User experience
 
 This feature is currently limited to stubbing functions and methods.
 We anticipate that the annotations we propose here could also be used when stubbing types, although the underlying technical approach might have to change.
@@ -195,7 +195,7 @@ mod my_mod {
 }
 ```
 
-### Stub Sets
+### Stub sets
 
 As a convenience, we will provide a macro `kani::stub_set` that allows users to specify sets of stubs that can be applied to multiple harnesses:
 
@@ -226,7 +226,7 @@ kani::stub_set!() {
 }
 ```
 
-### Error Conditions
+### Error conditions
 
 Given a set of `original`-`replacement` pairs, Kani will exit with an error if
 
@@ -238,7 +238,7 @@ Given a set of `original`-`replacement` pairs, Kani will exit with an error if
 
 To teach this feature, we will update the documentation with a section on function and method stubbing, including simple examples showing how stubbing can help Kani handle code that currently cannot be verified.
 
-## Detailed Design
+## Detailed design
 
 We expect that this feature will require changes primarily to `kani-compiler`.
 Before doing code generation, `kani-compiler` already collects harnesses; we will extend this to also collect stub mapping information.

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -274,8 +274,8 @@ To teach this feature, we will update the documentation with a section on functi
 
 We expect that this feature will require changes primarily to `kani-compiler`.
 Before doing code generation, `kani-compiler` already collects harnesses; we will extend this to also collect stub mapping information.
-We will update `kani-compiler` to generate multiple sets of code, one per set of stubs.
-We will plug in a new MIR-to-MIR transformation that replaces the bodies of specified functions with their replacements.
+Since stubs are specified on a per-harness basis, we need to generate multiple versions of code if all harnesses do not agree on their stub mappings; accordingly, we will update `kani-compiler` to generate multiple versions of code as appropriate. 
+To do the stubbing, we will plug in a new MIR-to-MIR transformation that replaces the bodies of specified functions with their replacements.
 This can be achieved via `rustc`'s query mechanism: if the user wants to replace `foo` with `bar`, then when the compiler requests the MIR for `foo`, we instead return the MIR for `bar`.
 `kani-compiler` will also be responsible for checking for the error conditions previously enumerated.
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -78,7 +78,7 @@ Under this substitution, Kani has a single check, which proves that the assertio
 ## User experience
 
 This feature is currently limited to stubbing functions and methods.
-We anticipate that the annotations we propose here could also be used when stubbing types, although the underlying technical approach might have to change.
+We anticipate that the annotations we propose here could also be used for stubbing types, although the underlying technical approach might have to change.
 
 Stubs will be specified per harness; that is, different harnesses can use different stubs.
 This is one of the main design points.

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -66,7 +66,7 @@ fn mock_random<T: kani::Arbitrary>() -> T {
 
 #[cfg(kani)]
 #[kani::proof]
-#[kani::stub_by(rand::random, mock_random)]
+#[kani::stub(rand::random, mock_random)]
 fn random_cannot_be_zero() {
     assert_ne!(rand::random::<u32>(), 0);
 }
@@ -123,7 +123,7 @@ fn get_vsock_device_config(action: RequestAction) -> Option<VsockDeviceConfig> {
 #[cfg(kani)]
 #[kani::proof]
 #[kani::unwind(2)]
-#[kani::stub_by(serde_json::deserialize_slice, mock_deserialize)]
+#[kani::stub(serde_json::deserialize_slice, mock_deserialize)]
 fn test_deprecation_vsock_id_consistent() {
     // We are going to mock the parsing of this body, so might as well use an empty one.
     let body: Vec<u8> = Vec::new();
@@ -182,7 +182,7 @@ Users might want to mock the behavior of a function within one proof harness, an
 It would be overly restrictive to impose the same stub definitions across all proof harnesses.
 A good example of this is compositional reasoning: in some harnesses, we want to prove properties of a particular function (and so want to use its actual implementation), and in other harnesses we want to assume that that function has those properties.
 
-Users will specify stubs by attaching the `#[kani::stub_by(<original>, <replacement>)]` attribute to each harness function.
+Users will specify stubs by attaching the `#[kani::stub(<original>, <replacement>)]` attribute to each harness function.
 The arguments `original` and `replacement` give the names of functions/methods.
 They will be resolved using Rust's standard name resolution rules; this includes supporting imports like `use foo::bar as baz`.
 The attribute may be specified multiple times per harness, so that multiple (non-conflicting) stub pairings are supported.
@@ -203,8 +203,8 @@ mod my_mod {
 
     #[cfg(kani)]
     #[kani::proof]
-    #[kani::stub_by(rand::random, super::mock_random)]
-    #[kani::stub_by(foo, bar)]
+    #[kani::stub(rand::random, super::mock_random)]
+    #[kani::stub(foo, bar)]
     fn my_harness() { ... }
 
 }
@@ -221,8 +221,8 @@ As a convenience, we will provide a macro `kani::stub_set` that allows users to 
 ```rust
 kani::stub_set! {
     my_io_stubs,
-    stub_by(std::fs::read, my_read),
-    stub_by(std::fs::write, my_write),
+    stub(std::fs::read, my_read),
+    stub(std::fs::write, my_write),
 }
 ```
 
@@ -310,11 +310,11 @@ The major downside with this approach is that it would not be possible to stub e
 
 ### Alternative #2: Annotate stubs
 
-In this alternative, users add an attribute `#[kani::stub(<original>)]` to the stub function itself, saying which function it replaces:
+In this alternative, users add an attribute `#[kani::stub_of(<original>)]` to the stub function itself, saying which function it replaces:
 
 ```rust
 #[cfg(kani)]
-#[kani::stub(rand::random)]
+#[kani::stub_of(rand::random)]
 fn mock_random<T: kani::Arbitrary>() -> T { ... }
 ```
 
@@ -332,15 +332,15 @@ This could be combined with modules, so that a module can be used to group stubs
 #[cfg(kani)]
 mod my_stubs {
 
-  #[kani::stub(foo)]
+  #[kani::stub_of(foo)]
   fn stub1() { ... }
 
-  #[kani::stub(bar)]
+  #[kani::stub_of(bar)]
   fn stub2() { ... }
 
 }
 
-#(cfg[kani])
+#[cfg(kani)]
 #[kani::proof]
 #[kani::use_stubs(my_stubs)]
 fn my_harness() { ... }
@@ -451,5 +451,5 @@ It is possible to do so using `std::mem::transmute` (see below); this is clunky 
   
   #[cfg(kani)]
   #[kani::proof]
-  #[kani::stub_by(Foo::m, mock_m)]
+  #[kani::stub(Foo::m, mock_m)]
   fn my_harness() { ... }```

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -119,8 +119,8 @@ If stubs were uniformly applied, then we could get away with a single call to `k
 
 ### Comparison to function contracts
 
-- Function contracts cannot be used on external code (**AARON**: why not?)
-- **TODO**
+- In many cases, stubs are more user-friendly than contracts. With contracts, it is necessary to explicitly provide information that is automatically captured in Rust (such as which memory is written).
+- The currently proposed function contract mechanism does not provide a way to put contracts on external functions. **[CHECK]**
 
 ### Alternative #1: Annotate stubbed functions
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -40,7 +40,7 @@ fn random_cannot_be_zero() {
 }
 ```
 
-For unwind values less than 2, Kani encounters an unwinding assertion error (there is a loop used to seed the random number generator); if we set an unwind value of 2, Kani fails to terminate in 5 minutes.
+For unwind values less than 2, Kani encounters an unwinding assertion error (there is a loop used to seed the random number generator); if we set an unwind value of 2, Kani fails to terminate within 5 minutes.
 
 Using stubbing, we can specify that the function `rand::random` should be replaced with a mocked version:
 
@@ -146,12 +146,12 @@ fn mock_deserialize(_data: &[u8]) -> serde_json::Result<VsockDeviceConfig> {
     };
     let guest_cid = kani::any();
     let uds_path = symbolic_string(STR_LEN);
-    let dev = VsockDeviceConfig {
+    let config = VsockDeviceConfig {
         vsock_id,
         guest_cid,
         uds_path,
     };
-    Ok(dev)
+    Ok(config)
 }
 ```
 
@@ -378,7 +378,7 @@ Furthermore, it would require that we have access to the AST/HIR for all externa
 Requiring the replacement's type to be a subtype of the original type is likely stronger than what we want.
 For example, if the original function is polymorphic but monomorphized to only a single type, then it seems okay to replace it with a function that matches the monomorphized type.
 - How can we allow a user to stub a method and access private fields of `self`?
-This should be possible using `std::mem::transmute`, but can we hide this from the user, and make it less brittle?
+This should be possible using `std::mem::transmute`, but can we hide this from the user and make it less brittle?
 
 ## Future possibilities
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -1,9 +1,9 @@
 - **Feature Name:** Function and method stubbing (`function_stubbing`)
 - **Feature Request Issue:** [model-checking#1695](https://github.com/model-checking/kani/issues/1695)
-- **RFC PR:** *Link to original PR*
+- **RFC PR:** <https://github.com/model-checking/kani/pull/1723> 
 - **Status:** Under Review
 - **Version:** 0
-- **Proof-of-concept:** https://github.com/aaronbembenek-aws/kani/tree/mir_transform
+- **Proof-of-concept:** <https://github.com/aaronbembenek-aws/kani/tree/mir_transform>
 
 ## Summary
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -192,18 +192,17 @@ mod my_mod {
 
 ### Stub Sets
 
-As a convenience, users will also be able to specify sets of stubs that can be applied to multiple harnesses.
-First, users write a "dummy" function with the name of the stub set, annotate it with the `#[kani::stub_set]` attribute, and add the desired stub pairings as further attributes:
+As a convenience, we will provide a macro `kani::stub_set` that allows users to specify sets of stubs that can be applied to multiple harnesses:
 
 ```rust
-#[cfg(kani)]
-#[kani::stub_set]
-#[kani::stub_by("std::fs::read", "my_read")]
-#[kani::stub_by("std::fs::write", "my_write")]
-fn my_io_stubs() {}
+kani::stub_set! {
+    my_io_stubs {
+        stub_by("std::fs::read", "my_read")
+        stub_by("std::fs::write", "my_write")
+    }
+}
 ```
 
-(It is likely that this could also be hidden behind a more ergonomic macro, that creates an empty function with the appropriate annotations.)
 When declaring a harness, users can use the `#[kani::use_stub_set("<stub_set_name>")]` attribute to apply the stub set:
 
 ```rust
@@ -213,14 +212,15 @@ When declaring a harness, users can use the `#[kani::use_stub_set("<stub_set_nam
 fn my_harness() { ... }
 ```
 
-The same mechanism can be used to aggregate stub sets:
+A similar mechanism can be used to aggregate stub sets:
 
 ```rust
-#[cfg(kani)]
-#[kani::stub_set]
-#[kani::use_stub_set("my_io_stubs")]
-#[kani::use_stub_set("other_stub_set")]
-fn all_my_stubs() {}
+kani::stub_set! {
+    all_my_stubs {
+        use_stub_set("my_io_stubs")
+        use_stub_set("my_other_stubs")
+    }
+}
 ```
 
 ### Error Conditions

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -363,7 +363,7 @@ It is possible to do so using `std::mem::transmute` (see below); this is clunky 
   fn my_harness() { ... }
   ```
 
-## Appendix: An extended example
+## Appendix: an extended example
 
 In this example, we mock a [serde_json](https://crates.io/crates/serde_json) (96M downloads) deserialization method so that we can prove a property about the following [Firecracker function](https://github.com/firecracker-microvm/firecracker/blob/01eba51ded2f5439da91a2d73280f579651b067c/src/api_server/src/request/vsock.rs#L11) that parses a configuration from some raw data:
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -66,7 +66,7 @@ fn mock_random<T: kani::Arbitrary>() -> T {
 
 #[cfg(kani)]
 #[kani::proof]
-#[kani::stub_by("rand::random", "mock_random")]
+#[kani::stub_by(rand::random, mock_random)]
 fn random_cannot_be_zero() {
     assert_ne!(rand::random::<u32>(), 0);
 }
@@ -123,7 +123,7 @@ fn get_vsock_device_config(action: RequestAction) -> Option<VsockDeviceConfig> {
 #[cfg(kani)]
 #[kani::proof]
 #[kani::unwind(2)]
-#[kani::stub_by("serde_json::deserialize_slice", "mock_deserialize")]
+#[kani::stub_by(serde_json::deserialize_slice, mock_deserialize)]
 fn test_deprecation_vsock_id_consistent() {
     // We are going to mock the parsing of this body, so might as well use an empty one.
     let body: Vec<u8> = Vec::new();
@@ -183,7 +183,7 @@ It would be overly restrictive to impose the same stub definitions across all pr
 A good example of this is compositional reasoning: in some harnesses, we want to prove properties of a particular function (and so want to use its actual implementation), and in other harnesses we want to assume that that function has those properties.
 
 Users will specify stubs by attaching the `#[kani::stub_by(<original>, <replacement>)]` attribute to each harness function.
-The arguments `original` and `replacement` give the names of functions (as string literals).
+The arguments `original` and `replacement` give the names of functions/methods.
 They will be resolved using Rust's standard name resolution rules; this includes supporting imports like `use foo::bar as baz`.
 The attribute may be specified multiple times per harness, so that multiple (non-conflicting) stub pairings are supported.
 
@@ -203,8 +203,8 @@ mod my_mod {
 
     #[cfg(kani)]
     #[kani::proof]
-    #[kani::stub_by("rand::random", "super::mock_random")]
-    #[kani::stub_by("foo", "bar")]
+    #[kani::stub_by(rand::random, super::mock_random)]
+    #[kani::stub_by(foo, bar)]
     fn my_harness() { ... }
 
 }
@@ -222,17 +222,17 @@ As a convenience, we will provide a macro `kani::stub_set` that allows users to 
 ```rust
 kani::stub_set! {
     my_io_stubs,
-    stub_by("std::fs::read", "my_read"),
-    stub_by("std::fs::write", "my_write"),
+    stub_by(std::fs::read, my_read),
+    stub_by(std::fs::write, my_write),
 }
 ```
 
-When declaring a harness, users can use the `#[kani::use_stub_set("<stub_set_name>")]` attribute to apply the stub set:
+When declaring a harness, users can use the `#[kani::use_stub_set(<stub_set_name>)]` attribute to apply the stub set:
 
 ```rust
 #[cfg(kani)]
 #[kani::proof]
-#[kani::use_stub_set("my_io_stubs")]
+#[kani::use_stub_set(my_io_stubs)]
 fn my_harness() { ... }
 ```
 
@@ -243,8 +243,8 @@ A similar mechanism can be used to aggregate stub sets:
 ```rust
 kani::stub_set!() {
     all_my_stubs,
-    use_stub_set("my_io_stubs"),
-    use_stub_set("my_other_stubs"),
+    use_stub_set(my_io_stubs),
+    use_stub_set(my_other_stubs),
 }
 ```
 
@@ -315,7 +315,7 @@ In this alternative, users add an attribute `#[kani::stub(<original>)]` to the s
 
 ```rust
 #[cfg(kani)]
-#[kani::stub("rand::random")]
+#[kani::stub(rand::random)]
 fn mock_random<T: kani::Arbitrary>() -> T { ... }
 ```
 
@@ -333,17 +333,17 @@ This could be combined with modules, so that a module can be used to group stubs
 #[cfg(kani)]
 mod my_stubs {
 
-  #[kani::stub("foo")]
+  #[kani::stub(foo)]
   fn stub1() { ... }
 
-  #[kani::stub("bar")]
+  #[kani::stub(bar)]
   fn stub2() { ... }
 
 }
 
 #(cfg[kani])
 #[kani::proof]
-#[kani::use_stubs("my_stubs")]
+#[kani::use_stubs(my_stubs)]
 fn my_harness() { ... }
 ```
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -272,21 +272,14 @@ To teach this feature, we will update the documentation with a section on functi
 
 ## Detailed Design
 
-We discuss both the design in its full form and a simplified version appropriate for a first step.
-We anticipate that this design will evolve and be iterated upon.
-
-### Full form
-
 We expect that this feature will require changes primarily to `kani-compiler`.
 Before doing code generation, `kani-compiler` already collects harnesses; we will extend this to also collect stub mapping information.
+We will update `kani-compiler` to generate multiple sets of code, one per set of stubs.
 We will plug in a new MIR-to-MIR transformation that replaces the bodies of specified functions with their replacements.
 This can be achieved via `rustc`'s query mechanism: if the user wants to replace `foo` with `bar`, then when the compiler requests the MIR for `foo`, we instead return the MIR for `bar`.
 `kani-compiler` will also be responsible for checking for the error conditions previously enumerated.
 
-### First step
-
-As a first step, we will require that stubbing will only be enabled if Kani is also run with the `--harness` flag.
-Since there is only a single stub set in this situation, `kani-driver` needs to run `kani-compiler` only once.
+We anticipate that this design will evolve and be iterated upon.
 
 ## Rationale and alternatives: user experience
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -1,5 +1,5 @@
 - **Feature Name:** Function and method stubbing (`function_stubbing`)
-- **Feature Request Issue:** [model-checking#1695](https://github.com/model-checking/kani/issues/1695)
+- **Feature Request Issue:** <https://github.com/model-checking/kani/issues/1695>
 - **RFC PR:** <https://github.com/model-checking/kani/pull/1723> 
 - **Status:** Under Review
 - **Version:** 0

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -3,6 +3,7 @@
 - **RFC PR:** *Link to original PR*
 - **Status:** Under Review
 - **Version:** 0
+- **Proof-of-concept:** https://github.com/aaronbembenek-aws/kani/tree/mir_transform
 
 ## Summary
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-This will feature will allow users to specify that certain functions and methods should be replaced with mock functions (stubs) during verification.
+Allow users to specify that certain functions and methods should be replaced with mock functions (stubs) during verification.
 
 ## User Impact
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -91,7 +91,7 @@ The arguments `original` and `replacement` give the names of functions/methods.
 They will be resolved using Rust's standard name resolution rules; this includes supporting imports like `use foo::bar as baz`.
 The attribute may be specified multiple times per harness, so that multiple (non-conflicting) stub pairings are supported.
 
-For example, this code specifies that the function `mock_random` should be used in place of the function `rand::random` and the function `my_mod::foo` should be used in place of the function `my_mod::bar` for the harness `my_mod::my_harness`:
+For example, this code specifies that the function `mock_random` should be used in place of the function `rand::random` and the function `my_mod::bar` should be used in place of the function `my_mod::foo` for the harness `my_mod::my_harness`:
 
 ```rust
 #[cfg(kani)]
@@ -144,7 +144,7 @@ The name of the stub set will be resolved through the module path (i.e., they ar
 A similar mechanism can be used to aggregate stub sets:
 
 ```rust
-kani::stub_set!() {
+kani::stub_set! {
     all_my_stubs,
     use_stub_set(my_io_stubs),
     use_stub_set(my_other_stubs),
@@ -200,11 +200,15 @@ All the stubbing code will be available, so it is possible to inspect the assump
 
 ### Comparison to function contracts
 
-- The [currently proposed function contract mechanism](https://github.com/model-checking/kani/tree/features/function-contracts) does not provide a way to specify contracts on external functions.
-This is one of the key motivations for stubbing.
 - In many cases, stubs are more user-friendly than contracts.
 With contracts, it is sometimes necessary to explicitly provide information that is automatically captured in Rust (such as which memory is written).
 Furthermore, contract predicates constitute a DSL of their own that needs to be learned; using stubbing, we can stick to using just Rust.
+- Function contracts sometimes come with a mechanism for verifying that a function satisfies its contract (for example, [CBMC provides this](http://www.cprover.org/cprover-manual/contracts/functions/)).
+While we do not plan to provide such a feature, it is possible to emulate this by writing proof harnesses comparing the behavior of the original function and the stub.
+Furthermore, our approach provides additional flexibility, as it is not always actually desirable for a stub to be an overapproximation of the function (e.g., we might want the stub to exhibit a certain behavior within a particular harness) or to have a consistent behavior across all harnesses.
+- The [currently proposed function contract mechanism](https://github.com/model-checking/kani/tree/features/function-contracts) does not provide a way to specify contracts on external functions.
+In principle, it would be possible to extend it to do so.
+Doing so would require some additional UX design decisions (e.g., "How do users specify this?"); with stubbing there does not need to be a distinction between local and external functions.
 
 ### Alternative #1: Annotate stubbed functions
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -58,66 +58,13 @@ fn random_cannot_be_zero() {
 
 Under this substitution, Kani has a single check, which proves that the assertion can fail. Verification time is 0.02 seconds.
 
-### Mocking IO
+### Mocking System Calls
 
-**TODO: build out this section**
+**TODO**
 
-- `std::fs::read` (currently can do)
-- `std::fs::write` (currently can do)
-- `std::fs::File`
-- Stub code containing inline assembly? 
+### Mocking Deserialization
 
-### Mocking `Vec`
-
-[Issue 1673](https://github.com/model-checking/kani/issues/1673) documents that Kani performs poorly on the following program (both in terms of memory and speed):
-
-```rust
-const N: usize = 9;
-
-#[cfg_attr(kani, kani::proof, kani::unwind(10))]
-fn vec_harness() {
-    let mut v: Vec<String> = Vec::new();
-    for _i in 0..N {
-        v.push(String::from("ABC"));
-    }
-    assert_eq!(v.len(), N);
-    let index: usize = kani::any();
-    kani::assume(index < v.len());
-    let x = &v[index];
-    assert_eq!(*x, "ABC");
-}
-```
-
-On my laptop, it takes 400 seconds to complete.
-The issue reports that performance is much improved if `Vec::new()` is replaced with `Vec::with_capacity(N)`.
-Using stubbing, we can perform this transformation without modifying the harness's code:
-
-```rust
-const N: usize = 9;
-
-fn mock_vec_new<T>() -> Vec<T> {
-    Vec::with_capacity(100)
-}
-
-#[cfg_attr(kani, kani::proof, kani::unwind(10))]
-#[cfg_attr(kani, kani::stub_by("std::vec::Vec::<T>::new", "mock_vec_new"))]
-fn vec_harness() {
-    let mut v: Vec<String> = Vec::new();
-    for _i in 0..N {
-        v.push(String::from("ABC"));
-    }
-    assert_eq!(v.len(), N);
-    let index: usize = kani::any();
-    kani::assume(index < v.len());
-    let x = &v[index];
-    assert_eq!(*x, "ABC");
-}
-```
-
-The harness now runs in 19 seconds (21x speedup).
-
-**What is intriguing is that, with stubbing, we can make this substitution not only in the harness (where we could have always done it by hand), but also everywhere else in the codebase, including external code that we could not have otherwise modified.**
-This could have a major impact on verification performance if a crate's external dependencies use `Vec`.
+**TODO**
 
 ## User Experience
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -355,9 +355,9 @@ The disadvantage with this approach is that it does not provide any way to stub 
 In this alternative, we rewrite the source code before it even gets to the compiler.
 The advantage with this approach is that it is very flexible, allowing us to stub functions, methods, and types, either by directly replacing them, or appending their replacements and injecting appropriate conditional compilation guards.
 
-The downside with this approach is that it requires all source code to be available.
+This approach entails less user effort than Alternative #1, but it has the same downside that it requires all source code to be available.
 It also might be difficult to inject code in a way that names are correctly resolved (e.g., if the replacement code comes from a different crate).
-Also, source code is difficult to work with, and includes things like unexpanded macros.
+Also, source code is difficult to work with (e.g., unexpanded macros).
 
 On the last two points, we might be able to take advantage of an existing source analysis platform like `rust-analyzer` (which has facilities like structural search replace), but this would add more (potentially fragile) dependencies to Kani.
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -123,11 +123,10 @@ In the documentation, we will discourage stubbing private functions/methods exce
 As a convenience, we will provide a macro `kani::stub_set` that allows users to specify sets of stubs that can be applied to multiple harnesses:
 
 ```rust
-kani::stub_set! {
-    my_io_stubs,
+kani::stub_set!(my_io_stubs(
     stub(std::fs::read, my_read),
     stub(std::fs::write, my_write),
-}
+));
 ```
 
 When declaring a harness, users can use the `#[kani::use_stub_set(<stub_set_name>)]` attribute to apply the stub set:
@@ -144,11 +143,10 @@ The name of the stub set will be resolved through the module path (i.e., they ar
 A similar mechanism can be used to aggregate stub sets:
 
 ```rust
-kani::stub_set! {
-    all_my_stubs,
+kani::stub_set!(all_my_stubs(
     use_stub_set(my_io_stubs),
     use_stub_set(my_other_stubs),
-}
+));
 ```
 
 ### Error conditions

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -47,7 +47,7 @@ Users will specify stubs by attaching the `#[kani::stub_by(original, replacement
 The attribute may be specified multiple times per harness, so that multiple (non-conflicting) stub pairings are supported.
 The arguments `original` and `replacement` give the names of functions, relative to the crate of the harness (*not* relative to the module of the harness).
 
-For example, this code specifies that the function `mock_random` should be used in place of the function `rand::random` for the harness `check_random`:
+For example, this code specifies that the function `mock_random` should be used in place of the function `rand::random` and the function `my_mod::foo` should be used in place of the function `my_mod::bar` for the harness `my_mod::my_harness`:
 
 ```rust
 #[cfg(kani)]
@@ -57,19 +57,27 @@ fn mock_random<T: kani::Arbitrary>() -> T {
 
 mod my_mod {
 
+    fn foo(x: u32) -> u32 { ... }
+
+    fn bar(x: u32) -> u32 { ... }
+
     #[cfg(kani)]
     #[kani::proof]
     #[kani::stub_by(rand::random, mock_random)]
-    fn check_random() {
-        assert!(rand::random::<u32>() != 0);
-    }
+    #[kani::stub_by(my_mod::foo, my_mod::bar)]
+    fn my_harness() { ... }
 
 }
 ```
 
-Kani will exit with an error if a specified `replacement` stub does not exist or if the user specifies conflicting stubs for the same harness (i.e., if the same `original` function is mapped to multiple `replacement` functions).
+Kani will exit with an error if
+
+1. a specified `replacement` stub does not exist;
+2. the user specifies conflicting stubs for the same harness (i.e., if the same `original` function is mapped to multiple `replacement` functions); or
+3. the signature of the `replacement` function is not compatible with the signature of the `original` function.
 
 To teach this feature, we will update the documentation with a section on function stubbing, including simple examples showing how stubbing can help Kani handle code that currently cannot be verified.
+
 
 ## Detailed Design
 

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -43,7 +43,7 @@ Other common examples that we should be able to handle include system calls and 
 ### Mocking randomization
 
 The crate [`rand`](https://crates.io/crates/rand) is widely used (150M downloads).
-However, Kani cannot currently handle code that uses it (Kani users have run into this; see <https://github.com/model-checking/kani/issues/1727>).
+However, Kani cannot currently handle code that uses it (Kani users have run into this; see [Issue 1727](<https://github.com/model-checking/kani/issues/1727>).
 Consider this example:
 
 ```rust
@@ -211,8 +211,7 @@ mod my_mod {
 ```
 
 We will support the stubbing of private functions and methods.
-This provides the flexibility that users will demand.
-On the other hand, it can also lead to brittle proofs: private functions/methods can change or disappear in even minor version upgrades (thanks to refactoring), and so proofs that depend on them might have a high maintenance burden.
+While this provides flexibility that we believe will be necessary in practice, it can also lead to brittle proofs: private functions/methods can change or disappear in even minor version upgrades (thanks to refactoring), and so proofs that depend on them might have a high maintenance burden.
 In the documentation, we will discourage stubbing private functions/methods except if absolutely necessary.
 
 ### Stub sets
@@ -352,7 +351,7 @@ The downside is that multiple annotations are required and the stub mappings the
 There are also several issues that would need to be resolved:
 
 - How do you mock multiple functions with the same stub?
-(Especially if, say, harness A wants to use `stub1` to mock `foo`, and harness B wants to use `stub1` to mock `bar`.)
+(Say harness A wants to use `stub1` to mock `foo`, and harness B wants to use `stub1` to mock `bar`.)
 - How do you combine stub sets defined via modules? Would you use the module hierarchy?
 - If you use modules to define stub sets, are these modules regular modules or not?
 In particular, given that modules can contain other constructs than functions, how should we interpret the extra stuff?
@@ -361,7 +360,7 @@ In particular, given that modules can contain other constructs than functions, h
 
 One alternative would be to specify stubs in a file that is passed to `kani-driver` via a command line option.
 Users would specify per-harness stub pairings in the file; JSON would be a possible format.
-Using a file would eliminate the need for `kani-driver` to extract harness information from the Rust source code; the rest of the implementation would stay the same.
+Using a file would eliminate the need for `kani-compiler` to do an extra pass to extract harness information from the Rust source code before doing code generation; the rest of the implementation would stay the same.
 It would also allow the same harness to be run with different stub selections (by supplying a different file).
 The disadvantage is that the stub selection is remote from the harness itself.
 
@@ -376,7 +375,7 @@ The major downside with the MIR-to-MIR transformation is that it does not appear
 Thus, our proposed approach will not be a fully general stubbing solution.
 However, it is technically feasible and relatively clean, and provides benefits over having no stubbing at all (as can be seen in the examples in the first part of this document).
 
-Furthermore, it can be used as part of a portfolio of stubbing approaches, where users stub local types using conditional compilation (see Alternative #1), and Kani provides a modified version of the standard library with verification-friendly versions of types like `std::vec::Vec`.
+Furthermore, it could be used as part of a portfolio of stubbing approaches, where users stub local types using conditional compilation (see Alternative #1), and Kani provides a modified version of the standard library with verification-friendly versions of types like `std::vec::Vec`.
 
 ### Alternative #1: Conditional compilation
 
@@ -427,7 +426,7 @@ One possibility would be writing proofs about stubs (possibly relating their beh
 - It would increase the utility of stubbing if we supported stubs for types.
 The source code annotations could likely stay the same, although the underlying technical approach performing these substitutions might be significantly more complex.
 - It would probably make sense to provide a library of common stubs for users, since many applications might want to stub the same functions and mock the same behaviors (e.g., `rand::random` can be replaced with a function returning `kani::any`).
-- How can we provide good user experience for accessing private fields of `self` in methods?
+- How can we provide a good user experience for accessing private fields of `self` in methods?
 It is possible to do so using `std::mem::transmute` (see below); this is clunky and error-prone, and it would be good to provide better support for users.
 
   ```rust
@@ -452,5 +451,5 @@ It is possible to do so using `std::mem::transmute` (see below); this is clunky 
   
   #[cfg(kani)]
   #[kani::proof]
-  #[kani::stub_by("Foo::m", "mock_m")]
+  #[kani::stub_by(Foo::m, mock_m)]
   fn my_harness() { ... }```


### PR DESCRIPTION
### Description of changes: 

Create an RFC for the UX and backend implementation of function and method stubbing. This would allow users to specify that, during verification, some functions/methods should be replaced with other functions/methods. These substitutions would help Kani handle code that has unsupported features (like inline assembly) or leads to bad verification performance.

I have created a [proof-of-concept](https://github.com/aaronbembenek-aws/kani/tree/mir_transform) of the backend MIR-to-MIR transformation; the stub mapping is read from a file.

You can also find a rendered version of this document [here](https://github.com/aaronbembenek-aws/kani/blob/issue-1695-rfc/rfc/src/rfcs/0002-function-stubbing.md).

### Related issues:

Resolves #1695

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
