### PR TITLE
Cleanup unused revision functionality from compiletest

### DIFF
--- a/tools/compiletest/src/common.rs
+++ b/tools/compiletest/src/common.rs
@@ -9,7 +9,6 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use crate::util::PathBufExt;
 use std::time::Duration;
 use test::ColorConfig;
 
@@ -153,22 +152,21 @@ pub fn output_relative_path(config: &Config, relative_dir: &Path) -> PathBuf {
     config.build_base.join(relative_dir)
 }
 
-/// Generates a unique name for the test, such as `testname.revision`.
-pub fn output_testname_unique(testpaths: &TestPaths, revision: Option<&str>) -> PathBuf {
-    PathBuf::from(&testpaths.file.file_stem().unwrap()).with_extra_extension(revision.unwrap_or(""))
+/// Generates a unique name for the test.
+pub fn output_testname_unique(testpaths: &TestPaths) -> PathBuf {
+    PathBuf::from(&testpaths.file.file_stem().unwrap())
 }
 
 /// Absolute path to the directory where all output for the given
-/// test/revision should reside. Example:
-///   /path/to/build/host-triple/test/ui/relative/testname.revision/
-pub fn output_base_dir(config: &Config, testpaths: &TestPaths, revision: Option<&str>) -> PathBuf {
-    output_relative_path(config, &testpaths.relative_dir)
-        .join(output_testname_unique(testpaths, revision))
+/// test should reside. Example:
+///   /path/to/build/host-triple/test/ui/relative/testname/
+pub fn output_base_dir(config: &Config, testpaths: &TestPaths) -> PathBuf {
+    output_relative_path(config, &testpaths.relative_dir).join(output_testname_unique(testpaths))
 }
 
 /// Absolute path to the base filename used as output for the given
-/// test/revision. Example:
-///   /path/to/build/host-triple/test/ui/relative/testname.revision.mode/testname
-pub fn output_base_name(config: &Config, testpaths: &TestPaths, revision: Option<&str>) -> PathBuf {
-    output_base_dir(config, testpaths, revision).join(testpaths.file.file_stem().unwrap())
+/// test. Example:
+///   /path/to/build/host-triple/test/ui/relative/testname.mode/testname
+pub fn output_base_name(config: &Config, testpaths: &TestPaths) -> PathBuf {
+    output_base_dir(config, testpaths).join(testpaths.file.file_stem().unwrap())
 }


### PR DESCRIPTION
### Description of changes: 

We were just passing `vec![None]` to `revisions` and not using it anywhere, so cleaning it up.

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change? Yes

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
