### PR TITLE
Let's try dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Description of changes: 

This seems like a simple and quick addition, so let's see what happens.

This should get us dependency update PRs (for cargo deps + github actions) every monday, if I'm reading the docs right.

### Call-outs:

This is the config for dependabot updates, which is different from the dependabot alerts thing that just checks for security issues.

One thing I'm concerned about is the lack of grouped updates: https://github.com/dependabot/dependabot-core/issues/1190

We might get a PR for every updated dependency individually, which is maybe awful and not what we want.

### Testing:

* How is this change tested? yolo

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
