### PR TITLE
Update assertion description with a less confusing alternative

### DIFF
--- a/docs/src/getting-started/verification-results/failure_example.expected
+++ b/docs/src/getting-started/verification-results/failure_example.expected
@@ -1,2 +1,2 @@
 FAILURE\
-Description: "assertion failed: arr.len() != 3"
+Description: "assertion holds: arr.len() != 3"

--- a/docs/src/getting-started/verification-results/success_example.expected
+++ b/docs/src/getting-started/verification-results/success_example.expected
@@ -1,2 +1,2 @@
 SUCCESS\
-Description: "assertion failed: sum == 6"
+Description: "assertion holds: sum == 6"

--- a/docs/src/getting-started/verification-results/undetermined_example.expected
+++ b/docs/src/getting-started/verification-results/undetermined_example.expected
@@ -1,2 +1,2 @@
 UNDETERMINED\
-Description: "assertion failed: x == 0"
+Description: "assertion holds: x == 0"

--- a/docs/src/getting-started/verification-results/unreachable_example.expected
+++ b/docs/src/getting-started/verification-results/unreachable_example.expected
@@ -1,2 +1,2 @@
 UNREACHABLE\
-Description: "assertion failed: x < 8"
+Description: "assertion holds: x < 8"

--- a/docs/src/tutorial/arbitrary-variables/safe_update.expected
+++ b/docs/src/tutorial/arbitrary-variables/safe_update.expected
@@ -1,5 +1,5 @@
 SUCCESS\
 "NonZeroU32 is internally a u32 but it should never be 0."
 SUCCESS\
-assertion failed: inventory.get(&id).unwrap() == quantity
+assertion holds: inventory.get(&id).unwrap() == quantity
 VERIFICATION:- SUCCESSFUL

--- a/docs/src/tutorial/first-steps-v2/verify_success.expected
+++ b/docs/src/tutorial/first-steps-v2/verify_success.expected
@@ -1,4 +1,4 @@
 SUCCESS\
-assertion failed: x < 4096
+assertion holds: x < 4096
 SUCCESS\
-assertion failed: y < 10
+assertion holds: y < 10

--- a/docs/src/tutorial/first-steps-v2/will_fail.expected
+++ b/docs/src/tutorial/first-steps-v2/will_fail.expected
@@ -1,2 +1,2 @@
 FAILURE\
-assertion failed: x < 4096
+assertion holds: x < 4096

--- a/tests/cargo-kani/asm/global/calls_crate_with_global_asm.expected
+++ b/tests/cargo-kani/asm/global/calls_crate_with_global_asm.expected
@@ -1,2 +1,2 @@
 Status: SUCCESS\
-Description: "assertion failed: x * y == 33"
+Description: "assertion holds: x * y == 33"

--- a/tests/cargo-kani/asm/global/reads_static_var_in_crate_with_global_asm.expected
+++ b/tests/cargo-kani/asm/global/reads_static_var_in_crate_with_global_asm.expected
@@ -1,2 +1,2 @@
 Status: SUCCESS\
-Description: "assertion failed: x == 98"
+Description: "assertion holds: x == 98"

--- a/tests/cargo-kani/assert-reach/test.expected
+++ b/tests/cargo-kani/assert-reach/test.expected
@@ -1,2 +1,2 @@
 UNREACHABLE\
-Description: "assertion failed: z == x - 1"
+Description: "assertion holds: z == x - 1"

--- a/tests/cargo-kani/dependencies/check_dummy.expected
+++ b/tests/cargo-kani/dependencies/check_dummy.expected
@@ -1,2 +1,2 @@
 SUCCESS\
-assertion failed: x > 2
+assertion holds: x > 2

--- a/tests/cargo-kani/itoa_dep/check_signed.expected
+++ b/tests/cargo-kani/itoa_dep/check_signed.expected
@@ -1,5 +1,5 @@
 Status: SUCCESS\
-Description: "assertion failed: result == &output"
+Description: "assertion holds: result == &output"
 
 Status: FAILURE\
 Description: "memcpy source region readable"

--- a/tests/cargo-kani/nested-dirs/crate1/a_check.expected
+++ b/tests/cargo-kani/nested-dirs/crate1/a_check.expected
@@ -1,3 +1,3 @@
 Status: SUCCESS\
-Description: "assertion failed: v.len() == 3"
+Description: "assertion holds: v.len() == 3"
 VERIFICATION:- SUCCESSFUL

--- a/tests/cargo-kani/nested-dirs/crate2/another_check.expected
+++ b/tests/cargo-kani/nested-dirs/crate2/another_check.expected
@@ -1,3 +1,3 @@
 Status: SUCCESS\
-Description: "assertion failed: result == 4"
+Description: "assertion holds: result == 4"
 VERIFICATION:- SUCCESSFUL

--- a/tests/cargo-kani/nested-dirs/crate2/nested_crate/yet_another_check.expected
+++ b/tests/cargo-kani/nested-dirs/crate2/nested_crate/yet_another_check.expected
@@ -1,4 +1,4 @@
 Status: SUCCESS\
-Description: "assertion failed: y - x == 0"
+Description: "assertion holds: y - x == 0"
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/cargo-kani/output-format/main.expected
+++ b/tests/cargo-kani/output-format/main.expected
@@ -1,1 +1,1 @@
-Description: "assertion failed: 1 + 1 == 2"
+Description: "assertion holds: 1 + 1 == 2"

--- a/tests/cargo-kani/simple-config-toml/test_one_plus_two.expected
+++ b/tests/cargo-kani/simple-config-toml/test_one_plus_two.expected
@@ -1,2 +1,2 @@
 SUCCESS\
-assertion failed: p.sum() == 3
+assertion holds: p.sum() == 3

--- a/tests/cargo-kani/simple-config-toml/test_sum.expected
+++ b/tests/cargo-kani/simple-config-toml/test_sum.expected
@@ -1,2 +1,2 @@
 SUCCESS\
-assertion failed: p.sum() == a.wrapping_add(b)
+assertion holds: p.sum() == a.wrapping_add(b)

--- a/tests/cargo-kani/simple-lib/test_one_plus_two.expected
+++ b/tests/cargo-kani/simple-lib/test_one_plus_two.expected
@@ -1,2 +1,2 @@
 SUCCESS\
-assertion failed: p.sum() == 3
+assertion holds: p.sum() == 3

--- a/tests/cargo-kani/simple-lib/test_sum.expected
+++ b/tests/cargo-kani/simple-lib/test_sum.expected
@@ -1,2 +1,2 @@
 SUCCESS\
-assertion failed: p.sum() == a.wrapping_add(b)
+assertion holds: p.sum() == a.wrapping_add(b)

--- a/tests/cargo-kani/simple-main/main.expected
+++ b/tests/cargo-kani/simple-main/main.expected
@@ -1,3 +1,3 @@
 FAILURE\
-assertion failed: 1 == 2
+assertion holds: 1 == 2
 VERIFICATION:- FAILED

--- a/tests/cargo-kani/simple-proof-annotation/expected
+++ b/tests/cargo-kani/simple-proof-annotation/expected
@@ -1,2 +1,2 @@
 FAILURE\
-assertion failed: 3 == 4
+assertion holds: 3 == 4

--- a/tests/cargo-kani/simple-unwind-annotation/expected
+++ b/tests/cargo-kani/simple-unwind-annotation/expected
@@ -1,2 +1,2 @@
 FAILURE\
-assertion failed: counter < 10
+assertion holds: counter < 10

--- a/tests/cargo-kani/simple-unwind-annotation/harness_1.expected
+++ b/tests/cargo-kani/simple-unwind-annotation/harness_1.expected
@@ -1,2 +1,2 @@
 UNDETERMINED\
-assertion failed: counter < 10
+assertion holds: counter < 10

