### PR TITLE
Update `kani-driver` to use `clap` v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,15 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,7 +86,7 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "clap 4.0.26",
+ "clap",
  "which",
 ]
 
@@ -139,21 +130,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "4.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
@@ -163,7 +139,7 @@ dependencies = [
  "clap_derive",
  "clap_lex",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
 ]
 
@@ -173,7 +149,7 @@ version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -380,15 +356,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -441,7 +408,7 @@ dependencies = [
  "ar",
  "atty",
  "bitflags",
- "clap 4.0.26",
+ "clap",
  "cprover_bindings",
  "home",
  "kani_metadata",
@@ -469,7 +436,7 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "clap 2.34.0",
+ "clap",
  "comfy-table",
  "console",
  "glob",
@@ -481,7 +448,6 @@ dependencies = [
  "rustc-demangle",
  "serde",
  "serde_json",
- "structopt",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -1041,39 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "strum"
@@ -1087,7 +1023,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1122,15 +1058,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1276,12 +1203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,12 +1213,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -24,8 +24,7 @@ console = "0.15.1"
 once_cell = "1.13.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-structopt = "0.3"
-clap = "2.34"
+clap = { version = "4.0.26", features = ["derive"] }
 glob = "0.3"
 toml = "0.5"
 regex = "1.6"

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -4,142 +4,141 @@
 #[cfg(feature = "unsound_experiments")]
 use crate::unsound_experiments::UnsoundExperimentArgs;
 
-use anyhow::bail;
-use clap::{arg_enum, Error, ErrorKind};
+use clap::{error::ErrorKind, Error, Parser, ValueEnum};
 use std::ffi::OsString;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 // By default we configure CBMC to use 16 bits to represent the object bits in pointers.
 const DEFAULT_OBJECT_BITS: u32 = 16;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[command(
+    version,
     name = "kani",
     about = "Verify a single Rust crate. For more information, see https://github.com/model-checking/kani",
-    setting = structopt::clap::AppSettings::AllArgsOverrideSelf
+    args_override_self = true
 )]
 pub struct StandaloneArgs {
     /// Rust file to verify
-    #[structopt(parse(from_os_str))]
     pub input: PathBuf,
 
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub common_opts: KaniArgs,
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[command(
+    version,
     name = "cargo-kani",
     about = "Verify a Rust crate. For more information, see https://github.com/model-checking/kani",
-    setting = structopt::clap::AppSettings::AllArgsOverrideSelf
+    args_override_self = true
 )]
 pub struct CargoKaniArgs {
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     pub command: Option<CargoKaniSubcommand>,
 
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub common_opts: KaniArgs,
 }
 
 // cargo-kani takes optional subcommands to request specialized behavior
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub enum CargoKaniSubcommand {
-    #[structopt(setting(structopt::clap::AppSettings::Hidden))]
+    #[command(hide = true)]
     Assess,
 }
 
 // Common arguments for invoking Kani. This gets put into KaniContext, whereas
 // anything above is "local" to "main"'s control flow.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct KaniArgs {
     /// Temporary option to trigger assess mode for out test suite
     /// where we are able to add options but not subcommands
-    #[structopt(long, hidden = true, requires("enable-unstable"))]
+    #[arg(long, hide = true, requires("enable_unstable"))]
     pub assess: bool,
 
     /// Generate visualizer report to `<target-dir>/report/html/index.html`
-    #[structopt(long)]
+    #[arg(long)]
     pub visualize: bool,
     /// Generate concrete playback unit test.
     /// If value supplied is 'print', Kani prints the unit test to stdout.
     /// If value supplied is 'inplace', Kani automatically adds the unit test to your source code.
     /// This option does not work with `--output-format old`.
-    #[structopt(
+    #[arg(
         long,
-        requires("enable-unstable"),
-        conflicts_with_all(&["visualize", "dry-run"]),
-        possible_values = &ConcretePlaybackMode::variants(),
-        case_insensitive = true,
+        requires("enable_unstable"),
+        conflicts_with_all(&["visualize", "dry_run"]),
+        ignore_case = true,
+        value_enum
     )]
     pub concrete_playback: Option<ConcretePlaybackMode>,
     /// Keep temporary files generated throughout Kani process
-    #[structopt(long, hidden_short_help(true))]
+    #[arg(long, hide_short_help = true)]
     pub keep_temps: bool,
 
     /// Produce full debug information
-    #[structopt(long)]
+    #[arg(long)]
     pub debug: bool,
     /// Produces no output, just an exit code and requested artifacts; overrides --verbose
-    #[structopt(long, short)]
+    #[arg(long, short)]
     pub quiet: bool,
     /// Output processing stages and commands, along with minor debug information
-    #[structopt(long, short, default_value_if("debug", None, "true"), min_values(0))]
+    #[arg(long, short, default_value_if("debug", "true", Some("true")))]
     pub verbose: bool,
     /// Enable usage of unstable options
-    #[structopt(long, hidden_short_help(true))]
+    #[arg(long, hide_short_help = true)]
     pub enable_unstable: bool,
 
     // Hide this since it depends on function that is a hidden option.
     /// Print commands instead of running them. This command uses "harness" as a place holder for
     /// name of the target harness.
-    #[structopt(long, hidden(true), requires("enable-unstable"))]
+    #[arg(long, hide = true, requires("enable_unstable"))]
     pub dry_run: bool,
 
     /// Generate C file equivalent to inputted program.
     /// This feature is unstable and it requires `--enable-unstable` to be used
-    #[structopt(long, hidden_short_help(true), requires("enable-unstable"))]
+    #[arg(long, hide_short_help = true, requires("enable_unstable"))]
     pub gen_c: bool,
 
     // TODO: currently only cargo-kani pays attention to this.
     /// Directory for all generated artifacts. Only effective when running Kani with cargo
-    #[structopt(long, parse(from_os_str))]
+    #[arg(long)]
     pub target_dir: Option<PathBuf>,
 
     /// Toggle between different styles of output
-    #[structopt(long, default_value = "regular", possible_values = &OutputFormat::variants(), case_insensitive = true)]
+    #[arg(long, default_value = "regular", ignore_case = true, value_enum)]
     pub output_format: OutputFormat,
 
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub checks: CheckArgs,
 
     #[cfg(feature = "unsound_experiments")]
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub unsound_experiments: UnsoundExperimentArgs,
 
     /// Entry point for verification (symbol name).
     /// This is an unstable feature. Consider using --harness instead
-    #[structopt(long, hidden = true, requires("enable-unstable"), conflicts_with("dry-run"))]
+    #[arg(long, hide = true, requires("enable_unstable"), conflicts_with("dry_run"))]
     pub function: Option<String>,
     /// Entry point for verification (proof harness)
     // In a dry-run, we don't have kani-metadata.json to read, so we can't use this flag
-    #[structopt(long, conflicts_with = "function", conflicts_with = "dry-run")]
+    #[arg(long, conflicts_with = "function", conflicts_with = "dry_run")]
     pub harness: Option<String>,
 
     /// Link external C files referenced by Rust code.
     /// This is an experimental feature and requires `--enable-unstable` to be used
-    #[structopt(long, parse(from_os_str), hidden = true, requires("enable-unstable"))]
+    #[arg(long, hide = true, requires("enable_unstable"), num_args(1..))]
     pub c_lib: Vec<PathBuf>,
     /// Enable test function verification. Only use this option when the entry point is a test function
-    #[structopt(long)]
+    #[arg(long)]
     pub tests: bool,
     /// Kani will only compile the crate. No verification will be performed
-    #[structopt(long, hidden_short_help(true))]
+    #[arg(long, hide_short_help = true)]
     pub only_codegen: bool,
 
     /// Disable the new MIR Linker. Using this option may result in missing symbols from the
     /// `std` library. See <https://github.com/model-checking/kani/issues/1213> for more details.
-    #[structopt(long, hidden = true)]
+    #[arg(long, hide = true)]
     pub legacy_linker: bool,
 
     /// Enable the new MIR Linker. This is already the default option and it will be removed once
@@ -147,95 +146,99 @@ pub struct KaniArgs {
     /// The MIR Linker affects how Kani prunes the code to be analyzed. It also fixes previous
     /// issues with missing `std` function definitions.
     /// See <https://model-checking.github.io/kani/rfc/rfcs/0001-mir-linker.html> for more details.
-    #[structopt(long, conflicts_with("legacy_linker"), hidden = true)]
+    #[arg(long, conflicts_with("legacy_linker"), hide = true)]
     pub mir_linker: bool,
 
     /// Compiles Kani harnesses in all features of all packages selected on the command-line.
-    #[structopt(long)]
+    #[arg(long)]
     pub all_features: bool,
     /// Run Kani on all packages in the workspace.
-    #[structopt(long)]
+    #[arg(long)]
     pub workspace: bool,
     /// Run Kani on the specified packages.
-    #[structopt(long, short, conflicts_with("workspace"))]
+    #[arg(long, short, conflicts_with("workspace"), num_args(1..))]
     pub package: Vec<String>,
 
     /// Specify the value used for loop unwinding in CBMC
-    #[structopt(long)]
+    #[arg(long)]
     pub default_unwind: Option<u32>,
     /// Specify the value used for loop unwinding for the specified harness in CBMC
-    #[structopt(long, requires("harness"))]
+    #[arg(long, requires("harness"))]
     pub unwind: Option<u32>,
     /// Pass through directly to CBMC; must be the last flag.
-    /// This feature is unstable and it requires `--enable-unstable` to be used
-    #[structopt(long, allow_hyphen_values = true, min_values(0), requires("enable-unstable"))]
+    /// This feature is unstable and it requires `--enable_unstable` to be used
+    #[arg(
+        long,
+        allow_hyphen_values = true,
+        requires("enable_unstable"),
+        num_args(0..)
+    )]
     // consumes everything
     pub cbmc_args: Vec<OsString>,
 
     /// Number of parallel jobs, defaults to 1
