### PR TITLE
Add missing bump for CBMC viewer version in kani-verifier package

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -113,7 +113,7 @@ fn setup_python_deps(kani_dir: &Path, os: &os_info::Info) -> Result<()> {
     let pyroot = kani_dir.join("pyroot");
 
     // TODO: this is a repetition of versions from kani/kani-dependencies
-    let pkg_versions = &["cbmc-viewer==3.6"];
+    let pkg_versions = &["cbmc-viewer==3.8"];
 
     if os_hacks::should_apply_ubuntu_18_04_python_hack(os)? {
         os_hacks::setup_python_deps_on_ubuntu_18_04(&pyroot, pkg_versions)?;


### PR DESCRIPTION
### Description of changes: 

Missing change from #2040. This is required for the `kani-verifier` to `pip install` the correct version of CBMC viewer.

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Current regressions

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