--- a/tests/cargo-kani/small-vec/check_vec.expected
+++ b/tests/cargo-kani/small-vec/check_vec.expected
@@ -1,5 +1,5 @@
 Status: SUCCESS\
-Description: "assertion failed: c < char::MAX"\
+Description: "assertion holds: c < char::MAX"\
 in function check_vec
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/cargo-kani/vecdeque-cve/reserve_available_capacity_is_no_op.expected
+++ b/tests/cargo-kani/vecdeque-cve/reserve_available_capacity_is_no_op.expected
@@ -1,17 +1,17 @@
 fixed::VecDeque::<u8>::handle_capacity_increase.assertion.7\
 Status: UNREACHABLE\
-Description: "assertion failed: self.head < self.tail"
+Description: "assertion holds: self.head < self.tail"
 
 fixed::VecDeque::<u8>::handle_capacity_increase.assertion.8\
 Status: UNREACHABLE\
-Description: "assertion failed: self.head < self.cap()"
+Description: "assertion holds: self.head < self.cap()"
 
 fixed::VecDeque::<u8>::handle_capacity_increase.assertion.9\
 Status: UNREACHABLE\
-Description: "assertion failed: self.tail < self.cap()"
+Description: "assertion holds: self.tail < self.cap()"
 
 fixed::VecDeque::<u8>::handle_capacity_increase.assertion.10\
 Status: UNREACHABLE\
-Description: "assertion failed: self.cap().count_ones() == 1"
+Description: "assertion holds: self.cap().count_ones() == 1"
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/cargo-kani/vecdeque-cve/reserve_available_capacity_should_fail.expected
+++ b/tests/cargo-kani/vecdeque-cve/reserve_available_capacity_should_fail.expected
@@ -1,6 +1,6 @@
 cve::VecDeque::<u8>::handle_capacity_increase.assertion\
 - Status: FAILURE\
-- Description: "assertion failed: self.head < self.cap()"
+- Description: "assertion holds: self.head < self.cap()"
 Location: src/cve.rs
 
-Failed Checks: assertion failed: self.head < self.cap()
+Failed Checks: assertion holds: self.head < self.cap()

--- a/tests/cargo-kani/vecdeque-cve/reserve_more_capacity_still_works.expected
+++ b/tests/cargo-kani/vecdeque-cve/reserve_more_capacity_still_works.expected
@@ -1,16 +1,16 @@
 cve::VecDeque::<u8>::handle_capacity_increase.assertion\
 Status: SUCCESS\
-Description: "assertion failed: self.head < self.cap()"\
+Description: "assertion holds: self.head < self.cap()"\
 Location: src/cve.rs
 
 cve::VecDeque::<u8>::handle_capacity_increase.assertion\
 Status: SUCCESS\
-Description: "assertion failed: self.tail < self.cap()"\
+Description: "assertion holds: self.tail < self.cap()"\
 Location: src/cve.rs
 
 cve::VecDeque::<u8>::handle_capacity_increase.assertion\
 Status: SUCCESS\
-Description: "assertion failed: self.cap().count_ones() == 1"\
+Description: "assertion holds: self.cap().count_ones() == 1"\
 Location: src/cve.rs
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/cargo-kani/vecdeque-cve/reserve_more_capacity_works.expected
+++ b/tests/cargo-kani/vecdeque-cve/reserve_more_capacity_works.expected
@@ -1,16 +1,16 @@
 fixed::VecDeque::<u8>::handle_capacity_increase.assertion\
 Status: SUCCESS\
-Description: "assertion failed: self.head < self.cap()"\
+Description: "assertion holds: self.head < self.cap()"\
 Location: src/fixed.rs
 
 fixed::VecDeque::<u8>::handle_capacity_increase.assertion\
 Status: SUCCESS\
-Description: "assertion failed: self.tail < self.cap()"\
+Description: "assertion holds: self.tail < self.cap()"\
 Location: src/fixed.rs
 
 fixed::VecDeque::<u8>::handle_capacity_increase.assertion\
 Status: SUCCESS\
-Description: "assertion failed: self.cap().count_ones() == 1"\
+Description: "assertion holds: self.cap().count_ones() == 1"\
 Location: src/fixed.rs
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/cargo-ui/function/expected
+++ b/tests/cargo-ui/function/expected
@@ -1,4 +1,4 @@
 Status: SUCCESS\
-"assertion failed: 1 + 2 == 3"
+"assertion holds: 1 + 2 == 3"
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/allocation/expected
+++ b/tests/expected/allocation/expected
@@ -1,4 +1,4 @@
 SUCCESS\
-assertion failed: foo() == None
+assertion holds: foo() == None
 SUCCESS\
-assertion failed: foo() == y
+assertion holds: foo() == y

--- a/tests/expected/array/expected
+++ b/tests/expected/array/expected
@@ -1,6 +1,6 @@
 SUCCESS\
-assertion failed: y[0] == 1
+assertion holds: y[0] == 1
 SUCCESS\
-assertion failed: y[1] == 2
+assertion holds: y[1] == 2
 FAILURE\
 index out of bounds: the length is less than or equal to the given index

--- a/tests/expected/assert-eq-chained/expected
+++ b/tests/expected/assert-eq-chained/expected
@@ -1,13 +1,13 @@
 Status: SUCCESS\
-Description: "assertion failed: x > 3 == true"
+Description: "assertion holds: x > 3 == true"
 
 Status: SUCCESS\
-Description: "assertion failed: x == 1 == false"
+Description: "assertion holds: x == 1 == false"
 
 Status: SUCCESS\
-Description: "assertion failed: x < 10 != false"
+Description: "assertion holds: x < 10 != false"
 
 Status: FAILURE\
-Description: "assertion failed: x == 7 != false"
+Description: "assertion holds: x == 7 != false"
 
 VERIFICATION:- FAILED

--- a/tests/expected/assert-eq/expected
+++ b/tests/expected/assert-eq/expected
@@ -1,6 +1,6 @@
 SUCCESS\
-assertion failed: x + 1 == y
+assertion holds: x + 1 == y
 FAILURE\
-assertion failed: x == y
+assertion holds: x == y
 UNREACHABLE\
-assertion failed: x != y
+assertion holds: x != y

--- a/tests/expected/binop/expected
+++ b/tests/expected/binop/expected
@@ -1,84 +1,84 @@
 SUCCESS\
 attempt to add with overflow
 SUCCESS\
-assertion failed: a + b == correct
+assertion holds: a + b == correct
 SUCCESS\
 attempt to add with overflow
 FAILURE\
-assertion failed: a + b == wrong
+assertion holds: a + b == wrong
 SUCCESS\
 attempt to subtract with overflow
 SUCCESS\
-assertion failed: a - b == correct
+assertion holds: a - b == correct
 SUCCESS\
 attempt to subtract with overflow
 FAILURE\
-assertion failed: a - b == wrong
+assertion holds: a - b == wrong
 SUCCESS\
 attempt to multiply with overflow
 SUCCESS\
-assertion failed: a * b == correct
+assertion holds: a * b == correct
 SUCCESS\
 attempt to multiply with overflow
 FAILURE\
-assertion failed: a * b == wrong
+assertion holds: a * b == wrong
 SUCCESS\
 attempt to divide by zero
 SUCCESS\
 attempt to divide with overflow
 SUCCESS\
-assertion failed: a / b == correct
+assertion holds: a / b == correct
 SUCCESS\
 attempt to divide by zero
 SUCCESS\
 attempt to divide with overflow
 FAILURE\
-assertion failed: a / b == wrong
+assertion holds: a / b == wrong
 SUCCESS\
 attempt to calculate the remainder with a divisor of zero
 SUCCESS\
 attempt to calculate the remainder with overflow
 SUCCESS\
