### PR TITLE
Unstabilize `--visualize` and disable coverage in reports

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -28,8 +28,6 @@ Common to both `kani` and `cargo kani` are many command-line flags:
  If used with `print`, Kani will only print the unit test to stdout.
  If used with `inplace`, Kani will automatically add the unit test to the user's source code, next to the proof harness. For more detailed instructions, see the [debugging verification failures](./debugging-verification-failures.md) section.
 
- * `--visualize`: Generates an HTML report showing coverage information and providing traces (i.e., counterexamples) for each failure found by Kani.
-
  * `--tests`: Build in "[test mode](https://doc.rust-lang.org/rustc/tests/index.html)", i.e. with `cfg(test)` set and `dev-dependencies` available (when using `cargo kani`).
 
  * `--harness <name>`: By default, Kani checks all proof harnesses it finds.

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -28,6 +28,8 @@ Common to both `kani` and `cargo kani` are many command-line flags:
  If used with `print`, Kani will only print the unit test to stdout.
  If used with `inplace`, Kani will automatically add the unit test to the user's source code, next to the proof harness. For more detailed instructions, see the [debugging verification failures](./debugging-verification-failures.md) section.
 
+ * `--visualize`: _Experimental_, `--enable-unstable` feature that generates an HTML report showing coverage information and providing traces (i.e., counterexamples) for each failure found by Kani.
+
  * `--tests`: Build in "[test mode](https://doc.rust-lang.org/rustc/tests/index.html)", i.e. with `cfg(test)` set and `dev-dependencies` available (when using `cargo kani`).
 
  * `--harness <name>`: By default, Kani checks all proof harnesses it finds.

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -28,7 +28,7 @@ Common to both `kani` and `cargo kani` are many command-line flags:
  If used with `print`, Kani will only print the unit test to stdout.
  If used with `inplace`, Kani will automatically add the unit test to the user's source code, next to the proof harness. For more detailed instructions, see the [debugging verification failures](./debugging-verification-failures.md) section.
 
