### PR TITLE
Introduce prototype `cargo-kani assess` feature to help find places to start writing proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121d8a5b0346092c18a4b2fd6f620d7a06f0eb7ac0a45860939a0884bc579c56"
+dependencies = [
+ "crossterm",
+ "strum",
+ "strum_macros",
+ "unicode-width",
+]
+
+[[package]]
 name = "compiletest"
 version = "0.0.0"
 dependencies = [
@@ -265,26 +277,49 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
- "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "once_cell",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -432,6 +467,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap 2.34.0",
+ "comfy-table",
  "console",
  "glob",
  "kani_metadata",
@@ -543,6 +579,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -915,6 +963,36 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "smallvec"

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -123,7 +123,7 @@ impl<'tcx> GotocCtx<'tcx> {
             self.symbol_table.update_fn_declaration_with_definition(&name, body);
 
             self.handle_kanitool_attributes();
-            self.record_test_metadata();
+            self.record_test_harness_metadata();
         }
         self.reset_current_fn();
     }
@@ -317,8 +317,14 @@ impl<'tcx> GotocCtx<'tcx> {
         }
     }
 
-    /// Records test harness closures for KaniMetadata
-    fn record_test_metadata(&mut self) {
+    /// We record test harness information in kani-metadata, just like we record
+    /// proof harness information. This is used to support e.g. cargo-kani assess.
+    ///
+    /// Note that we do not actually spot the function that was annotated by `#[test]`
+    /// but instead the closure that gets put into the "test description" that macro
+    /// expands into. (See comment below) This ends up being preferrable, actually,
+    /// as it add asserts for tests that return `Result` types.
+    fn record_test_harness_metadata(&mut self) {
         let def_id = self.current_fn().instance().def_id();
         if def_id.is_local() {
             let local_def_id = def_id.expect_local();

--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -124,6 +124,8 @@ impl CodegenBackend for GotocCodegenBackend {
         // Print compilation report.
         print_report(&gcx, tcx);
 
+        let unsupported_features = gcx.unsupported_metadata();
+
         // perform post-processing symbol table passes
         let passes = self.queries.get_symbol_table_passes();
         let symtab = symtab_transformer::do_passes(gcx.symbol_table, &passes);
@@ -139,7 +141,11 @@ impl CodegenBackend for GotocCodegenBackend {
             None
         };
 
-        let metadata = KaniMetadata { proof_harnesses: gcx.proof_harnesses };
+        let metadata = KaniMetadata {
+            proof_harnesses: gcx.proof_harnesses,
+            unsupported_features,
+            test_harnesses: gcx.test_harnesses,
+        };
 
         // No output should be generated if user selected no_codegen.
         if !tcx.sess.opts.unstable_opts.no_codegen && tcx.sess.opts.output_types.should_codegen() {

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -102,6 +102,11 @@ impl<'tcx> GotocCtx<'tcx> {
         self.current_fn.as_mut().unwrap()
     }
 
+    /// Maps the goto-context "unsupported features" data into the
+    /// KaniMetadata "unsupported features" format.
+    ///
+    /// These are different because the KaniMetadata is a flat serializable list,
+    /// while we need a more richly structured HashMap in the goto context.
     pub(crate) fn unsupported_metadata(&self) -> Vec<UnsupportedFeature> {
         self.unsupported_constructs
             .iter()

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -21,7 +21,7 @@ use cbmc::goto_program::{DatatypeComponent, Expr, Location, Stmt, Symbol, Symbol
 use cbmc::utils::aggr_tag;
 use cbmc::InternedString;
 use cbmc::{MachineModel, RoundingMode};
-use kani_metadata::HarnessMetadata;
+use kani_metadata::{HarnessMetadata, UnsupportedFeature};
 use kani_queries::{QueryDb, UserInput};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::owning_ref::OwningRef;
@@ -59,6 +59,7 @@ pub struct GotocCtx<'tcx> {
     pub current_fn: Option<CurrentFnCtx<'tcx>>,
     pub type_map: FxHashMap<InternedString, Ty<'tcx>>,
     pub proof_harnesses: Vec<HarnessMetadata>,
+    pub test_harnesses: Vec<HarnessMetadata>,
     /// a global counter for generating unique IDs for checks
     pub global_checks_count: u64,
     /// A map of unsupported constructs that were found while codegen
@@ -84,6 +85,7 @@ impl<'tcx> GotocCtx<'tcx> {
             current_fn: None,
             type_map: FxHashMap::default(),
             proof_harnesses: vec![],
+            test_harnesses: vec![],
             global_checks_count: 0,
             unsupported_constructs: FxHashMap::default(),
         }
@@ -98,6 +100,24 @@ impl<'tcx> GotocCtx<'tcx> {
 
     pub fn current_fn_mut(&mut self) -> &mut CurrentFnCtx<'tcx> {
         self.current_fn.as_mut().unwrap()
+    }
+
+    pub(crate) fn unsupported_metadata(&self) -> Vec<UnsupportedFeature> {
+        self.unsupported_constructs
+            .iter()
+            .map(|(construct, location)| UnsupportedFeature {
+                feature: construct.to_string(),
+                locations: location
+                    .iter()
+                    .map(|l| {
+                        (
+                            l.filename().unwrap_or_default(),
+                            l.start_line().map(|x| x.to_string()).unwrap_or_default(),
+                        )
+                    })
+                    .collect(),
+            })
+            .collect()
     }
 }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -115,6 +115,9 @@ impl<'tcx> GotocCtx<'tcx> {
                 locations: location
                     .iter()
                     .map(|l| {
+                        // We likely (and should) have no instances of
+                        // calling `codegen_unimplemented` without file/line.
+                        // So while we map out of `Option` here, we expect them to always be `Some`
                         (
                             l.filename().unwrap_or_default(),
                             l.start_line().map(|x| x.to_string()).unwrap_or_default(),

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -31,6 +31,7 @@ regex = "1.6"
 rustc-demangle = "0.1.21"
 pathdiff = "0.2.1"
 rayon = "1.5.3"
+comfy-table = "6.0.0"
 
 # A good set of suggested dependencies can be found in rustup:
 # https://github.com/rust-lang/rustup/blob/master/Cargo.toml

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -45,6 +45,7 @@ pub struct CargoKaniArgs {
 // cargo-kani takes optional subcommands to request specialized behavior
 #[derive(Debug, StructOpt)]
 pub enum CargoKaniSubcommand {
+    #[structopt(setting(structopt::clap::AppSettings::Hidden))]
     Assess,
 }
 
@@ -54,7 +55,7 @@ pub enum CargoKaniSubcommand {
 pub struct KaniArgs {
     /// Temporary option to trigger assess mode for out test suite
     /// where we are able to add options but not subcommands
-    #[structopt(long, hidden = true)]
+    #[structopt(long, hidden = true, requires("enable-unstable"))]
     pub assess: bool,
 
     /// Generate visualizer report to <target-dir>/report/html/index.html

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -51,6 +51,11 @@ pub enum CargoKaniSubcommand {
 // anything above is "local" to "main"'s control flow.
 #[derive(Debug, StructOpt)]
 pub struct KaniArgs {
+    /// Temporary option to trigger assess mode for out test suite
+    /// where we are able to add options but not subcommands
+    #[structopt(long, hidden = true)]
+    pub assess: bool,
+
     /// Generate visualizer report to <target-dir>/report/html/index.html
     #[structopt(long)]
     pub visualize: bool,

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -35,8 +35,16 @@ pub struct StandaloneArgs {
     setting = structopt::clap::AppSettings::AllArgsOverrideSelf
 )]
 pub struct CargoKaniArgs {
+    #[structopt(subcommand)]
+    pub command: Option<CargoKaniSubcommand>,
+
     #[structopt(flatten)]
     pub common_opts: KaniArgs,
+}
+
+#[derive(Debug, StructOpt)]
+pub enum CargoKaniSubcommand {
+    Assess,
 }
 
 // Common arguments for invoking Kani. This gets put into KaniContext, whereas

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -42,6 +42,7 @@ pub struct CargoKaniArgs {
     pub common_opts: KaniArgs,
 }
 
+// cargo-kani takes optional subcommands to request specialized behavior
 #[derive(Debug, StructOpt)]
 pub enum CargoKaniSubcommand {
     Assess,

--- a/kani-driver/src/assess.rs
+++ b/kani-driver/src/assess.rs
@@ -1,0 +1,215 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::{collections::HashMap, path::PathBuf};
+
+use anyhow::Result;
+use comfy_table::Table;
+use kani_metadata::KaniMetadata;
+
+use crate::harness_runner::HarnessResult;
+use crate::session::KaniSession;
+
+/// Set some defaults for how we format tables
+fn assess_table_new() -> Table {
+    use comfy_table::*;
+
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table
+        .load_preset(comfy_table::presets::NOTHING)
+        .set_style(TableComponent::BottomBorder, '=')
+        .set_style(TableComponent::BottomBorderIntersections, '=')
+        .set_style(TableComponent::TopBorder, '=')
+        .set_style(TableComponent::TopBorderIntersections, '=')
+        .set_style(TableComponent::HeaderLines, '-')
+        .set_style(TableComponent::MiddleHeaderIntersections, '+')
+        .set_style(TableComponent::VerticalLines, '|');
+    table
+}
+
+fn unsupported_features_table(metadata: &KaniMetadata) -> Table {
+    // Map "unsupported feature name" -> (crates impacted, instance of use)
+    let mut counts: HashMap<String, (usize, usize)> = HashMap::new();
+
+    for item in &metadata.unsupported_features {
+        // key is unsupported feature name
+        let mut key = item.feature.clone();
+        // There are several "feature for <instance of use>" unsupported features.
+        // We aggregate those here by reducing it to just "feature"
+        if let Some((prefix, _)) = key.split_once(" for ") {
+            key = prefix.to_string();
+        }
+        let entry = counts.entry(key).or_default();
+        // crates impacted:
+        entry.0 += 1;
+        // instances of use:
+        entry.1 += item.locations.len();
+    }
+
+    // Sort descending by number of crates impacted by this missing feature
+    let mut sorted_counts: Vec<(String, (usize, usize))> = counts.into_iter().collect();
+    sorted_counts.sort_by_key(|i| usize::MAX - i.1.0);
+
+    {
+        use comfy_table::*;
+
+        let mut table = assess_table_new();
+        table.set_header(vec!["Unsupported feature", "Crates\nimpacted", "Instances\nof use"]);
+        table.column_mut(0).unwrap().set_cell_alignment(CellAlignment::Left);
+        table
+            .column_mut(0)
+            .unwrap()
+            .set_constraint(ColumnConstraint::UpperBoundary(Width::Fixed(80)));
+        table.column_mut(1).unwrap().set_cell_alignment(CellAlignment::Right);
+        table.column_mut(2).unwrap().set_cell_alignment(CellAlignment::Right);
+
+        for item in sorted_counts {
+            table.add_row(vec![item.0, item.1.0.to_string(), item.1.1.to_string()]);
+        }
+
+        table
+    }
+}
+
+fn failure_reasons_table(results: &[HarnessResult]) -> Table {
+    // Map "Reason for failure" -> (Number of tests)
+    let mut counts: HashMap<String, usize> = HashMap::new();
+
+    for r in results {
+        let failures = r.result.failed_properties();
+        let classification = if failures.is_empty() {
+            "success".to_string()
+        } else {
+            let mut classes: Vec<_> = failures.iter().map(|p| p.property_class()).collect();
+            classes.sort();
+            classes.dedup();
+            classes.join(" + ")
+        };
+        let entry = counts.entry(classification).or_default();
+        *entry += 1;
+    }
+
+    // Sort descending by number of failures for this reason
+    let mut sorted_counts: Vec<(String, usize)> = counts.into_iter().collect();
+    sorted_counts.sort_by_key(|i| usize::MAX - i.1);
+
+    {
+        use comfy_table::*;
+
+        let mut table = assess_table_new();
+        table.set_header(vec!["Reason for failure", "Number of tests"]);
+        table.column_mut(0).unwrap().set_cell_alignment(CellAlignment::Left);
+        table
+            .column_mut(0)
+            .unwrap()
+            .set_constraint(ColumnConstraint::UpperBoundary(Width::Fixed(80)));
+        table.column_mut(1).unwrap().set_cell_alignment(CellAlignment::Right);
+
+        for item in sorted_counts {
+            table.add_row(vec![item.0, item.1.to_string()]);
+        }
+
+        table
+    }
+}
+
+fn promising_tests_table(results: &[HarnessResult]) -> Table {
+    {
+        use comfy_table::*;
+
+        let mut table = assess_table_new();
+        table.set_header(vec!["Candidate for proof harness", "Location"]);
+        table.column_mut(0).unwrap().set_cell_alignment(CellAlignment::Left);
+        table
+            .column_mut(0)
+            .unwrap()
+            .set_constraint(ColumnConstraint::UpperBoundary(Width::Fixed(80)));
+        table.column_mut(1).unwrap().set_cell_alignment(CellAlignment::Left);
+
+        for r in results {
+            // For now we're just reporting "successful" harnesses as candidates.
+            // In the future this heuristic should be expanded. More data is required to do this, however.
+            if r.result.failed_properties().is_empty() {
+                // The functions we extract are actually the closures inside the test harness macro expansion
+                // Strip that closure suffix, so we have better names:
+                let name = r.harness.pretty_name.trim_end_matches("::{closure#0}").to_string();
+                // Location in a format "clickable" in e.g. IDE terminals
+                let location =
+                    format!("{}:{}", r.harness.original_file, r.harness.original_start_line);
+
+                table.add_row(vec![name, location]);
+            }
+        }
+
+        table
+    }
+}
+
+pub(crate) fn cargokani_assess_main(mut ctx: KaniSession) -> Result<()> {
+    // fix some settings
+    ctx.args.unwind = Some(1);
+    ctx.args.tests = true;
+    ctx.args.output_format = crate::args::OutputFormat::Terse;
+    ctx.args.jobs = Some(None); // -j, num_cpu
+
+    let outputs = ctx.cargo_build()?;
+    let metadata = ctx.collect_kani_metadata(&outputs.metadata)?;
+
+    let crate_count = outputs.metadata.len();
+
+    // An interesting thing to print here would be "number of crates without any warnings"
+    // however this will have to wait until a refactoring of how we aggregate metadata
+    // from multiple crates together here.
+    println!("Analyzed {} crates", crate_count);
+
+    if !metadata.unsupported_features.is_empty() {
+        println!("{}", unsupported_features_table(&metadata));
+    } else {
+        println!("No crates contained Rust features unsupported by Kani");
+    }
+
+    // The section is a "copy and paste" from cargo kani.
+    // We could start thinking about abtracting this stuff out into a shared function...
+    let mut goto_objs: Vec<PathBuf> = Vec::new();
+    for symtab in &outputs.symtabs {
+        let goto_obj_filename = symtab.with_extension("out");
+        goto_objs.push(goto_obj_filename);
+    }
+
+    if ctx.args.only_codegen {
+        return Ok(());
+    }
+
+    let linked_obj = outputs.outdir.join("cbmc-linked.out");
+    ctx.link_goto_binary(&goto_objs, &linked_obj)?;
+    if let Some(restrictions) = outputs.restrictions {
+        ctx.apply_vtable_restrictions(&linked_obj, &restrictions)?;
+    }
+
+    // Done with the 'cargo-kani' part, now we're going to run *test* harnesses instead of proof:
+
+    let harnesses = metadata.test_harnesses;
+    let report_base = ctx.args.target_dir.clone().unwrap_or(PathBuf::from("target"));
+
+    let runner = crate::harness_runner::HarnessRunner {
+        sess: &ctx,
+        linked_obj: &linked_obj,
+        report_base: &report_base,
+        symtabs: &outputs.symtabs,
+        retain_specialized_harnesses: false,
+    };
+
+    let results = runner.check_all_harnesses(&harnesses)?;
+
+    // two tables we want to print:
+    // 1. "Reason for failure" map harness to reason, aggredate together
+    //    e.g.  successs   6
+    //          unwind     234
+    println!("{}", failure_reasons_table(&results));
+    // 2. "Test cases that might be good proof harness starting points"
+    //    e.g.  All Successes and maybe Assertions?
+    println!("{}", promising_tests_table(&results));
+
+    Ok(())
+}

--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -254,9 +254,18 @@ impl VerificationResult {
             )
         }
     }
+
+    /// Find the failed properties from this verification run
+    pub fn failed_properties(&self) -> Vec<&Property> {
+        if let Some(properties) = &self.results {
+            properties.iter().filter(|prop| prop.status == CheckStatus::Failure).collect()
+        } else {
+            vec![]
+        }
+    }
 }
 
-/// We decide if verificaiton succeeded based on properties, not (typically) on exit code
+/// We decide if verification succeeded based on properties, not (typically) on exit code
 fn determine_status_from_properties(properties: &[Property]) -> VerificationStatus {
     let number_failed_properties =
         properties.iter().filter(|prop| prop.status == CheckStatus::Failure).count();

--- a/kani-driver/src/main.rs
+++ b/kani-driver/src/main.rs
@@ -3,6 +3,7 @@
 #![feature(let_chains)]
 
 use anyhow::Result;
+use args::CargoKaniSubcommand;
 use args_toml::join_args;
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -41,7 +42,7 @@ fn cargokani_main(input_args: Vec<OsString>) -> Result<()> {
     args.validate();
     let ctx = session::KaniSession::new(args.common_opts)?;
 
-    if let Some(args::CargoKaniSubcommand::Assess) = args.command {
+    if matches!(args.command, Some(CargoKaniSubcommand::Assess)) || ctx.args.assess {
         // Run the alternative command instead
         return assess::cargokani_assess_main(ctx);
     }

--- a/kani-driver/src/main.rs
+++ b/kani-driver/src/main.rs
@@ -4,13 +4,13 @@
 
 use anyhow::Result;
 use args_toml::join_args;
-
 use std::ffi::OsString;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
 mod args;
 mod args_toml;
+mod assess;
 mod call_cargo;
 mod call_cbmc;
 mod call_cbmc_viewer;
@@ -40,6 +40,11 @@ fn cargokani_main(input_args: Vec<OsString>) -> Result<()> {
     let args = args::CargoKaniArgs::from_iter(input_args);
     args.validate();
     let ctx = session::KaniSession::new(args.common_opts)?;
+
+    if let Some(args::CargoKaniSubcommand::Assess) = args.command {
+        // Run the alternative command instead
+        return assess::cargokani_assess_main(ctx);
+    }
 
     let outputs = ctx.cargo_build()?;
 

--- a/kani-driver/src/main.rs
+++ b/kani-driver/src/main.rs
@@ -43,6 +43,14 @@ fn cargokani_main(input_args: Vec<OsString>) -> Result<()> {
     let ctx = session::KaniSession::new(args.common_opts)?;
 
     if matches!(args.command, Some(CargoKaniSubcommand::Assess)) || ctx.args.assess {
+        // --assess requires --enable-unstable, but the subcommand needs manual checking
+        if !ctx.args.enable_unstable {
+            clap::Error::with_description(
+                "Assess is unstable and requires 'cargo kani --enable-unstable assess'",
+                clap::ErrorKind::MissingRequiredArgument,
+            )
+            .exit()
+        }
         // Run the alternative command instead
         return assess::cargokani_assess_main(ctx);
     }

--- a/kani-driver/src/metadata.rs
+++ b/kani-driver/src/metadata.rs
@@ -117,6 +117,7 @@ fn merge_kani_metadata(files: Vec<KaniMetadata>) -> KaniMetadata {
         // Note that we're taking ownership of the original vec, and so we can move the data into the new data structure.
         result.proof_harnesses.extend(md.proof_harnesses);
         // TODO: these should be merged via a map to aggregate them all
+        // https://github.com/model-checking/kani/issues/1758
         result.unsupported_features.extend(md.unsupported_features);
         result.test_harnesses.extend(md.test_harnesses);
     }

--- a/kani-driver/src/metadata.rs
+++ b/kani-driver/src/metadata.rs
@@ -108,10 +108,17 @@ fn read_kani_metadata(path: &Path) -> Result<KaniMetadata> {
 
 /// Consumes a vector of parsed metadata, and produces a combined structure
 fn merge_kani_metadata(files: Vec<KaniMetadata>) -> KaniMetadata {
-    let mut result = KaniMetadata { proof_harnesses: Vec::new() };
+    let mut result = KaniMetadata {
+        proof_harnesses: vec![],
+        unsupported_features: vec![],
+        test_harnesses: vec![],
+    };
     for md in files {
         // Note that we're taking ownership of the original vec, and so we can move the data into the new data structure.
         result.proof_harnesses.extend(md.proof_harnesses);
+        // TODO: these should be merged via a map to aggregate them all
+        result.unsupported_features.extend(md.unsupported_features);
+        result.test_harnesses.extend(md.test_harnesses);
     }
     result
 }
@@ -121,7 +128,11 @@ impl KaniSession {
     pub fn collect_kani_metadata(&self, files: &[PathBuf]) -> Result<KaniMetadata> {
         if self.args.dry_run {
             // Mock an answer
-            Ok(KaniMetadata { proof_harnesses: vec![generate_mock_harness()] })
+            Ok(KaniMetadata {
+                proof_harnesses: vec![generate_mock_harness()],
+                unsupported_features: vec![],
+                test_harnesses: vec![],
+            })
         } else {
             // TODO: one possible future improvement here would be to return some kind of Lazy
             // value, that only computes this metadata if it turns out we need it.

--- a/kani_metadata/src/lib.rs
+++ b/kani_metadata/src/lib.rs
@@ -10,7 +10,21 @@ pub use vtable::*;
 use serde::{Deserialize, Serialize};
 
 /// The structure of `.kani-metadata.json` files, which are emitted for each crate
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KaniMetadata {
+    /// The proof harnesses (#[kani::proof]) found in this crate.
     pub proof_harnesses: Vec<HarnessMetadata>,
+    /// The features found in this crate that Kani does not support.
+    /// (These general translate to `assert(false)` so we can still attempt verification.)
+    pub unsupported_features: Vec<UnsupportedFeature>,
+    /// If crates are built in test-mode, then test harnesses will be recorded here.
+    pub test_harnesses: Vec<HarnessMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnsupportedFeature {
+    /// A string identifying the feature.
+    pub feature: String,
+    /// A list of locations (file, line) where this unsupported feature can be found.
+    pub locations: Vec<(String, String)>,
 }

--- a/kani_metadata/src/lib.rs
+++ b/kani_metadata/src/lib.rs
@@ -23,6 +23,7 @@ pub struct KaniMetadata {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnsupportedFeature {
+    // We could replace this with an enum: https://github.com/model-checking/kani/issues/1765
     /// A string identifying the feature.
     pub feature: String,
     /// A list of locations (file, line) where this unsupported feature can be found.

--- a/tests/cargo-kani/assess-works/Cargo.toml
+++ b/tests/cargo-kani/assess-works/Cargo.toml
@@ -6,10 +6,8 @@ name = "assess-works"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = "1"
 
 [package.metadata.kani]
-flags = { assess=true }
+flags = { assess=true, enable-unstable=true }

--- a/tests/cargo-kani/assess-works/Cargo.toml
+++ b/tests/cargo-kani/assess-works/Cargo.toml
@@ -1,0 +1,15 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+[package]
+name = "assess-works"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+
+[package.metadata.kani]
+flags = { assess=true }

--- a/tests/cargo-kani/assess-works/expected
+++ b/tests/cargo-kani/assess-works/expected
@@ -1,0 +1,2 @@
+Reason for failure
+Candidate for proof harness

--- a/tests/cargo-kani/assess-works/src/main.rs
+++ b/tests/cargo-kani/assess-works/src/main.rs
@@ -1,0 +1,9 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use anyhow::*;
+
+#[test]
+fn a_test_using_anyhow() -> Result<()> {
+    Ok(()).context("words")
+}

--- a/tests/cargo-kani/assess-works/src/main.rs
+++ b/tests/cargo-kani/assess-works/src/main.rs
@@ -3,6 +3,13 @@
 
 use anyhow::*;
 
+// This test invokes `cago kani assess`, so this test gets picked up
+// and run under kani as if it were a proof harness.
+// Here we try to use a dependency (anyhow).
+
+// At time of writing this actually leads to an unwinding assertion failure,
+// but all we're really looking for in `expected` is that assess ran.
+
 #[test]
 fn a_test_using_anyhow() -> Result<()> {
     Ok(()).context("words")


### PR DESCRIPTION
### Description of changes: 

This feature is far from something we can recommend to customers yet, but it should be quite useful for us to both (1) start helping customers find proofs to write and (2) start finding the other bugs that are standing in the way of applying Kani to various crates.

This PR includes several changes:

1. We now track unsupported features in `kani-metadata.json`
2. We now track test harnesses (when build with `--tests`) in `kani-metadata.json`
3. The assess feature itself, which prints three tables of summary information:
   1. Unsupported features table
   2. Reason for test harness failure
   3. Candidate for proof harness
4. (Temporarily) a `--assess` flag, purely for use with `compiletest` in CI, along with a simple test to exercise the code.

I tried assess on the `rand` crate and got summary information like the following:

```
===================================================
 Unsupported feature        |   Crates | Instances 
                            | impacted |    of use 
----------------------------+----------+-----------
 'simd_or' intrinsic        |        4 |         5 
 'simd_gt' intrinsic        |        3 |         3 
 'simd_eq' intrinsic        |        3 |         3 
 try                        |        2 |        17 
 drop_in_place              |        2 |         2 
 'simd_and' intrinsic       |        1 |         1 
 'simd_xor' intrinsic       |        1 |         3 
 'simd_shuffle16' intrinsic |        1 |         2 
 'simd_insert' intrinsic    |        1 |         5 
 'simd_shuffle8' intrinsic  |        1 |         6 
 'simd_shuffle4' intrinsic  |        1 |         8 
 'simd_shuffle2' intrinsic  |        1 |         2 
 'simd_extract' intrinsic   |        1 |         2 
 'powf64' intrinsic         |        1 |         1 
 'simd_add' intrinsic       |        1 |         3 
===================================================
================================================
 Reason for failure           | Number of tests 
------------------------------+-----------------
 unwind                       |              61 
 success                      |               6 
 assertion                    |               4 
 pointer_dereference + unwind |               2 
 assertion + overflow         |               2 
================================================
===============================================================================================================
 Candidate for proof harness                                          | Location                                            
----------------------------------------------------------------------+----------------------------------------
 distributions::float::tests::f64_edge_cases                          | rand/src/distributions/float.rs:226    
 distributions::float::tests::f32_edge_cases                          | rand/src/distributions/float.rs:184    
 distributions::integer::tests::test_integers                         | rand/src/distributions/integer.rs:171  
 distributions::other::tests::test_misc                               | rand/src/distributions/other.rs:284    
 distributions::uniform::tests::test_uniform_from_std_range_inclusive | rand/src/distributions/uniform.rs:1563 
 distributions::uniform::tests::test_uniform_from_std_range           | rand/src/distributions/uniform.rs:1553 
===============================================================================================================
real    7m51.665s
```

A manual inspection of those tests suggests at least half of them are definitely candidates for turning into proofs. (The other half required more investigation, as they're generated by macros. Only one was in the "probably not" camp.)

Trying on a few other crates reveals several issues we might want to prioritize:

* Several fail to link likely due to https://github.com/model-checking/kani/issues/1448 or general "multiple binaries linked together" problems
* I saw some different goto type checking errors as well, but these may have just been a different manifestation of the above.
* A remarkable number of crates failed to build properly and I haven't spent time yet trying to understand why. While we have examined normal builds (e.g. `cargo build --workspace --all-features`) we haven't tried this with `--tests`. Perhaps we should!

Of the crates in the Rust Playground that we successfully build for, we get these results (just unsupported features):

```
Analyzed 222 crates
===========================================================
 Unsupported feature                |   Crates | Instances 
                                    | impacted |    of use 
------------------------------------+----------+-----------
 'simd_eq' intrinsic                |       19 |        21 
 'simd_or' intrinsic                |       19 |        21 
 Constant slice value with 2+ bytes |       16 |        78 
 'simd_gt' intrinsic                |       15 |        15 
 try                                |        9 |       159 
 drop_in_place                      |        7 |         7 
 'simd_shuffle2' intrinsic          |        5 |        11 
 'simd_shuffle4' intrinsic          |        5 |        26 
 drop_in_place call                 |        4 |         7 
 'sqrtf64' intrinsic                |        4 |         4 
 'powif64' intrinsic                |        4 |         4 
 'simd_add' intrinsic               |        4 |         8 
 'simd_shuffle16' intrinsic         |        4 |         8 
 'simd_shuffle8' intrinsic          |        4 |        13 
 PointerCast::ClosureFnPointer      |        3 |         7 
 'simd_xor' intrinsic               |        3 |         7 
 TerminatorKind::InlineAsm          |        3 |         4 
 'expf64' intrinsic                 |        3 |         3 
 drop unsized struct                |        3 |         3 
 'simd_and' intrinsic               |        3 |         7 
 'simd_extract' intrinsic           |        3 |         6 
 'simd_shuffle32' intrinsic         |        2 |        50 
 'simd_mul' intrinsic               |        2 |         3 
 float_to_int_unchecked             |        2 |        24 
 'logf64' intrinsic                 |        2 |         2 
 'sqrtf32' intrinsic                |        1 |         1 
 'powif32' intrinsic                |        1 |         1 
 'simd_insert' intrinsic            |        1 |         5 
 simd_fma                           |        1 |         2 
 'log2f64' intrinsic                |        1 |         1 
 simd_saturating_sub                |        1 |         1 
 simd_saturating_add                |        1 |         1 
===========================================================
````

### Next steps

This is the very start of this feature.

1. I think the biggest priority is to switch away from `unwind` to force termination, and add real timeouts. This should eliminate `unwind` as a failure reasons, and probably not by entirely turning them into `timeout` either. The results should become more interesting. :)
2. Our ability to build under `--tests` needs to become more reliable. Fixing that bug linked above, for instance.
3. The feature needs improved documentation. The _meaning_ of these tables isn't fully clear to a curious user. While some of them have clear meaning to us (and this is, for now, a feature for us to experiment with), they won't be clear to customers. (For instance, "unwind" means what? Similarly "assertion" or "+" in that table.) This should be prioritized before we consider stabilization or making this customer-facing.)
4. I think we should add more support for detecting kinds of failures. If things fail for goto-cc linking problem, currently it's up to you to read that output. Making it more machine-readable will help for:
5. I think I should add a json (machine-readable) output for this, then work on a tool to automatically apply assess to a large number of crates, aggregating the results. This will help with some of the difficulty in finding appropriate target crates to analyze.
6. [Future] We should consider a more in-depth HTML report instead of just console. Users may want to explore some of this data in more depth.

More experimentation with more crates will be helpful in prioritizing things.


### Resolved issues:

Resolves #1497 
Resolves #1498 

### Call-outs:

* Interaction with the MIR linker hasn't been addressed yet.

### Testing:

* How is this change tested? new test

* Is this a refactor change? no

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
