### PR TITLE
Add a kani::any_value_where function to enable easy generation of constrained symbolic values

### DIFF
--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -109,6 +109,31 @@ pub fn any<T: Arbitrary>() -> T {
     T::any()
 }
 
+/// This creates an symbolic *valid* value of type `T`.
+/// The value is constrained to be a value accepted by the predicate passed to the filter.
+/// You can assign the return value of this function to a variable that you want to make symbolic.
+/// The explanation field gives a mechanism to explain why the assumption is required for the proof.
+///
+/// # Example:
+///
+/// In the snippet below, we are verifying the behavior of the function `fn_under_verification`
+/// under all possible `NonZeroU8` input values between 0 and 12.
+///
+/// ```rust
+/// let inputA = kani::filter_any::<std::num::NonZeroU8>(|x| x < 12, "explanation");
+/// fn_under_verification(inputA);
+/// ```
+///
+/// Note: This is a safe construct and can only be used with types that implement the `Arbitrary`
+/// trait. The Arbitrary trait is used to build a symbolic value that represents all possible
+/// valid values for type `T`.
+#[inline(always)]
+pub fn filter_any<T: Arbitrary, F: FnOnce(&T) -> bool>(f: F, _msg: &'static str) -> T {
+    let result = T::any();
+    assume(f(&result));
+    result
+}
+
 /// This function creates a symbolic value of type `T`. This may result in an invalid value.
 ///
 /// # Safety

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -120,7 +120,7 @@ pub fn any<T: Arbitrary>() -> T {
 /// under all possible `NonZeroU8` input values between 0 and 12.
 ///
 /// ```rust
-/// let inputA = kani::any_with::<std::num::NonZeroU8>(|x| *x < 12, "explanation");
+/// let inputA = kani::any_value_where::<std::num::NonZeroU8>(|x| *x < 12, "explanation");
 /// fn_under_verification(inputA);
 /// ```
 ///
@@ -128,7 +128,7 @@ pub fn any<T: Arbitrary>() -> T {
 /// trait. The Arbitrary trait is used to build a symbolic value that represents all possible
 /// valid values for type `T`.
 #[inline(always)]
-pub fn any_with<T: Arbitrary, F: FnOnce(&T) -> bool>(f: F, _msg: &'static str) -> T {
+pub fn any_value_where<T: Arbitrary, F: FnOnce(&T) -> bool>(f: F, _msg: &'static str) -> T {
     let result = T::any();
     assume(f(&result));
     result

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -109,7 +109,7 @@ pub fn any<T: Arbitrary>() -> T {
     T::any()
 }
 
-/// This creates an symbolic *valid* value of type `T`.
+/// This creates a symbolic *valid* value of type `T`.
 /// The value is constrained to be a value accepted by the predicate passed to the filter.
 /// You can assign the return value of this function to a variable that you want to make symbolic.
 /// The explanation field gives a mechanism to explain why the assumption is required for the proof.
@@ -120,7 +120,7 @@ pub fn any<T: Arbitrary>() -> T {
 /// under all possible `NonZeroU8` input values between 0 and 12.
 ///
 /// ```rust
-/// let inputA = kani::filter_any::<std::num::NonZeroU8>(|x| x < 12, "explanation");
+/// let inputA = kani::any_with::<std::num::NonZeroU8>(|x| *x < 12, "explanation");
 /// fn_under_verification(inputA);
 /// ```
 ///
@@ -128,7 +128,7 @@ pub fn any<T: Arbitrary>() -> T {
 /// trait. The Arbitrary trait is used to build a symbolic value that represents all possible
 /// valid values for type `T`.
 #[inline(always)]
-pub fn filter_any<T: Arbitrary, F: FnOnce(&T) -> bool>(f: F, _msg: &'static str) -> T {
+pub fn any_with<T: Arbitrary, F: FnOnce(&T) -> bool>(f: F, _msg: &'static str) -> T {
     let result = T::any();
     assume(f(&result));
     result

--- a/tests/kani/Assume/main.rs
+++ b/tests/kani/Assume/main.rs
@@ -7,3 +7,9 @@ fn main() {
     kani::assume(i < 10);
     assert!(i < 20);
 }
+
+#[kani::proof]
+fn verify_filter_assume() {
+    let i: i32 = kani::filter_any(|x| *x < 10, "Only single digit values are legal");
+    assert!(i < 20);
+}

--- a/tests/kani/Assume/main.rs
+++ b/tests/kani/Assume/main.rs
@@ -9,7 +9,7 @@ fn main() {
 }
 
 #[kani::proof]
-fn verify_filter_assume() {
-    let i: i32 = kani::filter_any(|x| *x < 10, "Only single digit values are legal");
+fn verify_any_value_where() {
+    let i: i32 = kani::any_value_where(|x| *x < 10, "Only single digit values are legal");
     assert!(i < 20);
 }


### PR DESCRIPTION
### Description of changes: 

Currently, users must first create a value using `kani::any`, then constain it using `kani::assume`.  This is unergonomic.  
### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

Feel free to bikeshed the name

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? New unit test

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
