### PR TITLE
Move all rustc arguments to kani-driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,8 @@ dependencies = [
  "rustc-demangle",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -32,6 +32,8 @@ rustc-demangle = "0.1.21"
 pathdiff = "0.2.1"
 rayon = "1.5.3"
 comfy-table = "6.0.0"
+strum = {version = "0.24.0"}
+strum_macros = {version = "0.24.0"}
 tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-subscriber = {version = "0.3.8", features = ["env-filter", "json", "fmt"]}
 tracing-tree = "0.2.2"

--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -114,6 +114,8 @@ impl KaniSession {
                     .args(&pkg_args)
                     .env("RUSTC", &self.kani_compiler)
                     .env("KANIFLAGS", kani_args.join(" "))
+                    // Use CARGO_ENCODED_RUSTFLAGS instead of RUSTFLAGS is preferred. See
+                    // https://doc.rust-lang.org/cargo/reference/environment-variables.html
                     .env("CARGO_ENCODED_RUSTFLAGS", rustc_args.join(OsStr::new("\x1f")))
                     .env("CARGO_TERM_PROGRESS_WHEN", "never");
 

--- a/kani-driver/src/call_single_file.rs
+++ b/kani-driver/src/call_single_file.rs
@@ -99,10 +99,6 @@ impl KaniSession {
     }
 
     /// This function generates all rustc configurations required by our goto-c codegen.
-    ///
-    /// We override the `std` library using the mechanism described here:
-    /// <https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20Globally.20override.20an.20std.20macro/near/268873354>
-    /// for more details.
     pub fn kani_rustc_flags(&self) -> Vec<OsString> {
         let lib_path = lib_folder().unwrap();
         let kani_std_rlib = lib_path.join("libstd.rlib");

--- a/kani-driver/src/session.rs
+++ b/kani-driver/src/session.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::Mutex;
 use std::time::Instant;
+use strum_macros::Display;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 use tracing_tree::HierarchicalLayer;
@@ -84,8 +85,12 @@ impl KaniSession {
     }
 }
 
+#[derive(Debug, Copy, Clone, Display)]
+#[strum(serialize_all = "snake_case")]
 pub enum ReachabilityMode {
+    #[strum(to_string = "harnesses")]
     ProofHarnesses,
+    #[strum(to_string = "pub_fns")]
     AllPubFns,
     Tests,
 }
@@ -222,6 +227,19 @@ fn bin_folder() -> Result<PathBuf> {
     let exe = std::env::current_exe().context("Cannot determine current executable location")?;
     let dir = exe.parent().context("Executable isn't in a directory")?.to_owned();
     Ok(dir)
+}
+
+/// Return the path for the folder where the pre-compiled rust libraries are located.
+pub fn lib_folder() -> Result<PathBuf> {
+    Ok(base_folder()?.join("lib"))
+}
+
+/// Return the base folder for the entire kani installation.
+pub fn base_folder() -> Result<PathBuf> {
+    Ok(bin_folder()?
+        .parent()
+        .context("Failed to find Kani's base installation folder.")?
+        .to_path_buf())
 }
 
 impl InstallType {

--- a/kani-driver/src/unsound_experiments.rs
+++ b/kani-driver/src/unsound_experiments.rs
@@ -3,7 +3,6 @@
 
 #![cfg(feature = "unsound_experiments")]
 use clap::Parser;
-use std::ffi::OsString;
 #[derive(Debug, Parser)]
 pub struct UnsoundExperimentArgs {
     /// Zero initilize variables.
@@ -16,7 +15,7 @@ pub struct UnsoundExperimentArgs {
 }
 
 impl UnsoundExperimentArgs {
-    pub fn process_args(&self) -> Vec<OsString> {
+    pub fn process_args(&self) -> Vec<String> {
         self.print_warnings();
         let mut flags = vec![];
         if self.unsound_experiment_zero_init_vars {

--- a/kani-driver/src/util.rs
+++ b/kani-driver/src/util.rs
@@ -41,19 +41,6 @@ pub fn executable_basename(argv0: &Option<&OsString>) -> Option<OsString> {
     None
 }
 
-/// Joining an OsString with a delimeter is missing from Rust libraries, so
-/// let's write out own, and with convenient types...
-pub fn join_osstring(elems: &[OsString], joiner: &str) -> OsString {
-    let mut str = OsString::new();
-    for (i, arg) in elems.iter().enumerate() {
-        if i != 0 {
-            str.push(OsString::from(joiner));
-        }
-        str.push(arg);
-    }
-    str
-}
-
 /// Render a Command as a string, to log it (e.g. in dry runs)
 pub fn render_command(cmd: &Command) -> OsString {
     let mut str = OsString::new();
@@ -136,20 +123,6 @@ mod tests {
         assert_eq!(executable_basename(&Some(&OsString::from("./foo.exe"))), Some("foo".into()));
         assert_eq!(executable_basename(&Some(&OsString::from("foo.exe"))), Some("foo".into()));
         assert_eq!(executable_basename(&Some(&OsString::from("foo"))), Some("foo".into()));
-    }
-
-    #[test]
-    fn check_join_osstring() {
-        assert_eq!(
-            join_osstring(&["a".into(), "b".into(), "cd".into()], " "),
-            OsString::from("a b cd")
-        );
-        assert_eq!(join_osstring(&[], " "), OsString::from(""));
-        assert_eq!(join_osstring(&["a".into()], " "), OsString::from("a"));
-        assert_eq!(
-            join_osstring(&["a".into(), "b".into(), "cd".into()], ", "),
-            OsString::from("a, b, cd")
-        );
     }
 
     #[test]

--- a/scripts/std-lib-regression.sh
+++ b/scripts/std-lib-regression.sh
@@ -50,8 +50,7 @@ cd std_lib_test
 
 # Add some content to the rust file including an std function that is non-generic.
 echo '
-#[kani::proof]
-fn check_format() {
+pub fn main() {
     assert!("2021".parse::<u32>().unwrap() == 2021);
 }
 ' > src/lib.rs
@@ -68,7 +67,7 @@ echo "Starting cargo build with Kani"
 export RUST_BACKTRACE=1
 export RUSTC_LOG=error
 export KANIFLAGS="--goto-c --ignore-global-asm --reachability=legacy"
-export RUSTFLAGS="--kani-flags"
+export RUSTFLAGS="--kani-flags -C panic=abort"
 export RUSTC="$KANI_DIR/target/kani/bin/kani-compiler"
 # Compile rust to iRep
 $WRAPPER cargo build --verbose -Z build-std --lib --target $TARGET


### PR DESCRIPTION
### Description of changes: 

Move all rustc arguments to kani-driver

1. It's good to have one source of truth.
2. This is needed for us to properly support caching compiler artifacts

### Resolved issues:

None. It's part of #2137 and needed for #2036.

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Current tests

* Is this a refactor change? Yes

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