-assertion failed: a % b == correct
+assertion holds: a % b == correct
 SUCCESS\
 attempt to calculate the remainder with a divisor of zero
 SUCCESS\
 attempt to calculate the remainder with overflow
 FAILURE\
-assertion failed: a % b == wrong
+assertion holds: a % b == wrong
 SUCCESS\
 attempt to shift left with overflow
 SUCCESS\
-assertion failed: a << b == correct
+assertion holds: a << b == correct
 SUCCESS\
 attempt to shift left with overflow
 FAILURE\
-assertion failed: a << b == wrong
+assertion holds: a << b == wrong
 SUCCESS\
 attempt to shift right with overflow
 SUCCESS\
-assertion failed: a >> b == correct
+assertion holds: a >> b == correct
 SUCCESS\
 attempt to shift right with overflow
 FAILURE\
-assertion failed: a >> b == wrong
+assertion holds: a >> b == wrong
 SUCCESS\
 attempt to shift right with overflow
 SUCCESS\
-assertion failed: a >> b == correct
+assertion holds: a >> b == correct
 SUCCESS\
 attempt to shift right with overflow
 FAILURE\
-assertion failed: a >> b == wrong
+assertion holds: a >> b == wrong
 SUCCESS\
-assertion failed: a & b == correct
+assertion holds: a & b == correct
 FAILURE\
-assertion failed: a & b == wrong
+assertion holds: a & b == wrong
 SUCCESS\
-assertion failed: a | b == correct
+assertion holds: a | b == correct
 FAILURE\
-assertion failed: a | b == wrong
+assertion holds: a | b == wrong
 SUCCESS\
-assertion failed: a ^ b == correct
+assertion holds: a ^ b == correct
 FAILURE\
-assertion failed: a ^ b == wrong
+assertion holds: a ^ b == wrong

--- a/tests/expected/closure/expected
+++ b/tests/expected/closure/expected
@@ -7,4 +7,4 @@ attempt to add with overflow
 SUCCESS\
 attempt to add with overflow
 SUCCESS\
-assertion failed: original_num + 12 == num
+assertion holds: original_num + 12 == num

--- a/tests/expected/closure2/expected
+++ b/tests/expected/closure2/expected
@@ -3,6 +3,6 @@ attempt to add with overflow
 SUCCESS\
 attempt to add with overflow
 SUCCESS\
-assertion failed: z == 102
+assertion holds: z == 102
 SUCCESS\
-assertion failed: g(z) == 206
+assertion holds: g(z) == 206

--- a/tests/expected/closure3/expected
+++ b/tests/expected/closure3/expected
@@ -3,4 +3,4 @@ attempt to add with overflow
 SUCCESS\
 attempt to add with overflow
 SUCCESS\
-assertion failed: num + 10 == y
+assertion holds: num + 10 == y

--- a/tests/expected/comp/expected
+++ b/tests/expected/comp/expected
@@ -3,7 +3,7 @@ attempt to add with overflow
 SUCCESS\
 attempt to add with overflow
 SUCCESS\
-assertion failed: a + b == b + a
+assertion holds: a + b == b + a
 SUCCESS\
 attempt to add with overflow
 SUCCESS\
@@ -11,12 +11,12 @@ attempt to add with overflow
 SUCCESS\
 attempt to add with overflow
 SUCCESS\
-assertion failed: a + b != a + b + 1
+assertion holds: a + b != a + b + 1
 SUCCESS\
 attempt to add with overflow
 SUCCESS\
-assertion failed: a + b > a
+assertion holds: a + b > a
 SUCCESS\
 attempt to subtract with overflow
 SUCCESS\
-assertion failed: a - b < a
+assertion holds: a - b < a

--- a/tests/expected/dynamic-error-trait/expected
+++ b/tests/expected/dynamic-error-trait/expected
@@ -1,4 +1,4 @@
 SUCCESS\
-assertion failed: mm.size == 2
+assertion holds: mm.size == 2
 FAILURE\
-assertion failed: mm.size == 3
+assertion holds: mm.size == 3

--- a/tests/expected/dynamic-trait-static-dispatch/expected
+++ b/tests/expected/dynamic-trait-static-dispatch/expected
@@ -1,4 +1,4 @@
 SUCCESS\
-assertion failed: bar.a() == 3
+assertion holds: bar.a() == 3
 SUCCESS\
-assertion failed: bar.b() == 5
+assertion holds: bar.b() == 5

--- a/tests/expected/dynamic-trait/expected
+++ b/tests/expected/dynamic-trait/expected
@@ -11,22 +11,22 @@ attempt to multiply with overflow
 SUCCESS\
 attempt to multiply with overflow
 SUCCESS\
-assertion failed: rec.vol(3) == 150
+assertion holds: rec.vol(3) == 150
 SUCCESS\
-assertion failed: impl_area(rec.clone()) == 50
+assertion holds: impl_area(rec.clone()) == 50
 SUCCESS\
-assertion failed: vol == 100
+assertion holds: vol == 100
 SUCCESS\
-assertion failed: square.vol(3) == 27
+assertion holds: square.vol(3) == 27
 SUCCESS\
-assertion failed: do_vol(&square, 2) == 18
+assertion holds: do_vol(&square, 2) == 18
 SUCCESS\
-assertion failed: impl_area(square.clone()) == 9
+assertion holds: impl_area(square.clone()) == 9
 SUCCESS\
-assertion failed: !square.compare_area(&square)
+assertion holds: !square.compare_area(&square)
 SUCCESS\
-assertion failed: !square.compare_area(&rec)
+assertion holds: !square.compare_area(&rec)
 SUCCESS\
-assertion failed: rec.compare_area(&square)
+assertion holds: rec.compare_area(&square)
 SUCCESS\
-assertion failed: !rec.compare_area(&rec)
+assertion holds: !rec.compare_area(&rec)

--- a/tests/expected/enum/expected
+++ b/tests/expected/enum/expected
@@ -1,10 +1,10 @@
 SUCCESS\
-assertion failed: x == 10
+assertion holds: x == 10
 UNREACHABLE\
-assertion failed: false
+assertion holds: false
 UNREACHABLE\
-assertion failed: false
+assertion holds: false
 SUCCESS\
-assertion failed: x == 30 && y == 60.0
+assertion holds: x == 30 && y == 60.0
 FAILURE\
-assertion failed: x == 31
+assertion holds: x == 31

--- a/tests/expected/float-nan/expected
+++ b/tests/expected/float-nan/expected
@@ -1,10 +1,10 @@
 SUCCESS\
-assertion failed: 1.0 / f != 0.0 / f
+assertion holds: 1.0 / f != 0.0 / f
 SUCCESS\
-assertion failed: !(1.0 / f == 0.0 / f)
+assertion holds: !(1.0 / f == 0.0 / f)
 FAILURE\
-assertion failed: 1.0 / f == 0.0 / f
+assertion holds: 1.0 / f == 0.0 / f
 FAILURE\
-assertion failed: 0.0 / f == 0.0 / f
+assertion holds: 0.0 / f == 0.0 / f
 SUCCESS\
-assertion failed: 0.0 / f != 0.0 / f
+assertion holds: 0.0 / f != 0.0 / f

--- a/tests/expected/function-stubbing-warning/expected
+++ b/tests/expected/function-stubbing-warning/expected
@@ -1,2 +1,2 @@
 Stubbing is not enabled; attribute `kani::stub` will be ignored
-Failed Checks: assertion failed: foo() == 42
+Failed Checks: assertion holds: foo() == 42

--- a/tests/expected/generators/expected
+++ b/tests/expected/generators/expected
@@ -1,8 +1,8 @@
 SUCCESS\
-Description: "assertion failed: res == GeneratorState::Yielded(val)"
+Description: "assertion holds: res == GeneratorState::Yielded(val)"
 
 SUCCESS\
