### PR TITLE
Remove deprecated Ubuntu 18.04 from GitHub Actions workflows

### DIFF
--- a/.github/workflows/cbmc-latest.yml
+++ b/.github/workflows/cbmc-latest.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [macos-11, ubuntu-20.04, ubuntu-22.04]
     steps:
       - name: Checkout Kani under "kani"
         uses: actions/checkout@v3

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [macos-11, ubuntu-20.04, ubuntu-22.04]
     steps:
       - name: Checkout Kani
         uses: actions/checkout@v3
@@ -119,11 +119,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, ubuntu-18.04]
+        os: [macos-11, ubuntu-20.04]
         include:
           - os: macos-11
             artifact: kani-latest-x86_64-apple-darwin.tar.gz
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             artifact: kani-latest-x86_64-unknown-linux-gnu.tar.gz
     steps:
       - name: Checkout Kani
@@ -140,16 +140,15 @@ jobs:
           cargo package -p kani-verifier
 
       - name: Build container test
-        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
           docker build -t kani-20-04 -f scripts/ci/Dockerfile.bundle-test-ubuntu-20-04 .
           docker build -t kani-20-04-alt -f scripts/ci/Dockerfile.bundle-test-ubuntu-20-04-alt .
-          docker build -t kani-18-04 -f scripts/ci/Dockerfile.bundle-test-ubuntu-18-04 .
           # this one does its tests automatically, for reasons documented in the file:
           docker build -t kani-nixos -f scripts/ci/Dockerfile.bundle-test-nixos .
 
       - name: Run installed tests
-        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
           for tag in kani-20-04 kani-20-04-alt kani-18-04; do
             docker run $tag  cargo kani --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Release:
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
     outputs:
@@ -58,11 +58,11 @@ jobs:
       contents: write
     strategy:
       matrix:
-        os: [macos-11, ubuntu-18.04]
+        os: [macos-11, ubuntu-20.04]
         include:
           - os: macos-11
             target: x86_64-apple-darwin
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
     steps:
       - name: Checkout code

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [macos-11, ubuntu-20.04, ubuntu-22.04]
     steps:
       - name: Checkout Kani
         uses: actions/checkout@v3


### PR DESCRIPTION
### Description of changes: 

GitHub has deprecated the 18.04 runner and will be killing it soon.  https://github.com/actions/runner-images/issues/6002. Remove it so our CI continues working.
### Resolved issues:

Resolves NA

### Related RFC:
NA

### Call-outs:

I moved to 20.04.  We can discuss 22.04 instead

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
