### PR TITLE
Fix a few rustdoc warnings

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -135,8 +135,8 @@ impl<'tcx> GotocCtx<'tcx> {
         }
     }
 
-    /// c.f. rustc_codegen_llvm::intrinsic impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx>
-    /// fn codegen_intrinsic_call
+    /// c.f. `rustc_codegen_llvm::intrinsic` `impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx>`
+    /// `fn codegen_intrinsic_call`
     /// c.f. <https://doc.rust-lang.org/std/intrinsics/index.html>
     fn codegen_intrinsic(
         &mut self,
@@ -1240,7 +1240,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
     /// This function computes the size and alignment of a dynamically-sized type.
     /// The implementations follows closely the SSA implementation found in
-    /// rustc_codegen_ssa::glue::size_and_align_of_dst.
+    /// `rustc_codegen_ssa::glue::size_and_align_of_dst`.
     fn size_and_align_of_dst(&self, t: Ty<'tcx>, arg: Expr) -> SizeAlign {
         let layout = self.layout_of(t);
         let usizet = Type::size_t();

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
@@ -45,7 +45,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
     /// Tries to extract a string message from an `Expr`.  If the expression is
     /// a pointer to a variable that represents a string literal (as created in
-    /// codegen_slice_value), this will return the string constant. Otherwise,
+    /// `codegen_slice_value`), this will return the string constant. Otherwise,
     /// return `None`.
     pub fn extract_const_message(&self, arg: &Expr) -> Option<String> {
         match arg.value() {
@@ -122,25 +122,25 @@ impl<'tcx> GotocCtx<'tcx> {
         })
     }
 
-    /// Best effort check if the struct represents a rust "std::alloc::Global".
+    /// Best effort check if the struct represents a rust `std::alloc::Global`
     fn assert_is_rust_global_alloc_like(&self, t: &Type) {
-        // TODO: A std::alloc::Global appears to be an empty struct, in the cases we've seen.
+        // TODO: A `std::alloc::Global` appears to be an empty struct, in the cases we've seen.
         // Is there something smarter we can do here?
         assert!(t.is_struct_like());
         let components = t.lookup_components(&self.symbol_table).unwrap();
         assert_eq!(components.len(), 0);
     }
 
-    /// Best effort check if the struct represents a rust "std::marker::PhantomData".
+    /// Best effort check if the struct represents a rust `std::marker::PhantomData`
     fn assert_is_rust_phantom_data_like(&self, t: &Type) {
-        // TODO: A std::marker::PhantomData appears to be an empty struct, in the cases we've seen.
+        // TODO: A `std::marker::PhantomData` appears to be an empty struct, in the cases we've seen.
         // Is there something smarter we can do here?
         assert!(t.is_struct_like());
         let components = t.lookup_components(&self.symbol_table).unwrap();
         assert_eq!(components.len(), 0);
     }
 
-    /// Best effort check if the struct represents a Rust "Box". May return false positives.
+    /// Best effort check if the struct represents a Rust `Box`. May return false positives.
     fn assert_is_rust_box_like(&self, t: &Type) {
         // struct std::boxed::Box<[u8; 8]>::15334369982748499855
         // {
@@ -161,7 +161,7 @@ impl<'tcx> GotocCtx<'tcx> {
         }
     }
 
-    /// Checks if the struct represents a Rust "std::ptr::Unique"
+    /// Checks if the struct represents a Rust `std::ptr::Unique`
     fn assert_is_rust_unique_pointer_like(&self, t: &Type) {
         // struct std::ptr::Unique<[u8; 8]>::14713681870393313245
         // {

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -58,7 +58,7 @@ pub struct KaniArgs {
     #[structopt(long, hidden = true, requires("enable-unstable"))]
     pub assess: bool,
 
-    /// Generate visualizer report to <target-dir>/report/html/index.html
+    /// Generate visualizer report to `<target-dir>/report/html/index.html`
     #[structopt(long)]
     pub visualize: bool,
     /// Generate concrete playback unit test.

--- a/kani-driver/src/args_toml.rs
+++ b/kani-driver/src/args_toml.rs
@@ -31,7 +31,7 @@ pub fn join_args(input_args: Vec<OsString>) -> Result<Vec<OsString>> {
 /// flag must only be included once.
 ///
 /// This function will return the arguments in the following order:
-/// ```
+/// ```text
 /// <bin_name> [<cfg_kani_args>]* [<cmd_kani_args>]* [--cbmc-args [<cfg_cbmc_args>]* [<cmd_cbmc_args>]*]
 /// ```
 fn merge_args(

--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -150,10 +150,10 @@ fn glob(path: &Path) -> Result<Vec<PathBuf>> {
 }
 
 /// Extract the packages that should be verified.
-/// If --package <pkg> is given, return the list of packages selected.
-/// If --workspace is given, return the list of workspace members.
+/// If `--package <pkg>` is given, return the list of packages selected.
+/// If `--workspace` is given, return the list of workspace members.
 /// If no argument provided, return the root package if there's one or all members.
-///   - I.e.: Do whatever cargo does when there's no default_members.
+///   - I.e.: Do whatever cargo does when there's no `default_members`.
 ///   - This is because `default_members` is not available in cargo metadata.
 ///     See <https://github.com/rust-lang/cargo/issues/8033>.
 fn packages_to_verify<'a, 'b>(args: &'a KaniArgs, metadata: &'b Metadata) -> Vec<&'b Package> {

--- a/kani-driver/src/cbmc_property_renderer.rs
+++ b/kani-driver/src/cbmc_property_renderer.rs
@@ -526,11 +526,11 @@ fn update_properties_with_reach_status(
 }
 
 /// Some Kani-generated asserts have a unique ID in their description of the form:
-/// ```
+/// ```text
 /// [KANI_CHECK_ID_<crate-fn-name>_<index>]
 /// ```
 /// e.g.:
-/// ```
+/// ```text
 /// [KANI_CHECK_ID_foo.6875c808::foo_0] assertion failed: x % 2 == 0
 /// ```
 /// This function removes those IDs from the property's description so that
@@ -591,21 +591,21 @@ fn filter_ptr_checks(properties: Vec<Property>) -> Vec<Property> {
 
 /// When assertion reachability checks are turned on, Kani prefixes each
 /// assert's description with an ID of the following form:
-/// ```
+/// ```text
 /// [KANI_CHECK_ID_<crate-name>_<index-of-check>]
 /// ```
 /// e.g.:
-/// ```
+/// ```text
 /// [KANI_CHECK_ID_foo.6875c808::foo_0] assertion failed: x % 2 == 0
 /// ```
 /// In addition, the description of each reachability check that it generates
 /// includes the ID of the assert for which we want to check its reachability.
 /// The description of a reachability check uses the following template:
-/// ```
+/// ```text
 /// [KANI_REACHABILITY_CHECK] <ID of original assert>
 /// ```
 /// e.g.:
-/// ```
+/// ```text
 /// [KANI_REACHABILITY_CHECK] KANI_CHECK_ID_foo.6875c808::foo_0
 /// ```
 /// This function first collects all data from reachability checks. Then,

--- a/tools/build-kani/src/sysroot.rs
+++ b/tools/build-kani/src/sysroot.rs
@@ -8,7 +8,7 @@
 //! - `legacy-lib/`: Kani libraries built based on the the toolchain standard libraries.
 //!
 //! Rustc expects the sysroot to have a specific folder layout:
-//! {SYSROOT}/rustlib/<target-triplet>/lib/<libraries>
+//! `{SYSROOT}/rustlib/<target-triplet>/lib/<libraries>`
 //!
 //! Note: We don't cross-compile. Target is the same as the host.
 


### PR DESCRIPTION
### Description of changes: 

Mostly trivial, but eliminates the current warnings our regression gets from rustdoc.

Plus a few other formatting fixes I noticed along the way.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
