### PR TITLE
Doc improvements: supported platforms and versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,9 @@ Kani verifies:
  * The absence of panics (e.g., `unwrap()` on `None` values)
  * The absence of some types of unexpected behavior (e.g., arithmetic overflows)
 
-## GitHub Action
-
-Use Kani in your CI with `model-checking/kani@VERSION`. See the
-[GitHub Action section in the Kani
-book](https://model-checking.github.io/kani/install-github-ci.html)
-for details.
-
 ## Installation
 
-To install the latest version of Kani, run:
+To install the latest version of Kani ([Rust 1.58+; Linux or Mac](https://model-checking.github.io/kani/install-guide.html)), run:
 
 ```bash
 cargo install --locked kani-verifier
@@ -53,6 +46,13 @@ fn check_my_property() {
 Kani will then try to prove that all valid inputs produce acceptable outputs, without panicking or executing unexpected behavior.
 Otherwise Kani will generate a trace that points to the failure.
 We recommend following [the tutorial](https://model-checking.github.io/kani/kani-tutorial.html) to learn more about how to use Kani.
+
+## GitHub Action
+
+Use Kani in your CI with `model-checking/kani-github-action@VERSION`. See the
+[GitHub Action section in the Kani
+book](https://model-checking.github.io/kani/install-github-ci.html)
+for details.
 
 ## Security
 See [SECURITY](https://github.com/model-checking/kani/security/policy) for more information.

--- a/docs/src/install-guide.md
+++ b/docs/src/install-guide.md
@@ -4,7 +4,7 @@ Kani offers an easy installation option on three platforms:
 
 * `x86_64-unknown-linux-gnu` (Most Linux distributions)
 * `x86_64-apple-darwin` (Intel Mac OS)
-* `aarch64-apple-darwin` (Apple M1)
+* `aarch64-apple-darwin` (Apple Silicon Mac OS)
 
 Other platforms are either not yet supported or require instead that
 you [build from source](build-from-source.md). To use Kani in your
@@ -14,8 +14,8 @@ GitHub CI workflows, see [GitHub CI Action](./install-github-ci.md).
 
 The following must already be installed:
 
-* **Python version 3.6 or greater** and the package installer `pip`.
-* Rust installed via `rustup`.
+* **Python version 3.6 or newer** and the package installer `pip`.
+* Rust 1.58 or newer installed via `rustup`.
 * `ctags` is required for Kani's `--visualize` option to work correctly. [Universal ctags](https://ctags.io/) is recommended.
 
 ## Installing the latest version


### PR DESCRIPTION
### Description of changes: 

1. Very compactly mention which OSes (linux and mac, not windows) are supported in our readme.
2. Add a quick note about Rust 1.58+. I think we can remove this eventually from the README because it's pretty old, but temporarily we should note it. And it should stay noted in the longer-form doc.
3. The github action bit stated the wrong action name and was waaaaay to prominent in the read me. I bumped it down and fixed the name
4. minor tweaks

### Resolved issues:

This was motivated by an issue that pointed out we don't clearly say we don't support windows, so now at least the readme says "linux or mac"

* #1954 

### Call-outs:

* Re-reading the README carefully, I think we need to re-do our "elevator pitch" for Kani. I think the blurb over-emphasized unsafe code.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
