### PR TITLE
Fix issue with mutable static from upstream crate

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/reachability.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/reachability.rs
@@ -436,7 +436,13 @@ pub fn collect_reachable_items<'tcx>(
 }
 
 /// Return whether we should include the item into codegen.
-/// We don't include foreign items and items that don't have MIR.
+/// - We only skip foreign items.
+///
+/// Note: Ideally, we should be able to assert that the MIR for non-foreign items are available via
+/// call to `tcx.is_mir_available (def_id)`.
+/// However, we found an issue where this function was returning `false` for a mutable static
+/// item with constant initializer from an upstream crate.
+/// See <https://github.com/model-checking/kani/issues/1760> for an example.
 fn should_codegen_locally<'tcx>(tcx: TyCtxt<'tcx>, instance: &Instance<'tcx>) -> bool {
     if let Some(def_id) = instance.def.def_id_if_not_guaranteed_local_codegen() {
         // We cannot codegen foreign items.

--- a/kani-compiler/src/codegen_cprover_gotoc/reachability.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/reachability.rs
@@ -439,17 +439,8 @@ pub fn collect_reachable_items<'tcx>(
 /// We don't include foreign items and items that don't have MIR.
 fn should_codegen_locally<'tcx>(tcx: TyCtxt<'tcx>, instance: &Instance<'tcx>) -> bool {
     if let Some(def_id) = instance.def.def_id_if_not_guaranteed_local_codegen() {
-        if tcx.is_foreign_item(def_id) {
-            // We cannot codegen foreign items.
-            false
-        } else {
-            // TODO: This should either be an assert or a warning.
-            // Need to compile std with --always-encode-mir first though.
-            // https://github.com/model-checking/kani/issues/1605
-            // assert!(tcx.is_mir_available(def_id), "no MIR available for {:?}", def_id);
-            //(!tcx.is_mir_available(def_id)).then(|| warn!(?def_id, "Missing MIR"));
-            tcx.is_mir_available(def_id)
-        }
+        // We cannot codegen foreign items.
+        !tcx.is_foreign_item(def_id)
     } else {
         // This will include things like VTableShim and other stuff. See the method
         // def_id_if_not_guaranteed_local_codegen for the full list.
@@ -523,30 +514,26 @@ fn extract_pointer<'tcx>(tcx: TyCtxt<'tcx>, typ: Ty<'tcx>) -> Ty<'tcx> {
 
 /// Scans the allocation type and collect static objects.
 fn collect_alloc_items<'tcx>(tcx: TyCtxt<'tcx>, alloc_id: AllocId) -> Vec<MonoItem> {
+    trace!(alloc=?tcx.global_alloc(alloc_id), ?alloc_id, "collect_alloc_items");
     let mut items = vec![];
     match tcx.global_alloc(alloc_id) {
         GlobalAlloc::Static(def_id) => {
+            // This differ from rustc's collector since rustc does not include static from
+            // upstream crates.
             assert!(!tcx.is_thread_local_static(def_id));
             let instance = Instance::mono(tcx, def_id);
-            should_codegen_locally(tcx, &instance).then(|| {
-                trace!(?def_id, "global_alloc");
-                items.push(MonoItem::Static(def_id))
-            });
+            should_codegen_locally(tcx, &instance).then(|| items.push(MonoItem::Static(def_id)));
         }
         GlobalAlloc::Function(instance) => {
-            should_codegen_locally(tcx, &instance).then(|| {
-                trace!(?alloc_id, ?instance, "global_alloc");
-                items.push(MonoItem::Fn(instance.polymorphize(tcx)))
-            });
+            should_codegen_locally(tcx, &instance)
+                .then(|| items.push(MonoItem::Fn(instance.polymorphize(tcx))));
         }
         GlobalAlloc::Memory(alloc) => {
-            trace!(?alloc_id, "global_alloc memory");
             items.extend(
                 alloc.inner().provenance().values().flat_map(|id| collect_alloc_items(tcx, *id)),
             );
         }
         GlobalAlloc::VTable(ty, trait_ref) => {
-            trace!(?alloc_id, "global_alloc vtable");
             let vtable_id = tcx.vtable_allocation((ty, trait_ref));
             items.append(&mut collect_alloc_items(tcx, vtable_id));
         }

--- a/tests/cargo-kani/asm/global/Cargo.toml
+++ b/tests/cargo-kani/asm/global/Cargo.toml
@@ -12,4 +12,5 @@ edition = "2021"
 crate_with_global_asm = { path = "crate_with_global_asm" }
 
 [package.metadata.kani]
-flags = { enable-unstable = true, ignore-global-asm = true }
+# Issue with MIR Linker on static constant.
+flags = { enable-unstable = true, ignore-global-asm = true, mir-linker = true }


### PR DESCRIPTION
### Description of changes: 

The static allocation function in this case was initializing with a constant. However, because the static is marked as `mut` the compiler doesn't inline the value. We need to codegen the static and its initialization too. The check that the MIR was available returned `false` for some strange reason.

Since we expect that everything that is not foreign to rust to be available, we just skip that check.

### Resolved issues:

Resolves #1760 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
N/A

### Call-outs:

I changed the test that was the source of this issue to just use the MIR linker.

### Testing:

* How is this change tested? Existing test

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
