### PR TITLE
Used install toolchain path instead of runtime RUSTUP_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install the latest version of Kani ([Rust 1.58+; Linux or Mac](https://model-
 
 ```bash
 cargo install --locked kani-verifier
-cargo-kani setup
+cargo kani setup
 ```
 
 See [the installation guide](https://model-checking.github.io/kani/install-guide.html) for more details.

--- a/docs/src/install-guide.md
+++ b/docs/src/install-guide.md
@@ -24,17 +24,17 @@ To install the latest version of Kani, run:
 
 ```bash
 cargo install --locked kani-verifier
-cargo-kani setup
+cargo kani setup
 ```
 
 This will build and place in `~/.cargo/bin` (in a typical environment) the `kani` and `cargo-kani` binaries.
-The second step (`cargo-kani setup`) will download the Kani compiler and other necessary dependencies (and place them under `~/.kani/`).
+The second step (`cargo kani setup`) will download the Kani compiler and other necessary dependencies (and place them under `~/.kani/`).
 
 ## Installing an older version
 
 ```bash
 cargo install --locked kani-verifier --version <VERSION>
-cargo-kani setup
+cargo kani setup
 ```
 
 ## Checking your installation

--- a/kani-compiler/src/main.rs
+++ b/kani-compiler/src/main.rs
@@ -214,6 +214,15 @@ fn convert_arg(arg: &OsStr) -> String {
 /// This function will soon be removed.
 #[deprecated]
 fn toolchain_sysroot_path() -> PathBuf {
+    // If we're installed normally, we'll find `$KANI/toolchain` as a symlink to our desired toolchain
+    {
+        let kani_root = kani_root();
+        let toolchain_path = kani_root.join("toolchain");
+        if toolchain_path.exists() {
+            return toolchain_path;
+        }
+    }
+
     // rustup sets some environment variables during build, but this is not clearly documented.
     // https://github.com/rust-lang/rustup/blob/master/src/toolchain.rs (search for RUSTUP_HOME)
     // We're using RUSTUP_TOOLCHAIN here, which is going to be set by our `rust-toolchain.toml` file.


### PR DESCRIPTION
### Description of changes: 

1. Look for the installer toolchain path before searching based on `rustup_home` from the runtime environment.
2. Recommend `cargo kani` without a dash in our install instructions. I swear I did this before but ???

### Testing:

* How is this change tested? For the particular environment in question I am testing manually. For exercising this code path, covered by existing `build-rs-works` test in docker

* Is this a refactor change? no

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
