### PR TITLE
Restore `simd_div` and `simd_rem` intrinsics

### DIFF
--- a/docs/src/rust-feature-support/intrinsics.md
+++ b/docs/src/rust-feature-support/intrinsics.md
@@ -256,7 +256,7 @@ Name | Support | Notes |
 --- | --- | --- |
 `simd_add` | Yes | |
 `simd_and`  | Yes | |
-`simd_div`  | No | |
+`simd_div`  | Yes | Doesn't check for overflow cases [#1970](https://github.com/model-checking/kani/issues/1970) |
 `simd_eq`  | Yes | |
 `simd_extract`  | No | |
 `simd_ge`  | Yes | |
@@ -267,9 +267,9 @@ Name | Support | Notes |
 `simd_mul`  | Yes | |
 `simd_ne`  | Yes | |
 `simd_or`  | Yes | |
-`simd_rem`  | No | |
-`simd_shl`  | Yes | Doesn't check for overflow cases (#1963)[https://github.com/model-checking/kani/issues/1963] |
-`simd_shr`  | Yes | Doesn't check for overflow cases (#1963)[https://github.com/model-checking/kani/issues/1963] |
+`simd_rem`  | Yes | Doesn't check for overflow cases [#1970](https://github.com/model-checking/kani/issues/1970) |
+`simd_shl`  | Yes | Doesn't check for overflow cases [#1963](https://github.com/model-checking/kani/issues/1963) |
+`simd_shr`  | Yes | Doesn't check for overflow cases [#1963](https://github.com/model-checking/kani/issues/1963) |
 `simd_shuffle*`  | Yes | |
 `simd_sub`  | Yes | |
 `simd_xor`  | Yes | |

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -574,7 +574,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 loc,
             ),
             "simd_and" => codegen_intrinsic_binop!(bitand),
-            "simd_div" => unstable_codegen!(codegen_intrinsic_binop!(div)),
+            "simd_div" => codegen_intrinsic_binop!(div),
             "simd_eq" => self.codegen_simd_cmp(Expr::vector_eq, fargs, p, span, farg_types, ret_ty),
             "simd_extract" => {
                 self.codegen_intrinsic_simd_extract(fargs, p, farg_types, ret_ty, span)
@@ -598,7 +598,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 self.codegen_simd_cmp(Expr::vector_neq, fargs, p, span, farg_types, ret_ty)
             }
             "simd_or" => codegen_intrinsic_binop!(bitor),
-            "simd_rem" => unstable_codegen!(codegen_intrinsic_binop!(rem)),
+            "simd_rem" => codegen_intrinsic_binop!(rem),
             // TODO: `simd_shl` and `simd_shr` don't check overflow cases.
             // <https://github.com/model-checking/kani/issues/1963>
             "simd_shl" => codegen_intrinsic_binop!(shl),

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -574,6 +574,8 @@ impl<'tcx> GotocCtx<'tcx> {
                 loc,
             ),
             "simd_and" => codegen_intrinsic_binop!(bitand),