-Description: "assertion failed: res == GeneratorState::Complete(!val)"
+Description: "assertion holds: res == GeneratorState::Complete(!val)"
 
 UNREACHABLE\
 Description: "generator resumed after completion"

--- a/tests/expected/generics/expected
+++ b/tests/expected/generics/expected
@@ -1,4 +1,4 @@
 SUCCESS\
-assertion failed: x == y.data
+assertion holds: x == y.data
 SUCCESS\
-assertion failed: z == w.data
+assertion holds: z == w.data

--- a/tests/expected/intrinsics/breakpoint/expected
+++ b/tests/expected/intrinsics/breakpoint/expected
@@ -1,2 +1,2 @@
 SUCCESS\
-assertion failed: true
+assertion holds: true

--- a/tests/expected/iterator/expected
+++ b/tests/expected/iterator/expected
@@ -3,4 +3,4 @@ unreachable code
 SUCCESS\
 attempt to multiply with overflow
 SUCCESS\
-assertion failed: z == 6
+assertion holds: z == 6

--- a/tests/expected/niche/expected
+++ b/tests/expected/niche/expected
@@ -1,6 +1,6 @@
 UNREACHABLE\
-assertion failed: false
+assertion holds: false
 UNREACHABLE\
-assertion failed: false
+assertion holds: false
 SUCCESS\
-assertion failed: a == *b
+assertion holds: a == *b

--- a/tests/expected/niche2/expected
+++ b/tests/expected/niche2/expected
@@ -1,8 +1,8 @@
 UNREACHABLE\
-assertion failed: false
+assertion holds: false
 SUCCESS\
-assertion failed: x == 10
+assertion holds: x == 10
 UNREACHABLE\
-assertion failed: false
+assertion holds: false
 UNREACHABLE\
-assertion failed: false
+assertion holds: false

--- a/tests/expected/nondet-slice-len/expected
+++ b/tests/expected/nondet-slice-len/expected
@@ -1,5 +1,5 @@
-Failed Checks: assertion failed: s.len() != 0
-Failed Checks: assertion failed: s.len() != 1
-Failed Checks: assertion failed: s.len() != 2
-Failed Checks: assertion failed: s.len() != 3
-Failed Checks: assertion failed: s.len() != 4
+Failed Checks: assertion holds: s.len() != 0
+Failed Checks: assertion holds: s.len() != 1
+Failed Checks: assertion holds: s.len() != 2
+Failed Checks: assertion holds: s.len() != 3
+Failed Checks: assertion holds: s.len() != 4

--- a/tests/expected/nondet/expected
+++ b/tests/expected/nondet/expected
@@ -7,4 +7,4 @@ attempt to subtract with overflow
 SUCCESS\
 attempt to add with overflow
 SUCCESS\
-assertion failed: x * x - 2 * x + 1 != 4 || (x == -1 || x == 3)
+assertion holds: x * x - 2 * x + 1 != 4 || (x == -1 || x == 3)

--- a/tests/expected/offset-wraps-around/expected
+++ b/tests/expected/offset-wraps-around/expected
@@ -1,2 +1,2 @@
 FAILURE\
-assertion failed: high_offset == wrapped_offset.try_into().unwrap()
+assertion holds: high_offset == wrapped_offset.try_into().unwrap()

--- a/tests/expected/raw_slice/expected
+++ b/tests/expected/raw_slice/expected
@@ -1,15 +1,15 @@
 Checking harness check_non_empty_raw...
 
 Status: SUCCESS\
-Description: "assertion failed: mem::size_of_val(raw) == 4"\
+Description: "assertion holds: mem::size_of_val(raw) == 4"\
 slice.rs:61:5 in function check_non_empty_raw
 
 Status: SUCCESS\
-Description: "assertion failed: raw.inner.len() == 4"\
+Description: "assertion holds: raw.inner.len() == 4"\
 slice.rs:62:5 in function check_non_empty_raw
 
 Status: SUCCESS\
-Description: "assertion failed: raw.inner[0] == 1"\
+Description: "assertion holds: raw.inner[0] == 1"\
 slice.rs:63:5 in function check_non_empty_raw
 
 VERIFICATION:- SUCCESSFUL
@@ -17,11 +17,11 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_empty_raw...
 
 Status: SUCCESS\
-Description: "assertion failed: mem::size_of_val(raw) == 0"\
+Description: "assertion holds: mem::size_of_val(raw) == 0"\
 slice.rs:70:5 in function check_empty_raw
 
 Status: SUCCESS\
-Description: "assertion failed: raw.inner.len() == 0"\
+Description: "assertion holds: raw.inner.len() == 0"\
 slice.rs:71:5 in function check_empty_raw
 
 VERIFICATION:- SUCCESSFUL
@@ -29,19 +29,19 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_non_empty_slice...
 
 Status: SUCCESS\
-Description: "assertion failed: mem::size_of_val(slice) == 2"\
+Description: "assertion holds: mem::size_of_val(slice) == 2"\
 slice.rs:78:5 in function check_non_empty_slice
 
 Status: SUCCESS\
-Description: "assertion failed: slice.others.len() == 1"\
+Description: "assertion holds: slice.others.len() == 1"\
 slice.rs:79:5 in function check_non_empty_slice
 
 Status: SUCCESS\
-Description: "assertion failed: slice.first == 1"\
+Description: "assertion holds: slice.first == 1"\
 slice.rs:80:5 in function check_non_empty_slice
 
 Status: SUCCESS\
-Description: "assertion failed: slice.others[0] == 5"\
+Description: "assertion holds: slice.others[0] == 5"\
 slice.rs:81:5 in function check_non_empty_slice
 
 VERIFICATION:- SUCCESSFUL
@@ -54,11 +54,11 @@ Description: ""Naive new should have the wrong slice len""\
 slice.rs:94:5 in function check_naive_iterator_should_fail
 
 Status: SUCCESS\
-Description: "assertion failed: slice.first == first"\
+Description: "assertion holds: slice.first == first"\
 slice.rs:95:5 in function check_naive_iterator_should_fail
 
 Status: SUCCESS\
-Description: "assertion failed: slice.others[0] == second"\
+Description: "assertion holds: slice.others[0] == second"\
 slice.rs:96:5 in function check_naive_iterator_should_fail
 
 Status: FAILURE\

--- a/tests/expected/raw_slice_c_repr/expected
+++ b/tests/expected/raw_slice_c_repr/expected
@@ -1,15 +1,15 @@
 Checking harness check_non_empty_raw...
 
 Status: SUCCESS\
-Description: "assertion failed: mem::size_of_val(raw) == 4"\
+Description: "assertion holds: mem::size_of_val(raw) == 4"\
 in function check_non_empty_raw
 
 Status: SUCCESS\
-Description: "assertion failed: raw.inner.len() == 4"\
+Description: "assertion holds: raw.inner.len() == 4"\
 in function check_non_empty_raw
 
 Status: SUCCESS\
-Description: "assertion failed: raw.inner[0] == 1"\
+Description: "assertion holds: raw.inner[0] == 1"\
 in function check_non_empty_raw
 
 VERIFICATION:- SUCCESSFUL
@@ -17,11 +17,11 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_empty_raw...
 
 Status: SUCCESS\
-Description: "assertion failed: mem::size_of_val(raw) == 0"\
+Description: "assertion holds: mem::size_of_val(raw) == 0"\
 in function check_empty_raw
 
 Status: SUCCESS\
-Description: "assertion failed: raw.inner.len() == 0"\
+Description: "assertion holds: raw.inner.len() == 0"\
 in function check_empty_raw
 
 VERIFICATION:- SUCCESSFUL
@@ -29,19 +29,19 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_non_empty_slice...
 
 Status: SUCCESS\
