### PR TITLE
Use release build when running assess scan script

### DIFF
--- a/scripts/exps/assess-scan-on-repos.sh
+++ b/scripts/exps/assess-scan-on-repos.sh
@@ -53,9 +53,15 @@ for repo in $REPOS; do
     fi
 done
 
+# Use release mode to speed up the run.
+echo "Build kani on release mode..."
+pushd ${KANI_DIR}
+cargo build-dev --release
+popd
+
 echo "Starting assess scan..."
 
-cargo kani --only-codegen --enable-unstable assess scan \
+time cargo kani --only-codegen --enable-unstable assess scan \
   --filter-packages-file $NAME_FILE \
   --emit-metadata ./scan-results.json
 


### PR DESCRIPTION
### Description of changes: 

Add a command to build Kani using the release mode so we speed up the metrics collection. From my previous experience, this can speed up by approx 2x.

### Resolved issues:

N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
