### PR TITLE
Fix target selection for MIR Linker

### DIFF
--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -49,6 +49,13 @@ impl KaniSession {
         cargo_args.push("--target-dir".into());
         cargo_args.push(target_dir.into());
 
+        if self.args.tests {
+            // Use test profile in order to pull dev-dependencies and compile using `--test`.
+            // Initially the plan was to use `--tests` but that brings in multiple targets.
+            cargo_args.push("--profile".into());
+            cargo_args.push("test".into());
+        }
+
         if self.args.verbose {
             cargo_args.push("-v".into());
         }

--- a/rfc/src/rfcs/0001-mir-linker.md
+++ b/rfc/src/rfcs/0001-mir-linker.md
@@ -1,8 +1,8 @@
 - **Feature Name:** MIR Linker (mir_linker)
 - **RFC Tracking Issue**: <https://github.com/model-checking/kani/issues/1588>
 - **RFC PR:** <https://github.com/model-checking/kani/pull/1600>
-- **Status:** In Progress
-- **Version:** 1
+- **Status:** Unstable
+- **Version:** 2
 
 -------------------
 
@@ -236,8 +236,8 @@ These results were obtained by looking at the artifacts generated during the sam
   Thus, it shouldn't have any side effect.
   That relies on all constant initializers being evaluated during compilation.
 - ~~What's the best way to handle `cargo kani --tests`?~~
-  We will use similar mechanism to regular Kani runs:
-  - `cargo rustc --tests -- --reachability=harnesses`
+  For now, we are going to use the test profile and iterate over all the targets available in the crate:
+  - `cargo rustc --profile test -- --reachability=harnesses`
 
 
 ## Future possibilities

--- a/tests/cargo-ui/ws-integ-tests/Cargo.toml
+++ b/tests/cargo-ui/ws-integ-tests/Cargo.toml
@@ -1,0 +1,19 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# Create a workspace with three independent libraries that have integration tests.
+# The `in_src_harness` has a proof harness co-located with the code.
+# The `integ_harness` has a proof harness co-located with an integration test.
+# The `all_harness` has proof harnesses with src and integration tests.
+[workspace]
+members = [
+  "in_src_harness",
+  "integ_harness",
+  "all_harness",
+]
+
+[workspace.metadata.kani.flags]
+workspace = true
+tests = true
+enable-unstable=true
+mir-linker=true

--- a/tests/cargo-ui/ws-integ-tests/all_harness/Cargo.toml
+++ b/tests/cargo-ui/ws-integ-tests/all_harness/Cargo.toml
@@ -1,0 +1,11 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+[package]
+name = "all_harness"
+version = "0.1.0"
+edition = "2021"
+description = "Package with harnesses that co-located with integration tests and src"
+
+[dependencies]
+integ_harness = { path= "../integ_harness" }
+in_src_harness = { path= "../in_src_harness" }

--- a/tests/cargo-ui/ws-integ-tests/all_harness/src/lib.rs
+++ b/tests/cargo-ui/ws-integ-tests/all_harness/src/lib.rs
@@ -1,0 +1,24 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//! Dummy harness and library that check left rotation.
+use in_src_harness::rotate_left;
+use integ_harness::rotate_right;
+
+/// Returns if any rotation would result in wrapping bits.
+pub fn will_rotate_wrap(num: u8, rhs: u32) -> bool {
+    rotate_left(num, rhs).1 || rotate_right(num, rhs).1
+}
+
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn check_propagate() {
+        let num = kani::any();
+        let shift = kani::any();
+        kani::assume(rotate_right(num, shift).1);
+        assert!(will_rotate_wrap(num, shift));
+    }
+}

--- a/tests/cargo-ui/ws-integ-tests/all_harness/tests/check_result.rs
+++ b/tests/cargo-ui/ws-integ-tests/all_harness/tests/check_result.rs
@@ -1,0 +1,14 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use all_harness::*;
+
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn with_no_panic() {
+        will_rotate_wrap(kani::any(), kani::any());
+    }
+}

--- a/tests/cargo-ui/ws-integ-tests/expected
+++ b/tests/cargo-ui/ws-integ-tests/expected
@@ -1,0 +1,14 @@
+Checking harness proofs::check_propagate...
+VERIFICATION:- SUCCESSFUL
+
+Checking harness proofs::with_no_panic...
+VERIFICATION:- SUCCESSFUL
+
+Checking harness proofs::no_panic...
+VERIFICATION:- SUCCESSFUL
+
+Checking harness proofs::will_not_panic...
+VERIFICATION:- SUCCESSFUL
+
+
+Complete - 4 successfully verified harnesses, 0 failures, 4 total.

--- a/tests/cargo-ui/ws-integ-tests/in_src_harness/Cargo.toml
+++ b/tests/cargo-ui/ws-integ-tests/in_src_harness/Cargo.toml
@@ -1,0 +1,9 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+[package]
+name = "in_src_harness"
+version = "0.1.0"
+edition = "2021"
+description = "Package with a harness that is co-located with the library code"
+
+[dependencies]

