### PR TITLE
Rename nightly workflows

### DIFF
--- a/.github/workflows/cbmc-latest.yml
+++ b/.github/workflows/cbmc-latest.yml
@@ -1,9 +1,15 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-name: Nightly regressions with latest CBMC
+
+# We use block scalar notation to allow us to add ":" to the workflow name.
+name: >-
+  Nightly: CBMC Latest
+
 on:
   schedule:
     - cron: "0 9 * * *" # Run this every day at 9 AM UTC (4 AM ET/1 AM PT)
+  workflow_dispatch:    # Allow manual dispatching for a custom branch / tag.
+
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -1,9 +1,14 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-name: Kani's slow tests
+
+# We use block scalar notation to allow us to add ":" to the workflow name.
+name: >-
+  Nightly: Slow tests
+
 on:
   schedule:
     - cron: "30 5 * * *" # Run this every day at 05:30 UTC
+  workflow_dispatch:     # Allow manual dispatching for a custom branch / tag.
 
 env:
   RUST_BACKTRACE: 1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](./kani-logo.png)
-![Kani regression](https://github.com/zhassan-aws/kani/actions/workflows/kani.yml/badge.svg)
-![Nightly: CBMC Latest](https://github.com/zhassan-aws/kani/actions/workflows/cbmc-latest.yml/badge.svg)
+![Kani regression](https://github.com/model-checking/kani/actions/workflows/kani.yml/badge.svg)
+![Nightly: CBMC Latest](https://github.com/model-checking/kani/actions/workflows/cbmc-latest.yml/badge.svg)
 
 The Kani Rust Verifier is a bit-precise model checker for Rust.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![](./kani-logo.png)
-![Regressions with latest CBMC](https://github.com/zhassan-aws/kani/actions/workflows/cbmc-latest.yml/badge.svg)
+![Kani regression](https://github.com/zhassan-aws/kani/actions/workflows/kani.yml/badge.svg)
+![Nightly: CBMC Latest](https://github.com/zhassan-aws/kani/actions/workflows/cbmc-latest.yml/badge.svg)
 
 The Kani Rust Verifier is a bit-precise model checker for Rust.
 


### PR DESCRIPTION
### Description of changes: 

Rename our 2 nightly workflows to follow the convention "Nightly: <Task Name>". I also added a manual trigger to them and added a Kani regression badge to our README.md.

### Resolved issues:
N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

The manual trigger seems to only work for branches and tags. So for PRs, developers have to enable workflow in their fork and trigger them from their fork. We should consider adding a trigger based on a comment or label, but I wanted to keep it simple for now.

### Testing:

* How is this change tested? Yes. I tested on my fork.

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
