### PR TITLE
Use const_format_args to parse format strings

### DIFF
--- a/kani-driver/src/call_single_file.rs
+++ b/kani-driver/src/call_single_file.rs
@@ -130,6 +130,10 @@ impl KaniSession {
             "--cfg=kani",
             "-Z",
             "crate-attr=feature(register_tool)",
+            // needed for the usage of `const_format_args!` in Kani's std
+            // overrides of `assert` and `panic`
+            "-Z",
+            "crate-attr=feature(const_format_args)",
             "-Z",
             "crate-attr=register_tool(kanitool)",
             "--sysroot",

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -12,12 +12,6 @@
 // re-export all std symbols
 pub use std::*;
 
-// Bind `core::assert` to a different name to avoid possible name conflicts if a
-// crate uses `extern crate std as core`. See
-// https://github.com/model-checking/kani/issues/1949
-#[allow(unused_imports)]
-use core::assert as __kani__workaround_core_assert;
-
 // Override process calls with stubs.
 pub mod process;
 
@@ -61,14 +55,7 @@ macro_rules! assert {
         // strategy, which is tracked in
         // https://github.com/model-checking/kani/issues/692
         if false {
-            #[cfg(not(feature = "std"))]
-            __kani__workaround_core_assert!(true, $($arg)+);
-            // In a `no_std` setting where `std` is used as a feature, defining
-            // the alias for `core::assert` doesn't work, so we need to use
-            // `core::assert` directly (see
-            // https://github.com/model-checking/kani/issues/2187)
-            #[cfg(feature = "std")]
-            core::assert!(true, $($arg)+);
+            let _ = const_format_args!($($arg)+);
         }
     }};
 }
@@ -172,11 +159,7 @@ macro_rules! unreachable {
     // handle.
     ($fmt:expr, $($arg:tt)*) => {{
         if false {
-            #[cfg(not(feature = "std"))]
-            __kani__workaround_core_assert!(true, $fmt, $($arg)+);
-            // See comment in `assert` definition
-            #[cfg(feature = "std")]
-            core::assert!(true, $fmt, $($arg)+);
+            let _ = const_format_args!($fmt, $($arg)+);
         }
         kani::panic(concat!("internal error: entered unreachable code: ",
         stringify!($fmt, $($arg)*)))}};
@@ -208,11 +191,7 @@ macro_rules! panic {
     // `panic!("Error: {}", code);`
     ($($arg:tt)+) => {{
         if false {
-            #[cfg(not(feature = "std"))]
-            __kani__workaround_core_assert!(true, $($arg)+);
-            // See comment in `assert` definition
-            #[cfg(feature = "std")]
-            core::assert!(true, $($arg)+);
+            let _ = const_format_args!($($arg)+);
         }
         kani::panic(stringify!($($arg)+));
     }};


### PR DESCRIPTION
### Description of changes: 

Potential fix for #1949. Doesn't yet work for `panic!("{}", "msg")`, so leaving it as draft till this is resolved.

### Resolved issues:

Resolves #1949 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
