### PR TITLE
Fix `cargo kani --debug` and remove debug logs from `--verbose`

### DIFF
--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -81,7 +81,7 @@ fn hier_logs(args: &ArgMatches, filter: EnvFilter) {
     let subscriber = Registry::default().with(filter);
     let subscriber = subscriber.with(
         HierarchicalLayer::default()
-            .with_writer(std::io::stdout)
+            .with_writer(std::io::stderr)
             .with_indent_lines(true)
             .with_ansi(use_colors)
             .with_targets(true)

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -69,7 +69,7 @@ pub struct KaniArgs {
     #[structopt(long, short)]
     pub quiet: bool,
     /// Output processing stages and commands, along with minor debug information
-    #[structopt(long, short)]
+    #[structopt(long, short, default_value_if("debug", None, "true"))]
     pub verbose: bool,
     /// Enable usage of unstable options
     #[structopt(long, hidden_short_help(true))]

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -69,7 +69,7 @@ pub struct KaniArgs {
     #[structopt(long, short)]
     pub quiet: bool,
     /// Output processing stages and commands, along with minor debug information
-    #[structopt(long, short, default_value_if("debug", None, "true"))]
+    #[structopt(long, short, default_value_if("debug", None, "true"), min_values(0))]
     pub verbose: bool,
     /// Enable usage of unstable options
     #[structopt(long, hidden_short_help(true))]

--- a/kani-driver/src/call_single_file.rs
+++ b/kani-driver/src/call_single_file.rs
@@ -107,8 +107,6 @@ impl KaniSession {
 
         if self.args.debug {
             flags.push("--log-level=debug".into());
-        } else if self.args.verbose {
-            flags.push("--log-level=info".into());
         } else {
             flags.push("--log-level=warn".into());
         }

--- a/tests/cargo-ui/debug/Cargo.toml
+++ b/tests/cargo-ui/debug/Cargo.toml
@@ -1,0 +1,11 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+[package]
+name = "debug"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.kani.flags]
+debug=true

--- a/tests/cargo-ui/debug/expected
+++ b/tests/cargo-ui/debug/expected
@@ -1,0 +1,3 @@
+DEBUG kani_compiler
+goto-cc
+cbmc

--- a/tests/cargo-ui/debug/src/lib.rs
+++ b/tests/cargo-ui/debug/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//! This is just to test that cargo kani --debug works.
+
+#[cfg(kani)]
+mod harnesses {
+    #[kani::proof]
+    fn harness() {}
+}

--- a/tests/cargo-ui/verbose/Cargo.toml
+++ b/tests/cargo-ui/verbose/Cargo.toml
@@ -1,0 +1,11 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+[package]
+name = "verbose"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.kani.flags]
+verbose=true

--- a/tests/cargo-ui/verbose/expected
+++ b/tests/cargo-ui/verbose/expected
@@ -1,0 +1,2 @@
+goto-cc
+cbmc

--- a/tests/cargo-ui/verbose/src/lib.rs
+++ b/tests/cargo-ui/verbose/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//! This is just to test that cargo kani --verbose works.
+
+#[cfg(kani)]
+mod harnesses {
+    #[kani::proof]
+    fn harness() {}
+}


### PR DESCRIPTION
### Description of changes: 

- Fix #1348: Fix `cargo kani --debug` by redirecting kani-compiler logs to the STDERR so it doesn't conflict with cargo's output expectations.
- Fix #1631: Remove `kani-compiler` logs from the output of `--verbose`.

### Resolved issues:

Fix #1631
Fix #1348

### Related RFC:

N/A

### Call-outs:

These were tiny fixes so I combined them in one PR.

### Testing:

* How is this change tested? N/A

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
