### PR TITLE
Fix regression with stub external resolve

### DIFF
--- a/tests/cargo-kani/stubbing-validate-random/main.expected
+++ b/tests/cargo-kani/stubbing-validate-random/main.expected
@@ -1,1 +1,1 @@
-error: failed to resolve `rand::random`: unable to find `rand` inside module `stubbing_validate_random`
+VERIFICATION:- SUCCESSFUL


### PR DESCRIPTION
### Description of changes: 

I just noticed a regression on https://github.com/model-checking/kani/pull/2227 where I incorrectly updated a test that should've caught this regression. Thus, fix the issue and revert the changes to the test.

### Resolved issues:

N/A

### Related RFC:


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing tests

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
