### PR TITLE
Update rust toolchain to nightly 1.66.0-nightly

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -32,4 +32,5 @@ rustflags = [ # Global lints/warnings. Need to use underscore instead of -.
     # New lints that we are not compliant yet
     "-Aclippy::needless-borrow",
     "-Aclippy::bool-to-int-with-if",
+    "-Aclippy::uninlined-format-args",
 ]

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -1264,7 +1264,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// Dynamic function calls first parameter is self which must be one of the following:
     ///
     /// As of Jul 2022:
-    /// `P = &Self | &mut Self | Box<Self> | Rc<Self> | Arc<Self>
+    /// `P = &Self | &mut Self | Box<Self> | Rc<Self> | Arc<Self>`
     /// `S = P | Pin<P>`
     ///
     /// See <https://doc.rust-lang.org/reference/items/traits.html#object-safety> for more details.

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -506,10 +506,10 @@ impl<'tcx> GotocCtx<'tcx> {
         self.codegen_ty(typ).to_pointer()
     }
 
-    /// A reference to a Struct<dyn T> { .., data: T} is translated to
+    /// A reference to a Struct\<dyn T\> { .., data: T} is translated to
     /// struct RefToTrait {
-    ///     Struct<dyn T>* data;
-    ///     Metadata<dyn T>* vtable;
+    ///     Struct\<dyn T\>* data;
+    ///     Metadata\<dyn T\>* vtable;
     /// }
     /// Note: T is a `typedef` but data represents the space in memory occupied by
     /// the concrete type. We just don't know its size during compilation time.