-    #[structopt(short, long, hidden = true, requires("enable-unstable"))]
+    #[arg(short, long, hide = true, requires("enable_unstable"))]
     pub jobs: Option<Option<usize>>,
 
     // Hide option till https://github.com/model-checking/kani/issues/697 is
     // fixed.
     /// Use abstractions for the standard library.
     /// This is an experimental feature and requires `--enable-unstable` to be used
-    #[structopt(long, hidden = true, requires("enable-unstable"))]
+    #[arg(long, hide = true, requires("enable_unstable"))]
     pub use_abs: bool,
     // Hide option till https://github.com/model-checking/kani/issues/697 is
     // fixed.
     /// Choose abstraction for modules of standard library if available
-    #[structopt(long, default_value = "std", possible_values = &AbstractionType::variants(),
-    case_insensitive = true, hidden = true)]
+    #[arg(long, default_value = "std", ignore_case = true, hide = true, value_enum)]
     pub abs_type: AbstractionType,
 
     /// Enable extra pointer checks such as invalid pointers in relation operations and pointer
     /// arithmetic overflow.
     /// This feature is unstable and it may yield false counter examples. It requires
     /// `--enable-unstable` to be used
-    #[structopt(long, hidden_short_help(true), requires("enable-unstable"))]
+    #[arg(long, hide_short_help = true, requires("enable_unstable"))]
     pub extra_pointer_checks: bool,
 
     /// Restrict the targets of virtual table function pointer calls.
     /// This feature is unstable and it requires `--enable-unstable` to be used