-Description: "assertion failed: mem::size_of_val(slice) == 2"\
+Description: "assertion holds: mem::size_of_val(slice) == 2"\
 in function check_non_empty_slice
 
 Status: SUCCESS\
-Description: "assertion failed: slice.others.len() == 1"\
+Description: "assertion holds: slice.others.len() == 1"\
 in function check_non_empty_slice
 
 Status: SUCCESS\
-Description: "assertion failed: slice.first == 1"\
+Description: "assertion holds: slice.first == 1"\
 in function check_non_empty_slice
 
 Status: SUCCESS\
-Description: "assertion failed: slice.others[0] == 5"\
+Description: "assertion holds: slice.others[0] == 5"\
 in function check_non_empty_slice
 
 VERIFICATION:- SUCCESSFUL
@@ -54,11 +54,11 @@ Description: ""Naive new should have the wrong slice len""\
 in function check_naive_iterator_should_fail
 
 Status: SUCCESS\
-Description: "assertion failed: slice.first == first"\
+Description: "assertion holds: slice.first == first"\
 in function check_naive_iterator_should_fail
 
 Status: SUCCESS\
-Description: "assertion failed: slice.others[0] == second"\
+Description: "assertion holds: slice.others[0] == second"\
 in function check_naive_iterator_should_fail
 
 Status: FAILURE\

--- a/tests/expected/raw_slice_packed/expected
+++ b/tests/expected/raw_slice_packed/expected
@@ -1,15 +1,15 @@
 Checking harness check_non_empty_raw...
 
 Status: SUCCESS\
-Description: "assertion failed: mem::size_of_val(raw) == 4"\
+Description: "assertion holds: mem::size_of_val(raw) == 4"\
 in function check_non_empty_raw
 
 Status: SUCCESS\
-Description: "assertion failed: raw.inner.len() == 4"\
+Description: "assertion holds: raw.inner.len() == 4"\
 in function check_non_empty_raw
 
 Status: SUCCESS\
-Description: "assertion failed: raw.inner[0] == 1"\
+Description: "assertion holds: raw.inner[0] == 1"\
 in function check_non_empty_raw
 
 VERIFICATION:- SUCCESSFUL
@@ -17,11 +17,11 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_empty_raw...
 
 Status: SUCCESS\
-Description: "assertion failed: mem::size_of_val(raw) == 0"\
+Description: "assertion holds: mem::size_of_val(raw) == 0"\
 in function check_empty_raw
 
 Status: SUCCESS\
-Description: "assertion failed: raw.inner.len() == 0"\
+Description: "assertion holds: raw.inner.len() == 0"\
 in function check_empty_raw
 
 VERIFICATION:- SUCCESSFUL
@@ -29,19 +29,19 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_non_empty_slice...
 
 Status: SUCCESS\
-Description: "assertion failed: mem::size_of_val(slice) == 2"\
+Description: "assertion holds: mem::size_of_val(slice) == 2"\
 in function check_non_empty_slice
 
 Status: SUCCESS\
-Description: "assertion failed: slice.others.len() == 1"\
+Description: "assertion holds: slice.others.len() == 1"\
 in function check_non_empty_slice
 
 Status: SUCCESS\
-Description: "assertion failed: slice.first == 1"\
+Description: "assertion holds: slice.first == 1"\
 in function check_non_empty_slice
 
 Status: SUCCESS\
-Description: "assertion failed: slice.others[0] == 5"\
+Description: "assertion holds: slice.others[0] == 5"\
 in function check_non_empty_slice
 
 VERIFICATION:- SUCCESSFUL
@@ -54,11 +54,11 @@ Description: ""Naive new should have the wrong slice len""\
 in function check_naive_iterator_should_fail
 
 Status: SUCCESS\
-Description: "assertion failed: slice.first == first"\
+Description: "assertion holds: slice.first == first"\
 in function check_naive_iterator_should_fail
 
 Status: SUCCESS\
-Description: "assertion failed: slice.others[0] == second"\
+Description: "assertion holds: slice.others[0] == second"\
 in function check_naive_iterator_should_fail
 
 Status: FAILURE\

--- a/tests/expected/reach/assert/reachable_fail/expected
+++ b/tests/expected/reach/assert/reachable_fail/expected
@@ -1,3 +1,3 @@
 FAILURE\
-Description: "assertion failed: x != 5"
-Failed Checks: assertion failed: x != 5
+Description: "assertion holds: x != 5"
+Failed Checks: assertion holds: x != 5

--- a/tests/expected/reach/assert/reachable_pass/expected
+++ b/tests/expected/reach/assert/reachable_pass/expected
@@ -1,3 +1,3 @@
 SUCCESS\
-Description: "assertion failed: x > 4"
+Description: "assertion holds: x > 4"
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/reach/assert/unreachable/expected
+++ b/tests/expected/reach/assert/unreachable/expected
@@ -1,3 +1,3 @@
 UNREACHABLE\
-Description: "assertion failed: x == 2"
+Description: "assertion holds: x == 2"
  ** 1 of 3 failed (1 unreachable)

--- a/tests/expected/reach/assert_eq/unreachable/expected
+++ b/tests/expected/reach/assert_eq/unreachable/expected
@@ -1,2 +1,2 @@
 UNREACHABLE\
-Description: "assertion failed: y == 55"
+Description: "assertion holds: y == 55"

--- a/tests/expected/reach/assert_ne/unreachable/expected
+++ b/tests/expected/reach/assert_ne/unreachable/expected
@@ -1,2 +1,2 @@
 UNREACHABLE\
-Description: "assertion failed: y != 1"
+Description: "assertion holds: y != 1"

--- a/tests/expected/reach/check_id/expected
+++ b/tests/expected/reach/check_id/expected
@@ -1,10 +1,10 @@
 Status: FAILURE\
-Description: "assertion failed: 3 + 3 == 5"
+Description: "assertion holds: 3 + 3 == 5"
 
 Status: UNREACHABLE\
-Description: "assertion failed: 2 + 2 == 4"
+Description: "assertion holds: 2 + 2 == 4"
 
 Status: SUCCESS\
-Description: "assertion failed: 1 + 1 == 2"
+Description: "assertion holds: 1 + 1 == 2"
 
 VERIFICATION:- FAILED

--- a/tests/expected/reach/debug-assert-eq/reachable_fail/expected
+++ b/tests/expected/reach/debug-assert-eq/reachable_fail/expected
@@ -1,3 +1,3 @@
 FAILURE\
-Description: "assertion failed: x == 10"
-Failed Checks: assertion failed: x == 10
+Description: "assertion holds: x == 10"
+Failed Checks: assertion holds: x == 10

--- a/tests/expected/reach/debug-assert-eq/reachable_pass/expected
+++ b/tests/expected/reach/debug-assert-eq/reachable_pass/expected
@@ -1,2 +1,2 @@
 SUCCESS\
-Description: "assertion failed: x == 10"
+Description: "assertion holds: x == 10"

--- a/tests/expected/reach/debug-assert-eq/unreachable/expected
+++ b/tests/expected/reach/debug-assert-eq/unreachable/expected
@@ -1,2 +1,2 @@
 UNREACHABLE\
-Description: "assertion failed: x == 10"
+Description: "assertion holds: x == 10"

--- a/tests/expected/reach/debug-assert-ne/reachable_fail/expected
+++ b/tests/expected/reach/debug-assert-ne/reachable_fail/expected
@@ -1,3 +1,3 @@
 FAILURE\
-Description: "assertion failed: x != 17"
-Failed Checks: assertion failed: x != 17
+Description: "assertion holds: x != 17"
+Failed Checks: assertion holds: x != 17

--- a/tests/expected/reach/debug-assert-ne/reachable_pass/expected
+++ b/tests/expected/reach/debug-assert-ne/reachable_pass/expected
@@ -1,2 +1,2 @@
 SUCCESS\