@@ -1264,8 +1264,8 @@ impl<'tcx> GotocCtx<'tcx> {
     /// Dynamic function calls first parameter is self which must be one of the following:
     ///
     /// As of Jul 2022:
-    /// P = &Self | &mut Self | Box<Self> | Rc<Self> | Arc<Self>
-    /// S = P | Pin<P>
+    /// P = &Self | &mut Self | Box\<Self\> | Rc\<Self\> | Arc\<Self\>
+    /// S = P | Pin\<P\>
     ///
     /// See <https://doc.rust-lang.org/reference/items/traits.html#object-safety> for more details.
     fn codegen_dynamic_function_sig(&mut self, sig: PolyFnSig<'tcx>) -> Type {

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -506,10 +506,10 @@ impl<'tcx> GotocCtx<'tcx> {
         self.codegen_ty(typ).to_pointer()
     }
 
-    /// A reference to a Struct\<dyn T\> { .., data: T} is translated to
+    /// A reference to a `Struct<dyn T>` { .., data: T} is translated to
     /// struct RefToTrait {
-    ///     Struct\<dyn T\>* data;
-    ///     Metadata\<dyn T\>* vtable;
+    ///     `Struct<dyn T>* data`;
+    ///     `Metadata<dyn T>* vtable;`
     /// }
     /// Note: T is a `typedef` but data represents the space in memory occupied by
     /// the concrete type. We just don't know its size during compilation time.
@@ -1264,8 +1264,8 @@ impl<'tcx> GotocCtx<'tcx> {
     /// Dynamic function calls first parameter is self which must be one of the following:
     ///
     /// As of Jul 2022:
-    /// P = &Self | &mut Self | Box\<Self\> | Rc\<Self\> | Arc\<Self\>
-    /// S = P | Pin\<P\>
+    /// `P = &Self | &mut Self | Box<Self> | Rc<Self> | Arc<Self>
+    /// `S = P | Pin<P>`
     ///
     /// See <https://doc.rust-lang.org/reference/items/traits.html#object-safety> for more details.
     fn codegen_dynamic_function_sig(&mut self, sig: PolyFnSig<'tcx>) -> Type {

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/names.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/names.rs
@@ -112,7 +112,7 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     /// Add a prefix of the form:
-    /// \[<prefix>\]
+    /// \[\<prefix\>\]
     /// to the provided message
     pub fn add_prefix_to_msg(msg: &str, prefix: &str) -> String {
         format!("[{}] {}", prefix, msg)
@@ -120,7 +120,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
     /// Generate a message for the reachability check of an assert with ID
     /// `check_id`. The message is of the form:
-    /// \[KANI_REACHABILITY_CHECK\] <ID of assert>
+    /// \[KANI_REACHABILITY_CHECK\] \<ID of assert\>
     /// The check_id is generated using the GotocCtx::next_check_id method and
     /// is a unique string identifier for that check.
     pub fn reachability_check_message(check_id: &str) -> String {

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/names.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/names.rs
@@ -112,7 +112,7 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     /// Add a prefix of the form:
-    /// \[\<prefix\>\]
+    /// \[`<prefix>`\]
     /// to the provided message
     pub fn add_prefix_to_msg(msg: &str, prefix: &str) -> String {
         format!("[{}] {}", prefix, msg)
@@ -120,7 +120,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
     /// Generate a message for the reachability check of an assert with ID
     /// `check_id`. The message is of the form:
-    /// \[KANI_REACHABILITY_CHECK\] \<ID of assert\>
+    /// \[KANI_REACHABILITY_CHECK\] `<ID of assert>`
     /// The check_id is generated using the GotocCtx::next_check_id method and
     /// is a unique string identifier for that check.
     pub fn reachability_check_message(check_id: &str) -> String {

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
@@ -90,7 +90,7 @@ impl<'tcx> GotocCtx<'tcx> {
         RAW_PTR_FROM_BOX.iter().fold(box_expr, |expr, name| expr.member(name, &self.symbol_table))
     }
 
-    /// Box<T> initializer
+    /// Box\<T\> initializer
     ///
     /// Traverse over the Box representation and only initialize the raw_ptr field. All other
     /// members are left uninitialized.
@@ -177,7 +177,7 @@ impl<'tcx> GotocCtx<'tcx> {
         }
     }
 
-    /// Best effort check if the struct represents a std::ptr::NonNull<T>.
+    /// Best effort check if the struct represents a std::ptr::NonNull\<T\>.
     ///
     /// This assumes the following structure. Any changes to this will break this code.
     /// ```

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
@@ -90,7 +90,7 @@ impl<'tcx> GotocCtx<'tcx> {
         RAW_PTR_FROM_BOX.iter().fold(box_expr, |expr, name| expr.member(name, &self.symbol_table))
     }
 
-    /// Box\<T\> initializer
+    /// `Box<T>` initializer
     ///
     /// Traverse over the Box representation and only initialize the raw_ptr field. All other
     /// members are left uninitialized.
@@ -177,7 +177,7 @@ impl<'tcx> GotocCtx<'tcx> {
         }
     }
 
-    /// Best effort check if the struct represents a std::ptr::NonNull\<T\>.
+    /// Best effort check if the struct represents a `std::ptr::NonNull<T>`.
     ///
     /// This assumes the following structure. Any changes to this will break this code.
     /// ```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2022-10-11"
+channel = "nightly-2022-10-25"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -70,8 +70,6 @@ for testp in "${TESTS[@]}"; do
   suite=${testl[0]}
   mode=${testl[1]}
   echo "Check compiletest suite=$suite mode=$mode"
-  # Note: `cargo-kani` tests fail if we do not add `$(pwd)` to `--build-base`
-  # Tracking issue: https://github.com/model-checking/kani/issues/755
   cargo run -p compiletest --quiet -- --suite $suite --mode $mode --quiet
 done
 

--- a/tests/ui/code-location/expected
+++ b/tests/ui/code-location/expected
@@ -1,6 +1,6 @@
 module/mod.rs:10:5 in function module::not_empty
 main.rs:13:5 in function same_file
 /toolchains/
-alloc/src/vec/mod.rs:3031:81 in function <std::vec::Vec<i32> as std::ops::Drop>::drop
+alloc/src/vec/mod.rs:3028:81 in function <std::vec::Vec<i32> as std::ops::Drop>::drop
 
 VERIFICATION:- SUCCESSFUL


### PR DESCRIPTION
### Description of changes: 

Update rust tool chain to new nightly build. One expected result was modified for a new line number, and other files were updated for escaping '<' for rustdoc.

* How is this change tested? kani-regressions

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
