### PR TITLE
Downgrade the toolchain to avoid blocking issue

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2022-10-25"
+channel = "nightly-2022-10-24"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -22,7 +22,7 @@ KANI_DIR=$SCRIPT_DIR/..
 export KANI_FAIL_ON_UNEXPECTED_DESCRIPTION="true"
 
 # Required dependencies
-check-cbmc-version.py --major 5 --minor 67
+check-cbmc-version.py --major 5 --minor 69
 check-cbmc-viewer-version.py --major 3 --minor 5
 
 # Formatting check
@@ -60,7 +60,7 @@ TESTS=(
 
 if [[ "" != "${KANI_ENABLE_UNSOUND_EXPERIMENTS-}" ]]; then
   TESTS+=("unsound_experiments kani")
-else 
+else
   TESTS+=("no_unsound_experiments expected")
 fi
 

--- a/tests/kani/ConstEval/limit.rs
+++ b/tests/kani/ConstEval/limit.rs
@@ -1,0 +1,20 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Ensure that constant propagation can deal with a large number.
+// This test used to trigger https://github.com/rust-lang/rust/issues/103814
+
+const LENGTH: usize = 131072;
+const CONST: usize = {
+    let data = [1; LENGTH];
+    let mut idx = 0;
+    while idx < data.len() {
+        idx += data[idx];
+    }
+    idx
+};
+
+#[kani::proof]
+fn check_eval() {
+    assert_eq!(CONST, LENGTH);
+}


### PR DESCRIPTION
### Description of changes: 

Downgrade the rust toolchain for the nighly before the current version. This mitigates https://github.com/model-checking/kani/issues/1822 which is caused by https://github.com/rust-lang/rust/issues/103814.

Ps.: I also bumped cbmc min version since older versions don't work with Kani.

### Resolved issues:

Mitigates #1822 

### Related RFC:

N/A

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? New test + manually tested against s2n-quic.

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