-    #[structopt(long, hidden_short_help(true), requires("enable-unstable"))]
+    #[arg(long, hide_short_help = true, requires("enable_unstable"))]
     pub restrict_vtable: bool,
     /// Disable restricting the targets of virtual table function pointer calls
-    #[structopt(long, hidden_short_help(true))]
+    #[arg(long, hide_short_help = true)]
     pub no_restrict_vtable: bool,
     /// Turn off assertion reachability checks
-    #[structopt(long)]
+    #[arg(long)]
     pub no_assertion_reach_checks: bool,
 
     /// Do not error out for crates containing `global_asm!`.
     /// This option may impact the soundness of the analysis and may cause false proofs and/or counterexamples
-    #[structopt(long, hidden_short_help(true), requires("enable-unstable"))]
+    #[arg(long, hide_short_help = true, requires("enable_unstable"))]
     pub ignore_global_asm: bool,
 
     /// Execute CBMC's sanity checks to ensure the goto-program we generate is correct.
-    #[structopt(long, hidden_short_help(true), requires("enable-unstable"))]
+    #[arg(long, hide_short_help = true, requires("enable_unstable"))]
     pub run_sanity_checks: bool,
 
     /// Disable CBMC's slice formula which prevents values from being assigned to redundant variables in traces.
-    #[structopt(long, hidden_short_help(true), requires("enable-unstable"))]
+    #[arg(long, hide_short_help = true, requires("enable_unstable"))]
     pub no_slice_formula: bool,
 
     /// Randomize the layout of structures. This option can help catching code that relies on
     /// a specific layout chosen by the compiler that is not guaranteed to be stable in the future.
     /// If a value is given, it will be used as the seed for randomization
     /// See the `-Z randomize-layout` and `-Z layout-seed` arguments of the rust compiler.
