### PR TITLE
Remove obsolete note on missing output when unwinding forever

### DIFF
--- a/docs/src/tutorial-loop-unwinding.md
+++ b/docs/src/tutorial-loop-unwinding.md
@@ -27,11 +27,6 @@ VERIFICATION:- FAILED
 If we try removing this "unwind" annotation and re-running Kani, the result is worse: non-termination.
 Kani simply doesn't produce a result.
 
-> **NOTE**: Presently, [due to a bug](https://github.com/model-checking/kani/issues/493), this is especially bad: we don't see any output at all.
-> Kani is supposed to emit some log lines that might give some clue that an infinite loop is occurring.
-> If Kani doesn't terminate, it's most frequently the problem that this section covers.
-> The workaround is to use the technique we're demoing here: use `#[kani::unwind(1)]` to force termination of the loops, and work upwards from there.
-
 The problem we're struggling with is the technique Kani uses to verify code.
 We're not able to handle code with "unbounded" loops, and what "bounded" means can be quite subtle.
 It has to have a constant number of iterations that's _"obviously constant"_ enough for the verifier to actually figure this out.


### PR DESCRIPTION
### Description of changes: 

Remove obsolete note on missing output when unwinding forever from the unwinding tutorial section of the docs.

### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
