### PR TITLE
Upgrade toolchain to `nightly-2023-01-23`

### DIFF
--- a/kani-compiler/kani_queries/src/lib.rs
+++ b/kani-compiler/kani_queries/src/lib.rs
@@ -15,7 +15,7 @@ use {
     std::sync::{Arc, Mutex},
 };
 
-#[derive(Debug, Clone, Copy, AsRefStr, EnumString, EnumVariantNames, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, AsRefStr, EnumString, EnumVariantNames, PartialEq, Eq)]
 #[strum(serialize_all = "snake_case")]
 pub enum ReachabilityType {
     /// Start the cross-crate reachability analysis from all harnesses in the local crate.
@@ -23,17 +23,12 @@ pub enum ReachabilityType {
     /// Use standard rustc monomorphizer algorithm.
     Legacy,
     /// Don't perform any reachability analysis. This will skip codegen for this crate.
+    #[default]
     None,
     /// Start the cross-crate reachability analysis from all public functions in the local crate.
     PubFns,
     /// Start the cross-crate reachability analysis from all *test* (i.e. `#[test]`) harnesses in the local crate.
     Tests,
-}
-
-impl Default for ReachabilityType {
-    fn default() -> Self {
-        ReachabilityType::None
-    }
 }
 
 pub trait UserInput {

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -365,7 +365,9 @@ impl<'tcx> GotocCtx<'tcx> {
             "add_with_overflow" => codegen_op_with_overflow!(add_overflow_result),
             "arith_offset" => self.codegen_offset(intrinsic, instance, fargs, p, loc),
             "assert_inhabited" => self.codegen_assert_intrinsic(instance, intrinsic, span),
-            "assert_uninit_valid" => self.codegen_assert_intrinsic(instance, intrinsic, span),
+            "assert_mem_uninitialized_valid" => {
+                self.codegen_assert_intrinsic(instance, intrinsic, span)
+            }
             "assert_zero_valid" => self.codegen_assert_intrinsic(instance, intrinsic, span),
             // https://doc.rust-lang.org/core/intrinsics/fn.assume.html
             // Informs the optimizer that a condition is always true.

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
@@ -243,7 +243,8 @@ impl<'tcx> GotocCtx<'tcx> {
         match t {
             TypeOrVariant::Type(t) => {
                 match t.kind() {
-                    ty::Bool
+                    ty::Alias(..)
+                    | ty::Bool
                     | ty::Char
                     | ty::Int(_)
                     | ty::Uint(_)
@@ -254,10 +255,8 @@ impl<'tcx> GotocCtx<'tcx> {
                     | ty::GeneratorWitness(..)
                     | ty::Foreign(..)
                     | ty::Dynamic(..)
-                    | ty::Projection(_)
                     | ty::Bound(..)
                     | ty::Placeholder(..)
-                    | ty::Opaque(..)
                     | ty::Param(_)
                     | ty::Infer(_)
                     | ty::Error(_) => unreachable!("type {:?} does not have a field", t),

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -358,20 +358,41 @@ impl<'tcx> GotocCtx<'tcx> {
         // `Generator::resume(...) -> GeneratorState` function in case we
         // have an ordinary generator, or the `Future::poll(...) -> Poll`
         // function in case this is a special generator backing an async construct.
-        let ret_ty = if self.tcx.generator_is_async(*did) {
-            let state_did = self.tcx.require_lang_item(LangItem::Poll, None);
-            let state_adt_ref = self.tcx.adt_def(state_did);
-            let state_substs = self.tcx.intern_substs(&[sig.return_ty.into()]);
-            self.tcx.mk_adt(state_adt_ref, state_substs)
+        let tcx = self.tcx;
+        let (resume_ty, ret_ty) = if tcx.generator_is_async(*did) {
+            // The signature should be `Future::poll(_, &mut Context<'_>) -> Poll<Output>`
+            let poll_did = tcx.require_lang_item(LangItem::Poll, None);
+            let poll_adt_ref = tcx.adt_def(poll_did);
+            let poll_substs = tcx.intern_substs(&[sig.return_ty.into()]);
+            let ret_ty = tcx.mk_adt(poll_adt_ref, poll_substs);
+
+            // We have to replace the `ResumeTy` that is used for type and borrow checking
+            // with `&mut Context<'_>` which is used in codegen.
+            #[cfg(debug_assertions)]
+            {
+                if let ty::Adt(resume_ty_adt, _) = sig.resume_ty.kind() {
+                    let expected_adt = tcx.adt_def(tcx.require_lang_item(LangItem::ResumeTy, None));
+                    assert_eq!(*resume_ty_adt, expected_adt);
+                } else {
+                    panic!("expected `ResumeTy`, found `{:?}`", sig.resume_ty);
+                };
+            }
+            let context_mut_ref = tcx.mk_task_context();
+
+            (context_mut_ref, ret_ty)
         } else {
-            let state_did = self.tcx.require_lang_item(LangItem::GeneratorState, None);
-            let state_adt_ref = self.tcx.adt_def(state_did);
-            let state_substs = self.tcx.intern_substs(&[sig.yield_ty.into(), sig.return_ty.into()]);
-            self.tcx.mk_adt(state_adt_ref, state_substs)
+            // The signature should be `Generator::resume(_, Resume) -> GeneratorState<Yield, Return>`
+            let state_did = tcx.require_lang_item(LangItem::GeneratorState, None);
+            let state_adt_ref = tcx.adt_def(state_did);
+            let state_substs = tcx.intern_substs(&[sig.yield_ty.into(), sig.return_ty.into()]);
+            let ret_ty = tcx.mk_adt(state_adt_ref, state_substs);
+
+            (sig.resume_ty, ret_ty)
         };
+
         ty::Binder::bind_with_vars(
-            self.tcx.mk_fn_sig(
-                [env_ty, sig.resume_ty].iter(),
+            tcx.mk_fn_sig(
+                [env_ty, resume_ty].iter(),
                 &ret_ty,
                 false,
                 Unsafety::Normal,

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -813,7 +813,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     )
                 }
             }
-            ty::Projection(_) | ty::Opaque(_, _) => {
+            ty::Alias(..) => {
                 unreachable!("Type should've been normalized already")
             }
 
@@ -1226,7 +1226,7 @@ impl<'tcx> GotocCtx<'tcx> {
             ty::Dynamic(..) | ty::Slice(_) | ty::Str => {
                 unreachable!("Should have generated a fat pointer")
             }
-            ty::Projection(_) | ty::Opaque(..) => {
+            ty::Alias(..) => {
                 unreachable!("Should have been removed by normalization")
             }
 

--- a/kani-compiler/src/kani_middle/coercion.rs
+++ b/kani-compiler/src/kani_middle/coercion.rs
@@ -17,7 +17,7 @@ use rustc_hir::lang_items::LangItem;
 use rustc_middle::traits::{ImplSource, ImplSourceUserDefinedData};
 use rustc_middle::ty::adjustment::CustomCoerceUnsized;
 use rustc_middle::ty::TypeAndMut;
-use rustc_middle::ty::{self, ParamEnv, TraitRef, Ty, TyCtxt};
+use rustc_middle::ty::{self, ParamEnv, Ty, TyCtxt};
 use rustc_span::symbol::Symbol;
 use tracing::trace;
 
@@ -213,10 +213,9 @@ fn custom_coerce_unsize_info<'tcx>(
 ) -> CustomCoerceUnsized {
     let def_id = tcx.require_lang_item(LangItem::CoerceUnsized, None);
 
-    let trait_ref = ty::Binder::dummy(TraitRef {
-        def_id,
-        substs: tcx.mk_substs_trait(source_ty, [target_ty.into()]),
-    });
+    let trait_ref = ty::Binder::dummy(
+        tcx.mk_trait_ref(def_id, tcx.mk_substs_trait(source_ty, [target_ty.into()])),
+    );
 
     match tcx.codegen_select_candidate((ParamEnv::reveal_all(), trait_ref)) {
         Ok(ImplSource::UserDefined(ImplSourceUserDefinedData { impl_def_id, .. })) => {

--- a/kani-compiler/src/kani_middle/stubbing/annotations.rs
+++ b/kani-compiler/src/kani_middle/stubbing/annotations.rs
@@ -40,7 +40,7 @@ impl Callbacks for CollectorCallbacks {
         _compiler: &Compiler,
         queries: &'tcx Queries<'tcx>,
     ) -> Compilation {
-        queries.global_ctxt().unwrap().peek_mut().enter(|tcx| {
+        queries.global_ctxt().unwrap().enter(|tcx| {
             for item in tcx.hir_crate_items(()).items() {
                 let local_def_id = item.owner_id.def_id;
                 let def_id = local_def_id.to_def_id();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2022-12-11"
+channel = "nightly-2023-01-16"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-01-16"
+channel = "nightly-2023-01-23"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/cargo-kani/vecdeque-cve/src/abstract_vecdeque.rs
+++ b/tests/cargo-kani/vecdeque-cve/src/abstract_vecdeque.rs
@@ -275,8 +275,8 @@ impl AbstractRawVec {
 
 fn handle_reserve(result: Result<(), TryReserveError>) {
     match result.map_err(|e| e.kind()) {
-        Err(CapacityOverflow) => capacity_overflow(),
-        Err(AllocError) => handle_alloc_error(),
+        Err(TryReserveErrorKind::CapacityOverflow) => capacity_overflow(),
+        Err(TryReserveErrorKind::AllocError) => handle_alloc_error(),
         Ok(()) => { /* yay */ }
     }
 }

--- a/tests/ui/code-location/expected
+++ b/tests/ui/code-location/expected
@@ -1,6 +1,6 @@
 module/mod.rs:10:5 in function module::not_empty
 main.rs:13:5 in function same_file
 /toolchains/
-alloc/src/vec/mod.rs:3054:81 in function <std::vec::Vec<i32> as std::ops::Drop>::drop
+alloc/src/vec/mod.rs:3059:81 in function <std::vec::Vec<i32> as std::ops::Drop>::drop
 
 VERIFICATION:- SUCCESSFUL


### PR DESCRIPTION
### Description of changes: 
Upgrade our toolchain to `nightly-2023-01-23`. The changes here are related to the following changes:
- https://github.com/rust-lang/rust/pull/104986
- https://github.com/rust-lang/rust/pull/105657
- https://github.com/rust-lang/rust/pull/105603
- https://github.com/rust-lang/rust/pull/105613
- https://github.com/rust-lang/rust/pull/105977.

### Resolved issues:

Resolves #2113 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

I initially upgraded the toolchain to `nightly-2023-01-16` as planned in #2113. However, the AsyncAwait tests were failing due to wrong monomorphization. To fix that, I decided to upgrade to `nightly-2023-01-23` instead to include the changes related to https://github.com/rust-lang/rust/pull/105977. That fixed the regression.

Note: We should consider prioritizing #1365 to stop having to amend the function abi code.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
