### PR TITLE
Remove Kani temp files from book upload

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -36,6 +36,9 @@ if [ -d $HTML_DIR ]; then
     # Replace artifacts by examples under test
     BOOKS_DIR=$KANI_DIR/tests/bookrunner/books
     rm -r src/bookrunner/artifacts
+    # Remove any json files that Kani might've left behind due to crash or timeout.
+    find $BOOKS_DIR -name '*.json' -exec rm {} \;
+    find $BOOKS_DIR -name '*.out' -exec rm {} \;
     cp -r $BOOKS_DIR src/bookrunner/artifacts
     # Update paths in HTML report
     python $KANI_DIR/scripts/ci/update_bookrunner_report.py src/bookrunner/index.html new_index.html


### PR DESCRIPTION
### Description of changes: 

When Kani crashes or timeout, it leaves behind all the temporary files. While running the bookrunner, that can happen because of some instability or timeout. Thus, we need to manually delete these files for now to avoid uploading them as part of the bookrunner artifacts.

### Resolved issues:

Resolves #1792 

### Related RFC:

N/A

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
