### PR TITLE
Allow custom path for installation/setup

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Run installed tests
         if: ${{ matrix.os == 'ubuntu-18.04' }}
         run: |
-          for tag in kani-20-04 kani-18-04; do
+          for tag in kani-20-04 kani-20-04-alt kani-18-04; do
             docker run $tag  cargo kani --version
             docker run -w /tmp/kani/tests/cargo-kani/simple-lib  $tag  cargo kani
             docker run -w /tmp/kani/tests/cargo-kani/simple-visualize  $tag  cargo kani
@@ -160,17 +160,6 @@ jobs:
           done
           # While the above test OS issues, now try testing with nightly as default:
           docker run -w /tmp/kani/tests/cargo-kani/simple-lib  kani-20-04  bash -c "rustup default nightly && cargo kani"
-
-      - name: Run installed tests (alt. install path)
-        if: ${{ matrix.os == 'ubuntu-18.04' }}
-        run: |
-          for tag in kani-20-04-alt; do
-            docker run $tag  cargo kani --version
-            docker run -w /tmp/kani/tests/cargo-kani/simple-lib  $tag  cargo kani
-            docker run -w /tmp/kani/tests/cargo-kani/simple-visualize  $tag  cargo kani
-            docker run -w /tmp/kani/tests/cargo-kani/build-rs-works  $tag  cargo kani
-            docker run $tag  cargo-kani setup --use-local-bundle ./${{ matrix.artifact }}
-          done
 
       # We can't run macos in a container, so we can only test locally.
       # Hopefully any dependency issues won't be unique to macos.

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -143,6 +143,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-18.04' }}
         run: |
           docker build -t kani-20-04 -f scripts/ci/Dockerfile.bundle-test-ubuntu-20-04 .
+          docker build -t kani-20-04-alt -f scripts/ci/Dockerfile.bundle-test-ubuntu-20-04-alt .
           docker build -t kani-18-04 -f scripts/ci/Dockerfile.bundle-test-ubuntu-18-04 .
           # this one does its tests automatically, for reasons documented in the file:
           docker build -t kani-nixos -f scripts/ci/Dockerfile.bundle-test-nixos .
@@ -159,6 +160,18 @@ jobs:
           done
           # While the above test OS issues, now try testing with nightly as default:
           docker run -w /tmp/kani/tests/cargo-kani/simple-lib  kani-20-04  bash -c "rustup default nightly && cargo kani"
+
+      - name: Run installed tests (alt. install path)
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        env: 
+        run: |
+          for tag in kani-20-04-alt; do
+            docker run $tag  cargo kani --version
+            docker run -w /tmp/kani/tests/cargo-kani/simple-lib  $tag  cargo kani
+            docker run -w /tmp/kani/tests/cargo-kani/simple-visualize  $tag  cargo kani
+            docker run -w /tmp/kani/tests/cargo-kani/build-rs-works  $tag  cargo kani
+            docker run $tag  cargo-kani setup --use-local-bundle ./${{ matrix.artifact }}
+          done
 
       # We can't run macos in a container, so we can only test locally.
       # Hopefully any dependency issues won't be unique to macos.

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -163,7 +163,6 @@ jobs:
 
       - name: Run installed tests (alt. install path)
         if: ${{ matrix.os == 'ubuntu-18.04' }}
-        env: 
         run: |
           for tag in kani-20-04-alt; do
             docker run $tag  cargo kani --version

--- a/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04-alt
+++ b/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04-alt
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 # Note: this file is intended only for testing the kani release bundle
+# using an alternative install path *
 
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true \
-    CARGO_HOME="/tmp" \
     KANI_HOME="/tmp"
 RUN apt-get update && \
     apt-get install -y python3 python3-pip curl ctags && \
     curl -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/tmp/bin:${PATH}"
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /tmp/kani
 COPY ./tests ./tests

