### PR TITLE
Disable debug_asserts inside `std` due to poor UX

### DIFF
--- a/tests/expected/intrinsics/copy-nonoverlapping/copy-overflow/main.rs
+++ b/tests/expected/intrinsics/copy-nonoverlapping/copy-overflow/main.rs
@@ -1,14 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// kani-flags: --legacy-linker
 //! Checks that `copy_nonoverlapping` triggers an overflow failure if the `count`
 //! argument can overflow a `usize`
-//!
-//! When enabling "--mir-linker", the error we currently get is:
-//! > Failed checks: Called `Option::unwrap()` on a `None` value
-//! This happens because of std debug checks. The `is_nonoverlapping` check has a
-//! `checked_mul().unwrap()` that fails in the overflow scenario.
-//! See <https://github.com/model-checking/kani/issues/1740> for more details.
 #[kani::proof]
 fn test_copy_nonoverlapping_unaligned() {
     let arr: [i32; 3] = [0, 1, 0];

--- a/tests/expected/intrinsics/copy-nonoverlapping/copy-unaligned-dst/main.rs
+++ b/tests/expected/intrinsics/copy-nonoverlapping/copy-unaligned-dst/main.rs
@@ -1,9 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --legacy-linker
-//! The MIR linker errors are not quite user friendly. For more details, see
-//! <https://github.com/model-checking/kani/issues/1740>
 //! Checks that `copy_nonoverlapping` fails when `dst` is not aligned.
 
 #[kani::proof]

--- a/tests/expected/intrinsics/copy-nonoverlapping/copy-unaligned-src/main.rs
+++ b/tests/expected/intrinsics/copy-nonoverlapping/copy-unaligned-src/main.rs
@@ -1,9 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --legacy-linker
-//! The MIR linker errors are not quite user friendly. For more details, see
-//! <https://github.com/model-checking/kani/issues/1740>
 //! Checks that `copy_nonoverlapping` fails when `src` is not aligned.
 #[kani::proof]
 fn test_copy_nonoverlapping_unaligned() {

--- a/tests/expected/intrinsics/copy/copy-unaligned-dst/main.rs
+++ b/tests/expected/intrinsics/copy/copy-unaligned-dst/main.rs
@@ -1,9 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --legacy-linker
-//! The MIR linker errors are not quite user friendly. For more details, see
-//! <https://github.com/model-checking/kani/issues/1740>
 //! Checks that `copy` fails when `dst` is not aligned.
 #[kani::proof]
 fn test_copy_unaligned() {

--- a/tests/expected/intrinsics/copy/copy-unaligned-src/main.rs
+++ b/tests/expected/intrinsics/copy/copy-unaligned-src/main.rs
@@ -1,9 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --legacy-linker
-//! The MIR linker errors are not quite user friendly. For more details, see
-//! <https://github.com/model-checking/kani/issues/1740>
 //! Checks that `copy` fails when `src` is not aligned.
 #[kani::proof]
 fn test_copy_unaligned() {

--- a/tests/expected/intrinsics/write_bytes/unaligned/main.rs
+++ b/tests/expected/intrinsics/write_bytes/unaligned/main.rs
@@ -1,9 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --legacy-linker
-//! The MIR linker errors are not quite user friendly. For more details, see
-//! <https://github.com/model-checking/kani/issues/1740>
 //! Checks that `write_bytes` fails when `dst` is not aligned.
 //! This test is a modified version of the example in
 //! https://doc.rust-lang.org/std/ptr/fn.write_bytes.html

--- a/tools/build-kani/src/sysroot.rs
+++ b/tools/build-kani/src/sysroot.rs
@@ -93,6 +93,10 @@ pub fn build_lib() {
         "dev",
         "--config",
         "profile.dev.panic=\"abort\"",
+        // Disable debug assertions for now as a mitigation for
+        // https://github.com/model-checking/kani/issues/1740
+        "--config",
+        "profile.dev.debug-assertions=false",
         "--config",
         "host.rustflags=[\"--cfg=kani\"]",
         "--target",
@@ -126,7 +130,6 @@ pub fn build_lib() {
     cp_files(&kani_rlib_folder, &sysroot_lib, &is_rlib).unwrap();
 
     // Copy `std` libraries and dependencies to sysroot folder following expected path format.
-    // TODO: Create a macro for all these push.
     let src_path = path_buf!(target_folder, target, "debug", "deps");
 
     let dst_path = path_buf!(sysroot_lib, "rustlib", target, "lib");


### PR DESCRIPTION
### Description of changes: 

This is a possible workaround for now to improve the UX around UB detection in intrinsics when using the MIR Linker. The issue is tracked by https://github.com/model-checking/kani/issues/1740.

Basically, the rust toolchain uses a release build that removes all debug assertions from the standard library. When we switched to using our custom build of the `std` we decided to enable the debug assertions in order to catch more potential UBs. However, the UX is not great. Many assertions and validation logic don't have clear descriptions and they may fail in unexpected places. E.g.: The violation of an intrinsic safety condition triggers the following failures:
```
> Failed checks: Called `Option::unwrap()` on a `None` value
```

### Resolved issues:

Mitigates #1740

### Related RFC:

#1588 

### Call-outs:

I'm creating this PR to get some feedback on a possible mitigation proposed by @tedinski. I think in the long run, we should see if it's possible to make these errors more user friendly inside the standard library.

The downside of this PR is that other UBs that could be detected via `debug_assert` inside the `std` might be missed or can cause a side effect resulting in another type of failure.

### Testing:

* How is this change tested? Modified tests.

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