+            // TODO: `simd_div` and `simd_rem` don't check for overflow cases.
+            // <https://github.com/model-checking/kani/issues/1970>
             "simd_div" => codegen_intrinsic_binop!(div),
             "simd_eq" => self.codegen_simd_cmp(Expr::vector_eq, fargs, p, span, farg_types, ret_ty),
             "simd_extract" => {
@@ -598,6 +600,8 @@ impl<'tcx> GotocCtx<'tcx> {
                 self.codegen_simd_cmp(Expr::vector_neq, fargs, p, span, farg_types, ret_ty)
             }
             "simd_or" => codegen_intrinsic_binop!(bitor),
+            // TODO: `simd_div` and `simd_rem` don't check for overflow cases.
+            // <https://github.com/model-checking/kani/issues/1970>
             "simd_rem" => codegen_intrinsic_binop!(rem),
             // TODO: `simd_shl` and `simd_shr` don't check overflow cases.
             // <https://github.com/model-checking/kani/issues/1963>

--- a/tests/expected/intrinsics/simd-div-div-zero/expected
+++ b/tests/expected/intrinsics/simd-div-div-zero/expected
@@ -1,0 +1,2 @@
+FAILURE\
+division by zero

--- a/tests/expected/intrinsics/simd-div-div-zero/main.rs
+++ b/tests/expected/intrinsics/simd-div-div-zero/main.rs
@@ -1,0 +1,23 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Checks that `simd_div` triggers a failure when the divisor is zero.
+#![feature(repr_simd, platform_intrinsics)]
+
+#[repr(simd)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct i32x2(i32, i32);
+
+extern "platform-intrinsic" {
+    fn simd_div<T>(x: T, y: T) -> T;
+}
+
+#[kani::proof]
+fn test_simd_div() {
+    let dividend = kani::any();
+    let dividends = i32x2(dividend, dividend);
+    let divisor = 0;
+    let divisors = i32x2(divisor, divisor);
+    let _ = unsafe { simd_div(dividends, divisors) };
+}

--- a/tests/expected/intrinsics/simd-rem-div-zero/expected
+++ b/tests/expected/intrinsics/simd-rem-div-zero/expected
@@ -1,0 +1,2 @@
+FAILURE\
+division by zero

--- a/tests/expected/intrinsics/simd-rem-div-zero/main.rs
+++ b/tests/expected/intrinsics/simd-rem-div-zero/main.rs
@@ -1,0 +1,23 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Checks that `simd_rem` triggers a failure when the divisor is zero
+#![feature(repr_simd, platform_intrinsics)]
+
+#[repr(simd)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct i32x2(i32, i32);
+
+extern "platform-intrinsic" {
+    fn simd_rem<T>(x: T, y: T) -> T;
+}
+
+#[kani::proof]
+fn test_simd_rem() {
+    let dividend = kani::any();
+    let dividends = i32x2(dividend, dividend);
+    let divisor = 0;
+    let divisors = i32x2(divisor, divisor);
+    let _ = unsafe { simd_rem(dividends, divisors) };
+}

--- a/tests/kani/Intrinsics/SIMD/Operators/division.rs
+++ b/tests/kani/Intrinsics/SIMD/Operators/division.rs
@@ -1,0 +1,44 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Checks that the `simd_div` and `simd_rem` intrinsics are supported and they
+//! return the expected results.
+#![feature(repr_simd, platform_intrinsics)]
+
+#[repr(simd)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct i32x2(i32, i32);
+
+extern "platform-intrinsic" {
+    fn simd_div<T>(x: T, y: T) -> T;
+    fn simd_rem<T>(x: T, y: T) -> T;
+}
+
+#[kani::proof]
+fn test_simd_div() {
+    let dividend = kani::any();
+    let dividends = i32x2(dividend, dividend);
+    let divisor = kani::any();
+    // Narrow down the divisor interval so the operation doesn't overflow and
+    // the test finishes in a short time
+    kani::assume(divisor > 0 && divisor < 5);
+    let divisors = i32x2(divisor, divisor);
+    let normal_result = dividend / divisor;
+    let simd_result = unsafe { simd_div(dividends, divisors) };
+    assert_eq!(normal_result, simd_result.0);
+}
+
+#[kani::proof]
+fn test_simd_rem() {
+    let dividend = kani::any();
+    let dividends = i32x2(dividend, dividend);
+    let divisor = kani::any();
+    // Narrow down the divisor interval so the operation doesn't overflow and
+    // the test finishes in a short time
+    kani::assume(divisor > 0 && divisor < 5);
+    let divisors = i32x2(divisor, divisor);
+    let normal_result = dividend % divisor;
+    let simd_result = unsafe { simd_rem(dividends, divisors) };
+    assert_eq!(normal_result, simd_result.0);
+}


### PR DESCRIPTION
### Description of changes: 

* Restores support for the `simd_div` and `simd_rem` intrinsics.
* Adds some tests for them.
* Documents missing overflow check which isn't easy to reproduce.

### Resolved issues:

Towards #1148 
Opens #1970 

### Testing:

* How is this change tested? Existing regression + 3 new tests.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