--- a/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04-alt
+++ b/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04-alt
@@ -1,0 +1,22 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# Note: this file is intended only for testing the kani release bundle
+
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive \
+    DEBCONF_NONINTERACTIVE_SEEN=true \
+    CARGO_HOME="/tmp" \
+    KANI_HOME="/tmp"
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip curl ctags && \
+    curl -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/tmp/bin:${PATH}"
+
+WORKDIR /tmp/kani
+COPY ./tests ./tests
+COPY ./kani-latest-x86_64-unknown-linux-gnu.tar.gz ./
+# Very awkward glob (not regex!) to get `kani-verifier-*` and not `kani-verifier-*.crate`
+COPY ./target/package/kani-verifier-*[^e] ./kani-verifier
+RUN cargo install --path ./kani-verifier
+RUN cargo-kani setup --use-local-bundle ./kani-latest-x86_64-unknown-linux-gnu.tar.gz

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ fn fail_if_in_dev_environment() -> Result<()> {
 /// Executes `kani-driver` in `bin` mode (kani or cargo-kani)
 /// augmenting environment variables to accomodate our release environment
 fn exec(bin: &str) -> Result<()> {
-    let kani_dir = setup::kani_dir();
+    let kani_dir = setup::kani_dir()?;
     let program = kani_dir.join("bin").join("kani-driver");
     let pyroot = kani_dir.join("pyroot");
     let bin_kani = kani_dir.join("bin");

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -19,19 +19,22 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 const TARGET: &str = env!("TARGET");
 
 /// The directory where Kani is installed, either:
-///  * `${KANI_HOME}/.kani/kani-<VERSION>` if the environment variable
+///  * `${KANI_HOME}/kani-<VERSION>` if the environment variable
 ///    `KANI_HOME` is set.
 ///  * `${HOME}/.kani/kani-<VERSION>` where `HOME` is the canonical definition
 ///    of home directory used by Cargo and rustup.
 pub fn kani_dir() -> Result<PathBuf> {
-    let home_dir = match env::var("KANI_HOME") {
-        Ok(val) => PathBuf::from(val),
-        Err(_) => home::home_dir().expect("couldn't find home directory"),
+    let (home_dir, origin) = match env::var("KANI_HOME") {
+        Ok(val) => (PathBuf::from(val), "KANI_HOME"),
+        Err(_) => (home::home_dir().expect("couldn't find home directory").join(".kani"), "HOME"),
     };
     if !home_dir.is_dir() {
-        bail!("got home directory which isn't a directory");
+        bail!(
+            "got home directory `{}` (from `{origin}`) which isn't a directory",
+            home_dir.display()
+        );
     }
-    let kani_dir = home_dir.join(".kani").join(format!("kani-{VERSION}"));
+    let kani_dir = home_dir.join(format!("kani-{VERSION}"));
     Ok(kani_dir)
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -18,19 +18,31 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Set by our `build.rs`, reflects the Rust target triple we're building for
 const TARGET: &str = env!("TARGET");
 
-/// Where Kani has been installed. Typically `~/.kani/kani-1.x/`
-pub fn kani_dir() -> PathBuf {
-    home::home_dir().expect("Couldn't find home dir?").join(".kani").join(format!("kani-{VERSION}"))
+/// The directory where Kani is installed, either:
+///  * `${KANI_HOME}/.kani/kani-<VERSION>` if the environment variable
+///    `KANI_HOME` is set.
+///  * `${HOME}/.kani/kani-<VERSION>` where `HOME` is the canonical definition
+///    of home directory used by Cargo and rustup.
+pub fn kani_dir() -> Result<PathBuf> {
+    let home_dir = match env::var("KANI_HOME") {
+        Ok(val) => PathBuf::from(val),
+        Err(_) => home::home_dir().expect("couldn't find home directory"),
+    };
+    if !home_dir.is_dir() {
+        bail!("got home directory which isn't a directory");
+    }
+    let kani_dir = home_dir.join(".kani").join(format!("kani-{VERSION}"));
+    Ok(kani_dir)
 }
 
 /// Fast check to see if we look setup already
 pub fn appears_setup() -> bool {
-    kani_dir().exists()
+    kani_dir().expect("couldn't find kani directory").exists()
 }
 
 /// Sets up Kani by unpacking/installing to `~/.kani/kani-VERSION`
 pub fn setup(use_local_bundle: Option<OsString>) -> Result<()> {
-    let kani_dir = kani_dir();
+    let kani_dir = kani_dir()?;
     let os = os_info::get();
 
     println!("[0/5] Running Kani first-time setup...");

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -25,7 +25,7 @@ const TARGET: &str = env!("TARGET");
 ///    definition of home directory used by Cargo and rustup.
 pub fn kani_dir() -> Result<PathBuf> {
     let kani_dir = match env::var("KANI_HOME") {
-        Ok(val) => custom_kani_dir(val)?,
+        Ok(val) => custom_kani_dir(val),
         Err(_) => default_kani_dir()?,
     };
     let kani_dir = kani_dir.join(format!("kani-{VERSION}"));
@@ -33,12 +33,10 @@ pub fn kani_dir() -> Result<PathBuf> {
 }
 
 /// Returns the custom Kani home directory: `${KANI_HOME}`
-fn custom_kani_dir(path: String) -> Result<PathBuf> {
+fn custom_kani_dir(path: String) -> PathBuf {
     let kani_dir = PathBuf::from(path);
-    if !kani_dir.is_dir() {
-        bail!("got custom Kani directory `{}` which isn't a directory", kani_dir.display());
-    }
-    Ok(kani_dir)
+    // We don't check if it doesn't exist since we create it later
+    kani_dir
 }
 
 /// Returns the default Kani home directory: `${HOME}/.kani`

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -34,9 +34,8 @@ pub fn kani_dir() -> Result<PathBuf> {
 
 /// Returns the custom Kani home directory: `${KANI_HOME}`
 fn custom_kani_dir(path: String) -> PathBuf {
-    let kani_dir = PathBuf::from(path);
     // We don't check if it doesn't exist since we create it later
-    kani_dir
+    PathBuf::from(path)
 }
 
 /// Returns the default Kani home directory: `${HOME}/.kani`


### PR DESCRIPTION
### Description of changes: 

Adds the option to install Kani using an alternative path by using the `KANI_HOME` environment variable.

The downside is that the variable needs to be set in subsequent Kani invocations, otherwise the proxy binaries will fail to detect a previous installation.

### Resolved issues:

Resolves #1735 

### Testing:

* How is this change tested? Tested manually and in CI (using a new docker)

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
