### PR TITLE
Remove old environment variables from cbmc

### DIFF
--- a/cprover_bindings/src/env.rs
+++ b/cprover_bindings/src/env.rs
@@ -74,9 +74,6 @@ pub fn machine_model_symbols(mm: &MachineModel) -> Vec<Symbol> {
 pub fn additional_env_symbols() -> Vec<Symbol> {
     vec![
         Symbol::builtin_function("__CPROVER_initialize", vec![], Type::empty()),
-        // https://github.com/diffblue/cbmc/blob/b26d3479679574c6c179f911b488a314bc2f1085/src/util/config.h#L214
-        int_constant("__CPROVER_malloc_failure_mode_assert_then_assume", 2),
-        int_constant("__CPROVER_malloc_failure_mode_return_null", 1),
         Symbol::typedef("__CPROVER_size_t", "__CPROVER_size_t", Type::size_t(), Location::none()),
         Symbol::static_variable(
             "__CPROVER_memory",

--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -124,17 +124,12 @@ impl KaniSession {
             args.push("--validate-ssa-equation".into());
         }
 
-        // Push `--slice-formula` argument.
-        // Previously, this would happen if the condition below was satisfied:
-        // ```rust
-        // if !self.args.visualize
-        //   && self.args.concrete_playback.is_none()
-        //   && !self.args.no_slice_formula
-        // ```
-        // But for some reason, not pushing it causes a CBMC invariant violation
-        // since version 5.68.0.
-        // <https://github.com/model-checking/kani/issues/1810>
-        args.push("--slice-formula".into());
+        if !self.args.visualize
+            && self.args.concrete_playback.is_none()
+            && !self.args.no_slice_formula
+        {
+            args.push("--slice-formula".into());
+        }
 
         if self.args.concrete_playback.is_some() {
             args.push("--trace".into());


### PR DESCRIPTION
### Description of changes: 

Remove old environment variables from cbmc and remove the always `--slice-formula` issue. Thanks @tautschnig for helping with this one.

### Resolved issues:

Resolves #1810 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
