### PR TITLE
Workarounds for "unsupported features" experiments

### DIFF
--- a/scripts/exps/kani-run-on-repos.sh
+++ b/scripts/exps/kani-run-on-repos.sh
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT'
 export SELF_SCRIPT=$0
 export SELF_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 NPROC=$(nproc 2> /dev/null || sysctl -n hw.ncpu 2> /dev/null || echo 4)  # Linux or Mac or hard-coded default of 4
-export WORK_DIRECTORY_PREFIX="$SELF_DIR/../../target/remote-repos"
+export WORK_DIRECTORY_PREFIX="/tmp/remote-repos"
 export TMP_UNSUPPORTED_FEATURES_DATA="/tmp/unsupported_features_data.txt"
 
 export STDOUT_SUFFIX='stdout.cargo-kani'

--- a/scripts/exps/kani-run-on-repos.sh
+++ b/scripts/exps/kani-run-on-repos.sh
@@ -54,7 +54,7 @@ function clone_and_run_kani {
 
     # run cargo kani compile on repo. save results to file.
     PATH=$PATH:$(readlink -f $SELF_DIR/..)
-    (cd $REPO_DIRECTORY; nice -n15 cargo kani --only-codegen) \
+    (cd $REPO_DIRECTORY; nice -n15 cargo kani --only-codegen --legacy-linker) \
          1> $REPO_DIRECTORY/$STDOUT_SUFFIX \
          2> $REPO_DIRECTORY/$STDERR_SUFFIX
     echo $? > $REPO_DIRECTORY/$EXIT_CODE_SUFFIX


### PR DESCRIPTION
### Description of changes: 

Commits a couple of workarounds for the "unsupported features" experiment that I've had to use for some weeks now:
 * Use `/tmp/remote-repos` as the work directory (to avoid #1890)
 * Use `--legacy-linker` so the results aren't empty.

### Testing:

* How is this change tested? Manually, running the experiment.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
