### PR TITLE
Fix nightly CBMC regressions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,10 +5,6 @@ inputs:
   os:
     description: In which Operating System is this running
     required: true
-  install_cbmc:
-    description: Whether to install CBMC
-    required: false
-    default: 'true'
 runs:
   using: composite
   steps:

--- a/.github/workflows/cbmc-latest.yml
+++ b/.github/workflows/cbmc-latest.yml
@@ -41,10 +41,16 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Kani Dependencies
-        uses: ./.github/actions/setup
-        with:
-          os: ${{ matrix.os }}
-          install_cbmc: 'false'
+        run: |
+          ./scripts/setup/${{ matrix.os }}/install_packages.sh
+          ./scripts/setup/${{ matrix.os }}/install_viewer.sh
+          ./scripts/setup/install_kissat.sh
+          ./scripts/setup/install_rustup.sh
+
+      - name: Update submodules
+        run: |
+          git submodule update --init --depth 1
+        shell: bash
 
       - name: Build Kani
         run: cargo build-dev
@@ -75,10 +81,16 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Kani Dependencies
-        uses: ./.github/actions/setup
-        with:
-          os: ubuntu-20.04
-          install_cbmc: 'false'
+        run: |
+          ./scripts/setup/ubuntu-20.04/install_packages.sh
+          ./scripts/setup/ubuntu-20.04/install_viewer.sh
+          ./scripts/setup/install_kissat.sh
+          ./scripts/setup/install_rustup.sh
+
+      - name: Update submodules
+        run: |
+          git submodule update --init --depth 1
+        shell: bash
 
       - name: Build Kani using release mode
         run: cargo build-dev -- --release

--- a/scripts/setup/macos/install_deps.sh
+++ b/scripts/setup/macos/install_deps.sh
@@ -4,24 +4,10 @@
 
 set -eux
 
-# Github promises weekly build image updates, so we can skip the update step and
-# worst case we should only be 1-2 weeks behind upstream brew.
-# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
-#brew update
-
-# Install dependencies via `brew`
-brew install universal-ctags wget
-
-# Add Python package dependencies
-PYTHON_DEPS=(
-  autopep8
-)
-
-python3 -m pip install "${PYTHON_DEPS[@]}"
-
 # Get the directory containing this script
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+${SCRIPT_DIR}/install_packages.sh
 ${SCRIPT_DIR}/install_cbmc.sh
 ${SCRIPT_DIR}/install_viewer.sh
 # The Kissat installation script is platform-independent, so is placed one level up

--- a/scripts/setup/macos/install_packages.sh
+++ b/scripts/setup/macos/install_packages.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+set -eux
+
+# Github promises weekly build image updates, so we can skip the update step and
+# worst case we should only be 1-2 weeks behind upstream brew.
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
+#brew update
+
+# Install dependencies via `brew`
+brew install universal-ctags wget
+
+# Add Python package dependencies
+PYTHON_DEPS=(
+  autopep8
+)
+
+python3 -m pip install "${PYTHON_DEPS[@]}"

--- a/scripts/setup/ubuntu/install_deps.sh
+++ b/scripts/setup/ubuntu/install_deps.sh
@@ -2,60 +2,12 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-set -eu
-
-# Dependencies.
-DEPS=(
-  bison
-  cmake
-  curl
-  flex
-  g++
-  gcc
-  git
-  gpg-agent
-  libssl-dev
-  lsb-release
-  make
-  ninja-build
-  patch
-  pkg-config
-  python3-pip # Default in CI, but missing in AWS AMI
-  python3-setuptools
-  software-properties-common
-  wget
-  zlib1g
-  zlib1g-dev
-)
-
-# Version specific dependencies.
-declare -A VERSION_DEPS
-VERSION_DEPS["20.04"]="universal-ctags python-is-python3"
-VERSION_DEPS["18.04"]="exuberant-ctags"
-
-UBUNTU_VERSION=$(lsb_release -rs)
-OTHER_DEPS="${VERSION_DEPS[${UBUNTU_VERSION}]:-""}"
-
-set -x
-
-# Github promises weekly build image updates, but recommends running
-# `sudo apt-get update` before installing packages in case the `apt`
-# index is stale. This prevents package installation failures.
-# https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners
-sudo apt-get --yes update
-
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes "${DEPS[@]}" ${OTHER_DEPS[@]}
-
-# Add Python package dependencies
-PYTHON_DEPS=(
-  autopep8
-)
-
-python3 -m pip install "${PYTHON_DEPS[@]}"
+set -eux
 
 # Get the directory containing this script
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+${SCRIPT_DIR}/install_packages.sh
 ${SCRIPT_DIR}/install_cbmc.sh
 ${SCRIPT_DIR}/install_viewer.sh
 # The Kissat installation script is platform-independent, so is placed one level up

--- a/scripts/setup/ubuntu/install_packages.sh
+++ b/scripts/setup/ubuntu/install_packages.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+set -eu
+
+# Dependencies.
+DEPS=(
+  bison
+  cmake
+  curl
+  flex
+  g++
+  gcc
+  git
+  gpg-agent
+  libssl-dev
+  lsb-release
+  make
+  ninja-build
+  patch
+  pkg-config
+  python3-pip # Default in CI, but missing in AWS AMI
+  python3-setuptools
+  software-properties-common
+  wget
+  zlib1g
+  zlib1g-dev
+)
+
+# Version specific dependencies.
+declare -A VERSION_DEPS
+VERSION_DEPS["20.04"]="universal-ctags python-is-python3"
+VERSION_DEPS["18.04"]="exuberant-ctags"
+
+UBUNTU_VERSION=$(lsb_release -rs)
+OTHER_DEPS="${VERSION_DEPS[${UBUNTU_VERSION}]:-""}"
+
+set -x
+
+# Github promises weekly build image updates, but recommends running
+# `sudo apt-get update` before installing packages in case the `apt`
+# index is stale. This prevents package installation failures.
+# https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners
+sudo apt-get --yes update
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes "${DEPS[@]}" ${OTHER_DEPS[@]}
+
+# Add Python package dependencies
+PYTHON_DEPS=(
+  autopep8
+)
+
+python3 -m pip install "${PYTHON_DEPS[@]}"


### PR DESCRIPTION
### Description of changes: 

#2142 broke the nightly CBMC regressions, as the refactoring caused the CBMC release to be installed, which shouldn't be installed in the nightly CBMC regressions since we build it from source.

This PR fixes this issue by updating the CBMC nightly workflow to call the individual setup scripts (instead of relying on the setup action) so that it can skip installing CBMC.

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? CI

* Is this a refactor change? Partly.

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
