### PR TITLE
PropProof: Choice strategy support.

### DIFF
--- a/proptest/src/strategy/unions.rs
+++ b/proptest/src/strategy/unions.rs
@@ -97,7 +97,7 @@ impl<T: Strategy> Union<T> {
         );
         let options: Vec<WA<T>> = options
             .into_iter()
-            .filter(|(w, _)| w > &0)
+            .filter(|(w, _)| *w > 0)
             .map(|(w, v)| (w, Arc::new(v)))
             .collect();
         assert!(!options.is_empty());

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -348,6 +348,21 @@ mod test {
         }
     }
 
+    proptest! {
+    #[test]
+    #[cfg_attr(kani, kani::proof)]
+    fn possible_values_are_even(
+            x in
+        crate::prop_oneof![
+                    1 => Just(0 as u32),
+                    2 => Just(2 as u32),
+                    0 => Just(3 as u32), // cannot be picked
+        ]
+    ) {
+            assert_eq!(x % 2, 0, "Just(3) cannot be picked b/c weight is 0");
+    }
+    }
+
     #[test]
     #[cfg_attr(kani, kani::proof)]
     fn test_pass() {


### PR DESCRIPTION
### Description of changes: 

This PR will add support for strategies that choose between multiple other strategies.

### Resolved issues:

Works towards; #1608 

### Call-outs:

- Placing the test case in `union.rs` triggered a bug where assertion macros were no longer properly replaced with Kani assertions. To avoid this, the test case was put into `runner.rs`. ~~TODO:~~ tracking issue: #1856.

### Testing:

* How is this change tested? `proptest/src/test_runner/runner.rs`

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
