### PR TITLE
Update developer docs after custom sysroot

### DIFF
--- a/docs/src/build-from-source.md
+++ b/docs/src/build-from-source.md
@@ -57,7 +57,7 @@ source $HOME/.cargo/env
 Build the Kani package:
 
 ```
-cargo build
+cargo build-dev
 ```
 
 Then, optionally, run the regression tests:
@@ -66,7 +66,7 @@ Then, optionally, run the regression tests:
 ./scripts/kani-regression.sh
 ```
 
-This script has a lot of noisy output, but on a successful run you'll see:
+This script has a lot of noisy output, but on a successful run you'll see at the end of the execution:
 
 ```
 All Kani regression tests completed successfully.

--- a/docs/src/cheat-sheets.md
+++ b/docs/src/cheat-sheets.md
@@ -10,10 +10,9 @@ development purposes.
 
 ```bash
 # Error "'rustc' panicked at 'failed to lookup `SourceFile` in new context'"
-# or similar error?
-# Clean `kani-compiler` and re-build:
-cargo clean -p kani-compiler
-cargo build -p kani-compiler
+# or similar error? Uncomment the line below and to clean all build artifacts.
+# cargo clean
+cargo build-dev
 ```
 
 ### Test

--- a/docs/src/cheat-sheets.md
+++ b/docs/src/cheat-sheets.md
@@ -10,8 +10,9 @@ development purposes.
 
 ```bash
 # Error "'rustc' panicked at 'failed to lookup `SourceFile` in new context'"
-# or similar error? Uncomment the line below and to clean all build artifacts.
-# cargo clean
+# or similar error? Cleaning artifacts might help.
+# Otherwise, comment the line below.
+cargo clean
 cargo build-dev
 ```
 

--- a/docs/src/repo-crawl.md
+++ b/docs/src/repo-crawl.md
@@ -84,7 +84,7 @@ will refer to the name as `$CONTAINER_NAME` from now on.
 In this step we will download the list of repositories using a script
 [kani-run-on-repos.sh](../../scripts/exps/kani-run-on-repos.sh)
 
-Make sure to have Kani ready to run. If not, compile with `cargo build`.
+Make sure to have Kani ready to run. For that, see the [build instructions](cheat-sheets.md#build).
 
 From the repository root, you can run the script with
 `./scripts/exps/kani-run-on-repos.sh $URL_LIST_FILE` where

--- a/docs/src/rustc-hacks.md
+++ b/docs/src/rustc-hacks.md
@@ -199,7 +199,7 @@ Finally, override the current toolchain in your kani workspace and rebuild kani:
 cd ${KANI_WORKSPACE}
 rustup override set custom-toolchain
 cargo clean
-cargo build
+cargo build-dev
 ```
 
 # Enable `rustc` logs


### PR DESCRIPTION
### Description of changes: 

After #1717 was merged, users need to run `cargo build-dev` to build Kani binaries and the sysroot. Update the docs to reflect that change.

### Resolved issues:
N/A

### Related RFC:

N/A

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Build docs

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