--- a/tests/cargo-ui/ws-integ-tests/in_src_harness/src/lib.rs
+++ b/tests/cargo-ui/ws-integ-tests/in_src_harness/src/lib.rs
@@ -1,0 +1,21 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//! Dummy harness and library that check left rotation.
+
+/// Return the left rotation of the give number and whether the result had wrapped bits.
+pub fn rotate_left(num: u8, rhs: u32) -> (u8, bool) {
+    let result = num.rotate_left(rhs);
+    let wrapped = if rhs >= 8 { num != 0 } else { result > (num << rhs) };
+    (result, wrapped)
+}
+
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn will_not_panic() {
+        rotate_left(kani::any(), kani::any());
+    }
+}

--- a/tests/cargo-ui/ws-integ-tests/in_src_harness/tests/check_result.rs
+++ b/tests/cargo-ui/ws-integ-tests/in_src_harness/tests/check_result.rs
@@ -1,0 +1,12 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use in_src_harness::*;
+
+#[test]
+fn test_no_overflow() {
+    assert_eq!(rotate_left(0x0, 0), (0x0, false));
+    assert_eq!(rotate_left(0x0, 100), (0x0, false));
+    assert_eq!(rotate_left(0xF, 0), (0xF, false));
+    assert_eq!(rotate_left(0x1, 7), (0x80, false));
+}

--- a/tests/cargo-ui/ws-integ-tests/integ_harness/Cargo.toml
+++ b/tests/cargo-ui/ws-integ-tests/integ_harness/Cargo.toml
@@ -1,0 +1,9 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+[package]
+name = "integ_harness"
+version = "0.1.0"
+edition = "2021"
+description = "Package with a harness that is co-located with integration tests"
+
+[dependencies]

--- a/tests/cargo-ui/ws-integ-tests/integ_harness/src/lib.rs
+++ b/tests/cargo-ui/ws-integ-tests/integ_harness/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//! Dummy harness and library that check left rotation.
+
+/// Return the right rotation of the give number and whether the result has wrapped bits.
+pub fn rotate_right(num: u8, rhs: u32) -> (u8, bool) {
+    let result = num.rotate_right(rhs);
+    let wrapped = if rhs >= 8 { num != 0 } else { result < (num >> rhs) };
+    (result, wrapped)
+}

--- a/tests/cargo-ui/ws-integ-tests/integ_harness/tests/check_result.rs
+++ b/tests/cargo-ui/ws-integ-tests/integ_harness/tests/check_result.rs
@@ -1,0 +1,22 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use integ_harness::*;
+
+#[test]
+fn test_no_overflow() {
+    assert_eq!(rotate_right(0x0, 0), (0x0, false));
+    assert_eq!(rotate_right(0x0, 100), (0x0, false));
+    assert_eq!(rotate_right(0xF, 0), (0xF, false));
+    assert_eq!(rotate_right(0x80, 7), (0x1, false));
+}
+
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn no_panic() {
+        rotate_right(kani::any(), kani::any());
+    }
+}


### PR DESCRIPTION
### Description of changes: 

When running MIR Linker with multiple targets (e.g., integration tests), we were failing to compile since the call to `cargo rustc` would have multiple targets.

Invoke separate calls for each target for now.

### Resolved issues:

Resolves #1764

### Related RFC:


### Call-outs:

I was wondering if it's worth suppressing cargo's messages and printing our own (in a follow up PR). The output is not great right now since it just have some multiple cargo logs in sequence. For the test below, you would get the following:

<details>

```
$ cargo kani --only-codegen
   Compiling all_harness v0.1.0 (/home/ANT.AMAZON.COM/celinval/workspace/kani-project/kani/tests/cargo-ui/ws-integ-tests/all_harness)
    Finished dev [unoptimized + debuginfo] target(s) in 0.92s
   Compiling all_harness v0.1.0 (/home/ANT.AMAZON.COM/celinval/workspace/kani-project/kani/tests/cargo-ui/ws-integ-tests/all_harness)
    Finished dev [unoptimized + debuginfo] target(s) in 0.85s
   Compiling in_src_harness v0.1.0 (/home/ANT.AMAZON.COM/celinval/workspace/kani-project/kani/tests/cargo-ui/ws-integ-tests/in_src_harness)
    Finished dev [unoptimized + debuginfo] target(s) in 0.79s
   Compiling in_src_harness v0.1.0 (/home/ANT.AMAZON.COM/celinval/workspace/kani-project/kani/tests/cargo-ui/ws-integ-tests/in_src_harness)
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
   Compiling integ_harness v0.1.0 (/home/ANT.AMAZON.COM/celinval/workspace/kani-project/kani/tests/cargo-ui/ws-integ-tests/integ_harness)
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
   Compiling integ_harness v0.1.0 (/home/ANT.AMAZON.COM/celinval/workspace/kani-project/kani/tests/cargo-ui/ws-integ-tests/integ_harness)
    Finished dev [unoptimized + debuginfo] target(s) in 0.81s

```
</details>


### Testing:

* How is this change tested? New test

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
