### PR TITLE
Remove github action version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Check action code
-        uses: actions/checkout@v2
-        with:
-            repository: model-checking/kani-github-action
-            path: kani-action
-
       - name: Get version
         run: |
           # pkgid is something like file:///home/ubuntu/kani#kani-verifier:0.1.0
@@ -41,12 +35,6 @@ jobs:
           if [[ ${{ env.CRATE_VERSION }} != ${{ env.TAG_VERSION }} ]]; then
             echo "Git tag ${{env.TAG_VERSION}} did not match crate version ${{env.CRATE_VERSION}}"
             exit 1
-          fi
-          # Check the action script's tag.
-          if ! grep -F "KANI_VERSION=\"${{ env.TAG_VERSION }}" kani-action/action.yml; then
-            echo "Git tag ${{env.TAG_VERSION}} did not match version in action.yml. Found:"
-            grep -F "KANI_VERSION=" kani-action/action.yml
-            exit 1;
           fi
 
       - name: Create release


### PR DESCRIPTION
### Description of changes: 

We currently have a circular dependency. The action repository cannot be on the same version as Kani by the time we run the release workflow.

The github action CI enforces that the tracking version has been released. So we can't really update the github action until the release is complete.

### Resolved issues:

### Related RFC:

### Call-outs:

This is a short term fix. We should figure out a better testing strategy later.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