-Description: "assertion failed: x != 17"
+Description: "assertion holds: x != 17"

--- a/tests/expected/reach/debug-assert-ne/unreachable/expected
+++ b/tests/expected/reach/debug-assert-ne/unreachable/expected
@@ -1,2 +1,2 @@
 UNREACHABLE\
-Description: "assertion failed: x != 17"
+Description: "assertion holds: x != 17"

--- a/tests/expected/reach/debug-assert/reachable_fail/expected
+++ b/tests/expected/reach/debug-assert/reachable_fail/expected
@@ -1,3 +1,3 @@
 FAILURE\
-Description: "assertion failed: x != -10"
-Failed Checks: assertion failed: x != -10
+Description: "assertion holds: x != -10"
+Failed Checks: assertion holds: x != -10

--- a/tests/expected/reach/debug-assert/reachable_pass/expected
+++ b/tests/expected/reach/debug-assert/reachable_pass/expected
@@ -1,2 +1,2 @@
 SUCCESS\
-Description: "assertion failed: x != -10"
+Description: "assertion holds: x != -10"

--- a/tests/expected/reach/debug-assert/unreachable/expected
+++ b/tests/expected/reach/debug-assert/unreachable/expected
@@ -1,2 +1,2 @@
 UNREACHABLE\
-Description: "assertion failed: x != -10"
+Description: "assertion holds: x != -10"

--- a/tests/expected/reach/turned-off/expected
+++ b/tests/expected/reach/turned-off/expected
@@ -1,2 +1,2 @@
 SUCCESS\
-assertion failed: x != 11
+assertion holds: x != 11

--- a/tests/expected/references/expected
+++ b/tests/expected/references/expected
@@ -1,2 +1,2 @@
 SUCCESS\
-assertion failed: z == 2
+assertion holds: z == 2

--- a/tests/expected/report/insufficient_unwind/expected
+++ b/tests/expected/report/insufficient_unwind/expected
@@ -1,4 +1,4 @@
 UNDETERMINED\
-Description: "assertion failed: sum == 6"
+Description: "assertion holds: sum == 6"
 [Kani] info: Verification output shows one or more unwinding failures.
 [Kani] tip: Consider increasing the unwinding value or disabling `--unwinding-assertions`.

--- a/tests/expected/report/uncolor/expected
+++ b/tests/expected/report/uncolor/expected
@@ -1,5 +1,5 @@
 - Status: SUCCESS\
-Description: "assertion failed: 1 + 1 == 2"
+Description: "assertion holds: 1 + 1 == 2"
 - Status: FAILURE\
-- Description: "assertion failed: 2 + 2 == 3"
+- Description: "assertion holds: 2 + 2 == 3"
 VERIFICATION:- FAILED

--- a/tests/expected/report/unsupported/failure/expected
+++ b/tests/expected/report/unsupported/failure/expected
@@ -1,5 +1,5 @@
 FAILURE\
-Description: "assertion failed: x == 0"
-Failed Checks: assertion failed: x == 0
+Description: "assertion holds: x == 0"
+Failed Checks: assertion holds: x == 0
 Failed Checks: TerminatorKind::InlineAsm is not currently supported by Kani. Please post your example at https://github.com/model-checking/kani/issues/2
 ** WARNING: A Rust construct that is not currently supported by Kani was found to be reachable. Check the results for more details.

--- a/tests/expected/report/unsupported/reachable/expected
+++ b/tests/expected/report/unsupported/reachable/expected
@@ -1,4 +1,4 @@
 Status: UNDETERMINED\
-Description: "assertion failed: x == 0"
+Description: "assertion holds: x == 0"
 Failed Checks: TerminatorKind::InlineAsm is not currently supported by Kani. Please post your example at https://github.com/model-checking/kani/issues/2
 ** WARNING: A Rust construct that is not currently supported by Kani was found to be reachable. Check the results for more details.

--- a/tests/expected/report/unsupported/unreachable/expected
+++ b/tests/expected/report/unsupported/unreachable/expected
@@ -1,3 +1,3 @@
 SUCCESS\
-Description: "assertion failed: x == 0"
+Description: "assertion holds: x == 0"
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/slice/expected
+++ b/tests/expected/slice/expected
@@ -1,8 +1,8 @@
 SUCCESS\
-assertion failed: y.len() == 5
+assertion holds: y.len() == 5
 SUCCESS\
 index out of bounds: the length is less than or equal to the given index
 SUCCESS\
-assertion failed: y[1] == 2
+assertion holds: y[1] == 2
 SUCCESS\
-assertion failed: z.len() == 3
+assertion holds: z.len() == 3

--- a/tests/expected/static-mutable-struct/expected
+++ b/tests/expected/static-mutable-struct/expected
@@ -1,22 +1,22 @@
 SUCCESS\
-assertion failed: foo().x == 12
+assertion holds: foo().x == 12
 FAILURE\
-assertion failed: foo().y == 12
+assertion holds: foo().y == 12
 FAILURE\
-assertion failed: foo().x == 14
+assertion holds: foo().x == 14
 SUCCESS\
-assertion failed: foo().y == 14
+assertion holds: foo().y == 14
 SUCCESS\
-assertion failed: foo().x == 1
+assertion holds: foo().x == 1
 FAILURE\
-assertion failed: foo().y == 1
+assertion holds: foo().y == 1
 FAILURE\
-assertion failed: foo().x == 2
+assertion holds: foo().x == 2
 SUCCESS\
-assertion failed: foo().y == 2
+assertion holds: foo().y == 2
 SUCCESS\
-assertion failed: foo().x == 1 << 62
+assertion holds: foo().x == 1 << 62
 FAILURE\
-assertion failed: foo().x == 1 << 31
+assertion holds: foo().x == 1 << 31
 SUCCESS\
-assertion failed: foo().y == 1 << 31
+assertion holds: foo().y == 1 << 31

--- a/tests/expected/static-mutable/expected
+++ b/tests/expected/static-mutable/expected
@@ -1,8 +1,8 @@
 FAILURE\
-assertion failed: 10 == foo()
+assertion holds: 10 == foo()
 SUCCESS\
-assertion failed: 12 == foo()
+assertion holds: 12 == foo()
 SUCCESS\
-assertion failed: 10 == foo()
+assertion holds: 10 == foo()
 FAILURE\
-assertion failed: 12 == foo()
+assertion holds: 12 == foo()

--- a/tests/expected/static/expected
+++ b/tests/expected/static/expected
@@ -1,4 +1,4 @@
 FAILURE\
-assertion failed: 10 == foo()
+assertion holds: 10 == foo()
 UNREACHABLE\
-assertion failed: 12 == foo()
+assertion holds: 12 == foo()

--- a/tests/expected/test1/expected
+++ b/tests/expected/test1/expected
@@ -3,8 +3,8 @@ attempt to add with overflow
 SUCCESS\
 attempt to subtract with overflow
 FAILURE\
-assertion failed: a == 54
+assertion holds: a == 54
 UNREACHABLE\
-assertion failed: a == 55
+assertion holds: a == 55
 UNREACHABLE\
-assertion failed: a >= 55
+assertion holds: a >= 55

--- a/tests/expected/test2/expected
+++ b/tests/expected/test2/expected
@@ -3,8 +3,8 @@ attempt to shift right with overflow
 SUCCESS\
 attempt to add with overflow
 FAILURE\
-assertion failed: i == 3
+assertion holds: i == 3
 UNREACHABLE\
-assertion failed: i == 2
+assertion holds: i == 2
 UNREACHABLE\
-assertion failed: i == 2 || i == 3
+assertion holds: i == 2 || i == 3

--- a/tests/expected/test3/expected
+++ b/tests/expected/test3/expected
@@ -1,18 +1,18 @@
 SUCCESS\
 attempt to subtract with overflow
 FAILURE\
