### PR TITLE
fix: add kissat to the nixos patchelf list

### DIFF
--- a/src/os_hacks.rs
+++ b/src/os_hacks.rs
@@ -148,7 +148,8 @@ fn setup_nixos_patchelf(kani_dir: &Path) -> Result<()> {
     for filename in &["kani-compiler", "kani-driver"] {
         patch_interp(&bin.join(filename))?;
     }
-    for filename in &["cbmc", "goto-analyzer", "goto-cc", "goto-instrument", "symtab2gb"] {
+    for filename in &["cbmc", "goto-analyzer", "goto-cc", "goto-instrument", "kissat", "symtab2gb"]
+    {
         let file = bin.join(filename);
         patch_interp(&file)?;
         patch_rpath(&file)?;


### PR DESCRIPTION
### Description of changes: 

In #2087, kissat was added to the kani-verifier distribution bundle. However, the binary wasn't included in the NixOS list of binaries to patch with `patchelf` and results in it not being executable on that platform. This change simply adds it to the list.

### Call-outs:

I wonder if we need a better mechanism of keeping the list of binaries we ship in sync?

### Testing:

I tested it locally by running the `patchelf` command manually. After running it I was able to use the solver as expected.

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
