### PR TITLE
Correctly identify extern statics

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -505,9 +505,9 @@ impl<'tcx> GotocCtx<'tcx> {
             //          #[linkage = "extern_weak"]
             //          static __cxa_thread_atexit_impl: *const libc::c_void;
             //      }
-            // CBMC shares C's notion of "extern" global variables. However, CBMC mostly does 
+            // CBMC shares C's notion of "extern" global variables. However, CBMC mostly does
             // not use this information except when doing C typechecking.
-            // The one exception is handling static variables with no initializer in 
+            // The one exception is handling static variables with no initializer in
             // CBMC's `static_lifetime_init`:
             //   1. If they are `is_extern` they are nondet-initialized.
             //   2. If they are `!is_extern`, they are zero-initialized.

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -507,12 +507,11 @@ impl<'tcx> GotocCtx<'tcx> {
             //      }
             // CBMC shares C's notion of "extern" global variables. However, CBMC mostly does
             // not use this information except when doing C typechecking.
-            // The one exception is handling static variables with no initializer in
-            // CBMC's `static_lifetime_init`:
+            // The one exception is handling static variables with no initializer (see
+            // CBMC's `static_lifetime_init`):
             //   1. If they are `is_extern` they are nondet-initialized.
             //   2. If they are `!is_extern`, they are zero-initialized.
-            // Replacing `is_extern` with a constant `true` or `false` both pass the Kani regressions.
-            // Nevertheless, we can correctly recognize a Rust "extern" declaration and pass that along.
+            // So we recognize a Rust "extern" declaration and pass that information along.
             let is_extern = ctx.tcx.is_foreign_item(def_id);
 
             let span = ctx.tcx.def_span(def_id);

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -505,11 +505,14 @@ impl<'tcx> GotocCtx<'tcx> {
             //          #[linkage = "extern_weak"]
             //          static __cxa_thread_atexit_impl: *const libc::c_void;
             //      }
-            // CBMC shares C's notion of "extern" global variables. However, I believe
-            // CBMC actually only uses this information during C typechecking.
-            // A quick `git grep is_extern` in the CBMC sources seems to support this theory.
-            // Replacing `is_extern` with a constant `true` or `false` all pass the regression.
-            // Nevertheless, we can recognize a Rust "extern" declaration and pass that along.
+            // CBMC shares C's notion of "extern" global variables. However, CBMC mostly does 
+            // not use this information except when doing C typechecking.
+            // The one exception is handling static variables with no initializer in 
+            // CBMC's `static_lifetime_init`:
+            //   1. If they are `is_extern` they are nondet-initialized.
+            //   2. If they are `!is_extern`, they are zero-initialized.
+            // Replacing `is_extern` with a constant `true` or `false` both pass the Kani regressions.
+            // Nevertheless, we can correctly recognize a Rust "extern" declaration and pass that along.
             let is_extern = ctx.tcx.is_foreign_item(def_id);
 
             let span = ctx.tcx.def_span(def_id);

--- a/tests/kani/Static/unsafe_extern_static_uninitialized.rs
+++ b/tests/kani/Static/unsafe_extern_static_uninitialized.rs
@@ -1,0 +1,24 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-verify-fail
+
+//! This test exercises the `is_extern` property that CBMC makes use of during proof initialization.
+//! CBMC has two behaviors with an *uninitialized* static variable:
+//!   1. If it is declared `extern`, then it is nondet-initialized. (Possible in unsafe Rust)
+//!   2. If it is not `extern`, then it is zero-initialized. (Not possible in Rust)
+//!
+//! Here we test to see that we observe the nondet-initialization.
+//! If this extern static were zero-initialized, the assert below would pass.
+//! Instead, we expect to see failure, because nondet-initialization could be 1.
+
+extern "C" {
+    static an_uninitialized_variable: u32;
+}
+
+#[kani::proof]
+fn check_extern_static_isnt_deterministic() {
+    // If this is zero-initialized, this assertion will pass, but this
+    // test is labeled 'kani-verify-fail', and so the test would fail.
+    assert!(unsafe { an_uninitialized_variable } != 1);
+}


### PR DESCRIPTION
### Description of changes: 

Fixes Kani's detection of extern static variables. This has no observable effect, because I believe this has no animating semantics on the CBMC side. I suspect this flag on the symbol exists for the CBMC C compiler's benefit only.

Nevertheless, this corrects our behavior. The old `linkage` check was wrong: that only detects the presence of a `#[linkage]` attribute, not the `extern`ness of the declaration.

### Resolved issues:

Resolves #388 
Resolves #400

### Testing:

* How is this change tested? N/A apparently: a comment describes my experiments. It doesn't matter.

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
