### PR TITLE
Fix call to core::assert in macro overrides

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -54,7 +54,7 @@ macro_rules! assert {
         // strategy, which is tracked in
         // https://github.com/model-checking/kani/issues/692
         if false {
-            core::assert!(true, $($arg)+);
+            ::core::assert!(true, $($arg)+);
         }
     }};
 }
@@ -158,7 +158,7 @@ macro_rules! unreachable {
     // handle.
     ($fmt:expr, $($arg:tt)*) => {{
         if false {
-            core::assert!(true, $fmt, $($arg)+);
+            ::core::assert!(true, $fmt, $($arg)+);
         }
         kani::panic(concat!("internal error: entered unreachable code: ",
         stringify!($fmt, $($arg)*)))}};
@@ -190,7 +190,7 @@ macro_rules! panic {
     // `panic!("Error: {}", code);`
     ($($arg:tt)+) => {{
         if false {
-            core::assert!(true, $($arg)+);
+            ::core::assert!(true, $($arg)+);
         }
         kani::panic(stringify!($($arg)+));
     }};

--- a/tests/kani/Panic/core_mod.rs
+++ b/tests/kani/Panic/core_mod.rs
@@ -1,0 +1,18 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test checks that the panic macro does not cause a compiler error if
+//! there is a user-defined `core` module, which previously did (see
+//! https://github.com/model-checking/kani/issues/1984)
+
+mod core {}
+
+#[kani::proof]
+fn main() {
+    let x: u8 = kani::any();
+    let y = x / 2;
+    if y > x {
+        // impossible
+        panic!("y is {}", y);
+    }
+}


### PR DESCRIPTION
### Description of changes: 

Prefix calls to `core:assert` by double parentheses: `::core::assert`.

### Resolved issues:

Resolves #1984 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Added one test

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
