### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/code---infrastructure-improvement.md
+++ b/.github/ISSUE_TEMPLATE/code---infrastructure-improvement.md
@@ -1,7 +1,6 @@
 ---
 name: Code / Infrastructure Improvement
-about: 'Internal issues that track improvements that don''t affect Kani users, e.g.:
-  CI, code clean up.'
+about: 'Internal issues that track improvements that don't affect Kani users, e.g.: CI, code clean up.'
 title: ''
 labels: "[C] Internal"
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/code---infrastructure-improvement.md
+++ b/.github/ISSUE_TEMPLATE/code---infrastructure-improvement.md
@@ -1,6 +1,6 @@
 ---
 name: Code / Infrastructure Improvement
-about: 'Internal issues that track improvements that don't affect Kani users, e.g.:
+about: 'Internal issues that track improvements that don''t affect Kani users, e.g.:
   CI, code clean up.'
 title: ''
 labels: "[C] Internal"


### PR DESCRIPTION
For some reason, the template added in #1882 is still not showing up. I was wondering if it's because I created it in my local repository and merged it here.

This time, I created the template using our repo settings and I'm using a branch in our repository to see if it works. However, since the template file has already been pushed, the changes are minimum. If this doesn't work, I might have to remove the file and add it again using the github interface.

Other suggestions are welcomed.