### PR TITLE
Add stub RFC to SUMMARY.md + add step to instructions

### DIFF
--- a/rfc/src/SUMMARY.md
+++ b/rfc/src/SUMMARY.md
@@ -7,4 +7,5 @@
 # Kani RFCs
 
 - [0001-mir-linker](rfcs/0001-mir-linker.md)
+- [0002-function-stubbing](rfcs/0002-function-stubbing.md)
 

--- a/rfc/src/intro.md
+++ b/rfc/src/intro.md
@@ -34,9 +34,10 @@ This is the overall workflow for the RFC process:
 1. Create an RFC
    1. Create a tracking issue for your RFC (e.g.: [Issue-1588](https://github.com/model-checking/kani/issues/1588)).
    2. Start from a fork of the Kani repository.
-   3. Copy the template file ([`rfc/src/template.md`](./template.md)) to `rfc/src/<ID_NUMBER><my-feature>.md`.
+   3. Copy the template file ([`rfc/src/template.md`](./template.md)) to `rfc/src/rfcs/<ID_NUMBER><my-feature>.md`.
    4. Fill in the details according to the template instructions.
-   5. Submit a pull request.
+   5. Add a link to the new RFC inside [`rfc/src/SUMMARY.md`](https://github.com/model-checking/kani/blob/main/rfc/src/SUMMARY.md)
+   6. Submit a pull request.
 2. Build consensus and integrate feedback.
    1. RFCs should get approved by at least 2 Kani developers.
    2. Once the RFC has been approved, update the RFC status and merge the PR.


### PR DESCRIPTION
### Description of changes: 

We forgot to add a link in the SUMMARY.md to the new function stubbing RFC (#1695). Because of that, the new RFC was not being included in the RFC Book. Fix that and add a step in the RFC instructions.

### Resolved issues:

N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
N/A

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
