### PR TITLE
Add `kani::stub` attribute

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -375,7 +375,10 @@ impl<'tcx> GotocCtx<'tcx> {
         let mut harness = self.default_kanitool_proof();
         for attr in other_attributes.iter() {
             match attr.0.as_str() {
-                "stub" => (), // do nothing
+                "stub" => self
+                    .tcx
+                    .sess
+                    .span_warn(attr.1.span, "Attribute `kani::stub` is currently ignored by Kani"),
                 "unwind" => self.handle_kanitool_unwind(attr.1, &mut harness),
                 _ => {
                     self.tcx.sess.span_err(

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -375,6 +375,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let mut harness = self.default_kanitool_proof();
         for attr in other_attributes.iter() {
             match attr.0.as_str() {
+                "stub" => (), // do nothing
                 "unwind" => self.handle_kanitool_unwind(attr.1, &mut harness),
                 _ => {
                     self.tcx.sess.span_err(

--- a/library/kani_macros/src/lib.rs
+++ b/library/kani_macros/src/lib.rs
@@ -118,3 +118,30 @@ pub fn unwind(attr: TokenStream, item: TokenStream) -> TokenStream {
     result.extend(item);
     result
 }
+
+#[cfg(not(kani))]
+#[proc_macro_attribute]
+pub fn stub(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    // When the config is not kani, we should leave the function alone
+    item
+}
+
+/// Specify a function/method stub pair to use for proof harness
+///
+/// The attribute `#[kani::stub(original, replacement)]` can only be used alongside `#[kani::proof]`.
+///
+/// # Arguments
+/// * `original` - The function or method to replace, specified as a path.
+/// * `replacement` - The function or method to use as a replacement, specified as a path.
+#[cfg(kani)]
+#[proc_macro_attribute]
+pub fn stub(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut result = TokenStream::new();
+
+    // Translate #[kani::stub(original, replacement)] to #[kanitool::stub(original, replacement)]
+    let insert_string = "#[kanitool::stub(".to_owned() + &attr.to_string() + ")]";
+    result.extend(insert_string.parse::<TokenStream>().unwrap());
+
+    result.extend(item);
+    result
+}

--- a/tests/kani/FunctionStubbing/attribute.rs
+++ b/tests/kani/FunctionStubbing/attribute.rs
@@ -1,0 +1,10 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+fn foo() {}
+
+fn bar() {}
+
+#[kani::proof]
+#[kani::stub(foo, bar)]
+fn main() {}

--- a/tests/ui/stub-attribute/attribute.rs
+++ b/tests/ui/stub-attribute/attribute.rs
@@ -1,5 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//! Checks that the `kani::stub` attribute is accepted
 
 fn foo() {}
 

--- a/tests/ui/stub-attribute/expected
+++ b/tests/ui/stub-attribute/expected
@@ -1,0 +1,1 @@
+warning: Attribute `kani::stub` is currently ignored by Kani


### PR DESCRIPTION
### Description of changes: 

Add `kani::stub` attribute and allow harnesses to be annotated with it. This PR does not try to actually parse or use the arguments of the attribute.

### Relate issues:

Related to #1809

### Testing:

* How is this change tested? New regression test

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
