### PR TITLE
Add new tests for unsized coercion

### DIFF
--- a/tests/kani/UnsizedCoercion/basic_coercion.rs
+++ b/tests/kani/UnsizedCoercion/basic_coercion.rs
@@ -1,0 +1,15 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: --mir-linker --enable-unstable
+//! Check the basic coercion from using built-in references and pointers.
+//! Tests are broken down into different crates to ensure that the reachability works for each case.
+
+mod defs;
+use defs::*;
+
+#[kani::proof]
+fn check_base_coercion() {
+    let id = kani::any();
+    let inner = Inner { id };
+    assert_eq!(id_from_dyn(&inner), id.into());
+}

--- a/tests/kani/UnsizedCoercion/basic_inner_coercion.rs
+++ b/tests/kani/UnsizedCoercion/basic_inner_coercion.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: --mir-linker --enable-unstable
+//! Check the basic coercion from using built-in references and pointers.
+//! Tests are broken down into different crates to ensure that the reachability works for each case.
+
+mod defs;
+use defs::*;
+
+#[kani::proof]
+fn check_inner_dyn_coercion() {
+    let inner_id = kani::any();
+    let outer_id = kani::any();
+    let outer: &Outer<dyn Identity> = &Outer { inner: Inner { id: inner_id }, outer_id };
+    assert_eq!(id_from_dyn(&outer.inner), inner_id.into());
+}

--- a/tests/kani/UnsizedCoercion/basic_outer_coercion.rs
+++ b/tests/kani/UnsizedCoercion/basic_outer_coercion.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: --mir-linker --enable-unstable
+//! Check the basic coercion from using built-in references and pointers.
+//! Tests are broken down into different crates to ensure that the reachability works for each case.
+
+mod defs;
+use defs::*;
+
+#[kani::proof]
+fn check_outer_coercion() {
+    let inner_id = kani::any();
+    let outer_id = kani::any();
+    let outer = Outer { inner: Inner { id: inner_id }, outer_id };
+    assert_eq!(id_from_dyn(&outer) >> 8, outer_id.into());
+}

--- a/tests/kani/UnsizedCoercion/box_coercion.rs
+++ b/tests/kani/UnsizedCoercion/box_coercion.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: --mir-linker --enable-unstable
+//! Check the basic coercion when using boxes.
+//! Tests are broken down into different crates to ensure that the reachability works for each case.
+
+mod defs;
+use defs::*;
+use std::boxed::Box;
+
+#[kani::proof]
+fn check_base_coercion() {
+    let id = kani::any();
+    let inner: Box<dyn Identity> = Box::new(Inner { id });
+    assert_eq!(id_from_coerce(inner), id.into());
+}

--- a/tests/kani/UnsizedCoercion/box_outer_coercion.rs
+++ b/tests/kani/UnsizedCoercion/box_outer_coercion.rs
@@ -1,0 +1,15 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: --mir-linker --enable-unstable
+//! Check the basic coercion when using boxes.
+//! Tests are broken down into different crates to ensure that the reachability works for each case.
+mod defs;
+use defs::*;
+
+#[kani::proof]
+fn check_outer_coercion() {
+    let inner_id = kani::any();
+    let outer_id = kani::any();
+    let outer: Box<dyn Identity> = Box::new(Outer { inner: Inner { id: inner_id }, outer_id });
+    assert_eq!(id_from_coerce(outer) >> 8, outer_id.into());
+}

--- a/tests/kani/UnsizedCoercion/custom_outer_coercion.rs
+++ b/tests/kani/UnsizedCoercion/custom_outer_coercion.rs
@@ -1,0 +1,37 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: --mir-linker --enable-unstable
+//! Check the basic coercion when using a custom CoerceUnsized implementation.
+//! Tests are broken down into different crates to ensure that the reachability works for each case.
+#![feature(coerce_unsized)]
+#![feature(unsize)]
+use std::marker::Unsize;
+use std::ops::{CoerceUnsized, Deref};
+
+mod defs;
+use defs::*;
+
+/// Dummy reference wrapper that allow unsized coercion.
+pub struct MyPtr<'a, T: ?Sized> {
+    ptr: &'a T,
+}
+
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<MyPtr<'a, U>> for MyPtr<'a, T> {}
+
+impl<'a, T: ?Sized> Deref for MyPtr<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.ptr
+    }
+}
+
+#[kani::proof]
+fn check_outer_coercion() {
+    let inner_id = kani::any();
+    let outer_id = kani::any();
+    let outer = Outer { inner: Inner { id: inner_id }, outer_id };
+    let outer_ptr = MyPtr { ptr: &outer };
+    let id_ptr: MyPtr<dyn Identity> = outer_ptr;
+    assert_eq!(id_from_coerce(id_ptr) >> 8, outer_id.into());
+}

