### PR TITLE
Update CONTRIBUTING.md to point at the correct licence file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,4 +56,4 @@ See our [security disclosure instructions](.github/SECURITY.md) for more details
 
 Kani is distributed under the terms of both the MIT license and the Apache License (Version 2.0).
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
-We will ask you to confirm the licensing of your contribution.
+By submitting a pull request, you confirm that your contribution is made under the terms of the Apache 2.0 and MIT licenses.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,5 +54,6 @@ See our [security disclosure instructions](.github/SECURITY.md) for more details
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
-
+Kani is distributed under the terms of both the MIT license and the Apache License (Version 2.0).
+See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
+We will ask you to confirm the licensing of your contribution.


### PR DESCRIPTION
### Description of changes: 

Kani is dual-licenced: we have two licence files. Make sure that we reference this correctly in the CONTRIBUTING.md file the same way we do in README.md

### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