- * `--visualize`: _Experimental_, `--enable-unstable` feature that generates an HTML report showing coverage information and providing traces (i.e., counterexamples) for each failure found by Kani.
+ * `--visualize`: _Experimental_, `--enable-unstable` feature that generates an HTML report providing traces (i.e., counterexamples) for each failure found by Kani.
 
  * `--tests`: Build in "[test mode](https://doc.rust-lang.org/rustc/tests/index.html)", i.e. with `cfg(test)` set and `dev-dependencies` available (when using `cargo kani`).
 

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -482,7 +482,7 @@ impl KaniArgs {
             return Err(Error::raw(
                 ErrorKind::MissingRequiredArgument,
                 "Missing argument: --visualize now requires --enable-unstable
-                due to recent issues involving incorrect results.",
+                due to open issues involving incorrect results.",
             ));
         }
         if self.mir_linker {

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -481,7 +481,7 @@ impl KaniArgs {
         if self.visualize && !self.enable_unstable {
             return Err(Error::raw(
                 ErrorKind::MissingRequiredArgument,
-                "Missing argument: --visualize is now requires --enable-unstable\n
+                "Missing argument: --visualize is now requires --enable-unstable
                 due to recent issues involving incorrect coverage results.
                 More details in <https://github.com/model-checking/kani/issues/2048>",
             ));

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -478,6 +478,14 @@ impl KaniArgs {
             );
         }
 
+        if self.visualize && !self.enable_unstable {
+            return Err(Error::raw(
+                ErrorKind::MissingRequiredArgument,
+                "Missing argument: --visualize is now requires --enable-unstable\n
+                due to recent issues involving incorrect coverage results.
+                More details in <https://github.com/model-checking/kani/issues/2048>",
+            ));
+        }
         if self.mir_linker {
             self.print_deprecated("--mir-linker");
         }

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -478,12 +478,16 @@ impl KaniArgs {
             );
         }
 
-        if self.visualize && !self.enable_unstable {
-            return Err(Error::raw(
-                ErrorKind::MissingRequiredArgument,
-                "Missing argument: --visualize now requires --enable-unstable
-                due to open issues involving incorrect results.",
-            ));
+        if self.visualize {
+            if !self.enable_unstable {
+                return Err(Error::raw(
+                    ErrorKind::MissingRequiredArgument,
+                    "Missing argument: --visualize now requires --enable-unstable
+                    due to open issues involving incorrect results.",
+                ));
+            } else {
+                warning("coverage information has been disabled for --visualize reports");
+            }
         }
         if self.mir_linker {
             self.print_deprecated("--mir-linker");

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -482,8 +482,7 @@ impl KaniArgs {
             return Err(Error::raw(
                 ErrorKind::MissingRequiredArgument,
                 "Missing argument: --visualize now requires --enable-unstable
-                due to recent issues involving incorrect coverage results.
-                More details in <https://github.com/model-checking/kani/issues/2048>",
+                due to recent issues involving incorrect results.",
             ));
         }
         if self.mir_linker {

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -478,17 +478,14 @@ impl KaniArgs {
             );
         }
 
-        if self.visualize {
-            if !self.enable_unstable {
-                return Err(Error::raw(
-                    ErrorKind::MissingRequiredArgument,
-                    "Missing argument: --visualize now requires --enable-unstable
+        if self.visualize && !self.enable_unstable {
+            return Err(Error::raw(
+                ErrorKind::MissingRequiredArgument,
+                "Missing argument: --visualize now requires --enable-unstable
                     due to open issues involving incorrect results.",
-                ));
-            } else {
-                warning("coverage information has been disabled for --visualize reports");
-            }
+            ));
         }
+
         if self.mir_linker {
             self.print_deprecated("--mir-linker");
         }

--- a/kani-driver/src/args.rs
+++ b/kani-driver/src/args.rs
@@ -481,7 +481,7 @@ impl KaniArgs {
         if self.visualize && !self.enable_unstable {
             return Err(Error::raw(
                 ErrorKind::MissingRequiredArgument,
-                "Missing argument: --visualize is now requires --enable-unstable
+                "Missing argument: --visualize now requires --enable-unstable
                 due to recent issues involving incorrect coverage results.
                 More details in <https://github.com/model-checking/kani/issues/2048>",
             ));

--- a/kani-driver/src/call_cbmc_viewer.rs
+++ b/kani-driver/src/call_cbmc_viewer.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::session::KaniSession;
-use crate::util::alter_extension;
+use crate::util::{alter_extension, warning};
 
 impl KaniSession {
     /// Run CBMC appropriately to produce 3 output XML files, then run cbmc-viewer on them to produce a report.
@@ -56,6 +56,7 @@ impl KaniSession {
         // Let the user know
         if !self.args.quiet {
             println!("Report written to: {}/html/index.html", report_dir.to_string_lossy());
+            warning("coverage information has been disabled for `--visualize` reports");
             // If using VS Code with Remote-SSH, suggest an option for remote viewing:
             if std::env::var("VSCODE_IPC_HOOK_CLI").is_ok()
                 && std::env::var("SSH_CONNECTION").is_ok()

--- a/kani-driver/src/call_cbmc_viewer.rs
+++ b/kani-driver/src/call_cbmc_viewer.rs
@@ -20,18 +20,11 @@ impl KaniSession {
         harness_metadata: &HarnessMetadata,
     ) -> Result<()> {
         let results_filename = alter_extension(file, "results.xml");
-        let coverage_filename = alter_extension(file, "coverage.xml");
         let property_filename = alter_extension(file, "property.xml");
 
-        self.record_temporary_files(&[&results_filename, &coverage_filename, &property_filename]);
+        self.record_temporary_files(&[&results_filename, &property_filename]);
 
         self.cbmc_variant(file, &["--xml-ui", "--trace"], &results_filename, harness_metadata)?;
-        self.cbmc_variant(
-            file,
-            &["--xml-ui", "--cover", "location"],
-            &coverage_filename,
-            harness_metadata,
-        )?;
         self.cbmc_variant(
             file,
             &["--xml-ui", "--show-properties"],
@@ -42,8 +35,6 @@ impl KaniSession {
         let args: Vec<OsString> = vec![
             "--result".into(),
             results_filename.into(),
-            "--coverage".into(),
-            coverage_filename.into(),
             "--property".into(),
             property_filename.into(),
             "--srcdir".into(),

--- a/tests/cargo-kani/simple-visualize/Cargo.toml
+++ b/tests/cargo-kani/simple-visualize/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 [workspace]
 
 [package.metadata.kani]
-flags = {visualize = true}
+flags = {enable-unstable = true, visualize = true}


### PR DESCRIPTION
### Description of changes: 

Unstabilizes the `--visualize` feature due to incorrect coverage results (see #2048). It uses a custom message to inform users about issues around the flag. In addition, it removes coverage information from the `cbmc-viewer` reports.

### Resolved issues:

Related #2048 

### Call-outs:

The plan is to convert `--visualize` into a standard unstable feature after the next release. Another option here is to print the message but continue the analysis (as a kind of warning).
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing tests.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