--- a/tests/kani/UnsizedCoercion/defs.rs
+++ b/tests/kani/UnsizedCoercion/defs.rs
@@ -1,0 +1,54 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: --only-codegen
+//! Definitions of traits and structs to be used in the unsized coercion tests.
+//! We skip running the verification since there's no harness in this file.
+
+use std::ops::Deref;
+
+/// Trait that returns an ID.
+pub trait Identity {
+    fn id(&self) -> u16;
+}
+
+/// Outer struct which wraps another Identity type.
+pub struct Outer<T: ?Sized> {
+    pub outer_id: u8,
+    pub inner: T,
+}
+
+/// Inner type that implements Identity.
+pub struct Inner {
+    pub id: u8,
+}
+
+// Implementation for cases where T implements Identity.
+impl<T> Identity for Outer<T>
+where
+    T: ?Sized + Identity,
+{
+    fn id(&self) -> u16 {
+        ((self.outer_id as u16) << 8) + (self.inner.id() as u16)
+    }
+}
+
+impl Identity for Inner {
+    fn id(&self) -> u16 {
+        self.id.into()
+    }
+}
+
+/// Get the id from a fat pointer.
+#[allow(dead_code)]
+pub fn id_from_dyn(identity: &dyn Identity) -> u16 {
+    identity.id()
+}
+
+/// Get the id from a smart pointer.
+#[allow(dead_code)]
+pub fn id_from_coerce<T>(identity: T) -> u16
+where
+    T: Deref<Target = dyn Identity>,
+{
+    identity.id()
+}

--- a/tests/kani/UnsizedCoercion/fixme_box_inner_coercion.rs
+++ b/tests/kani/UnsizedCoercion/fixme_box_inner_coercion.rs
@@ -1,0 +1,19 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: --mir-linker --enable-unstable
+//! Check the basic coercion when using boxes.
+//! Tests are broken down into different crates to ensure that the reachability works for each case.
+//! FIXME: Drop of struct with dyn member unsupported for now.
+//! https://github.com/model-checking/kani/issues/1072
+
+mod defs;
+use defs::*;
+
+#[kani::proof]
+fn check_inner_dyn_coercion() {
+    let inner_id = kani::any();
+    let outer_id = kani::any();
+    let outer: Box<Outer<dyn Identity>> =
+        Box::new(Outer { inner: Inner { id: inner_id }, outer_id });
+    assert_eq!(id_from_dyn(&outer.inner), inner_id.into());
+}

--- a/tests/kani/UnsizedCoercion/rc_outer_coercion.rs
+++ b/tests/kani/UnsizedCoercion/rc_outer_coercion.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: --mir-linker --enable-unstable
+//! Check the basic coercion from using reference counter.
+//! Tests are broken down into different crates to ensure that the reachability works for each case.
+mod defs;
+use defs::*;
+use std::rc::Rc;
+
+#[kani::proof]
+fn check_outer_coercion() {
+    let inner_id = kani::any();
+    let outer_id = kani::any();
+    let outer: Rc<dyn Identity> = Rc::new(Outer { inner: Inner { id: inner_id }, outer_id });
+    assert_eq!(id_from_coerce(outer) >> 8, outer_id.into());
+}


### PR DESCRIPTION
### Description of changes: 

Adding extra tests that specifically cover the logic introduced in #1754. Note that if we revert the related fix, the following two new tests would fail:
 - `custom_outer_coercion.rs`
 - `rc_outer_coercion.rs`


### Resolved issues:

None

### Related RFC:

N/A

### Call-outs:

### Testing:

* How is this change tested? New tests

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
