### PR TITLE
Fix postprocessing by also considering unwinding assertion failures from recursion

### DIFF
--- a/kani-driver/src/cbmc_property_renderer.rs
+++ b/kani-driver/src/cbmc_property_renderer.rs
@@ -150,6 +150,7 @@ static CBMC_ALT_DESCRIPTIONS: Lazy<CbmcAltDescriptions> = Lazy::new(|| {
 
 const UNSUPPORTED_CONSTRUCT_DESC: &str = "is not currently supported by Kani";
 const UNWINDING_ASSERT_DESC: &str = "unwinding assertion loop";
+const UNWINDING_ASSERT_REC_DESC: &str = "recursion unwinding assertion";
 const DEFAULT_ASSERTION: &str = "assertion";
 
 impl ParserItem {
@@ -388,7 +389,7 @@ pub fn format_result(properties: &Vec<Property>, show_checks: bool) -> String {
         more details.",
         );
     }
-    if has_check_failure(properties, UNWINDING_ASSERT_DESC) {
+    if has_unwinding_assertion_failures(properties) {
         result_str.push_str("[Kani] info: Verification output shows one or more unwinding failures.\n\
         [Kani] tip: Consider increasing the unwinding value or disabling `--unwinding-assertions`.\n");
     }
@@ -460,7 +461,7 @@ pub fn postprocess_result(properties: Vec<Property>, extra_ptr_checks: bool) -> 
     // First, determine if there are reachable unsupported constructs or unwinding assertions
     let has_reachable_unsupported_constructs =
         has_check_failure(&properties, UNSUPPORTED_CONSTRUCT_DESC);
-    let has_failed_unwinding_asserts = has_check_failure(&properties, UNWINDING_ASSERT_DESC);
+    let has_failed_unwinding_asserts = has_unwinding_assertion_failures(&properties);
     // Then, determine if there are reachable undefined functions, and change
     // their description to highlight this fact
     let (properties_with_undefined, has_reachable_undefined_functions) =
@@ -498,6 +499,12 @@ fn has_check_failure(properties: &Vec<Property>, description: &str) -> bool {
         }
     }
     false
+}
+
+// Determines if there were unwinding assertion failures in a set of properties
+fn has_unwinding_assertion_failures(properties: &Vec<Property>) -> bool {
+    has_check_failure(&properties, UNWINDING_ASSERT_DESC)
+        || has_check_failure(&properties, UNWINDING_ASSERT_REC_DESC)
 }
 
 /// Replaces the description of all properties from functions with a missing

--- a/tests/expected/unwind-recursion-fail/expected
+++ b/tests/expected/unwind-recursion-fail/expected
@@ -1,0 +1,8 @@
+UNDETERMINED\
+assertion failed: f == 120
+UNDETERMINED\
+attempt to subtract with overflow
+UNDETERMINED\
+attempt to multiply with overflow
+[Kani] info: Verification output shows one or more unwinding failures.
+[Kani] tip: Consider increasing the unwinding value or disabling `--unwinding-assertions`.

--- a/tests/expected/unwind-recursion-fail/main.rs
+++ b/tests/expected/unwind-recursion-fail/main.rs
@@ -1,0 +1,17 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Checks that all other checks are reported as `UNDETERMINED` when there is an
+//! unwinding assertion failure in a recursive program.
+
+fn factorial(x: u32) -> u32 {
+    if x == 1 { x } else { x * factorial(x - 1) }
+}
+
+#[kani::proof]
+#[kani::unwind(3)]
+fn main() {
+    let x = 5;
+    let f = factorial(x);
+    assert_eq!(f, 120);
+}


### PR DESCRIPTION
### Description of changes: 

We realized in #2110 that unwinding assertions from recursion weren't used to determine if there were unwinding assertion failures in general. This PR adds a new function for doing it, which now considers that case as well.

Thanks @zhassan-aws for the test!

### Resolved issues:

Related #2110 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing tests + new one.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
