### PR TITLE
Enable concrete playback for satisfiable cover properties

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -38,6 +38,8 @@ pub struct VerificationResult {
     pub exit_status: i32,
     /// The runtime duration of this CBMC invocation.
     pub runtime: Duration,
+    /// Whether concrete playback generated a test
+    pub generated_concrete_test: bool,
 }
 
 impl KaniSession {
@@ -51,7 +53,8 @@ impl KaniSession {
 
         let start_time = Instant::now();
 
-        let verification_results = if self.args.output_format == crate::args::OutputFormat::Old {
+        let mut verification_results = if self.args.output_format == crate::args::OutputFormat::Old
+        {
             if self.run_terminal(cmd).is_err() {
                 VerificationResult::mock_failure()
             } else {
@@ -80,7 +83,7 @@ impl KaniSession {
             }
         };
 
-        self.gen_and_add_concrete_playback(harness, &verification_results)?;
+        self.gen_and_add_concrete_playback(harness, &mut verification_results)?;
         Ok(verification_results)
     }
 
@@ -204,6 +207,7 @@ impl VerificationResult {
                 results: Some(results),
                 exit_status: output.process_status,
                 runtime,
+                generated_concrete_test: false,
             }
         } else {
             // We never got results from CBMC - something went wrong (e.g. crash) so it's failure
@@ -213,6 +217,7 @@ impl VerificationResult {
                 results: None,
                 exit_status: output.process_status,
                 runtime,
+                generated_concrete_test: false,
             }
         }
     }
@@ -224,6 +229,7 @@ impl VerificationResult {
             results: None,
             exit_status: 42, // on success, exit code is ignored, so put something weird here
             runtime: Duration::from_secs(0),
+            generated_concrete_test: false,
         }
     }
 
@@ -237,6 +243,7 @@ impl VerificationResult {
             // so again use something weird:
             exit_status: 42,
             runtime: Duration::from_secs(0),
+            generated_concrete_test: false,
         }
     }
 

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -116,7 +116,10 @@ impl KaniSession {
         let failing = failures.len();
         let total = succeeding + failing;
 
-        if self.args.concrete_playback.is_some() && !self.args.quiet && failures.is_empty() {
+        if self.args.concrete_playback.is_some()
+            && !self.args.quiet
+            && results.iter().all(|r| !r.result.generated_concrete_test)
+        {
             println!(
                 "INFO: The concrete playback feature never generated unit tests because there were no failing harnesses."
             )

--- a/tests/ui/concrete-playback/cover/expected
+++ b/tests/ui/concrete-playback/cover/expected
@@ -1,0 +1,14 @@
+1 of 1 cover properties satisfied
+VERIFICATION:- SUCCESSFUL
+
+Concrete playback
+```
+#[test]
+fn kani_concrete_playback_harness
+    let concrete_vals: Vec<Vec<u8>> = vec![
+        // 1
+        vec![1, 0, 0, 0]
+    ];
+    kani::concrete_playback_run(concrete_vals, harness);
+}
+```

--- a/tests/ui/concrete-playback/cover/main.rs
+++ b/tests/ui/concrete-playback/cover/main.rs
@@ -5,6 +5,6 @@
 
 #[kani::proof]
 pub fn harness() {
-    let x: i32 = kani::any();
+    let x: u32 = kani::any();
     kani::cover!(x != 0 && x / 2 == 0);
 }

--- a/tests/ui/concrete-playback/cover/main.rs
+++ b/tests/ui/concrete-playback/cover/main.rs
@@ -1,0 +1,10 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags: --enable-unstable --concrete-playback=print
+
+#[kani::proof]
+pub fn harness() {
+    let x: i32 = kani::any();
+    kani::cover!(x != 0 && x / 2 == 0);
+}


### PR DESCRIPTION
### Description of changes: 

Include satisfiable cover properties as part of what concrete playback can generate tests for.

### Resolved issues:

Resolves #2133 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Added a new test

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
