### PR TITLE
Rename core::assert to avoid possible conflicts in user crate

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -16,7 +16,7 @@ pub use std::*;
 // crate uses `extern crate std as core`. See
 // https://github.com/model-checking/kani/issues/1949
 #[allow(unused_imports)]
-use core::assert as __core_assert;
+use core::assert as __kani__workaround_core_assert;
 
 // Override process calls with stubs.
 pub mod process;
@@ -60,7 +60,7 @@ macro_rules! assert {
         // strategy, which is tracked in
         // https://github.com/model-checking/kani/issues/692
         if false {
-            __core_assert!(true, $($arg)+);
+            __kani__workaround_core_assert!(true, $($arg)+);
         }
     }};
 }
@@ -164,7 +164,7 @@ macro_rules! unreachable {
     // handle.
     ($fmt:expr, $($arg:tt)*) => {{
         if false {
-            __core_assert!(true, $fmt, $($arg)+);
+            __kani__workaround_core_assert!(true, $fmt, $($arg)+);
         }
         kani::panic(concat!("internal error: entered unreachable code: ",
         stringify!($fmt, $($arg)*)))}};
@@ -196,7 +196,7 @@ macro_rules! panic {
     // `panic!("Error: {}", code);`
     ($($arg:tt)+) => {{
         if false {
-            __core_assert!(true, $($arg)+);
+            __kani__workaround_core_assert!(true, $($arg)+);
         }
         kani::panic(stringify!($($arg)+));
     }};

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -12,6 +12,12 @@
 // re-export all std symbols
 pub use std::*;
 
+// Bind `core::assert` to a different name to avoid possible name conflicts if a
+// crate uses `extern crate std as core`. See
+// https://github.com/model-checking/kani/issues/1949
+#[allow(unused_imports)]
+use core::assert as __core_assert;
+
 // Override process calls with stubs.
 pub mod process;
 
@@ -54,7 +60,7 @@ macro_rules! assert {
         // strategy, which is tracked in
         // https://github.com/model-checking/kani/issues/692
         if false {
-            ::core::assert!(true, $($arg)+);
+            __core_assert!(true, $($arg)+);
         }
     }};
 }
@@ -158,7 +164,7 @@ macro_rules! unreachable {
     // handle.
     ($fmt:expr, $($arg:tt)*) => {{
         if false {
-            ::core::assert!(true, $fmt, $($arg)+);
+            __core_assert!(true, $fmt, $($arg)+);
         }
         kani::panic(concat!("internal error: entered unreachable code: ",
         stringify!($fmt, $($arg)*)))}};
@@ -190,7 +196,7 @@ macro_rules! panic {
     // `panic!("Error: {}", code);`
     ($($arg:tt)+) => {{
         if false {
-            ::core::assert!(true, $($arg)+);
+            __core_assert!(true, $($arg)+);
         }
         kani::panic(stringify!($($arg)+));
     }};

--- a/tests/kani/Panic/extern_core.rs
+++ b/tests/kani/Panic/extern_core.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test checks that the panic macro does not cause a "recursion limit
+//! reached" compiler error if the user crate contains an `extern crate std as
+//! core` line (see https://github.com/model-checking/kani/issues/1949)
+
+extern crate std as core;
+
+#[kani::proof]
+fn main() {
+    let x = if kani::any() { 11 } else { 33 };
+    if x < 10 {
+        panic!("x is {}", x);
+    }
+}


### PR DESCRIPTION
### Description of changes: 

Rename `core::assert` in Kani's `std` crate to work around the case of having an `extern crate std as core` line in the user crate, which results in making Kani's definition of the `assert` and `panic` macros (which both use `core::assert`) self-referential.

### Resolved issues:

Resolves #1949 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Added a new test

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
