### PR TITLE
Update `tracing-tree` dependency to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,12 +1252,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-tree"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07e90b329c621ade432823988574e820212648aa40e7a2497777d58de0fb453"
+checksum = "758e983ab7c54fee18403994507e7f212b9005e957ce7984996fac8d11facedb"
 dependencies = [
- "ansi_term",
  "atty",
+ "nu-ansi-term",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -28,7 +28,7 @@ strum_macros = {version = "0.24.0", optional = true}
 shell-words = "1.0.0"
 tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-subscriber = {version = "0.3.8", features = ["env-filter", "json", "fmt"]}
-tracing-tree = "0.2.0"
+tracing-tree = "0.2.2"
 
 # Future proofing: enable backend dependencies using feature.
 [features]


### PR DESCRIPTION
### Description of changes: 

Update the `tracing-tree` dependency to 0.2.2. Earlier versions depend on the `ansi_term` crate, which is no longer maintained.

### Resolved issues:

Related #1696 

### Testing:

* How is this change tested? Existing tests

* Is this a refactor change? Yes

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
