### PR TITLE
Checkout Kani and CBMC in parallel directories and install Kani dependencies before building CBMC from source

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,22 +5,22 @@ inputs:
   os:
     description: In which Operating System is this running
     required: true
-  install_cbmc:
-    description: Whether to install CBMC
+  kani_dir:
+    description: Path to Kani's root directory
     required: false
-    default: 'true'
+    default: '.'
 runs:
   using: composite
   steps:
       - name: Install dependencies
-        run: ./scripts/setup/${{ inputs.os }}/install_deps.sh
+        run: cd ${{ inputs.kani_dir }} && ./scripts/setup/${{ inputs.os }}/install_deps.sh
         shell: bash
 
       - name: Install Rust toolchain
-        run: ./scripts/setup/install_rustup.sh
+        run: cd ${{ inputs.kani_dir }} && ./scripts/setup/install_rustup.sh
         shell: bash
 
       - name: Update submodules
         run: |
-          git submodule update --init --depth 1
+          cd ${{ inputs.kani_dir }} && git submodule update --init --depth 1
         shell: bash

--- a/.github/workflows/cbmc-latest.yml
+++ b/.github/workflows/cbmc-latest.yml
@@ -21,6 +21,21 @@ jobs:
       matrix:
         os: [macos-11, ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
     steps:
+      - name: Checkout Kani under "kani"
+        uses: actions/checkout@v3
+        with:
+          path: kani
+
+      - name: Setup Kani Dependencies
+        uses: ./kani/.github/actions/setup
+        with:
+          os: ${{ matrix.os }}
+          kani_dir: 'kani'
+
+      - name: Build Kani
+        working-directory: ./kani
+        run: cargo build-dev
+
       - name: Checkout CBMC under "cbmc"
         uses: actions/checkout@v3
         with:
@@ -37,24 +52,28 @@ jobs:
           cd ..
           rm -rf cbmc
 
-      - name: Checkout Kani
-        uses: actions/checkout@v3
-
-      - name: Setup Kani Dependencies
-        uses: ./.github/actions/setup
-        with:
-          os: ${{ matrix.os }}
-          install_cbmc: 'false'
-
-      - name: Build Kani
-        run: cargo build-dev
-
       - name: Execute Kani regressions
+        working-directory: ./kani
         run: ./scripts/kani-regression.sh
 
   perf:
     runs-on: ubuntu-20.04
     steps:
+      - name: Checkout Kani under "kani"
+        uses: actions/checkout@v3
+        with:
+          path: kani
+
+      - name: Setup Kani Dependencies
+        uses: ./kani/.github/actions/setup
+        with:
+          os: ubuntu-20.04
+          kani_dir: 'kani'
+
+      - name: Build Kani using release mode
+        working-directory: ./kani
+        run: cargo build-dev -- --release
+
       - name: Checkout CBMC under "cbmc"
         uses: actions/checkout@v3
         with:
@@ -71,17 +90,6 @@ jobs:
           cd ..
           rm -rf cbmc
 
-      - name: Checkout Kani
-        uses: actions/checkout@v3
-
-      - name: Setup Kani Dependencies
-        uses: ./.github/actions/setup
-        with:
-          os: ubuntu-20.04
-          install_cbmc: 'false'
-
-      - name: Build Kani using release mode
-        run: cargo build-dev -- --release
-
       - name: Execute Kani performance tests
+        working-directory: ./kani
         run: ./scripts/kani-perf.sh

--- a/.github/workflows/cbmc-latest.yml
+++ b/.github/workflows/cbmc-latest.yml
@@ -43,14 +43,12 @@ jobs:
           path: cbmc
 
       - name: Build CBMC
+        working-directory: ./cbmc
         run: |
-          cd cbmc
           cmake -S . -Bbuild -DWITH_JBMC=OFF
           cmake --build build -- -j 4
-          sudo cmake --build build --target install
-          # Cleanup cbmc directory
-          cd ..
-          rm -rf cbmc
+          # Prepend the bin directory to $PATH
+          echo "${GITHUB_WORKSPACE}/cbmc/build/bin" >> $GITHUB_PATH
 
       - name: Execute Kani regressions
         working-directory: ./kani
@@ -81,14 +79,12 @@ jobs:
           path: cbmc
 
       - name: Build CBMC
+        working-directory: ./cbmc
         run: |
-          cd cbmc
           cmake -S . -Bbuild -DWITH_JBMC=OFF
           cmake --build build -- -j 4
-          sudo cmake --build build --target install
-          # Cleanup cbmc directory
-          cd ..
-          rm -rf cbmc
+          # Prepend the bin directory to $PATH
+          echo "${GITHUB_WORKSPACE}/cbmc/build/bin" >> $GITHUB_PATH
 
       - name: Execute Kani performance tests
         working-directory: ./kani


### PR DESCRIPTION
### Description of changes: 

This PR fixes the nightly CBMC regressions, which got broken by #2142. The PR does the following:
1. Checks out Kani and CBMC in parallel directories to avoid the issue with the CBMC build complaining about being inside the Kani workspace
2. It adds an input parameter to the setup action to allow the action to work if Kani is checked out in a directory other than "."
3. It reverses the order so that the Kani dependencies (including a CBMC release) are installed first before building CBMC from source, so that the built-from-source binaries override the release ones

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? CI

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
