### PR TITLE
Eliminate source of caller_location warnings in kani library

### DIFF
--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -136,7 +136,13 @@ pub(crate) unsafe fn any_raw_internal<T, const SIZE_T: usize>() -> T {
 #[inline(never)]
 #[allow(dead_code)]
 fn any_raw_inner<T>() -> T {
-    unimplemented!("Kani any_raw_inner");
+    // while we could use `unreachable!()` or `panic!()` as the body of this
+    // function, both cause Kani to produce a warning on any program that uses
+    // kani::any() (see https://github.com/model-checking/kani/issues/2010).
+    // This function is handled via a hook anyway, so we just need to put a body
+    // that rustc does not complain about. An infinite loop works out nicely.
+    #[allow(clippy::empty_loop)]
+    loop {}
 }
 
 /// Function used to generate panic with a static message as this is the only one currently


### PR DESCRIPTION
### Description of changes: 

Currently, running Kani on any program involving `kani::any()` results in a `caller_location` warning (see #2010). Turns out this intrinsic is brought in by the Kani library itself, more specifically due to the body of the `kani::any_raw_inner` function:
```rust
    unimplemented!("Kani any_raw_inner");
```
This macro ends up calling `panic!`, which calls `panic_fmt`, which calls `std::panic::Location::caller` which in turn calls `std::intrinsics::caller_location`. Thus, this PR replaces this call by another construct (empty loop) that does not result in the same call stack.

As a side effect, Kani compilation is sped up a bit. Even on this tiny program:
```rust
#[kani::proof]
fn main() {
    let _x: bool = kani::any();
}
```
I was noticing a slight pause when running Kani, which this PR eliminates. More specifically, before this change:
```bash
$ /usr/bin/time -p kani test.rs
...

real 0.91
user 0.75
sys 0.16
```
and after this change:
```bash
$ /usr/bin/time -p kani test.rs
...

real 0.15
user 0.12
sys 0.03
```

Another nice side effect is that the generated MIR is significantly smaller. Before this change:
```bash
$ RUSTFLAGS="--emit mir" kani test.rs
$ wc test.kani.mir
  7010  49876 865082 test.kani.mir
```
and after this change:
```bash
$ RUSTFLAGS="--emit mir" kani test.rs
$ wc test.kani.mir
  163  1019 10329 test.kani.mir
```
### Resolved issues:

Resolves #2010 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

I could not find a way to test this. I tried creating a test with `#![deny(warnings)]`, but even without the change, it doesn't fail, apparently because it's a Kani warning and not a compiler warning.

### Testing:

* How is this change tested? See callout

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
