### PR TITLE
Introduce (experimental, unstable) parallel runner for proof harnesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "once_cell",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +437,7 @@ dependencies = [
  "kani_metadata",
  "once_cell",
  "pathdiff",
+ "rayon",
  "regex",
  "rustc-demangle",
  "serde",
@@ -491,6 +537,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +619,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -686,6 +751,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -30,6 +30,7 @@ toml = "0.5"
 regex = "1.6"
 rustc-demangle = "0.1.21"
 pathdiff = "0.2.1"
+rayon = "1.5.3"
 
 # A good set of suggested dependencies can be found in rustup:
 # https://github.com/rust-lang/rustup/blob/master/Cargo.toml

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -148,6 +148,10 @@ pub struct KaniArgs {
     // consumes everything
     pub cbmc_args: Vec<OsString>,
 
+    #[structopt(short, long, requires("enable-unstable"))]
+    // consumes everything
+    pub jobs: Option<Option<usize>>,
+
     // Hide option till https://github.com/model-checking/kani/issues/697 is
     // fixed.
     /// Use abstractions for the standard library.
@@ -224,6 +228,15 @@ impl KaniArgs {
             None
         } else {
             Some(DEFAULT_OBJECT_BITS)
+        }
+    }
+
+    /// Computes how many threads should be used to verify harnesses.
+    pub fn jobs(&self) -> Option<usize> {
+        match self.jobs {
+            None => Some(1),          // no argument, default 1
+            Some(None) => None,       // -j
+            Some(Some(x)) => Some(x), // -j=x
         }
     }
 }
@@ -365,7 +378,6 @@ impl KaniArgs {
                 String::new()
             };
 