-assertion failed: a == 10.0 && i == 1
+assertion holds: a == 10.0 && i == 1
 FAILURE\
-assertion failed: a == 9.0 && i == 0
+assertion holds: a == 9.0 && i == 0
 FAILURE\
-assertion failed: a == 9.0 && i == 1
+assertion holds: a == 9.0 && i == 1
 SUCCESS\
-assertion failed: a == 10.0 && i == 0
+assertion holds: a == 10.0 && i == 0
 SUCCESS\
-assertion failed: a == 9.0 || i == 0
+assertion holds: a == 9.0 || i == 0
 SUCCESS\
-assertion failed: a == 10.0 || i == 1
+assertion holds: a == 10.0 || i == 1
 FAILURE\
-assertion failed: a == 9.0 || i == 1
+assertion holds: a == 9.0 || i == 1
 SUCCESS\
-assertion failed: a == 10.0 || i == 0
+assertion holds: a == 10.0 || i == 0

--- a/tests/expected/test4/expected
+++ b/tests/expected/test4/expected
@@ -1,11 +1,11 @@
 SUCCESS\
 attempt to add with overflow
 FAILURE\
-assertion failed: i == 3
+assertion holds: i == 3
 UNREACHABLE\
-assertion failed: i == 2
+assertion holds: i == 2
 UNREACHABLE\
-assertion failed: i == 2 || i == 3
+assertion holds: i == 2 || i == 3
 SUCCESS\
 attempt to divide by zero
 SUCCESS\

--- a/tests/expected/test5/expected
+++ b/tests/expected/test5/expected
@@ -1,7 +1,7 @@
 SUCCESS\
-assertion failed: div(4, 2) == 2
+assertion holds: div(4, 2) == 2
 FAILURE\
-assertion failed: div(6, 2) == 2
+assertion holds: div(6, 2) == 2
 SUCCESS\
 attempt to divide by zero
 SUCCESS\

--- a/tests/expected/test6/expected
+++ b/tests/expected/test6/expected
@@ -1,4 +1,4 @@
 SUCCESS\
-assertion failed: add2(1, 1) == 2.0
+assertion holds: add2(1, 1) == 2.0
 FAILURE\
-assertion failed: add2(2, 1) == 2.0
+assertion holds: add2(2, 1) == 2.0

--- a/tests/expected/trait-receiver/expected
+++ b/tests/expected/trait-receiver/expected
@@ -1,16 +1,16 @@
 Checking harness check_box...
 
 Status: SUCCESS\
-Description: "assertion failed: boxed.ref_id() == id"\
+Description: "assertion holds: boxed.ref_id() == id"\
 in function check_box
 
 Status: SUCCESS\
-Description: "assertion failed: boxed.box_id() == id"\
+Description: "assertion holds: boxed.box_id() == id"\
 in function check_box
 
 
 Status: SUCCESS\
-Description: "assertion failed: self.as_ref().id == self.id"\
+Description: "assertion holds: self.as_ref().id == self.id"\
 in function <Concrete as Trait>::box_id
 
 VERIFICATION:- SUCCESSFUL
@@ -19,16 +19,16 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_rc...
 
 Status: SUCCESS\
-Description: "assertion failed: ref_count.ref_id() == id"\
+Description: "assertion holds: ref_count.ref_id() == id"\
 in function check_rc
 
 Status: SUCCESS\
-Description: "assertion failed: ref_count.rc_id() == id"\
+Description: "assertion holds: ref_count.rc_id() == id"\
 in function check_rc
 
 
 Status: SUCCESS\
-Description: "assertion failed: self.as_ref().id == self.id"\
+Description: "assertion holds: self.as_ref().id == self.id"\
 in function <Concrete as Trait>::rc_id
 
 VERIFICATION:- SUCCESSFUL
@@ -37,16 +37,16 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_arc...
 
 Status: SUCCESS\
-Description: "assertion failed: async_ref.ref_id() == id"\
+Description: "assertion holds: async_ref.ref_id() == id"\
 in function check_arc
 
 Status: SUCCESS\
-Description: "assertion failed: async_ref.arc_id() == id"\
+Description: "assertion holds: async_ref.arc_id() == id"\
 in function check_arc
 
 
 Status: SUCCESS\
-Description: "assertion failed: self.as_ref().id == self.id"\
+Description: "assertion holds: self.as_ref().id == self.id"\
 in function <Concrete as Trait>::arc_id
 
 VERIFICATION:- SUCCESSFUL
@@ -55,15 +55,15 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_pin...
 
 Status: SUCCESS\
-Description: "assertion failed: pin.ref_id() == id"\
+Description: "assertion holds: pin.ref_id() == id"\
 in function check_pin
 
 Status: SUCCESS\
-Description: "assertion failed: pin.pin_id() == id"\
+Description: "assertion holds: pin.pin_id() == id"\
 in function check_pin
 
 Status: SUCCESS\
-Description: "assertion failed: self.as_ref().id == self.id"\
+Description: "assertion holds: self.as_ref().id == self.id"\
 in function <Concrete as Trait>::pin_id
 
 
@@ -72,15 +72,15 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_pin_box...
 
 Status: SUCCESS\
-Description: "assertion failed: pin.ref_id() == id"\
+Description: "assertion holds: pin.ref_id() == id"\
 in function check_pin_box
 
 Status: SUCCESS\
-Description: "assertion failed: pin.pin_box_id() == id"\
+Description: "assertion holds: pin.pin_box_id() == id"\
 in function check_pin_box
 
 Status: SUCCESS\
-Description: "assertion failed: self.as_ref().id == self.id"\
+Description: "assertion holds: self.as_ref().id == self.id"\
 in function <Concrete as Trait>::pin_box_id
 
 VERIFICATION:- SUCCESSFUL
@@ -89,11 +89,11 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_mut...
 
 Status: SUCCESS\
-Description: "assertion failed: trt.replace_id(new_id) == initial_id"\
+Description: "assertion holds: trt.replace_id(new_id) == initial_id"\
 in function check_mut
 
 Status: SUCCESS\
-Description: "assertion failed: trt.ref_id() == new_id"\
+Description: "assertion holds: trt.ref_id() == new_id"\
 in function check_mut
 
 VERIFICATION:- SUCCESSFUL
@@ -102,7 +102,7 @@ VERIFICATION:- SUCCESSFUL
 Checking harness check_bound...
 
 Status: SUCCESS\
-Description: "assertion failed: obj.bound_value() == id"\
+Description: "assertion holds: obj.bound_value() == id"\
 in function check_bound::assert_value::<Concrete>
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/transmute/expected
+++ b/tests/expected/transmute/expected
@@ -1,4 +1,4 @@
 SUCCESS\
-assertion failed: bitpattern == 0x3F800000
+assertion holds: bitpattern == 0x3F800000
 SUCCESS\
-assertion failed: f == 1.0
+assertion holds: f == 1.0

--- a/tests/expected/unwind-recursion-fail/expected
+++ b/tests/expected/unwind-recursion-fail/expected
@@ -1,5 +1,5 @@
 UNDETERMINED\
-assertion failed: f == 120
+assertion holds: f == 120
 UNDETERMINED\
 attempt to subtract with overflow
 UNDETERMINED\

--- a/tests/expected/vec/expected
+++ b/tests/expected/vec/expected
@@ -27,8 +27,8 @@ free called for new[] object
 SUCCESS\
 free called for stack-allocated object
 SUCCESS\
-assertion failed: x[0] == 10
+assertion holds: x[0] == 10
 SUCCESS\
-assertion failed: y == 10
+assertion holds: y == 10
 FAILURE\
-assertion failed: y != 10
+assertion holds: y != 10

