### PR TITLE
fix paths to install_viewer.sh in scripts/setup

### DIFF
--- a/docs/src/build-from-source.md
+++ b/docs/src/build-from-source.md
@@ -29,7 +29,7 @@ cd kani
 git submodule update --init
 ./scripts/setup/ubuntu/install_deps.sh
 ./scripts/setup/ubuntu/install_cbmc.sh
-./scripts/setup/install_viewer.sh
+./scripts/setup/ubuntu/install_viewer.sh
 # If you haven't already:
 ./scripts/setup/install_rustup.sh
 source $HOME/.cargo/env
@@ -46,7 +46,7 @@ cd kani
 git submodule update --init
 ./scripts/setup/macos/install_deps.sh
 ./scripts/setup/macos/install_cbmc.sh
-./scripts/setup/install_viewer.sh
+./scripts/setup/macos/install_viewer.sh
 # If you haven't already:
 ./scripts/setup/install_rustup.sh
 source $HOME/.cargo/env


### PR DESCRIPTION
### Description of changes: 

A doc update: the "Building from source" command sequence had incorrect (presumably outdated) paths to `install_viewer.sh`

### Resolved issues:

(no issue filed)

### Related RFC:

(no related RFC)

### Call-outs:

Is there any reasonable way to include testing of the documented command sequence as part of CI? Would that be at all worthwhile?

### Testing:

* How is this change tested?

Its a doc change. I'd love if it had some way to test automatically (see above)

* Is this a refactor change?

No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
