### PR TITLE
Fix deserialization of property IDs for special case

### DIFF
--- a/kani-driver/src/cbmc_output_parser.rs
+++ b/kani-driver/src/cbmc_output_parser.rs
@@ -133,7 +133,7 @@ impl<'de> serde::Deserialize<'de> for PropertyId {
         //
         // As of CBMC 5.74.0, the property ID is `<function>.recursion`.
         // In earlier versions, it would just be `.recursion`.
-        if id_str.ends_with(".recursion")  {
+        if id_str.ends_with(".recursion") {
             let attributes: Vec<&str> = id_str.splitn(2, '.').collect();
             let fn_name = if attributes[0] == "" {
                 None
@@ -639,6 +639,38 @@ mod tests {
             trace: None,
         };
         assert_eq!(dummy_prop.property_name(), "recursion.1");
+    }
+
+    #[test]
+    fn check_property_id_deserialization_special_name() {
+        let prop_id_string = "\"alloc::raw_vec::RawVec::<u8>::allocate_in.recursion\"";
+        let prop_id_result: Result<PropertyId, serde_json::Error> =
+            serde_json::from_str(prop_id_string);
+        let prop_id = prop_id_result.unwrap();
+        assert_eq!(
+            prop_id.fn_name,
+            Some(String::from("alloc::raw_vec::RawVec::<u8>::allocate_in"))
+        );
+        assert_eq!(prop_id.class, String::from("recursion"));
+        assert_eq!(prop_id.id, 1);
+
+        let dummy_prop = Property {
+            description: "".to_string(),
+            property_id: prop_id,
+            source_location: SourceLocation {
+                function: None,
+                file: None,
+                column: None,
+                line: None,
+            },
+            status: CheckStatus::Success,
+            reach: None,
+            trace: None,
+        };
+        assert_eq!(
+            dummy_prop.property_name(),
+            "alloc::raw_vec::RawVec::<u8>::allocate_in.recursion.1"
+        );
     }
 
     #[test]

--- a/kani-driver/src/cbmc_output_parser.rs
+++ b/kani-driver/src/cbmc_output_parser.rs
@@ -127,15 +127,15 @@ impl<'de> serde::Deserialize<'de> for PropertyId {
     {
         let id_str = String::deserialize(d)?;
 
-        // Handle two special cases that doen't respect the format, and appears
-        // at least in the test `tests/expected/dynamic-error-trait/main.rs`
-        // with the description "recursion unwinding assertion".
+        // Handle a special case that doesn't respect the format, and appears at
+        // least in the test `tests/expected/dynamic-error-trait/main.rs` with
+        // the description "recursion unwinding assertion".
         //
         // As of CBMC 5.74.0, the property ID is `<function>.recursion`.
         // In earlier versions, it would just be `.recursion`.
         if id_str.ends_with(".recursion") {
             let attributes: Vec<&str> = id_str.splitn(2, '.').collect();
-            let fn_name = if attributes[0] == "" {
+            let fn_name = if attributes[0].is_empty() {
                 None
             } else {
                 Some(format!("{:#}", demangle(attributes[0])))


### PR DESCRIPTION
### Description of changes: 

Extends the deserialization of property IDs to handle the "recursion" special case so it now accepts both
 * `<function>.recursion` (new in CBMC 5.74.0)
 * `.recursion` (in earlier CBMC versions)
as valid property IDs and returns the expected values.

One unit test with this special case is included.

### Resolved issues:

Resolves #2106 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing tests + new one.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
