### PR TITLE
Do not apply Ubuntu 18.04 workaround if user has installed newer versions of Python

### DIFF
--- a/src/os_hacks.rs
+++ b/src/os_hacks.rs
@@ -15,7 +15,7 @@ use os_info::Info;
 use crate::cmd::AutoRun;
 
 pub fn should_apply_ubuntu_18_04_python_hack(os: &os_info::Info) -> Result<bool> {
-    if os.os_type() == os_info::Type::Ubuntu {
+    if os.os_type() != os_info::Type::Ubuntu {
         return Ok(false);
     }
     // Check both versions: https://github.com/stanislav-tkach/os_info/issues/318

--- a/src/os_hacks.rs
+++ b/src/os_hacks.rs
@@ -14,6 +14,41 @@ use os_info::Info;
 
 use crate::cmd::AutoRun;
 
+pub fn should_apply_ubuntu_18_04_python_hack(os: &os_info::Info) -> Result<bool> {
+    if os.os_type() == os_info::Type::Ubuntu {
+        return Ok(false);
+    }
+    // Check both versions: https://github.com/stanislav-tkach/os_info/issues/318
+    if *os.version() != os_info::Version::Semantic(18, 4, 0)
+        && *os.version() != os_info::Version::Custom("18.04".into())
+    {
+        return Ok(false);
+    }
+    // It's not enough to check that we're on Ubuntu 18.04 because the user may have
+    // manually updated to a newer version of Python instead of using what the OS ships.
+    // So check if it looks like the OS-shipped version as best we can.
+    let cmd = Command::new("python3").args(["-m", "pip", "--version"]).output()?;
+    let output = std::str::from_utf8(&cmd.stdout)?;
+    // The problem version looks like:
+    //    'pip 9.0.1 from /usr/lib/python3/dist-packages (python 3.6)'
+    // So we'll test for version 9.
+    Ok(pip_major_version(output)? == 9)
+}
+
+/// Unit testable parsing function for extracting pip version numbers, from strings that look like:
+///    'pip 9.0.1 from /usr/lib/python3/dist-packages (python 3.6)'
+fn pip_major_version(output: &str) -> Result<u32> {
+    // We don't want dependencies so parse with stdlib string functions as best we can.
+    let mut words = output.split_whitespace();
+    let _pip = words.next().context("No pip output")?;
+    let version = words.next().context("No pip version")?;
+
+    let mut versions = version.split('.');
+    let major = versions.next().context("No pip major version")?;
+
+    Ok(major.parse()?)
+}
+
 /// See [`crate::setup::setup_python_deps`]
 pub fn setup_python_deps_on_ubuntu_18_04(pyroot: &Path, pkg_versions: &[&str]) -> Result<()> {
     println!("Applying a workaround for 18.04...");
@@ -120,4 +155,26 @@ fn setup_nixos_patchelf(kani_dir: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_pip_major_version() -> Result<()> {
+        // These read a lot better formatted on one line, so shorten them:
+        use pip_major_version as p;
+        // 18.04 example: (with extra newline to test whitespace handling)
+        assert_eq!(p("pip 9.0.1 from /usr/lib/python3/dist-packages (python 3.6)\n")?, 9);
+        // a mac
+        assert_eq!(p("pip 21.1.1 from /usr/local/python3.9/site-packages/pip (python 3.9)")?, 21);
+        // 20.04
+        assert_eq!(p("pip 20.0.2 from /usr/lib/python3/dist-packages/pip (python 3.8)")?, 20);
+        // How mangled can we get and still "work"?
+        assert_eq!(p("pip 1")?, 1);
+        assert_eq!(p("p 1")?, 1);
+        assert_eq!(p("\n\n p 1 p")?, 1);
+        Ok(())
+    }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -112,11 +112,7 @@ fn setup_python_deps(kani_dir: &Path, os: &os_info::Info) -> Result<()> {
     // TODO: this is a repetition of versions from kani/kani-dependencies
     let pkg_versions = &["cbmc-viewer==3.6"];
 
-    if os.os_type() == os_info::Type::Ubuntu
-        // Check both versions: https://github.com/stanislav-tkach/os_info/issues/318
-        && (*os.version() == os_info::Version::Semantic(18, 4, 0)
-            || *os.version() == os_info::Version::Custom("18.04".into()))
-    {
+    if os_hacks::should_apply_ubuntu_18_04_python_hack(os)? {
         os_hacks::setup_python_deps_on_ubuntu_18_04(&pyroot, pkg_versions)?;
         return Ok(());
     }


### PR DESCRIPTION
### Description of changes: 

Newer versions of Python do not have the option we use to workaround the broken `pip` in default Ubuntu 18.04, so the install fails for them.

However the broken version is only due to a debian/ubuntu-specific patch they applied. So if the user has done anything to get a different version of Python installed, we don't need this workaround.

So test for version 9 of pip. Any different version almost certainly means the user has installed their own python, instead of the system-supplied one for 18.04.

### Resolved issues:

Resolves #1721 

### Call-outs:

* I have not added a system integration test for this scenario. I think there's limits to the number of user system configurations we can test in CI. I believe the unit test for the version checker should be enough, and we're strictly narrower in scope for when we apply this hacky workaround, so I think this is good.

### Testing:

* How is this change tested? unit tests + ci for existing workaround

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
