### PR TITLE
Update Kani to Rust nightly-2022-10-11

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -404,8 +404,11 @@ impl<'tcx> GotocCtx<'tcx> {
             }};
         }
 
-        if let Some(stripped) = intrinsic.strip_prefix("simd_shuffle") {
-            let _n: u64 = stripped.parse().unwrap();
+        if let Some(_stripped) = intrinsic.strip_prefix("simd_shuffle") {
+            // TODO: can be empty now (i.e. `simd_shuffle` instead of `simd_shuffle8`)
+            // `parse` fails on empty, so comment that bit of code out.
+            // To re-enable this we'll need to investigate how size is computed now.
+            // let n: u64 = stripped.parse().unwrap();
             return unstable_codegen!(self.codegen_intrinsic_simd_shuffle(
                 fargs,
                 p,

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -63,7 +63,7 @@ impl<'tcx> GotocCtx<'tcx> {
         ty: Ty<'tcx>,
         span: Option<&Span>,
     ) -> Expr {
-        debug!("The literal was a Unevaluated");
+        debug!(?unevaluated, "codegen_const_unevaluated");
         let const_val =
             self.tcx.const_eval_resolve(ty::ParamEnv::reveal_all(), unevaluated, None).unwrap();
         self.codegen_const_value(const_val, ty, span)
@@ -76,7 +76,7 @@ impl<'tcx> GotocCtx<'tcx> {
         match lit.kind() {
             // A `ConstantKind::Ty(ConstKind::Unevaluated)` should no longer show up
             // and should be a `ConstantKind::Unevaluated` instead (and thus handled
-            // in `codegen_constant` not here.)
+            // at the level of `codegen_constant` instead of `codegen_const`.)
             ConstKind::Unevaluated(_) => unreachable!(),
 
             ConstKind::Value(valtree) => {

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -9,7 +9,7 @@ use rustc_ast::ast::Mutability;
 use rustc_middle::mir::interpret::{
     read_target_uint, AllocId, Allocation, ConstValue, GlobalAlloc, Scalar,
 };
-use rustc_middle::mir::{Constant, ConstantKind, Operand};
+use rustc_middle::mir::{Constant, ConstantKind, Operand, UnevaluatedConst};
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{self, Const, ConstKind, FloatTy, Instance, IntTy, Ty, Uint, UintTy};
 use rustc_span::def_id::DefId;
@@ -47,12 +47,26 @@ impl<'tcx> GotocCtx<'tcx> {
 
     fn codegen_constant(&mut self, c: &Constant<'tcx>) -> Expr {
         trace!(constant=?c, "codegen_constant");
-        let const_ = match self.monomorphize(c.literal) {
-            ConstantKind::Ty(ct) => ct,
-            ConstantKind::Val(val, ty) => return self.codegen_const_value(val, ty, Some(&c.span)),
-        };
+        let span = Some(&c.span);
+        match self.monomorphize(c.literal) {
+            ConstantKind::Ty(ct) => self.codegen_const(ct, span),
+            ConstantKind::Val(val, ty) => self.codegen_const_value(val, ty, span),
+            ConstantKind::Unevaluated(unevaluated, ty) => {
+                self.codegen_const_unevaluated(unevaluated, ty, span)
+            }
+        }
+    }
 
-        self.codegen_const(const_, Some(&c.span))
+    fn codegen_const_unevaluated(
+        &mut self,
+        unevaluated: UnevaluatedConst<'tcx>,
+        ty: Ty<'tcx>,
+        span: Option<&Span>,
+    ) -> Expr {
+        debug!("The literal was a Unevaluated");
+        let const_val =
+            self.tcx.const_eval_resolve(ty::ParamEnv::reveal_all(), unevaluated, None).unwrap();
+        self.codegen_const_value(const_val, ty, span)
     }
 
     pub fn codegen_const(&mut self, lit: Const<'tcx>, span: Option<&Span>) -> Expr {
@@ -60,15 +74,10 @@ impl<'tcx> GotocCtx<'tcx> {
         let lit = self.monomorphize(lit);
 
         match lit.kind() {
-            // evaluate constant if it has no been evaluated yet
-            ConstKind::Unevaluated(unevaluated) => {
-                debug!("The literal was a Unevaluated");
-                let const_val = self
-                    .tcx
-                    .const_eval_resolve(ty::ParamEnv::reveal_all(), unevaluated, None)
-                    .unwrap();
-                self.codegen_const_value(const_val, lit.ty(), span)
-            }
+            // A `ConstantKind::Ty(ConstKind::Unevaluated)` should no longer show up
+            // and should be a `ConstantKind::Unevaluated` instead (and thus handled
+            // in `codegen_constant` not here.)
+            ConstKind::Unevaluated(_) => unreachable!(),
 
             ConstKind::Value(valtree) => {
                 let value = self.tcx.valtree_to_const_val((lit.ty(), valtree));

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
@@ -547,6 +547,13 @@ impl<'tcx> GotocCtx<'tcx> {
                     self,
                 )
             }
+            ProjectionElem::OpaqueCast(ty) => ProjectedPlace::try_new(
+                before.goto_expr.cast_to(self.codegen_ty(ty)),
+                TypeOrVariant::Type(ty),
+                before.fat_ptr_goto_expr,
+                before.fat_ptr_mir_typ,
+                self,
+            ),
         }
     }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -555,7 +555,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// We follow the order from the `TyCtxt::COMMON_VTABLE_ENTRIES`.
     fn trait_vtable_field_types(&mut self, t: ty::Ty<'tcx>) -> Vec<DatatypeComponent> {
         let mut vtable_base = common_vtable_fields(self.trait_vtable_drop_type(t));
-        if let ty::Dynamic(binder, _region) = t.kind() {
+        if let ty::Dynamic(binder, _, _) = t.kind() {
             // The virtual methods on the trait ref. Some auto traits have no methods.
             if let Some(principal) = binder.principal() {
                 let poly = principal.with_self_ty(self.tcx, t);
@@ -710,7 +710,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// codegen for types. it finds a C type which corresponds to a rust type.
     /// that means [ty] has to be monomorphized before calling this function.
     ///
-    /// check [rustc_middle::ty::layout::LayoutCx::layout_of_uncached] for LLVM codegen
+    /// check `rustc_ty_utils::layout::layout_of_uncached` for LLVM codegen
     ///
     /// also c.f. <https://www.ralfj.de/blog/2020/04/04/layout-debugging.html>
     ///      c.f. <https://rust-lang.github.io/unsafe-code-guidelines/introduction.html>

--- a/kani_metadata/src/lib.rs
+++ b/kani_metadata/src/lib.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// The structure of `.kani-metadata.json` files, which are emitted for each crate
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KaniMetadata {
-    /// The proof harnesses (#[kani::proof]) found in this crate.
+    /// The proof harnesses (`#[kani::proof]`) found in this crate.
     pub proof_harnesses: Vec<HarnessMetadata>,
     /// The features found in this crate that Kani does not support.
     /// (These general translate to `assert(false)` so we can still attempt verification.)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2022-09-13"
+channel = "nightly-2022-10-11"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/kani/Intrinsics/Assert/uninit_valid_panic.rs
+++ b/tests/kani/Intrinsics/Assert/uninit_valid_panic.rs
@@ -5,11 +5,11 @@
 #![feature(core_intrinsics)]
 use std::intrinsics;
 
-// The code below attempts to leave type `!` uninitialized, causing the
+// The code below attempts to leave type `&u32` uninitialized, causing the
 // intrinsic `assert_uninit_valid` to generate a panic during compilation.
 #[kani::proof]
 fn main() {
     let _var: () = unsafe {
-        intrinsics::assert_uninit_valid::<!>();
+        intrinsics::assert_uninit_valid::<&u32>();
     };
 }

--- a/tests/kani/Intrinsics/Assert/uninit_valid_panic.rs
+++ b/tests/kani/Intrinsics/Assert/uninit_valid_panic.rs
@@ -5,11 +5,11 @@
 #![feature(core_intrinsics)]
 use std::intrinsics;
 
-// The code below attempts to leave type `bool` uninitialized, causing the
+// The code below attempts to leave type `!` uninitialized, causing the
 // intrinsic `assert_uninit_valid` to generate a panic during compilation.
 #[kani::proof]
 fn main() {
     let _var: () = unsafe {
-        intrinsics::assert_uninit_valid::<bool>();
+        intrinsics::assert_uninit_valid::<!>();
     };
 }

--- a/tests/kani/ProjectionElem/OpaqueCast/check_opaque_cast.rs
+++ b/tests/kani/ProjectionElem/OpaqueCast/check_opaque_cast.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+//
 // Modifications Copyright Kani Contributors
 // See GitHub history for details.
 

--- a/tests/kani/ProjectionElem/OpaqueCast/check_opaque_cast.rs
+++ b/tests/kani/ProjectionElem/OpaqueCast/check_opaque_cast.rs
@@ -1,11 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
 // Modifications Copyright Kani Contributors
 // See GitHub history for details.
-//
-// NOTE: The initial fix for this has been reverted from rustc. I'm keeping this test here so we
-// will know when it has been reverted back.
-// kani-check-fail
 
 //! Tests that check handling of opaque casts. Tests were adapted from the rustc repository.
 

--- a/tests/ui/code-location/expected
+++ b/tests/ui/code-location/expected
@@ -1,6 +1,6 @@
 module/mod.rs:10:5 in function module::not_empty
 main.rs:13:5 in function same_file
 /toolchains/
-alloc/src/vec/mod.rs:2921:81 in function <std::vec::Vec<i32> as std::ops::Drop>::drop
+alloc/src/vec/mod.rs:3031:81 in function <std::vec::Vec<i32> as std::ops::Drop>::drop
 
 VERIFICATION:- SUCCESSFUL

--- a/tools/bookrunner/librustdoc/lib.rs
+++ b/tools/bookrunner/librustdoc/lib.rs
@@ -12,7 +12,6 @@
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(box_syntax)]
-#![feature(let_else)]
 #![feature(test)]
 #![feature(never_type)]
 #![feature(once_cell)]
@@ -62,7 +61,6 @@ extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_target;
 extern crate rustc_trait_selection;
-extern crate rustc_typeck;
 extern crate test;
 
 pub mod doctest;

--- a/tools/compiletest/src/main.rs
+++ b/tools/compiletest/src/main.rs
@@ -511,5 +511,8 @@ fn make_test_closure(
     let config = config.clone();
     let testpaths = testpaths.clone();
     let revision = revision.cloned();
-    test::DynTestFn(Box::new(move || Ok(runtest::run(config, &testpaths, revision.as_deref()))))
+    test::DynTestFn(Box::new(move || {
+        runtest::run(config, &testpaths, revision.as_deref());
+        Ok(())
+    }))
 }

--- a/tools/compiletest/src/main.rs
+++ b/tools/compiletest/src/main.rs
@@ -511,5 +511,5 @@ fn make_test_closure(
     let config = config.clone();
     let testpaths = testpaths.clone();
     let revision = revision.cloned();
-    test::DynTestFn(Box::new(move || runtest::run(config, &testpaths, revision.as_deref())))
+    test::DynTestFn(Box::new(move || Ok(runtest::run(config, &testpaths, revision.as_deref()))))
 }


### PR DESCRIPTION
### Description of changes: 

Updates to newer nightly. Notable impacting changes from upstream:

1. https://github.com/rust-lang/rust/pull/102675
   * `CastKind::Misc` became `CastKind::IntToInt | CastKind::FloatToFloat | CastKind::FloatToInt | CastKind::IntToFloat | CastKind::FnPtrToPtr | CastKind::PtrToPtr`

2. https://github.com/rust-lang/rust/pull/98588
   * MIR created `ConstantKind::Unevaluated` to replace `ContantKind::Ty` wrapping a `ConstKind::Unevaluated`. Note the `ANT` in `Constant` distinguishing these!
   * `visit_const` was removed from `MirVisitor` as a consequence

3. https://github.com/rust-lang/rust/pull/101212
   * Initial implementation of `dyn*` might create problems for us in the future but simple change for now
   * It looks like they just littered fixmes about... so the only place that broke I've added a `codegen_unimplemented` for now

4. https://github.com/rust-lang/rust/pull/98582
   * Reintroduce `ProjectionElem::OpaqueCast`
   * We'd seen this before (thanks, @celinval!). I re-added the code from https://github.com/model-checking/kani/pull/1399

5. https://github.com/rust-lang/rust/pull/101061
   * Seems like `intrinsics::assert_uninit_valid::<bool>()` is ok now? Switch to ! like that pull request

### Resolved issues:

Resolves #1746 

### Call-outs:

* `simd_shuffle` is disabled right now, but there's probably a new issue in the way of re-enabling it (it is or can be plain `simd_shuffle` now not just e.g. `simd_shuffle8`) @adpaco-aws 
* `let_else` is getting stabilized? Woo hoo!

### Testing:

* How is this change tested? ci

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
