### PR TITLE
Install Kani into the action, instead of using a docker

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,18 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+name: Kani Action Check
+on: pull_request
+
+jobs:
+  test-action:
+    runs-on: ubuntu-latest
+    name: Ensure that the Kani action continues to work
+    steps:
+      # To use this repository's private action,
+      # you must check out the repository
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run Kani
+        uses: ./ # Uses the action in the root directory
+        with:
+          command: cd tests/cargo-kani/simple-lib && cargo-kani

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
         curl "${KANI_SCRIPT_FOLDER}/ubuntu/install_deps.sh" | bash ; \
         curl "${KANI_SCRIPT_FOLDER}/install_rustup.sh" | bash  ; \
         source  ~/.cargo/env; \
-        cargo install --locked kani-verifier; \
+        cargo install --version $KANI_VERSION --locked kani-verifier; \
         cargo-kani setup;
 
     - name: Run Kani

--- a/action.yml
+++ b/action.yml
@@ -13,12 +13,25 @@ inputs:
   command:
     description: 'Command to run.'
     required: false
-    default: 'cargo kani --workspace'
+    default: 'cargo-kani'
 
 runs:
-  using: 'docker'
-  image: docker://ghcr.io/model-checking/kani-ubuntu-20.04:0.11.0
-  args:
-    - bash
-    - '-c'
-    - 'set -e; export HOME=/root USER=$(id -nu) PATH=/root/.cargo/bin:$PATH; source $HOME/.bashrc; ${{ inputs.command }}'
+  using: "composite"
+  steps:
+    - name: Install Kani
+      shell: bash
+      run: |
+        export KANI_VERSION="0.11.0"; \
+        export KANI_SCRIPT_FOLDER="https://raw.githubusercontent.com/model-checking/kani/kani-${KANI_VERSION}/scripts/setup"; \
+        curl "${KANI_SCRIPT_FOLDER}/ubuntu/install_deps.sh" | bash ; \
+        curl "${KANI_SCRIPT_FOLDER}/install_rustup.sh" | bash  ; \
+        source  ~/.cargo/env; \
+        cargo install --locked kani-verifier; \
+        cargo-kani setup;
+
+    - name: Run Kani
+      shell: bash
+      run: | 
+        source  ~/.cargo/env; \
+        ${{ inputs.command }}
+

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
         export KANI_VERSION="0.11.0"; \
         export KANI_SCRIPT_FOLDER="https://raw.githubusercontent.com/model-checking/kani/kani-${KANI_VERSION}/scripts/setup"; \
         #curl "${KANI_SCRIPT_FOLDER}/ubuntu/install_deps.sh" | bash ; \
-        curl "${KANI_SCRIPT_FOLDER}/install_rustup.sh" | bash  ; \
+        #curl "${KANI_SCRIPT_FOLDER}/install_rustup.sh" | bash  ; \
         source  ~/.cargo/env; \
         cargo install --version $KANI_VERSION --locked kani-verifier; \
         cargo-kani setup;

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   command:
     description: 'Command to run.'
     required: false
-    default: 'cargo-kani'
+    default: 'cargo-kani --workspace'
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -22,16 +22,11 @@ runs:
       shell: bash
       run: |
         export KANI_VERSION="0.11.0"; \
-        export KANI_SCRIPT_FOLDER="https://raw.githubusercontent.com/model-checking/kani/kani-${KANI_VERSION}/scripts/setup"; \
-        #curl "${KANI_SCRIPT_FOLDER}/ubuntu/install_deps.sh" | bash ; \
-        #curl "${KANI_SCRIPT_FOLDER}/install_rustup.sh" | bash  ; \
-        source  ~/.cargo/env; \
         cargo install --version $KANI_VERSION --locked kani-verifier; \
         cargo-kani setup;
 
     - name: Run Kani
       shell: bash
       run: | 
-        source  ~/.cargo/env; \
         ${{ inputs.command }}
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
       run: |
         export KANI_VERSION="0.11.0"; \
         export KANI_SCRIPT_FOLDER="https://raw.githubusercontent.com/model-checking/kani/kani-${KANI_VERSION}/scripts/setup"; \
-        curl "${KANI_SCRIPT_FOLDER}/ubuntu/install_deps.sh" | bash ; \
+        #curl "${KANI_SCRIPT_FOLDER}/ubuntu/install_deps.sh" | bash ; \
         curl "${KANI_SCRIPT_FOLDER}/install_rustup.sh" | bash  ; \
         source  ~/.cargo/env; \
         cargo install --version $KANI_VERSION --locked kani-verifier; \


### PR DESCRIPTION
### Description of changes: 

Currently, the action requires a docker, which is not yet published. Instead, as a temporary solution, just install the dependencies every time. 

### Resolved issues:

Resolves #1589 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

- Installing the dependencies takes about 1-1.5 minutes according to some initial testing.

### Testing:

* How is this change tested? Made a repo with Kani proofs, ran this action on it.

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