-    #[structopt(long)]
+    #[arg(long)]
     pub randomize_layout: Option<Option<u64>>,
 
     /// Enable the stubbing of functions and methods.
-    /// TODO: Stubbing should in principle work with concrete playback.
-    /// <https://github.com/model-checking/kani/issues/1842>
-    #[structopt(
+    // TODO: Stubbing should in principle work with concrete playback.
+    // <https://github.com/model-checking/kani/issues/1842>
+    #[arg(
         long,
-        hidden_short_help(true),
-        requires("enable-unstable"),
+        hide_short_help = true,
+        requires("enable_unstable"),
         requires("harness"),
-        conflicts_with("concrete-playback")
+        conflicts_with("concrete_playback")
     )]
     pub enable_stubbing: bool,
     /*
@@ -278,43 +281,29 @@ impl KaniArgs {
     }
 }
 
-arg_enum! {
-    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-    pub enum ConcretePlaybackMode {
-        Print,
-        InPlace,
-    }
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum ConcretePlaybackMode {
+    Print,
+    // Otherwise clap will default to `in-place`
+    #[value(name = "inplace")]
+    InPlace,
 }
 
-arg_enum! {
-    #[derive(Debug, PartialEq, Eq)]
-    pub enum OutputFormat {
-        Regular,
-        Terse,
-        Old,
-    }
+#[derive(Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    Regular,
+    Terse,
+    Old,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub enum AbstractionType {
     Std,
     Kani,
+    // Clap defaults to `c-ffi`
     CFfi,
+    // Clap defaults to `no-back`
     NoBack,
-}
-// We need customization to support dashes like 'no-back'
-impl std::str::FromStr for AbstractionType {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_string().to_lowercase().as_ref() {
-            "std" => Ok(Self::Std),
-            "kani" => Ok(Self::Kani),
-            "c-ffi" => Ok(Self::CFfi),
-            "no-back" => Ok(Self::NoBack),
-            _ => bail!("Unknown abs_type {}", s),
-        }
-    }
 }
 impl std::fmt::Display for AbstractionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -326,49 +315,50 @@ impl std::fmt::Display for AbstractionType {
         }
     }
 }
+#[cfg(test)]
 impl AbstractionType {
     pub fn variants() -> Vec<&'static str> {
         vec!["std", "kani", "c-ffi", "no-back"]
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct CheckArgs {
     // Rust argument parsers (/clap) don't have the convenient '--flag' and '--no-flag' boolean pairs, so approximate
     // We're put both here then create helper functions to "intepret"
     /// Turn on all default checks
-    #[structopt(long)]
+    #[arg(long)]
     pub default_checks: bool,
     /// Turn off all default checks
-    #[structopt(long)]
+    #[arg(long)]
     pub no_default_checks: bool,
 
     /// Turn on default memory safety checks
-    #[structopt(long)]
+    #[arg(long)]
     pub memory_safety_checks: bool,
     /// Turn off default memory safety checks
-    #[structopt(long)]
+    #[arg(long)]
     pub no_memory_safety_checks: bool,
 
     /// Turn on default overflow checks
-    #[structopt(long)]
+    #[arg(long)]
     pub overflow_checks: bool,
     /// Turn off default overflow checks
-    #[structopt(long)]
+    #[arg(long)]
     pub no_overflow_checks: bool,
 
     /// Turn on undefined function checks
-    #[structopt(long)]
+    #[arg(long)]
     pub undefined_function_checks: bool,
     /// Turn off undefined function checks
-    #[structopt(long)]
+    #[arg(long)]
     pub no_undefined_function_checks: bool,
 
     /// Turn on default unwinding checks
-    #[structopt(long)]
+    #[arg(long)]
     pub unwinding_checks: bool,
     /// Turn off default unwinding checks
-    #[structopt(long)]
+    #[arg(long)]
     pub no_unwinding_checks: bool,
 }
 
@@ -426,43 +416,43 @@ impl KaniArgs {
         // TODO: these conflicting flags reflect what's necessary to pass current tests unmodified.
         // We should consider improving the error messages slightly in a later pull request.
         if natives_unwind && extra_unwind {
-            return Err(Error::with_description(
-                "Conflicting flags: unwind flags provided to kani and in --cbmc-args.",
+            return Err(Error::raw(
                 ErrorKind::ArgumentConflict,
+                "Conflicting flags: unwind flags provided to kani and in --cbmc-args.",
             ));
         }
         if self.cbmc_args.contains(&OsString::from("--function")) {
-            return Err(Error::with_description(
-                "Invalid flag: --function should be provided to Kani directly, not via --cbmc-args.",
+            return Err(Error::raw(
                 ErrorKind::ArgumentConflict,
+                "Invalid flag: --function should be provided to Kani directly, not via --cbmc-args.",
             ));
         }
         if self.quiet && self.concrete_playback == Some(ConcretePlaybackMode::Print) {
-            return Err(Error::with_description(
-                "Conflicting options: --concrete-playback=print and --quiet.",
+            return Err(Error::raw(
                 ErrorKind::ArgumentConflict,
+                "Conflicting options: --concrete-playback=print and --quiet.",
             ));
         }
         if self.concrete_playback.is_some() && self.output_format == OutputFormat::Old {
-            return Err(Error::with_description(
+            return Err(Error::raw(
+                ErrorKind::ArgumentConflict,
                 "Conflicting options: --concrete-playback isn't compatible with \
                 --output-format=old.",
-                ErrorKind::ArgumentConflict,
             ));
         }
         if self.concrete_playback.is_some() && self.jobs() != Some(1) {
             // Concrete playback currently embeds a lot of assumptions about the order in which harnesses get called.
-            return Err(Error::with_description(
-                "Conflicting options: --concrete-playback isn't compatible with --jobs.",
+            return Err(Error::raw(
                 ErrorKind::ArgumentConflict,
+                "Conflicting options: --concrete-playback isn't compatible with --jobs.",
             ));
         }
         if self.jobs.is_some() && self.output_format != OutputFormat::Terse {
             // More verbose output formats make it hard to interpret output right now when run in parallel.
             // This can be removed when we change up how results are printed.
-            return Err(Error::with_description(
-                "Conflicting options: --jobs requires `--output-format=terse`",
+            return Err(Error::raw(
                 ErrorKind::ArgumentConflict,
+                "Conflicting options: --jobs requires `--output-format=terse`",
             ));
         }
 
@@ -472,14 +462,11 @@ impl KaniArgs {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use super::*;
-    use clap::ArgMatches;
 
     #[test]
     fn check_arg_parsing() {
-        let a = StandaloneArgs::from_iter(vec![
+        let a = StandaloneArgs::parse_from(vec![
             "kani",
             "file.rs",
             "--enable-unstable",
@@ -490,92 +477,112 @@ mod tests {
         ]);
         assert_eq!(a.common_opts.cbmc_args, vec!["--multiple", "args", "--here"]);
         let _b =
-            StandaloneArgs::from_iter(vec!["kani", "file.rs", "--enable-unstable", "--cbmc-args"]);
+            StandaloneArgs::parse_from(vec!["kani", "file.rs", "--enable-unstable", "--cbmc-args"]);
         // no assertion: the above might fail if it fails to allow 0 args to cbmc-args
+    }
+
+    fn check(args: &str, require_unstable: bool, pred: fn(StandaloneArgs) -> bool) {
+        let mut res = parse_unstable_disabled(&args);
+        if require_unstable {
+            // Should fail without --enable-unstable.
+            assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
+            // Should succeed with --enable-unstable.
+            res = parse_unstable_enabled(&args);
+        }
+        assert!(res.is_ok());
+        assert!(pred(res.unwrap()));
+    }
+
+    macro_rules! check_unstable_flag {
+        ($args:expr, $name:ident) => {
+            check($args, true, |p| p.common_opts.$name)
+        };
+    }
+
+    macro_rules! check_opt {
+        ($args:expr, $require_unstable:expr, $name:ident, $expected:expr) => {
+            check($args, $require_unstable, |p| p.common_opts.$name == $expected)
+        };
     }
 
     #[test]
     fn check_abs_type() {
         // Since we manually implemented this, consistency check it
         for t in AbstractionType::variants() {
-            assert_eq!(t, format!("{}", AbstractionType::from_str(t).unwrap()));
+            assert_eq!(t, format!("{}", AbstractionType::from_str(t, false).unwrap()));
         }
+        check_opt!("--abs-type std", false, abs_type, AbstractionType::Std);
+        check_opt!("--abs-type kani", false, abs_type, AbstractionType::Kani);
+        check_opt!("--abs-type c-ffi", false, abs_type, AbstractionType::CFfi);
+        check_opt!("--abs-type no-back", false, abs_type, AbstractionType::NoBack);
     }
 
     #[test]
     fn check_dry_run_harness_conflicts() {
         // harness needs metadata which we don't have with dry-run
         let args = vec!["kani", "file.rs", "--dry-run", "--harness", "foo"];
-        let app = StandaloneArgs::clap();
-        let err = app.get_matches_from_safe(args).unwrap_err();
-        assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+        let err = StandaloneArgs::try_parse_from(args).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     }
 
     #[test]
     fn check_unwind_conflicts() {
         // --unwind cannot be called without --harness
         let args = vec!["kani", "file.rs", "--unwind", "3"];
-        let app = StandaloneArgs::clap();
-        let err = app.get_matches_from_safe(args).unwrap_err();
-        assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+        let err = StandaloneArgs::try_parse_from(args).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     }
 
-    fn parse_unstable_disabled(args: &str) -> Result<ArgMatches<'_>, Error> {
+    fn parse_unstable_disabled(args: &str) -> Result<StandaloneArgs, Error> {
         let args = format!("kani file.rs {args}");
-        let app = StandaloneArgs::clap();
-        app.get_matches_from_safe(args.split(' '))
+        StandaloneArgs::try_parse_from(args.split(' '))
     }
 
-    fn parse_unstable_enabled(args: &str) -> Result<ArgMatches<'_>, Error> {
+    fn parse_unstable_enabled(args: &str) -> Result<StandaloneArgs, Error> {
         let args = format!("kani --enable-unstable file.rs {args}");
-        let app = StandaloneArgs::clap();
-        app.get_matches_from_safe(args.split(' '))
-    }
-
-    fn check_unstable_flag(args: &str) {
-        // Should fail without --enable-unstable.
-        assert_eq!(
-            parse_unstable_disabled(&args).unwrap_err().kind,
-            ErrorKind::MissingRequiredArgument
-        );
-
-        // Should succeed with --enable-unstable.
-        let result = parse_unstable_enabled(&args);
-        assert!(result.is_ok());
-        let flag = args.split(' ').next().unwrap();
-        assert!(result.unwrap().is_present(&flag[2..]));
+        StandaloneArgs::try_parse_from(args.split(' '))
     }
 
     #[test]
     fn check_abs_unstable() {
-        check_unstable_flag("--use-abs")
+        check_unstable_flag!("--use-abs", use_abs);
     }
 
     #[test]
     fn check_restrict_vtable_unstable() {
-        check_unstable_flag("--restrict-vtable")
+        check_unstable_flag!("--restrict-vtable", restrict_vtable);
     }
 
     #[test]
     fn check_restrict_cbmc_args() {
-        check_unstable_flag("--cbmc-args --json-ui")
+        check_opt!("--cbmc-args --json-ui", true, cbmc_args, vec!["--json-ui"]);
     }
 
     #[test]
     fn check_disable_slicing_unstable() {
-        check_unstable_flag("--no-slice-formula")
+        check_unstable_flag!("--no-slice-formula", no_slice_formula);
     }
 
     #[test]
     fn check_concrete_playback_unstable() {
-        check_unstable_flag("--concrete-playback inplace");
-        check_unstable_flag("--concrete-playback print");
+        check_opt!(
+            "--concrete-playback inplace",
+            true,
+            concrete_playback,
+            Some(ConcretePlaybackMode::InPlace)
+        );
+        check_opt!(
+            "--concrete-playback print",
+            true,
+            concrete_playback,
+            Some(ConcretePlaybackMode::Print)
+        );
     }
 
     /// Check if parsing the given argument string results in the given error.
     fn expect_validation_error(arg: &str, err: ErrorKind) {
-        let args = StandaloneArgs::from_iter(arg.split_whitespace());
-        assert_eq!(args.common_opts.validate_inner().unwrap_err().kind, err);
+        let args = StandaloneArgs::parse_from(arg.split_whitespace());
+        assert_eq!(args.common_opts.validate_inner().unwrap_err().kind(), err);
     }
 
     #[test]
@@ -592,16 +599,16 @@ mod tests {
 
     #[test]
     fn check_enable_stubbing() {
-        check_unstable_flag("--enable-stubbing --harness foo");
+        check_unstable_flag!("--enable-stubbing --harness foo", enable_stubbing);
 
         // `--enable-stubbing` cannot be called without `--harness`
         let err = parse_unstable_enabled("--enable-stubbing").unwrap_err();
-        assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 
         // `--enable-stubbing` cannot be called with `--concrete-playback`
         let err =
             parse_unstable_enabled("--enable-stubbing --harness foo --concrete-playback=print")
                 .unwrap_err();
-        assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     }
 }

--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -292,7 +292,7 @@ pub fn resolve_unwind_value(args: &KaniArgs, harness_metadata: &HarnessMetadata)
 mod tests {
     use crate::args;
     use crate::metadata::mock_proof_harness;
-    use structopt::StructOpt;
+    use clap::Parser;
 
     use super::*;
 
@@ -310,37 +310,37 @@ mod tests {
 
         // test against no unwind annotation
         assert_eq!(
-            resolve_unwind_value(&args::KaniArgs::from_iter(args_empty), &harness_none),
+            resolve_unwind_value(&args::KaniArgs::parse_from(args_empty), &harness_none),
             None
         );
         assert_eq!(
-            resolve_unwind_value(&args::KaniArgs::from_iter(args_only_default), &harness_none),
+            resolve_unwind_value(&args::KaniArgs::parse_from(args_only_default), &harness_none),
             Some(2)
         );
         assert_eq!(
-            resolve_unwind_value(&args::KaniArgs::from_iter(args_only_harness), &harness_none),
+            resolve_unwind_value(&args::KaniArgs::parse_from(args_only_harness), &harness_none),
             Some(1)
         );
         assert_eq!(
-            resolve_unwind_value(&args::KaniArgs::from_iter(args_both), &harness_none),
+            resolve_unwind_value(&args::KaniArgs::parse_from(args_both), &harness_none),
             Some(1)
         );
 
         // test against unwind annotation
         assert_eq!(
-            resolve_unwind_value(&args::KaniArgs::from_iter(args_empty), &harness_some),
+            resolve_unwind_value(&args::KaniArgs::parse_from(args_empty), &harness_some),
             Some(3)
         );
         assert_eq!(
-            resolve_unwind_value(&args::KaniArgs::from_iter(args_only_default), &harness_some),
+            resolve_unwind_value(&args::KaniArgs::parse_from(args_only_default), &harness_some),
             Some(3)
         );
         assert_eq!(
-            resolve_unwind_value(&args::KaniArgs::from_iter(args_only_harness), &harness_some),
+            resolve_unwind_value(&args::KaniArgs::parse_from(args_only_harness), &harness_some),
             Some(1)
         );
         assert_eq!(
-            resolve_unwind_value(&args::KaniArgs::from_iter(args_both), &harness_some),
+            resolve_unwind_value(&args::KaniArgs::parse_from(args_both), &harness_some),
             Some(1)
         );
     }

--- a/kani-driver/src/main.rs
+++ b/kani-driver/src/main.rs
@@ -5,9 +5,9 @@
 use anyhow::Result;
 use args::CargoKaniSubcommand;
 use args_toml::join_args;
+use clap::Parser;
 use std::ffi::OsString;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 mod args;
 mod args_toml;
@@ -38,16 +38,16 @@ fn main() -> Result<()> {
 
 fn cargokani_main(input_args: Vec<OsString>) -> Result<()> {
     let input_args = join_args(input_args)?;
-    let args = args::CargoKaniArgs::from_iter(input_args);
+    let args = args::CargoKaniArgs::parse_from(input_args);
     args.validate();
     let ctx = session::KaniSession::new(args.common_opts)?;
 
     if matches!(args.command, Some(CargoKaniSubcommand::Assess)) || ctx.args.assess {
         // --assess requires --enable-unstable, but the subcommand needs manual checking
         if !ctx.args.enable_unstable {
-            clap::Error::with_description(
-                "Assess is unstable and requires 'cargo kani --enable-unstable assess'",
-                clap::ErrorKind::MissingRequiredArgument,
+            clap::Error::raw(
+                clap::error::ErrorKind::MissingRequiredArgument,
+                "Assess is unstable and requires 'cargo kani --enable-unstable assess'".to_string(),
             )
             .exit()
         }
@@ -91,7 +91,7 @@ fn cargokani_main(input_args: Vec<OsString>) -> Result<()> {
 }
 
 fn standalone_main() -> Result<()> {
-    let args = args::StandaloneArgs::from_args();
+    let args = args::StandaloneArgs::parse();
     args.validate();
     let ctx = session::KaniSession::new(args.common_opts)?;
 

--- a/kani-driver/src/unsound_experiments.rs
+++ b/kani-driver/src/unsound_experiments.rs
@@ -2,16 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #![cfg(feature = "unsound_experiments")]
+use clap::Parser;
 use std::ffi::OsString;
-use structopt::StructOpt;
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct UnsoundExperimentArgs {
     /// Zero initilize variables.
     /// This is useful for experiments to see whether assigning constant values produces better
     /// performance by allowing CBMC to do more constant propegation.
     /// Unfortunatly, it is unsafe to use for production code, since it may unsoundly hide bugs.
     /// Marked as `unsound` to prevent use outside of experimental contexts.
-    #[structopt(long, hidden_short_help(true), requires("enable-unstable"))]
+    #[arg(long, hide_short_help = true, requires("enable_unstable"))]
     pub unsound_experiment_zero_init_vars: bool,
 }
 


### PR DESCRIPTION
### Description of changes: 

Update `kani-driver` to use `clap` v4, which has a slightly different derive API than `structopt` (which is what `kani-driver` is currently using). I followed the [migration guide](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#migrating). This is the final part of removing our (transitive) dependency on the unmaintained `ansi_term` crate (https://github.com/model-checking/kani/issues/1696).

### Resolved issues:

Resolves #1901 
Resolves #1696 

### Call-outs:

The only place where I am aware of a behavior mismatch between the original code and this PR is with the `--verbose` argument. In both cases, it is a boolean flag. However, in the original code, it also accepts an arbitrary number of arguments (e.g., `--verbose foo bar` is allowed). As far as I can tell, these arguments are never accessed. It is not clear how to reproduce this behavior with `clap` v4, so the new version does not allow `--verbose` to take any arguments.

### Testing:

* How is this change tested? Existing tests and some manual tests

* Is this a refactor change? Y

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
