### PR TITLE
Prevent printing when `--quiet` is used

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -72,6 +72,7 @@ impl KaniSession {
                     kani_cbmc_output_filter(
                         i,
                         self.args.extra_pointer_checks,
+                        self.args.quiet,
                         &self.args.output_format,
                     )
                 })?;

--- a/kani-driver/src/cbmc_property_renderer.rs
+++ b/kani-driver/src/cbmc_property_renderer.rs
@@ -168,6 +168,7 @@ impl ParserItem {
 pub fn kani_cbmc_output_filter(
     item: ParserItem,
     extra_ptr_checks: bool,
+    quiet: bool,
     output_format: &OutputFormat,
 ) -> Option<ParserItem> {
     // Some items (e.g., messages) are skipped.
@@ -178,9 +179,11 @@ pub fn kani_cbmc_output_filter(
     let processed_item = process_item(item, extra_ptr_checks);
     // Both formatting and printing could be handled by objects which
     // implement a trait `Printer`.
-    let formatted_item = format_item(&processed_item, output_format);
-    if let Some(fmt_item) = formatted_item {
-        println!("{fmt_item}");
+    if !quiet {
+        let formatted_item = format_item(&processed_item, output_format);
+        if let Some(fmt_item) = formatted_item {
+            println!("{fmt_item}");
+        }
     }
     // TODO: Record processed items and dump them into a JSON file
     // <https://github.com/model-checking/kani/issues/942>

--- a/tests/script-based-pre/check-quiet/assume.rs
+++ b/tests/script-based-pre/check-quiet/assume.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#[kani::proof]
+fn assume1() {
+    let i: i32 = kani::any();
+    kani::assume(i < 10);
+    assert!(i < 20);
+}
+
+#[kani::proof]
+fn assume2() {
+    let i: u32 = kani::any();
+    kani::assume(i < 10);
+    assert!(i < 20);
+}

--- a/tests/script-based-pre/check-quiet/check-quiet.expected
+++ b/tests/script-based-pre/check-quiet/check-quiet.expected
@@ -1,0 +1,1 @@
+success: `--quiet` produced NO output

--- a/tests/script-based-pre/check-quiet/check-quiet.sh
+++ b/tests/script-based-pre/check-quiet/check-quiet.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# Checks that no output is produced if `--quiet` is used
+
+set -eu
+
+KANI_OUTPUT=`kani assume.rs --quiet | wc -l`
+
+if [[ ${KANI_OUTPUT} -ne 0 ]]; then
+    echo "error: \`--quiet\` produced some output"
+    exit 1
+else
+    echo "success: \`--quiet\` produced NO output"
+fi

--- a/tests/script-based-pre/check-quiet/config.yml
+++ b/tests/script-based-pre/check-quiet/config.yml
@@ -1,0 +1,4 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: check-quiet.sh
+expected: 

--- a/tests/script-based-pre/check-quiet/config.yml
+++ b/tests/script-based-pre/check-quiet/config.yml
@@ -1,4 +1,4 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 script: check-quiet.sh
-expected: 
+expected: check-quiet.expected


### PR DESCRIPTION
### Description of changes: 

Prevents printing any items when `--quiet` is used. One test is included.

### Resolved issues:

Resolves #1937 
Related #1194 

### Call-outs:

The `if !quiet { ... }` block prevents both formatting and printing. The `quiet` value could be passed down to a `print_item` function and just avoid printing in that case, but I just went for the simpler solution.
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing tests + new one.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
