### PR TITLE
Update `kani-compiler` to use `clap` v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "clap 4.0.24",
+ "clap 4.0.25",
  "which",
 ]
 
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.24"
+version = "4.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60494cedb60cb47462c0ff7be53de32c0e42a6fc2c772184554fa12bd9489c03"
+checksum = "389ca505fd2c00136e0d0cd34bcd8b6bd0b59d5779aab396054b716334230c1c"
 dependencies = [
  "atty",
  "bitflags",
@@ -441,7 +441,7 @@ dependencies = [
  "ar",
  "atty",
  "bitflags",
- "clap 2.34.0",
+ "clap 4.0.25",
  "cprover_bindings",
  "home",
  "kani_metadata",

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -13,7 +13,7 @@ ar = { version = "0.9.0", optional = true }
 atty = "0.2.14"
 bitflags = { version = "1.0", optional = true }
 cbmc = { path = "../cprover_bindings", package = "cprover_bindings", optional = true }
-clap = "2.33.0"
+clap = { version = "4.0.25", features = ["cargo"] }
 home = "0.5"
 kani_queries = {path = "kani_queries"}
 kani_metadata = { path = "../kani_metadata", optional = true }

--- a/kani-compiler/src/parser.rs
+++ b/kani-compiler/src/parser.rs
@@ -1,12 +1,11 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use clap::{
-    app_from_crate, crate_authors, crate_description, crate_name, crate_version, App, AppSettings,
-    Arg, ArgMatches,
-};
+use clap::value_parser;
+use clap::{builder::PossibleValuesParser, command, Arg, ArgAction, ArgMatches, Command};
 use kani_queries::ReachabilityType;
 use std::env;
+use std::ffi::OsString;
 use std::str::FromStr;
 use strum::VariantNames as _;
 
@@ -65,119 +64,135 @@ const KANIFLAGS_ENV_VAR: &str = "KANIFLAGS";
 const KANI_ARGS_FLAG: &str = "--kani-flags";
 
 /// Configure command options for the Kani compiler.
-pub fn parser<'a, 'b>() -> App<'a, 'b> {
-    let app = app_from_crate!()
-        .setting(AppSettings::TrailingVarArg) // This allow us to fwd commands to rustc.
-        .setting(clap::AppSettings::AllowLeadingHyphen)
-        .version_short("?")
+pub fn parser() -> Command {
+    let app = command!()
+        .disable_version_flag(true)
         .arg(
-            Arg::with_name(KANI_LIB)
-                .long("--kani-lib")
+            Arg::new("kani-compiler-version")
+                .short('?')
+                .action(ArgAction::Version)
+                .help("Gets `kani-compiler` version."),
+        )
+        .arg(
+            Arg::new(KANI_LIB)
+                .long(KANI_LIB)
                 .value_name("FOLDER_PATH")
                 .help("Sets the path to locate the kani library.")
-                .takes_value(true),
+                .action(ArgAction::Set),
         )
         .arg(
-            Arg::with_name(GOTO_C)
-                .long("--goto-c")
-                .help("Enables compilation to goto-c intermediate representation."),
+            Arg::new(GOTO_C)
+                .long(GOTO_C)
+                .help("Enables compilation to goto-c intermediate representation.")
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name(SYM_TABLE_PASSES)
-                .long("--symbol-table-passes")
+            Arg::new(SYM_TABLE_PASSES)
+                .long(SYM_TABLE_PASSES)
                 .value_name("PASS")
                 .help("Transformations to perform to the symbol table after it has been generated.")
-                .takes_value(true)
-                .use_delimiter(true)
-                .multiple(true),
+                .value_delimiter(',')
+                .value_parser(value_parser!(OsString)) // Allow invalid UTF-8
+                .action(ArgAction::Append),
         )
         .arg(
-            Arg::with_name(LOG_LEVEL)
-                .long("--log-level")
-                .takes_value(true)
-                .possible_values(&["error", "warn", "info", "debug", "trace"])
+            Arg::new(LOG_LEVEL)
+                .long(LOG_LEVEL)
+                .value_parser(["error", "warn", "info", "debug", "trace"])
                 .value_name("LOG_LEVEL")
                 .help(
                     "Sets the maximum log level to the value given. Use KANI_LOG for more granular \
             control.",
-                ),
+                )
+                .action(ArgAction::Set),
         )
         .arg(
-            Arg::with_name(JSON_OUTPUT)
-                .long("--json-output")
-                .help("Print output including logs in json format."),
+            Arg::new(JSON_OUTPUT)
+                .long(JSON_OUTPUT)
+                .help("Print output including logs in json format.")
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name(COLOR_OUTPUT)
-                .long("--color-output")
+            Arg::new(COLOR_OUTPUT)
+                .long(COLOR_OUTPUT)
                 .help("Print output using colors.")
-                .conflicts_with(JSON_OUTPUT),
+                .conflicts_with(JSON_OUTPUT)
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name(RESTRICT_FN_PTRS)
-                .long("--restrict-vtable-fn-ptrs")
-                .help("Restrict the targets of virtual table function pointer calls."),
+            Arg::new(RESTRICT_FN_PTRS)
+                .long(RESTRICT_FN_PTRS)
+                .help("Restrict the targets of virtual table function pointer calls.")
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name(SYSROOT)
-                .long("--sysroot")
-                .takes_value(true)
+            Arg::new(SYSROOT)
+                .long(SYSROOT)
                 .help("Override the system root.")
                 .long_help(
                     "The \"sysroot\" is the location where Kani will look for the Rust \
                 distribution.",
-                ),
+                )
+                .action(ArgAction::Set),
         )
         .arg(
             // TODO: Move this to a cargo wrapper. This should return kani version.
-            Arg::with_name(RUSTC_VERSION)
-                .short("V")
-                .long("--version")
-                .help("Gets underlying rustc version."),
+            Arg::new(RUSTC_VERSION)
+                .short('V')
+                .long("version")
+                .help("Gets underlying rustc version.")
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name(RUSTC_OPTIONS)
+            Arg::new(RUSTC_OPTIONS)
                 .help("Arguments to be passed down to rustc.")
-                .multiple(true)
-                .takes_value(true),
+                .trailing_var_arg(true) // This allow us to fwd commands to rustc.
+                .allow_hyphen_values(true)
+                .value_parser(value_parser!(OsString)) // Allow invalid UTF-8
+                .action(ArgAction::Append),
         )
         .arg(
-            Arg::with_name(ASSERTION_REACH_CHECKS)
-                .long("--assertion-reach-checks")
-                .help("Check the reachability of every assertion."),
+            Arg::new(ASSERTION_REACH_CHECKS)
+                .long(ASSERTION_REACH_CHECKS)
+                .help("Check the reachability of every assertion.")
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name(REACHABILITY)
-                .long(REACHABILITY_FLAG)
-                .possible_values(ReachabilityType::VARIANTS)
+            Arg::new(REACHABILITY)
+                .long(REACHABILITY)
+                .value_parser(PossibleValuesParser::new(ReachabilityType::VARIANTS))
                 .required(false)
                 .default_value(ReachabilityType::None.as_ref())
-                .help("Selects the type of reachability analysis to perform."),
+                .help("Selects the type of reachability analysis to perform.")
+                .action(ArgAction::Set),
         )
         .arg(
-            Arg::with_name(PRETTY_OUTPUT_FILES)
-                .long("--pretty-json-files")
-                .help("Output json files in a more human-readable format (with spaces)."),
+            Arg::new(PRETTY_OUTPUT_FILES)
+                .long(PRETTY_OUTPUT_FILES)
+                .help("Output json files in a more human-readable format (with spaces).")
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name(IGNORE_GLOBAL_ASM)
-                .long("--ignore-global-asm")
-                .help("Suppress error due to the existence of global_asm in a crate"),
+            Arg::new(IGNORE_GLOBAL_ASM)
+                .long(IGNORE_GLOBAL_ASM)
+                .help("Suppress error due to the existence of global_asm in a crate")
+                .action(ArgAction::SetTrue),
         )
         .arg(
             // TODO: Remove this argument once stubbing works for multiple harnesses at a time.
             // <https://github.com/model-checking/kani/issues/1841>
-            Arg::with_name(HARNESS)
-                .long("--harness")
+            Arg::new(HARNESS)
+                .long(HARNESS)
                 .help("Selects the harness to target.")
                 .value_name("HARNESS")
-                .takes_value(true),
+                .action(ArgAction::Set),
         )
         .arg(
-            Arg::with_name(ENABLE_STUBBING)
-                .long("--enable-stubbing")
+            Arg::new(ENABLE_STUBBING)
+                .long(ENABLE_STUBBING)
                 .help("Instruct the compiler to perform stubbing.")
-                .requires(HARNESS),
+                .requires(HARNESS)
+                .action(ArgAction::SetTrue),
         );
     #[cfg(feature = "unsound_experiments")]
     let app = crate::unsound_experiments::arg_parser::add_unsound_experiments_to_parser(app);
@@ -189,9 +204,9 @@ pub trait KaniCompilerParser {
     fn reachability_type(&self) -> ReachabilityType;
 }
 
-impl<'a> KaniCompilerParser for ArgMatches<'a> {
+impl KaniCompilerParser for ArgMatches {
     fn reachability_type(&self) -> ReachabilityType {
-        self.value_of(REACHABILITY)
+        self.get_one::<String>(REACHABILITY)
             .map_or(ReachabilityType::None, |arg| ReachabilityType::from_str(arg).unwrap())
     }
 }
@@ -235,7 +250,7 @@ pub fn command_arguments(args: &Vec<String>) -> Vec<String> {
 
 #[cfg(test)]
 mod parser_test {
-    use clap::ErrorKind;
+    use clap::error::ErrorKind;
 
     use super::*;
 
@@ -243,28 +258,28 @@ mod parser_test {
     fn test_rustc_version() {
         let args = vec!["kani-compiler", "-V"];
         let matches = parser().get_matches_from(args);
-        assert!(matches.is_present("rustc-version"));
+        assert!(matches.get_flag("rustc-version"));
     }
 
     #[test]
     fn test_kani_flags() {
         let args = vec!["kani-compiler", "--goto-c", "--kani-lib", "some/path"];
         let matches = parser().get_matches_from(args);
-        assert!(matches.is_present("goto-c"));
-        assert_eq!(matches.value_of("kani-lib"), Some("some/path"));
+        assert!(matches.get_flag("goto-c"));
+        assert_eq!(matches.get_one::<String>("kani-lib"), Some(&"some/path".to_string()));
     }
 
     #[test]
     fn test_stubbing_flags() {
         let args = vec!["kani-compiler", "--enable-stubbing", "--harness", "foo"];
         let matches = parser().get_matches_from(args);
-        assert!(matches.is_present("enable-stubbing"));
-        assert_eq!(matches.value_of("harness"), Some("foo"));
+        assert!(matches.get_flag("enable-stubbing"));
+        assert_eq!(matches.get_one::<String>("harness"), Some(&"foo".to_string()));
 
         // `--enable-stubbing` cannot be called without `--harness`
         let args = vec!["kani-compiler", "--enable-stubbing"];
-        let err = parser().get_matches_from_safe(args).unwrap_err();
-        assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+        let err = parser().try_get_matches_from(args).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     }
 
     #[test]

--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -55,13 +55,13 @@ pub fn init_session(args: &ArgMatches) {
 /// Initialize the logger using the KANI_LOG environment variable and the --log-level argument.
 fn init_logger(args: &ArgMatches) {
     let filter = EnvFilter::from_env(LOG_ENV_VAR);
-    let filter = if let Some(log_level) = args.value_of(parser::LOG_LEVEL) {
+    let filter = if let Some(log_level) = args.get_one::<String>(parser::LOG_LEVEL) {
         filter.add_directive(Directive::from_str(log_level).unwrap())
     } else {
         filter
     };
 
-    if args.is_present(parser::JSON_OUTPUT) {
+    if args.get_flag(parser::JSON_OUTPUT) {
         json_logs(filter);
     } else {
         hier_logs(args, filter);
@@ -77,7 +77,7 @@ fn json_logs(filter: EnvFilter) {
 
 /// Configure global logger to use a hierarchical view.
 fn hier_logs(args: &ArgMatches, filter: EnvFilter) {
-    let use_colors = atty::is(atty::Stream::Stdout) || args.is_present(parser::COLOR_OUTPUT);
+    let use_colors = atty::is(atty::Stream::Stdout) || args.get_flag(parser::COLOR_OUTPUT);
     let subscriber = Registry::default().with(filter);
     let subscriber = subscriber.with(
         HierarchicalLayer::default()

--- a/kani-compiler/src/unsound_experiments/arg_parser.rs
+++ b/kani-compiler/src/unsound_experiments/arg_parser.rs
@@ -2,20 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #![cfg(feature = "unsound_experiments")]
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use kani_queries::{QueryDb, UserInput};
 /// Option used for zero initilizing variables.
 const ZERO_INIT_VARS: &str = "unsound-experiment-zero-init-vars";
 
-pub fn add_unsound_experiments_to_parser<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
+pub fn add_unsound_experiments_to_parser(app: Command) -> Command {
     app.arg(
-        Arg::with_name(ZERO_INIT_VARS)
+        Arg::new(ZERO_INIT_VARS)
             .long(ZERO_INIT_VARS)
-            .help("POTENTIALLY UNSOUND EXPERIMENTAL FEATURE. Zero initialize variables"),
+            .help("POTENTIALLY UNSOUND EXPERIMENTAL FEATURE. Zero initialize variables")
+            .action(ArgAction::SetTrue),
     )
 }
 
 pub fn add_unsound_experiment_args_to_queries(queries: &mut QueryDb, matches: &ArgMatches) {
     queries.get_unsound_experiments().lock().unwrap().zero_init_vars =
-        matches.is_present(ZERO_INIT_VARS);
+        matches.get_flag(ZERO_INIT_VARS);
 }


### PR DESCRIPTION
### Description of changes: 

Update `kani-compiler` to use `clap` v4, which has a slightly different builder API than `clap` v2 (which is what it is currently using). I followed the [migration guide](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#migrating). This is part of removing our (transitive) dependency on the unmaintained `ansi_term` crate (#1696).

### Resolved issues:

Resolves #1902 

### Related RFC:

### Call-outs:

- The old code specified that `-?` should return the `kani-compiler` version (`-V` is used to return the rustc version). However, when I tried to actually use `-?` with the old parser, it does not work. The new parser does correctly handle this argument, although I'm not sure if it something we genuinely want (or if it was in the original code as some sort of hack).
- Do we want to allow non-valid UTF-8 in arguments? I tried to reproduce the behavior of the old parser, so that the new parser panics in the same places where the old parser would have. In particular, there are some cases where the panic would have occurred in `clap`, and other cases where the old parser extracts an `OsString` from `clap` and then panics when trying to convert it to a string. However, as far as I can tell, the old parser always panic one way or another on non-valid UTF-8; in this case, it seems cleaner just to instruct `clap` to disallow it entirely.

### Testing:

* How is this change tested? Existing tests

* Is this a refactor change? Yes

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
