### PR TITLE
Remove duplicate symtab calls from stdlib test

### DIFF
--- a/scripts/std-lib-regression.sh
+++ b/scripts/std-lib-regression.sh
@@ -73,11 +73,16 @@ export RUSTC="$KANI_DIR/target/kani/bin/kani-compiler"
 # Compile rust to iRep
 $WRAPPER cargo build --verbose -Z build-std --lib --target $TARGET
 
+# Runs a command, but suppresses output unless it fails
+function go {
+  OUTPUT=$("$@" 2>&1) || (echo "$OUTPUT" && exit 1)
+}
+
 # Generate goto-program. This will make sure the representation is well formed.
 cd target/${TARGET}/debug/deps
 for symtab in *.symtab.json; do
     echo "======== File: $symtab"
-    symtab2gb ${symtab} --out ${symtab}.out
+    go symtab2gb ${symtab} --out ${symtab}.out
 done
 
 echo

--- a/scripts/std-lib-regression.sh
+++ b/scripts/std-lib-regression.sh
@@ -73,18 +73,6 @@ export RUSTC="$KANI_DIR/target/kani/bin/kani-compiler"
 # Compile rust to iRep
 $WRAPPER cargo build --verbose -Z build-std --lib --target $TARGET
 
-# Runs a command, but suppresses output unless it fails
-function go {
-  OUTPUT=$("$@" 2>&1) || (echo "$OUTPUT" && exit 1)
-}
-
-# Generate goto-program. This will make sure the representation is well formed.
-cd target/${TARGET}/debug/deps
-for symtab in *.symtab.json; do
-    echo "======== File: $symtab"
-    go symtab2gb ${symtab} --out ${symtab}.out
-done
-
 echo
 echo "Finished Kani codegen for the Rust standard library successfully..."
 echo


### PR DESCRIPTION
### Description of changes: 

Does the same thing we usually do with `symtab2gb` output, but for that test shell script that explicitly calls it.

### Testing:

* How is this change tested? ci

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
