### PR TITLE
Fix Kani crash with const-generic `[e; N]` expression

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -204,7 +204,7 @@ impl<'tcx> GotocCtx<'tcx> {
     fn codegen_rvalue_repeat(
         &mut self,
         op: &Operand<'tcx>,
-        sz: &ty::Const<'tcx>,
+        sz: ty::Const<'tcx>,
         res_ty: Ty<'tcx>,
         loc: Location,
     ) -> Expr {
@@ -393,7 +393,10 @@ impl<'tcx> GotocCtx<'tcx> {
         debug!(?rv, "codegen_rvalue");
         match rv {
             Rvalue::Use(p) => self.codegen_operand(p),
-            Rvalue::Repeat(op, sz) => self.codegen_rvalue_repeat(op, sz, res_ty, loc),
+            Rvalue::Repeat(op, sz) => {
+                let sz = self.monomorphize(*sz);
+                self.codegen_rvalue_repeat(op, sz, res_ty, loc)
+            }
             Rvalue::Ref(_, _, p) | Rvalue::AddressOf(_, p) => self.codegen_rvalue_ref(p, res_ty),
             Rvalue::Len(p) => self.codegen_rvalue_len(p),
             // Rust has begun distinguishing "ptr -> num" and "num -> ptr" (providence-relevant casts) but we do not yet:

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -708,7 +708,7 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     /// codegen for types. it finds a C type which corresponds to a rust type.
-    /// that means [ty] has to be monomorphized.
+    /// that means [ty] has to be monomorphized before calling this function.
     ///
     /// check [rustc_middle::ty::layout::LayoutCx::layout_of_uncached] for LLVM codegen
     ///

--- a/tests/kani/Array/repeat_const_generic.rs
+++ b/tests/kani/Array/repeat_const_generic.rs
@@ -23,6 +23,6 @@ mod proofs {
     #[kani::proof]
     fn hope_kani_does_not_crash() {
         let x = Foo::<32>::new();
-        assert!(x.len() == 32);
+        assert!(x.field.len() == 32);
     }
 }

--- a/tests/kani/Array/repeat_const_generic.rs
+++ b/tests/kani/Array/repeat_const_generic.rs
@@ -1,0 +1,24 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Ensure Kani can evaluate `[e; N]` when `N` is a const generic
+
+struct Foo<const N: usize> {
+    field: [u64; N],
+}
+
+impl<const N: usize> Foo<N> {
+    fn new() -> Self {
+        Self { field: [0; N] }
+    }
+}
+
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn kani_crash() {
+        Foo::<32>::new();
+    }
+}

--- a/tests/kani/Array/repeat_const_generic.rs
+++ b/tests/kani/Array/repeat_const_generic.rs
@@ -1,7 +1,8 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// Ensure Kani can evaluate `[e; N]` when `N` is a const generic
+// Ensure Kani can compile `[e; N]` when `N` is a const generic.
+// Test from <https://github.com/model-checking/kani/issues/1728>
 
 struct Foo<const N: usize> {
     field: [u64; N],
@@ -9,6 +10,8 @@ struct Foo<const N: usize> {
 
 impl<const N: usize> Foo<N> {
     fn new() -> Self {
+        // Was a crash during codegen because N hadn't been "monomorphized"
+        // and so could not be evaluated to a compile-time constant.
         Self { field: [0; N] }
     }
 }
@@ -18,7 +21,8 @@ mod proofs {
     use super::*;
 
     #[kani::proof]
-    fn kani_crash() {
-        Foo::<32>::new();
+    fn hope_kani_does_not_crash() {
+        let x = Foo::<32>::new();
+        assert!(x.len() == 32);
     }
 }


### PR DESCRIPTION
### Description of changes: 

Fixes an omitted call to `monomorphize` when translating `Rvalue::Repeat`

### Resolved issues:

* Resolves #1768 Confirmed the mentioned crate now builds under Kani.
* Resolves #1728 Thanks for the test case!
* Fixes this issue, but reveals another bug, in #1662

### Call-outs:

* The only two instances of `try_eval_usize` where here and in the code under `codegen_ty`. The latter already has a comment (that I clarified) that things should be monomorphized, and we haven't seen a crash there. So just the one fix needed to `Repeat` sounds probable here.

### Testing:

* How is this change tested? new test, failed before, passes now

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
