### PR TITLE
Print Rustc unparsed messages in cargo kani

### DIFF
--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -202,8 +202,18 @@ impl KaniSession {
                     | Message::BuildFinished(_) => {
                         // do nothing
                     }
+                    Message::TextLine(msg) => {
+                        if !self.args.quiet {
+                            println!("{msg}");
+                        }
+                    }
+
                     // Non-exhaustive enum.
-                    _ => {}
+                    _ => {
+                        if !self.args.quiet {
+                            println!("{message:?}");
+                        }
+                    }
                 }
             }
             let status = cargo_process.wait()?;


### PR DESCRIPTION
### Description of changes: 

In some cases, like `-Zunpretty=expanded`, Rustc will print information to the stdout that is not in json format. For those cases, we should print the message as is.

### Resolved issues:

N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

This was a regression introduced after we started parsing the cargo output https://github.com/model-checking/kani/pull/2166.

### Testing:

* How is this change tested? Manually tested

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