--- a/tests/expected/vecdq/expected
+++ b/tests/expected/vecdq/expected
@@ -1,9 +1,9 @@
 SUCCESS\
-assertion failed: q.len() == 2
+assertion holds: q.len() == 2
 SUCCESS\
-assertion failed: q.pop_front().unwrap() == x
+assertion holds: q.pop_front().unwrap() == x
 SUCCESS\
-assertion failed: q.pop_front().unwrap() == y
+assertion holds: q.pop_front().unwrap() == y
 SUCCESS\
 max allocation size exceeded
 SUCCESS\

--- a/tests/kani/LoopLoop_NonReturning/main_no_unwind_asserts.rs
+++ b/tests/kani/LoopLoop_NonReturning/main_no_unwind_asserts.rs
@@ -10,13 +10,13 @@
 // and generates this verification output:
 //
 // [main.unwind.0] line 30 unwinding assertion loop 0: FAILURE
-// [main.assertion.1] line 38 assertion failed: a == 0: SUCCESS
+// [main.assertion.1] line 38 assertion holds: a == 0: SUCCESS
 // ** 1 of 2 failed (2 iterations)
 // VERIFICATION FAILED
 //
 // But with `--no-default-checks` we will avoid introducing a unwinding assertion:
 //
-// [main.assertion.1] line 38 assertion failed: a == 0: SUCCESS
+// [main.assertion.1] line 38 assertion holds: a == 0: SUCCESS
 //
 // ** 0 of 1 failed (1 iterations)
 // VERIFICATION SUCCESSFUL

--- a/tests/kani/LoopLoop_NonReturning/main_no_unwind_asserts.rs
+++ b/tests/kani/LoopLoop_NonReturning/main_no_unwind_asserts.rs
@@ -10,13 +10,13 @@
 // and generates this verification output:
 //
 // [main.unwind.0] line 30 unwinding assertion loop 0: FAILURE
-// [main.assertion.1] line 38 assertion holds: a == 0: SUCCESS
+// [main.assertion.1] line 38 assertion failed: a == 0: SUCCESS
 // ** 1 of 2 failed (2 iterations)
 // VERIFICATION FAILED
 //
 // But with `--no-default-checks` we will avoid introducing a unwinding assertion:
 //
-// [main.assertion.1] line 38 assertion holds: a == 0: SUCCESS
+// [main.assertion.1] line 38 assertion failed: a == 0: SUCCESS
 //
 // ** 0 of 1 failed (1 iterations)
 // VERIFICATION SUCCESSFUL

--- a/tests/kani/LoopWhile_NonReturning/main_no_unwind_asserts.rs
+++ b/tests/kani/LoopWhile_NonReturning/main_no_unwind_asserts.rs
@@ -10,14 +10,14 @@
 // and generates this verification output:
 //
 // [main.unwind.0] line 30 unwinding assertion loop 0: FAILURE
-// [main.assertion.1] line 34 assertion holds: a == 0: SUCCESS
+// [main.assertion.1] line 34 assertion failed: a == 0: SUCCESS
 //
 // ** 1 of 2 failed (2 iterations)
 // VERIFICATION FAILED
 //
 // But with `--no-default-checks` we will avoid introducing a unwinding assertion:
 //
-// [main.assertion.1] line 34 assertion holds: a == 0: SUCCESS
+// [main.assertion.1] line 34 assertion failed: a == 0: SUCCESS
 //
 // ** 0 of 1 failed (1 iterations)
 // VERIFICATION SUCCESSFUL

--- a/tests/kani/LoopWhile_NonReturning/main_no_unwind_asserts.rs
+++ b/tests/kani/LoopWhile_NonReturning/main_no_unwind_asserts.rs
@@ -10,14 +10,14 @@
 // and generates this verification output:
 //
 // [main.unwind.0] line 30 unwinding assertion loop 0: FAILURE
-// [main.assertion.1] line 34 assertion failed: a == 0: SUCCESS
+// [main.assertion.1] line 34 assertion holds: a == 0: SUCCESS
 //
 // ** 1 of 2 failed (2 iterations)
 // VERIFICATION FAILED
 //
 // But with `--no-default-checks` we will avoid introducing a unwinding assertion:
 //
-// [main.assertion.1] line 34 assertion failed: a == 0: SUCCESS
+// [main.assertion.1] line 34 assertion holds: a == 0: SUCCESS
 //
 // ** 0 of 1 failed (1 iterations)
 // VERIFICATION SUCCESSFUL

--- a/tests/perf/vec/vec/expected
+++ b/tests/perf/vec/vec/expected
@@ -1,4 +1,4 @@
 Status: SUCCESS\
-Description: "assertion failed: v2 == vec![1]"
+Description: "assertion holds: v2 == vec![1]"
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/ui/derive-arbitrary/enum/expected
+++ b/tests/ui/derive-arbitrary/enum/expected
@@ -1,15 +1,15 @@
 Checking harness check_comparison...
 SUCCESS\
-"assertion failed: disc >= -1 && disc <= 1"
+"assertion holds: disc >= -1 && disc <= 1"
 
 SUCCESS\
-"assertion failed: disc == 1"
+"assertion holds: disc == 1"
 
 SUCCESS\
-"assertion failed: disc == -1"
+"assertion holds: disc == -1"
 
 SUCCESS\
-"assertion failed: disc == 0"
+"assertion holds: disc == 0"
 
 
 Checking harness check_enum_wrapper...

--- a/tests/ui/entry-fn/non-main/expected
+++ b/tests/ui/entry-fn/non-main/expected
@@ -1,4 +1,4 @@
 SUCCESS\
-assertion failed: pos != 0
+assertion holds: pos != 0
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/ui/missing-function/extern_c/expected
+++ b/tests/ui/missing-function/extern_c/expected
@@ -1,5 +1,5 @@
 Status: UNDETERMINED\
-Description: "assertion failed: x == 5"
+Description: "assertion holds: x == 5"
 Status: FAILURE\
 Description: "Function `missing_function` with missing definition is unreachable"
 VERIFICATION:- FAILED

--- a/tests/ui/regular-output-format-fail/expected
+++ b/tests/ui/regular-output-format-fail/expected
@@ -1,2 +1,2 @@
-Description: "assertion failed: 1 + 1 == 3"
-Failed Checks: assertion failed: 1 + 1 == 3
+Description: "assertion holds: 1 + 1 == 3"
+Failed Checks: assertion holds: 1 + 1 == 3

--- a/tests/ui/regular-output-format-pass/expected
+++ b/tests/ui/regular-output-format-pass/expected
@@ -1,3 +1,3 @@
-Description: "assertion failed: 1 + 1 == 2"\
+Description: "assertion holds: 1 + 1 == 2"\
 Location:
 tests/ui/regular-output-format-pass/main.rs:7:5 in function main

--- a/tests/ui/terse-output-format-fail/expected
+++ b/tests/ui/terse-output-format-fail/expected
@@ -1,2 +1,2 @@
 VERIFICATION RESULT:
-Failed Checks: assertion failed: 1 + 1 == 3
+Failed Checks: assertion holds: 1 + 1 == 3


### PR DESCRIPTION
### Description of changes: 

Replaces `"assertion failed"` with `"assertion holds"` in the description of checks from the `assertion` class.

The new description is less confusing for users.

### Resolved issues:

Resolves #1240 

### Call-outs:
 * [This comment](https://github.com/model-checking/kani/issues/1240#issuecomment-1144180339) mentions that there are other cases where we don't have control over the message, but I don't if this was considering doing it during post-processing.
 * We can discuss other options to update the message, it's not a problem. For example, I initially though about replacing `"assertion failed"` with just `"assertion"`, but the message is short and doesn't really describe anything. So I'm using the proposed text instead, but I'm open to suggestions.
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing tests.

* Is this a refactor change? Yes.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
