### PR TITLE
Restrict platform when issuing metadata command

### DIFF
--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -38,7 +38,13 @@ impl KaniSession {
     /// Calls `cargo_build` to generate `*.symtab.json` files in `target_dir`
     pub fn cargo_build(&self) -> Result<CargoOutputs> {
         let build_target = env!("TARGET"); // see build.rs
-        let metadata = MetadataCommand::new().exec().context("Failed to get cargo metadata.")?;
+        let metadata = MetadataCommand::new()
+            // restrict metadata command to host platform. References:
+            // https://github.com/rust-lang/rust-analyzer/issues/6908
+            // https://github.com/rust-lang/rust-analyzer/pull/6912
+            .other_options(vec![String::from("--filter-platform"), build_target.to_owned()])
+            .exec()
+            .context("Failed to get cargo metadata.")?;
         let target_dir = self
             .args
             .target_dir


### PR DESCRIPTION
### Description of changes: 

The metadata command issued by the Kani driver by default includes all targets unlike other cargo commands (e.g. `cargo build`) which only focus on the host target.

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
