### PR TITLE
Update some concrete playback expected files for upcoming CBMC integration.

### DIFF
--- a/tests/ui/concrete-playback/i64/expected
+++ b/tests/ui/concrete-playback/i64/expected
@@ -5,15 +5,15 @@ Concrete playback
 #[test]
 fn kani_concrete_playback_harness
     let concrete_vals: Vec<Vec<u8>> = vec![
-        // -9223372036854775808l
+        // -9223372036854775808
         vec![0, 0, 0, 0, 0, 0, 0, 128],
-        // -101l
+        // -101
         vec![155, 255, 255, 255, 255, 255, 255, 255],
-        // 0l
+        // 0
         vec![0, 0, 0, 0, 0, 0, 0, 0],
-        // 101l
+        // 101
         vec![101, 0, 0, 0, 0, 0, 0, 0],
-        // 9223372036854775807l
+        // 9223372036854775807
         vec![255, 255, 255, 255, 255, 255, 255, 127]
     ];
     kani::concrete_playback_run(concrete_vals, harness);

--- a/tests/ui/concrete-playback/isize/expected
+++ b/tests/ui/concrete-playback/isize/expected
@@ -5,15 +5,15 @@ Concrete playback
 #[test]
 fn kani_concrete_playback_harness
     let concrete_vals: Vec<Vec<u8>> = vec![
-        // -9223372036854775808l
+        // -9223372036854775808
         vec![0, 0, 0, 0, 0, 0, 0, 128],
-        // -101l
+        // -101
         vec![155, 255, 255, 255, 255, 255, 255, 255],
-        // 0l
+        // 0
         vec![0, 0, 0, 0, 0, 0, 0, 0],
-        // 101l
+        // 101
         vec![101, 0, 0, 0, 0, 0, 0, 0],
-        // 9223372036854775807l
+        // 9223372036854775807
         vec![255, 255, 255, 255, 255, 255, 255, 127]
     ];
     kani::concrete_playback_run(concrete_vals, harness);

--- a/tests/ui/concrete-playback/u32/expected
+++ b/tests/ui/concrete-playback/u32/expected
@@ -5,11 +5,11 @@ Concrete playback
 #[test]
 fn kani_concrete_playback_harness
     let concrete_vals: Vec<Vec<u8>> = vec![
-        // 0u
+        // 0
         vec![0, 0, 0, 0],
-        // 101u
+        // 101
         vec![101, 0, 0, 0],
-        // 4294967295u
+        // 4294967295
         vec![255, 255, 255, 255]
     ];
     kani::concrete_playback_run(concrete_vals, harness);


### PR DESCRIPTION
### Description of changes: 

Starting CBMC 5.73.0, traces no longer include suffixes for integer literals (e.g. `u`, `l`, `ul`, etc.) (see discussion in #2123). This PR updates the expected files for the impacted concrete playback tests to fix the nightly CBMC regressions and enable the integration of the upcoming CBMC release.

This doesn't break the regressions with the currently integrated CBMC version (5.72.0) since expected tests check if the line in the output _contains_ the line in the expected file.

### Resolved issues:

Resolves #2123 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regressions

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