-            // `tracing` is not a dependency of `kani-driver`, so we println! here instead.
             println!(
                 "Using concrete playback with --randomize-layout.\n\
                 The produced tests will have to be played with the same rustc arguments:\n\
@@ -377,29 +389,47 @@ impl KaniArgs {
         // TODO: these conflicting flags reflect what's necessary to pass current tests unmodified.
         // We should consider improving the error messages slightly in a later pull request.
         if natives_unwind && extra_unwind {
-            Err(Error::with_description(
+            return Err(Error::with_description(
                 "Conflicting flags: unwind flags provided to kani and in --cbmc-args.",
                 ErrorKind::ArgumentConflict,
-            ))
-        } else if self.cbmc_args.contains(&OsString::from("--function")) {
-            Err(Error::with_description(
+            ));
+        }
+        if self.cbmc_args.contains(&OsString::from("--function")) {
+            return Err(Error::with_description(
                 "Invalid flag: --function should be provided to Kani directly, not via --cbmc-args.",
                 ErrorKind::ArgumentConflict,
-            ))
-        } else if self.quiet && self.concrete_playback == Some(ConcretePlaybackMode::Print) {
-            Err(Error::with_description(
+            ));
+        }
+        if self.quiet && self.concrete_playback == Some(ConcretePlaybackMode::Print) {
+            return Err(Error::with_description(
                 "Conflicting options: --concrete-playback=print and --quiet.",
                 ErrorKind::ArgumentConflict,
-            ))
-        } else if self.concrete_playback.is_some() && self.output_format == OutputFormat::Old {
-            Err(Error::with_description(
+            ));
+        }
+        if self.concrete_playback.is_some() && self.output_format == OutputFormat::Old {
+            return Err(Error::with_description(
                 "Conflicting options: --concrete-playback isn't compatible with \
                 --output-format=old.",
                 ErrorKind::ArgumentConflict,
-            ))
-        } else {
-            Ok(())
+            ));
         }
+        if self.concrete_playback.is_some() && self.jobs() != Some(1) {
+            // Concrete playback currently embeds a lot of assumptions about the order in which harnesses get called.
+            return Err(Error::with_description(
+                "Conflicting options: --concrete-playback isn't compatible with --jobs.",
+                ErrorKind::ArgumentConflict,
+            ));
+        }
+        if self.jobs.is_some() && self.output_format != OutputFormat::Terse {
+            // More verbose output formats make it hard to interpret output right now when run in parallel.
+            // This can be removed when we change up how results are printed.
+            return Err(Error::with_description(
+                "Conflicting options: --jobs requires `--output-format=terse`",
+                ErrorKind::ArgumentConflict,
+            ));
+        }
+
+        Ok(())
     }
 }
 

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -148,8 +148,8 @@ pub struct KaniArgs {
     // consumes everything
     pub cbmc_args: Vec<OsString>,
 
-    #[structopt(short, long, requires("enable-unstable"))]
-    // consumes everything
+    /// Number of parallel jobs, defaults to 1
+    #[structopt(short, long, hidden = true, requires("enable-unstable"))]
     pub jobs: Option<Option<usize>>,
 
     // Hide option till https://github.com/model-checking/kani/issues/697 is

--- a/kani-driver/src/call_cbmc_viewer.rs
+++ b/kani-driver/src/call_cbmc_viewer.rs
@@ -23,12 +23,7 @@ impl KaniSession {
         let coverage_filename = alter_extension(file, "coverage.xml");
         let property_filename = alter_extension(file, "property.xml");
 
-        {
-            let mut temps = self.temporaries.borrow_mut();
-            temps.push(results_filename.clone());
-            temps.push(coverage_filename.clone());
-            temps.push(property_filename.clone());
-        }
+        self.record_temporary_files(&[&results_filename, &coverage_filename, &property_filename]);
 
         self.cbmc_variant(file, &["--xml-ui", "--trace"], &results_filename, harness_metadata)?;
         self.cbmc_variant(

--- a/kani-driver/src/call_goto_instrument.rs
+++ b/kani-driver/src/call_goto_instrument.rs
@@ -64,10 +64,7 @@ impl KaniSession {
     pub fn apply_vtable_restrictions(&self, file: &Path, source: &Path) -> Result<()> {
         let linked_restrictions = alter_extension(file, "linked-restrictions.json");
 
-        {
-            let mut temps = self.temporaries.borrow_mut();
-            temps.push(linked_restrictions.clone());
-        }
+        self.record_temporary_files(&[&linked_restrictions]);
 
         collect_and_link_function_pointer_restrictions(source, &linked_restrictions)?;
 

--- a/kani-driver/src/call_single_file.rs
+++ b/kani-driver/src/call_single_file.rs
@@ -33,15 +33,14 @@ impl KaniSession {
         let restrictions_filename = alter_extension(file, "restrictions.json");
         let rlib_filename = guess_rlib_name(file);
 
-        {
-            let mut temps = self.temporaries.borrow_mut();
-            temps.push(rlib_filename);
-            temps.push(output_filename.clone());
-            temps.push(typemap_filename);
-            temps.push(metadata_filename.clone());
-            if self.args.restrict_vtable() {
-                temps.push(restrictions_filename.clone());
-            }
+        self.record_temporary_files(&[
+            &rlib_filename,
+            &output_filename,
+            &typemap_filename,
+            &metadata_filename,
+        ]);
+        if self.args.restrict_vtable() {
+            self.record_temporary_files(&[&restrictions_filename]);
         }
 
         let mut kani_args = self.kani_specific_flags();

--- a/kani-driver/src/call_symtab.rs
+++ b/kani-driver/src/call_symtab.rs
@@ -12,10 +12,7 @@ impl KaniSession {
     pub fn symbol_table_to_gotoc(&self, file: &Path) -> Result<PathBuf> {
         let output_filename = file.with_extension("out");
 
-        {
-            let mut temps = self.temporaries.borrow_mut();
-            temps.push(output_filename.clone());
-        }
+        self.record_temporary_files(&[&output_filename]);
 
         let args = vec![
             file.to_owned().into_os_string(),

--- a/kani-driver/src/main.rs
+++ b/kani-driver/src/main.rs
@@ -88,10 +88,7 @@ fn standalone_main() -> Result<()> {
     }
 
     let linked_obj = util::alter_extension(&args.input, "out");
-    {
-        let mut temps = ctx.temporaries.borrow_mut();
-        temps.push(linked_obj.to_owned());
-    }
+    ctx.record_temporary_files(&[&linked_obj]);
     ctx.link_goto_binary(&[goto_obj], &linked_obj)?;
     if let Some(restriction) = outputs.restrictions {
         ctx.apply_vtable_restrictions(&linked_obj, &restriction)?;


### PR DESCRIPTION
### Description of changes: 

What it says on the tin. :) Takes a 24s artificial benchmark down to under 4s to run.

1. Mimics the same options as `cargo build`: `--jobs` or `-j`. Default is 1. Default with just `-j` is num_cpus.
2. Conflicts with concrete-playback due to its dependence on order of harness running
3. Currently requires `--output-format=terse`. And `--enable-unstable` of course.

There is the problem of output. We actually don't have a huge problem with interleaving output because Adrian already wrote the renderer to print one big blob instead of multiple little ones. (Nice!) However, we do still have #1711 that this exacerbates, and the "verification time" isn't really paired with an output anymore. I think this is merge-able as-is, but I do plan on an independent PR to fix up that issue tomorrow, which it might be reasonable to want merged first.

### Call-outs:

Changes include:

1. Adding a new `--jobs` option to `kani-driver`
2. Replacing `KaniSession`'s `RefCell` with a `Mutex` (and adding `record_temporary_files`)
3. Swap a `for` to `rayon` `par_iter`

and that's it! It's actually a pretty simple change now. Sweet.


### Testing:

* How is this change tested? existing ci: all lines of code actually run by default, just without setting `j` higher than 1

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
