### PR TITLE
Minor refactoring for CI scripts

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,19 +16,6 @@ runs:
         run: ./scripts/setup/${{ inputs.os }}/install_deps.sh
         shell: bash
 
-      - name: Install CBMC
-        run: ./scripts/setup/${{ inputs.os }}/install_cbmc.sh
-        shell: bash
-        if: ${{format('{0}', inputs.install_cbmc) != 'false'}}
-
-      - name: Install cbmc-viewer
-        run: ./scripts/setup/${{ inputs.os }}/install_viewer.sh
-        shell: bash
-
-      - name: Install Kissat
-        run: ./scripts/setup/install_kissat.sh
-        shell: bash
-
       - name: Install Rust toolchain
         run: ./scripts/setup/install_rustup.sh
         shell: bash

--- a/docs/src/build-from-source.md
+++ b/docs/src/build-from-source.md
@@ -29,9 +29,6 @@ git clone https://github.com/model-checking/kani.git
 cd kani
 git submodule update --init
 ./scripts/setup/ubuntu/install_deps.sh
-./scripts/setup/ubuntu/install_cbmc.sh
-./scripts/setup/ubuntu/install_viewer.sh
-./scripts/setup/install_kissat.sh
 # If you haven't already (or from https://rustup.rs/):
 ./scripts/setup/install_rustup.sh
 source $HOME/.cargo/env
@@ -47,9 +44,6 @@ git clone https://github.com/model-checking/kani.git
 cd kani
 git submodule update --init
 ./scripts/setup/macos/install_deps.sh
-./scripts/setup/macos/install_cbmc.sh
-./scripts/setup/macos/install_viewer.sh
-./scripts/setup/install_kissat.sh
 # If you haven't already (or from https://rustup.rs/):
 ./scripts/setup/install_rustup.sh
 source $HOME/.cargo/env

--- a/scripts/setup/macos/install_deps.sh
+++ b/scripts/setup/macos/install_deps.sh
@@ -19,8 +19,10 @@ PYTHON_DEPS=(
 
 python3 -m pip install "${PYTHON_DEPS[@]}"
 
+# Get the directory containing this script
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 ${SCRIPT_DIR}/install_cbmc.sh
 ${SCRIPT_DIR}/install_viewer.sh
+# The Kissat installation script is platform-independent, so is placed one level up
 ${SCRIPT_DIR}/../install_kissat.sh

--- a/scripts/setup/macos/install_deps.sh
+++ b/scripts/setup/macos/install_deps.sh
@@ -18,3 +18,9 @@ PYTHON_DEPS=(
 )
 
 python3 -m pip install "${PYTHON_DEPS[@]}"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+${SCRIPT_DIR}/install_cbmc.sh
+${SCRIPT_DIR}/install_viewer.sh
+${SCRIPT_DIR}/../install_kissat.sh

--- a/scripts/setup/ubuntu/install_deps.sh
+++ b/scripts/setup/ubuntu/install_deps.sh
@@ -52,3 +52,9 @@ PYTHON_DEPS=(
 )
 
 python3 -m pip install "${PYTHON_DEPS[@]}"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+${SCRIPT_DIR}/install_cbmc.sh
+${SCRIPT_DIR}/install_viewer.sh
+${SCRIPT_DIR}/../install_kissat.sh

--- a/scripts/setup/ubuntu/install_deps.sh
+++ b/scripts/setup/ubuntu/install_deps.sh
@@ -53,8 +53,10 @@ PYTHON_DEPS=(
 
 python3 -m pip install "${PYTHON_DEPS[@]}"
 
+# Get the directory containing this script
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 ${SCRIPT_DIR}/install_cbmc.sh
 ${SCRIPT_DIR}/install_viewer.sh
+# The Kissat installation script is platform-independent, so is placed one level up
 ${SCRIPT_DIR}/../install_kissat.sh


### PR DESCRIPTION
### Description of changes: 

This is a follow-up to @celinval's [comment](https://github.com/model-checking/kani/pull/2087#discussion_r1083025802) from #2087. Instead of having to call multiple installation scripts (CBMC, Viewer, and Kissat), `install_deps.sh` now installs them, so one only needs to invoke one script to install all the dependencies.

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? CI

* Is this a refactor change? Yes

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
