### PR TITLE
Support ICE reporting using json diagnostics

### DIFF
--- a/kani-compiler/src/main.rs
+++ b/kani-compiler/src/main.rs
@@ -44,6 +44,9 @@ use kani_queries::{QueryDb, ReachabilityType, UserInput};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_driver::{Callbacks, RunCompiler};
 use rustc_hir::definitions::DefPathHash;
+use rustc_interface::Config;
+use rustc_session::config::ErrorOutputType;
+use session::json_panic_hook;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -141,7 +144,13 @@ fn main() -> Result<(), &'static str> {
 struct KaniCallbacks {}
 
 /// Use default function implementations.
-impl Callbacks for KaniCallbacks {}
+impl Callbacks for KaniCallbacks {
+    fn config(&mut self, config: &mut Config) {
+        if matches!(config.opts.error_format, ErrorOutputType::Json { .. }) {
+            json_panic_hook();
+        }
+    }
+}
 
 /// The Kani root folder has all binaries inside bin/ and libraries inside lib/.
 /// This folder can also be used as a rustc sysroot.

--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -5,6 +5,10 @@
 
 use crate::parser;
 use clap::ArgMatches;
+use rustc_errors::{
+    emitter::Emitter, emitter::HumanReadableErrorType, fallback_fluent_bundle, json::JsonEmitter,
+    ColorConfig, Diagnostic,
+};
 use std::panic;
 use std::str::FromStr;
 use std::sync::LazyLock;
@@ -18,7 +22,7 @@ const LOG_ENV_VAR: &str = "KANI_LOG";
 const BUG_REPORT_URL: &str =
     "https://github.com/model-checking/kani/issues/new?labels=bug&template=bug_report.md";
 
-// Custom panic hook.
+// Custom panic hook when running under user friendly message format.
 #[allow(clippy::type_complexity)]
 static PANIC_HOOK: LazyLock<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static>> =
     LazyLock::new(|| {
@@ -30,9 +34,36 @@ static PANIC_HOOK: LazyLock<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 's
 
             // Print the Kani message
             eprintln!("Kani unexpectedly panicked during compilation.");
-            eprintln!(
-                "If you are seeing this message, please file an issue here: {BUG_REPORT_URL}"
+            eprintln!("Please file an issue here: {BUG_REPORT_URL}");
+        }));
+        hook
+    });
+
+// Custom panic hook when executing under json error format `--error-format=json`.
+#[allow(clippy::type_complexity)]
+static JSON_PANIC_HOOK: LazyLock<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static>> =
+    LazyLock::new(|| {
+        let hook = panic::take_hook();
+        panic::set_hook(Box::new(|info| {
+            // Print stack trace.
+            let msg = format!(
+                "Kani unexpectedly panicked at {}",
+                info.location().map_or(String::from("Unknown Location"), |loc| loc.to_string())
             );
+            let fallback_bundle =
+                fallback_fluent_bundle(rustc_errors::DEFAULT_LOCALE_RESOURCES, false);
+            let mut emitter = JsonEmitter::basic(
+                false,
+                HumanReadableErrorType::Default(ColorConfig::Never),
+                None,
+                fallback_bundle,
+                None,
+                false,
+                false,
+            );
+            let diagnostic = Diagnostic::new(rustc_errors::Level::Bug, msg);
+            emitter.emit_diagnostic(&diagnostic);
+            (*JSON_PANIC_HOOK)(info);
         }));
         hook
     });
@@ -93,4 +124,9 @@ fn hier_logs(args: &ArgMatches, filter: EnvFilter) {
 fn init_panic_hook() {
     // Install panic hook
     LazyLock::force(&PANIC_HOOK); // Install ice hook
+}
+
+pub fn json_panic_hook() {
+    // Install panic hook
+    LazyLock::force(&JSON_PANIC_HOOK); // Install ice hook
 }

--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -46,10 +46,7 @@ static JSON_PANIC_HOOK: LazyLock<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send
         let hook = panic::take_hook();
         panic::set_hook(Box::new(|info| {
             // Print stack trace.
-            let msg = format!(
-                "Kani unexpectedly panicked at {}",
-                info.location().map_or(String::from("Unknown Location"), |loc| loc.to_string())
-            );
+            let msg = format!("Kani unexpectedly panicked at {info}.",);
             let fallback_bundle =
                 fallback_fluent_bundle(rustc_errors::DEFAULT_LOCALE_RESOURCES, false);
             let mut emitter = JsonEmitter::basic(


### PR DESCRIPTION
### Description of changes: 

This will allow us to retrieve crash information from Kani driver once we merge #2166.

### Resolved issues:

Part of #2166 

### Related RFC:



### Call-outs:

For now, I'm only added the line where the crashed occurred. I think it's probably our best mechanism today to categorize crashes. Does anyone have another suggestion?

Unfortunately this doesn't cover issues that happen before callback configuration, which is mostly argument parsing.

### Testing:

* How is this change tested? I manually tested this one by injecting a failure in the compiler.

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
