### PR TITLE
Allow assert with custom message to be used in const contexts

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -54,7 +54,7 @@ macro_rules! assert {
         // strategy, which is tracked in
         // https://github.com/model-checking/kani/issues/692
         if false {
-            let _ = format_args!($($arg)+);
+            ::std::panic!($($arg)+);
         }
     }};
 }

--- a/tests/kani/Assert/in_const_fn_args.rs
+++ b/tests/kani/Assert/in_const_fn_args.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test checks that `assert!` with a custom message can be used in a const
+//! fn
+
+const fn const_add(x: i32, y: i32) {
+    assert!(x + y == x, "some message");
+}
+
+#[kani::proof]
+fn check() {
+    let x = kani::any();
+    let y = 0;
+    const_add(x, y);
+}


### PR DESCRIPTION
### Description of changes: 

Currently, Kani fails to compile programs that use the `assert` macro with a custom message in a const context, e.g.
```rust
const fn my_const_fn(x: i32, y: i32) {
    assert!(x + y == 8, "message");
}

#[cfg_attr(kani, kani::proof)]
fn main() {
    let x = 5;
    let y = 3;
    my_const_fn(x, y);
}
```
This is due to Kani's overridden definition of the `assert` macro that uses the `format_args` macro, which [cannot yet be used in a const context](https://doc.rust-lang.org/std/macro.const_format_args.html).

This PR switches the `assert` macro definition to use the `panic` macro instead, which achieves the same effect (parsing of the format argument and emitting any associate warnings/errors).

### Resolved issues:

Resolves #1586 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Added a new test

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
