### PR TITLE
Fix nightly CBMC workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,6 +5,10 @@ inputs:
   os:
     description: In which Operating System is this running
     required: true
+  install_cbmc:
+    description: Whether to install CBMC
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -15,6 +19,7 @@ runs:
       - name: Install CBMC
         run: ./scripts/setup/${{ inputs.os }}/install_cbmc.sh
         shell: bash
+        if: ${{ inputs.install_cbmc }}
 
       - name: Install cbmc-viewer
         run: ./scripts/setup/${{ inputs.os }}/install_viewer.sh

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,7 +19,7 @@ runs:
       - name: Install CBMC
         run: ./scripts/setup/${{ inputs.os }}/install_cbmc.sh
         shell: bash
-        if: ${{ inputs.install_cbmc }}
+        if: ${{format('{0}', inputs.install_cbmc) != 'false'}}
 
       - name: Install cbmc-viewer
         run: ./scripts/setup/${{ inputs.os }}/install_viewer.sh

--- a/.github/workflows/cbmc-latest.yml
+++ b/.github/workflows/cbmc-latest.yml
@@ -21,6 +21,22 @@ jobs:
       matrix:
         os: [macos-11, ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
     steps:
+      - name: Checkout CBMC under "cbmc"
+        uses: actions/checkout@v3
+        with:
+          repository: diffblue/cbmc
+          path: cbmc
+
+      - name: Build CBMC
+        run: |
+          cd cbmc
+          cmake -S . -Bbuild -DWITH_JBMC=OFF
+          cmake --build build -- -j 4
+          sudo cmake --build build --target install
+          # Cleanup cbmc directory
+          cd ..
+          rm -rf cbmc
+
       - name: Checkout Kani
         uses: actions/checkout@v3
 
@@ -28,10 +44,17 @@ jobs:
         uses: ./.github/actions/setup
         with:
           os: ${{ matrix.os }}
+          install_cbmc: 'false'
 
       - name: Build Kani
         run: cargo build-dev
 
+      - name: Execute Kani regressions
+        run: ./scripts/kani-regression.sh
+
+  perf:
+    runs-on: ubuntu-20.04
+    steps:
       - name: Checkout CBMC under "cbmc"
         uses: actions/checkout@v3
         with:
@@ -44,12 +67,10 @@ jobs:
           cmake -S . -Bbuild -DWITH_JBMC=OFF
           cmake --build build -- -j 4
           sudo cmake --build build --target install
-      - name: Execute Kani regressions
-        run: ./scripts/kani-regression.sh
+          # Cleanup cbmc directory
+          cd ..
+          rm -rf cbmc
 
-  perf:
-    runs-on: ubuntu-20.04
-    steps:
       - name: Checkout Kani
         uses: actions/checkout@v3
 
@@ -57,21 +78,10 @@ jobs:
         uses: ./.github/actions/setup
         with:
           os: ubuntu-20.04
+          install_cbmc: 'false'
 
       - name: Build Kani using release mode
         run: cargo build-dev -- --release
 
-      - name: Checkout CBMC under "cbmc"
-        uses: actions/checkout@v3
-        with:
-          repository: diffblue/cbmc
-          path: cbmc
-
-      - name: Build CBMC
-        run: |
-          cd cbmc
-          cmake -S . -Bbuild -DWITH_JBMC=OFF
-          cmake --build build -- -j 4
-          sudo cmake --build build --target install
       - name: Execute Kani performance tests
         run: ./scripts/kani-perf.sh


### PR DESCRIPTION
### Description of changes: 

The CBMC repo recently introduced some `Cargo.toml` files (for the Rust API), and if CBMC is built after checking out Kani, the build fails because it thinks CBMC should be added as a workspace member to Kani:

https://github.com/model-checking/kani/actions/runs/3937611951/jobs/6735339605

This PR updates the nightly CBMC workflow to install CBMC _before_ checking out Kani to avoid this issue.

It also introduces an input parameter to the setup action to control whether to install CBMC as part of the setup. This is to avoid installing two CBMC versions (nightly and integrated version).

### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
