### PR TITLE
Move kani::proof back to macro.

### DIFF
--- a/proptest/src/collection.rs
+++ b/proptest/src/collection.rs
@@ -637,7 +637,6 @@ mod kani_tests {
 
     crate::proptest! {
         #[kani::unwind(5)]
-        #[kani::proof]
         fn vector_even_sums(
             vec_even in vec((0..10).prop_map(|x: i32| x * 2), 0..2),
         ) {

--- a/proptest/src/sugar.rs
+++ b/proptest/src/sugar.rs
@@ -161,6 +161,7 @@ macro_rules! proptest {
     )*) => {
         $(
             $(#[$meta])*
+            #[kani::proof]
             fn $test_name() {
                 let mut config = <$crate::test_runner::Config as Default>::default();
                 config.test_name = Some(
@@ -176,6 +177,7 @@ macro_rules! proptest {
     )*) => {
         $(
             $(#[$meta])*
+            #[kani::proof]
             fn $test_name() {
                 let mut config = <$crate::test_runner::Config as Default>::default();
                 config.test_name = Some(

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -337,7 +337,6 @@ mod test {
     proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
         #[test]
-        #[cfg_attr(kani, kani::proof)]
         fn successfully_linked_proptest(_ in &Just(()) ) {
             let config = Config::default();
             prop_assert_eq!(
@@ -350,7 +349,6 @@ mod test {
 
     proptest! {
     #[test]
-    #[cfg_attr(kani, kani::proof)]
     fn possible_values_are_even(
             x in
         crate::prop_oneof![
@@ -364,7 +362,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(kani, kani::proof)]
     fn test_pass() {
         let mut runner = TestRunner::default();
         let result = runner.run(&(1u32..), |v| {
@@ -384,7 +381,6 @@ mod test {
 
     #[cfg(feature = "fork")]
     #[test]
-    #[cfg_attr(kani, kani::proof)]
     fn normal_failure_in_fork_results_in_correct_failure() {
         let mut runner = TestRunner::new(Config {
             fork: true,


### PR DESCRIPTION
### Description of changes: 

This PR moves `kani::proof` back to the `protest!` macro, running every proptest by default.

### Resolved issues:

Works towards #1608 
### Call-outs:


### Testing: 

* How is this change tested? Same tests.

* Is this a refactor change? yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
