### PR TITLE
Encode string literals as a byte array

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/assert.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/assert.rs
@@ -18,7 +18,6 @@
 //! 7. `codegen_sanity` : `assert` but not normally displayed as failure would be a Kani bug
 //!
 
-use crate::codegen_cprover_gotoc::utils;
 use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::goto_program::{Expr, Location, Stmt, Type};
 use cbmc::InternedString;
@@ -171,7 +170,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // CBMC requires that the argument to the assertion must be a string constant.
         // If there is one in the MIR, use it; otherwise, explain that we can't.
         assert!(!fargs.is_empty(), "Panic requires a string message");
-        let msg = utils::extract_const_message(&fargs[0]).unwrap_or(String::from(
+        let msg = self.extract_const_message(&fargs[0]).unwrap_or(String::from(
             "This is a placeholder message; Kani doesn't support message formatted at runtime",
         ));
 

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -779,7 +779,7 @@ impl<'tcx> GotocCtx<'tcx> {
             // [T] -> memory location (flexible array)
             // Note: This is not valid C but CBMC seems to be ok with it.
             ty::Slice(e) => self.codegen_ty(*e).flexible_array_of(),
-            ty::Str => Type::c_char().flexible_array_of(),
+            ty::Str => Type::unsigned_int(8).flexible_array_of(),
             ty::Ref(_, t, _) | ty::RawPtr(ty::TypeAndMut { ty: t, .. }) => self.codegen_ty_ref(*t),
             ty::FnDef(def_id, substs) => {
                 let instance =
@@ -1180,7 +1180,7 @@ impl<'tcx> GotocCtx<'tcx> {
             let pretty_name = format!("&{}", self.ty_pretty_name(pointee_type));
             let element_type = match pointee_type.kind() {
                 ty::Slice(elt_type) => self.codegen_ty(*elt_type),
-                ty::Str => Type::c_char(),
+                ty::Str => Type::unsigned_int(8),
                 // For adt, see https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp
                 ty::Adt(..) => self.codegen_ty(pointee_type),
                 kind => unreachable!("Generating a slice fat pointer to {:?}", kind),

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -59,6 +59,7 @@ pub struct GotocCtx<'tcx> {
     pub current_fn: Option<CurrentFnCtx<'tcx>>,
     pub type_map: FxHashMap<InternedString, Ty<'tcx>>,
     /// map from symbol identifier to string literal
+    /// TODO: consider making the map from Expr to String instead
     pub str_literals: FxHashMap<InternedString, String>,
     pub proof_harnesses: Vec<HarnessMetadata>,
     pub test_harnesses: Vec<HarnessMetadata>,

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -58,6 +58,8 @@ pub struct GotocCtx<'tcx> {
     pub vtable_ctx: VtableCtx,
     pub current_fn: Option<CurrentFnCtx<'tcx>>,
     pub type_map: FxHashMap<InternedString, Ty<'tcx>>,
+    /// map from symbol identifier to string literal
+    pub str_literals: FxHashMap<InternedString, String>,
     pub proof_harnesses: Vec<HarnessMetadata>,
     pub test_harnesses: Vec<HarnessMetadata>,
     /// a global counter for generating unique IDs for checks
@@ -84,6 +86,7 @@ impl<'tcx> GotocCtx<'tcx> {
             vtable_ctx: VtableCtx::new(emit_vtable_restrictions),
             current_fn: None,
             type_map: FxHashMap::default(),
+            str_literals: FxHashMap::default(),
             proof_harnesses: vec![],
             test_harnesses: vec![],
             global_checks_count: 0,

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -9,7 +9,6 @@
 //! this module addresses this issue.
 
 use crate::codegen_cprover_gotoc::codegen::PropertyClass;
-use crate::codegen_cprover_gotoc::utils;
 use crate::codegen_cprover_gotoc::GotocCtx;
 use crate::unwrap_or_return_codegen_unimplemented_stmt;
 use cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, Type};
@@ -68,7 +67,7 @@ impl<'tcx> GotocHook<'tcx> for ExpectFail {
 
         // Add "EXPECTED FAIL" to the message because compiletest relies on it
         let msg =
-            format!("EXPECTED FAIL: {}", utils::extract_const_message(&fargs.remove(0)).unwrap());
+            format!("EXPECTED FAIL: {}", tcx.extract_const_message(&fargs.remove(0)).unwrap());
 
         let loc = tcx.codegen_span_option(span);
         Stmt::block(
@@ -129,7 +128,7 @@ impl<'tcx> GotocHook<'tcx> for Assert {
         assert_eq!(fargs.len(), 2);
         let cond = fargs.remove(0).cast_to(Type::bool());
         let msg = fargs.remove(0);
-        let msg = utils::extract_const_message(&msg).unwrap();
+        let msg = tcx.extract_const_message(&msg).unwrap();
         let target = target.unwrap();
         let caller_loc = tcx.codegen_caller_span(&span);
 

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
@@ -18,25 +18,6 @@ pub fn dynamic_fat_ptr(typ: Type, data: Expr, vtable: Expr, symbol_table: &Symbo
     Expr::struct_expr(typ, btree_string_map![("data", data), ("vtable", vtable)], symbol_table)
 }
 
-/// Tries to extract a string message from an `Expr`.
-/// If the expression represents a pointer to a string constant, this will return the string
-/// constant. Otherwise, return `None`.
-pub fn extract_const_message(arg: &Expr) -> Option<String> {
-    match arg.value() {
-        ExprValue::Struct { values } => match &values[0].value() {
-            ExprValue::AddressOf(address) => match address.value() {
-                ExprValue::Index { array, .. } => match array.value() {
-                    ExprValue::StringConstant { s } => Some(s.to_string()),
-                    _ => None,
-                },
-                _ => None,
-            },
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
 impl<'tcx> GotocCtx<'tcx> {
     /// Generates an expression `(ptr as usize) % align_of(T) == 0`
     /// to determine if a pointer `ptr` with pointee type `T` is aligned.
@@ -60,6 +41,30 @@ impl<'tcx> GotocCtx<'tcx> {
             s.push_str(url);
         }
         s
+    }
+
+    /// Tries to extract a string message from an `Expr`.  If the expression is
+    /// a pointer to a variable that represents a string literal (as created in
+    /// codegen_slice_value), this will return the string constant. Otherwise,
+    /// return `None`.
+    pub fn extract_const_message(&self, arg: &Expr) -> Option<String> {
+        match arg.value() {
+            ExprValue::Struct { values } => match &values[0].value() {
+                ExprValue::Typecast(expr) => match expr.value() {
+                    ExprValue::AddressOf(address) => match address.value() {
+                        ExprValue::Symbol { identifier } => {
+                            // lookup the string literal in the goto context
+                            let name = self.str_literals.get(identifier).unwrap();
+                            Some(name.clone())
+                        }
+                        _ => None,
+                    },
+                    _ => None,
+                },
+                _ => None,
+            },
+            _ => None,
+        }
     }
 }
 

--- a/tests/expected/offset-u8-fail/main.rs
+++ b/tests/expected/offset-u8-fail/main.rs
@@ -12,6 +12,6 @@ fn test_offset() {
     let ptr: *const u8 = s.as_ptr();
 
     unsafe {
-        let x = *offset(ptr, 4) as char;
+        let x = *offset(ptr, 3) as char;
     }
 }

--- a/tests/kani/Intrinsics/ArithOffset/offset_u8_ok.rs
+++ b/tests/kani/Intrinsics/ArithOffset/offset_u8_ok.rs
@@ -17,8 +17,8 @@ fn test_arith_offset() {
         assert_eq!(*arith_offset(ptr, 2).sub(1) as char, '2');
 
         // This is okay because it's one byte past the object,
-        // but there is nothing we can assert about it
-        let x = arith_offset(ptr, 3);
+        // but dereferencing it is UB
+        let _x = arith_offset(ptr, 3);
 
         // Check that the results are the same with a pointer
         // that goes 1 element behind the original one

--- a/tests/kani/Intrinsics/ArithOffset/offset_u8_ok.rs
+++ b/tests/kani/Intrinsics/ArithOffset/offset_u8_ok.rs
@@ -18,7 +18,7 @@ fn test_arith_offset() {
 
         // This is okay because it's one byte past the object,
         // but there is nothing we can assert about it
-        let x = *arith_offset(ptr, 3);
+        let x = arith_offset(ptr, 3);
 
         // Check that the results are the same with a pointer
         // that goes 1 element behind the original one

--- a/tests/kani/Intrinsics/Offset/offset_u8_ok.rs
+++ b/tests/kani/Intrinsics/Offset/offset_u8_ok.rs
@@ -18,7 +18,7 @@ fn test_offset() {
 
         // This is okay because it's one byte past the object,
         // but there is nothing we can assert about it
-        let x = *offset(ptr, 3);
+        let x = offset(ptr, 3);
 
         // Check that the results are the same with a pointer
         // that goes 1 element behind the original one

--- a/tests/kani/Intrinsics/Offset/offset_u8_ok.rs
+++ b/tests/kani/Intrinsics/Offset/offset_u8_ok.rs
@@ -17,8 +17,8 @@ fn test_offset() {
         assert_eq!(*offset(ptr, 2).sub(1) as char, '2');
 
         // This is okay because it's one byte past the object,
-        // but there is nothing we can assert about it
-        let x = offset(ptr, 3);
+        // but dereferencing it is UB
+        let _x = offset(ptr, 3);
 
         // Check that the results are the same with a pointer
         // that goes 1 element behind the original one

--- a/tests/kani/Str/utf8.rs
+++ b/tests/kani/Str/utf8.rs
@@ -1,0 +1,15 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// This test checks that Kani handles UTF-8-encoded string literals correctly
+
+#[kani::proof]
+fn check_utf8() {
+    let s = "⌚⌛⛪";
+
+    let mut chars = s.chars();
+    assert_eq!(chars.next(), Some('⌚'));
+    assert_eq!(chars.next(), Some('⌛'));
+    assert_eq!(chars.next(), Some('⛪'));
+    assert_eq!(chars.next(), None);
+}


### PR DESCRIPTION
### Description of changes: 

Kani currently encodes string slices (`str`) as null-terminated C slices, which is unsound. This PR changes the encoding to a byte array to guarantee that Kani reports pointer accesses outside the slice as invalid dereferences.

### Resolved issues:

Resolves #1665 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? A new test was added, and existing tests were slightly modified

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
