### PR TITLE
Fix leftover `nondet()` calls

### DIFF
--- a/tests/kani/ArithOperators/unchecked_add_fail.rs
+++ b/tests/kani/ArithOperators/unchecked_add_fail.rs
@@ -8,7 +8,7 @@
 
 #[kani::proof]
 fn main() {
-    let a: u8 = kani::nondet();
-    let b: u8 = kani::nondet();
+    let a: u8 = kani::any();
+    let b: u8 = kani::any();
     unsafe { a.unchecked_add(b) };
 }

--- a/tests/kani/ArithOperators/unchecked_mul_fail.rs
+++ b/tests/kani/ArithOperators/unchecked_mul_fail.rs
@@ -8,7 +8,7 @@
 
 #[kani::proof]
 fn main() {
-    let a: u8 = kani::nondet();
-    let b: u8 = kani::nondet();
+    let a: u8 = kani::any();
+    let b: u8 = kani::any();
     unsafe { a.unchecked_mul(b) };
 }

--- a/tests/kani/ArithOperators/unchecked_sub_fail.rs
+++ b/tests/kani/ArithOperators/unchecked_sub_fail.rs
@@ -8,7 +8,7 @@
 
 #[kani::proof]
 fn main() {
-    let a: u8 = kani::nondet();
-    let b: u8 = kani::nondet();
+    let a: u8 = kani::any();
+    let b: u8 = kani::any();
     unsafe { a.unchecked_sub(b) };
 }

--- a/tests/kani/Assert/multiple_asserts.rs
+++ b/tests/kani/Assert/multiple_asserts.rs
@@ -5,7 +5,7 @@
 // Check that this doesn't trigger a fake loop. See issue #636.
 #[kani::proof]
 fn main() {
-    let x: bool = kani::nondet();
+    let x: bool = kani::any();
     if x {
         assert!(1 + 1 == 1);
     }

--- a/tests/kani/DynTrait/vtable_restrictions_fail_fixme.rs
+++ b/tests/kani/DynTrait/vtable_restrictions_fail_fixme.rs
@@ -57,7 +57,7 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
 
 #[kani::proof]
 fn main() {
-    let random_number = kani::nondet();
+    let random_number = kani::any();
     let animal = random_animal(random_number);
     let s = animal.noise();
     if random_number < 5 {


### PR DESCRIPTION
### Description of changes: 

It seems that we have left a few `kani::nondet()` calls behind. The regression doesn't fail because the tests are expected to fail. Switching them to `kani::any()` instead.

### Resolved issues:

N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
N/A

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Test changes

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
