### PR TITLE
Stop building legacy-lib/

### DIFF
--- a/kani-compiler/src/main.rs
+++ b/kani-compiler/src/main.rs
@@ -173,11 +173,7 @@ fn generate_rustc_args(args: &ArgMatches) -> Vec<String> {
     let mut rustc_args = vec![String::from("rustc")];
     if args.get_flag(parser::GOTO_C) {
         let mut default_path = kani_root();
-        if args.reachability_type() == ReachabilityType::Legacy {
-            default_path.push("legacy-lib")
-        } else {
-            default_path.push("lib");
-        }
+        default_path.push("lib");
         let gotoc_args = rustc_gotoc_flags(
             args.get_one::<String>(parser::KANI_LIB)
                 .unwrap_or(&default_path.to_str().unwrap().to_string()),
@@ -262,8 +258,7 @@ fn sysroot_path(args: &ArgMatches) -> PathBuf {
     let sysroot_arg = args.get_one::<String>(parser::SYSROOT);
     let path = if let Some(s) = sysroot_arg {
         PathBuf::from(s)
-    } else if args.reachability_type() == ReachabilityType::Legacy || !args.get_flag(parser::GOTO_C)
-    {
+    } else if !args.get_flag(parser::GOTO_C) {
         toolchain_sysroot_path()
     } else {
         kani_root()

--- a/tools/build-kani/src/main.rs
+++ b/tools/build-kani/src/main.rs
@@ -10,9 +10,7 @@
 mod parser;
 mod sysroot;
 
-use crate::sysroot::{
-    build_bin, build_lib, build_lib_legacy, kani_sysroot_legacy_lib, kani_sysroot_lib,
-};
+use crate::sysroot::{build_bin, build_lib, kani_sysroot_lib};
 use anyhow::{bail, Result};
 use clap::Parser;
 use std::{ffi::OsString, path::Path, process::Command};
@@ -23,7 +21,6 @@ fn main() -> Result<()> {
     match args.subcommand {
         parser::Commands::BuildDev(build_parser) => {
             build_lib();
-            build_lib_legacy();
             build_bin(&build_parser.args);
         }
         parser::Commands::Bundle(bundle_parser) => {
@@ -76,7 +73,6 @@ fn prebundle(dir: &Path) -> Result<()> {
     build_bin(&["--release"]);
     // And that libraries have been built too.
     build_lib();
-    build_lib_legacy();
     Ok(())
 }
 
@@ -104,7 +100,6 @@ fn bundle_kani(dir: &Path) -> Result<()> {
 
     // 4. Pre-compiled library files
     cp_dir(&kani_sysroot_lib(), dir)?;
-    cp_dir(&kani_sysroot_legacy_lib(), dir)?;
 
     // 5. Record the exact toolchain we use
     std::fs::write(dir.join("rust-toolchain-version"), env!("RUSTUP_TOOLCHAIN"))?;
@@ -114,6 +109,7 @@ fn bundle_kani(dir: &Path) -> Result<()> {
 
     Ok(())
 }
+
 /// Copy CBMC files into `dir`
 fn bundle_cbmc(dir: &Path) -> Result<()> {
     // In an effort to avoid creating new places where we must specify the exact version

--- a/tools/build-kani/src/sysroot.rs
+++ b/tools/build-kani/src/sysroot.rs
@@ -5,7 +5,6 @@
 //! In this folder, you can find the following folders:
 //! - `bin/`: Where all Kani binaries will be located.
 //! - `lib/`: Kani libraries as well as rust standard libraries.
-//! - `legacy-lib/`: Kani libraries built based on the the toolchain standard libraries.
 //!
 //! Rustc expects the sysroot to have a specific folder layout:
 //! `{SYSROOT}/rustlib/<target-triplet>/lib/<libraries>`
@@ -48,15 +47,6 @@ pub fn kani_sysroot() -> PathBuf {
 /// Returns the path to where Kani and std pre-compiled libraries are stored.
 pub fn kani_sysroot_lib() -> PathBuf {
     path_buf!(kani_sysroot(), "lib")
-}
-
-/// Returns the path to where Kani pre-compiled library are stored.
-///
-/// The legacy libraries are compiled on the top of rustup sysroot. Using it results in missing
-/// symbols. This is still needed though because when we use the rust monomorphizer as our
-/// reachability algorithm, the resulting boundaries are different than the new sysroot.
-pub fn kani_sysroot_legacy_lib() -> PathBuf {
-    path_buf!(kani_sysroot(), "legacy-lib")
 }
 
 /// Returns the path to where Kani's pre-compiled binaries are stored.
@@ -195,44 +185,6 @@ fn build_artifacts(cargo_cmd: &mut Child) -> Vec<Artifact> {
             }
         })
         .collect()
-}
-
-/// Build Kani libraries using the regular rust toolchain standard libraries.
-/// We should be able to remove this once the MIR linker is stable.
-pub fn build_lib_legacy() {
-    // Run cargo build with -Z build-std
-    let target_dir = env!("KANI_LEGACY_LIBS");
-    let args = [
-        "build",
-        "-p",
-        "std",
-        "-p",
-        "kani",
-        "-p",
-        "kani_macros",
-        "--target-dir",
-        target_dir,
-        "--message-format",
-        "json-diagnostic-rendered-ansi",
-    ];
-    let mut child = Command::new("cargo")
-        .env("CARGO_ENCODED_RUSTFLAGS", ["--cfg=kani"].join("\x1f"))
-        .args(args)
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("Failed to build Kani libraries.");
-
-    // Collect the build artifacts.
-    let artifacts = build_artifacts(&mut child);
-    let _ = child.wait().expect("Couldn't get cargo's exit status");
-
-    // Create sysroot folder.
-    let legacy_lib = kani_sysroot_legacy_lib();
-    legacy_lib.exists().then(|| fs::remove_dir_all(&legacy_lib));
-    fs::create_dir_all(&legacy_lib).expect(&format!("Failed to create {legacy_lib:?}"));
-
-    //  Copy Kani libraries to inside the legacy-lib folder.
-    copy_libs(&artifacts, &legacy_lib, &is_kani_lib);
 }
 
 /// Extra arguments to be given to `cargo build` while building Kani's binaries.


### PR DESCRIPTION
### Description of changes: 

We no longer need to bundle the kani libraries for the legacy linker since its no longer supported.

This won't affect the std script which is the last place we still use the legacy reachability mode.

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

This is leftover from #2126 which I bumped into recently.

### Testing:

* How is this change tested? Current tests

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
