### PR TITLE
Add `--fix-expected` to help batch fix to expected tests (Internal tool only)

### DIFF
--- a/tools/compiletest/src/common.rs
+++ b/tools/compiletest/src/common.rs
@@ -140,6 +140,11 @@ pub struct Config {
 
     /// Whether we will run the tests or not.
     pub dry_run: bool,
+
+    /// Whether we should update expected tests when there is a mismatch. This is helpful for
+    /// updating multiple tests. Users should still manually edit the files after to only keep
+    /// relevant expectations.
+    pub fix_expected: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/tools/compiletest/src/main.rs
+++ b/tools/compiletest/src/main.rs
@@ -88,6 +88,8 @@ pub fn parse_config(args: Vec<String>) -> Config {
         .optopt("", "timeout", "the timeout for each test in seconds", "TIMEOUT")
         .optflag("", "no-fail-fast", "run all tests regardless of failure")
         .optflag("", "dry-run", "don't actually run the tests")
+        .optflag("", "fix-expected",
+        "override all expected files that did not match the output. Tests will NOT fail when there is a mismatch")
     ;
 
     let (argv0, args_) = args.split_first().unwrap();
@@ -160,6 +162,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         force_rerun: matches.opt_present("force-rerun"),
         fail_fast: !matches.opt_present("no-fail-fast"),
         dry_run: matches.opt_present("dry-run"),
+        fix_expected: matches.opt_present("fix-expected"),
         timeout,
     }
 }
@@ -180,6 +183,7 @@ pub fn log_config(config: &Config) {
     logv(c, format!("timeout: {:?}", config.timeout));
     logv(c, format!("fail-fast: {:?}", config.fail_fast));
     logv(c, format!("dry-run: {:?}", config.dry_run));
+    logv(c, format!("fix-expected: {:?}", config.fix_expected));
     logv(
         c,
         format!(


### PR DESCRIPTION
### Description of changes: 

This option will basically override the expected file with Kani's output for every test that fails the expectation. Developers should still prune the expected file to ensure only the information that is needed gets pushed.

My motivation is that I always find myself updating expected tests manually by rerunning Kani for each failure, piping the output to the expected file and edit the file after. With this hack, I only need to do the last step manually.

Since we still fail the test, the files that were updated are listed, which makes it very easy to track down the changes.

### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

Note that with great power comes great responsibility. Developers still need to manually edit the expected files before publishing a PR.

### Testing:

* How is this change tested? Manually tested in the last PR I created.

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
