### PR TITLE
Allow `&bool` in asserts

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -44,10 +44,11 @@ pub mod process;
 #[macro_export]
 macro_rules! assert {
     ($cond:expr $(,)?) => {
-        kani::assert($cond, concat!("assertion failed: ", stringify!($cond)));
+        // The double negation is to resolve https://github.com/model-checking/kani/issues/2108
+        kani::assert(!!$cond, concat!("assertion failed: ", stringify!($cond)));
     };
     ($cond:expr, $($arg:tt)+) => {{
-        kani::assert($cond, concat!(stringify!($($arg)+)));
+        kani::assert(!!$cond, concat!(stringify!($($arg)+)));
         // Process the arguments of the assert inside an unreachable block. This
         // is to make sure errors in the arguments (e.g. an unknown variable or
         // an argument that does not implement the Display or Debug traits) are

--- a/tests/kani/Assert/bool_ref.rs
+++ b/tests/kani/Assert/bool_ref.rs
@@ -1,0 +1,12 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test makes sure Kani handles the valid `assert!(&b)` syntax where `b` is a `bool`
+//! See https://github.com/model-checking/kani/issues/2108 for details.
+
+#[kani::proof]
+fn check_assert_with_reg() {
+    let b1: bool = kani::any();
+    let b2 = b1 || !b1; // true
+    assert!(&b2);
+}


### PR DESCRIPTION
### Description of changes: 

From investigating #2108, it turns out that due to how the standard library expands `assert!(x)` as
```rust
    if !x {
        ::core::panicking::panic("assertion failed: x")
    };
```
the following is valid Rust code:
```rust
fn main() {
    let b: bool = true;
    assert!(&b);
}
```
because it gets expanded to:
```rust
fn main() {
    let b: bool = true;
    if !&b {
        ::core::panicking::panic("assertion failed: &b")
    }
}
```
which, however, is rejected by Kani because `&b` is not a boolean (only `!&b` is!).

This PR adds a hacky fix, which is to inject `!!` (i.e. double negation) before the condition.

### Resolved issues:

Resolves #2108 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

TBH, I'm not sure about whether this should be merged as it is quite hacky. We should look into where this occurs, and why it is valid.

### Testing:

* How is this change tested? Added a new test

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
