### PR TITLE
Remove unused msg parameter from any_where

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,21 @@
+# Changelog
+
+This file contains notable changes (e.g. breaking changes, major changes, etc.) in Kani releases.
+
+This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
+
+## [0.23.0]
+
+### **Breaking Changes**
+
+- The second parameter in the `kani::any_where` function (`_msg: &'static str`) was removed to make the function more ergonomic to use.
+We suggest moving the explanation for why the assumption is introduced into a comment.
+For example, the following code:
+```rust
+    let len: usize = kani::any_where(|x| *x < 5, "Restrict the length to a value less than 5");
+```
+should be replaced by:
+```rust
+    // Restrict the length to a value less than 5
+    let len: usize = kani::any_where(|x| *x < 5);
+```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/model-checking/kani"
 documentation = "https://model-checking.github.io/kani/"
 homepage = "https://github.com/model-checking/kani"
 # N.B. Cargo.* is included automatically:
-include = ["/src", "/build.rs", "/rust-toolchain.toml", "/LICENSE-*", "/README.md"]
+include = ["/src", "/build.rs", "/rust-toolchain.toml", "/LICENSE-*", "/README.md", "/CHANGELOG"]
 
 [dependencies]
 anyhow = "1"

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -120,7 +120,7 @@ pub fn any<T: Arbitrary>() -> T {
 /// under all possible `NonZeroU8` input values between 0 and 12.
 ///
 /// ```rust
-/// let inputA = kani::any_where::<std::num::NonZeroU8>(|x| *x < 12, "explanation");
+/// let inputA = kani::any_where::<std::num::NonZeroU8>(|x| *x < 12);
 /// fn_under_verification(inputA);
 /// ```
 ///
@@ -128,7 +128,7 @@ pub fn any<T: Arbitrary>() -> T {
 /// trait. The Arbitrary trait is used to build a symbolic value that represents all possible
 /// valid values for type `T`.
 #[inline(always)]
-pub fn any_where<T: Arbitrary, F: FnOnce(&T) -> bool>(f: F, _msg: &'static str) -> T {
+pub fn any_where<T: Arbitrary, F: FnOnce(&T) -> bool>(f: F) -> T {
     let result = T::any();
     assume(f(&result));
     result

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -112,7 +112,6 @@ pub fn any<T: Arbitrary>() -> T {
 /// This creates a symbolic *valid* value of type `T`.
 /// The value is constrained to be a value accepted by the predicate passed to the filter.
 /// You can assign the return value of this function to a variable that you want to make symbolic.
-/// The explanation field gives a mechanism to explain why the assumption is required for the proof.
 ///
 /// # Example:
 ///

--- a/scripts/ci/copyright-exclude
+++ b/scripts/ci/copyright-exclude
@@ -6,6 +6,7 @@
 .props
 .public.key
 Cargo.lock
+CHANGELOG
 LICENSE-APACHE
 LICENSE-MIT
 editorconfig

--- a/tests/kani/Assume/main.rs
+++ b/tests/kani/Assume/main.rs
@@ -10,6 +10,7 @@ fn main() {
 
 #[kani::proof]
 fn verify_any_where() {
-    let i: i32 = kani::any_where(|x| *x < 10, "Only single digit values are legal");
+    // Only single digit values are legal
+    let i: i32 = kani::any_where(|x| *x < 10);
     assert!(i < 20);
 }

--- a/tools/build-kani/src/main.rs
+++ b/tools/build-kani/src/main.rs
@@ -104,8 +104,11 @@ fn bundle_kani(dir: &Path) -> Result<()> {
     // 5. Record the exact toolchain we use
     std::fs::write(dir.join("rust-toolchain-version"), env!("RUSTUP_TOOLCHAIN"))?;
 
-    // 5. Include a licensing note
+    // 6. Include a licensing note
     cp(Path::new("tools/build-kani/license-notes.txt"), dir)?;
+
+    // 7. CHANGELOG
+    cp(Path::new("./CHANGELOG"), dir)?;
 
     Ok(())
 }

--- a/tools/build-kani/src/main.rs
+++ b/tools/build-kani/src/main.rs
@@ -107,9 +107,6 @@ fn bundle_kani(dir: &Path) -> Result<()> {
     // 6. Include a licensing note
     cp(Path::new("tools/build-kani/license-notes.txt"), dir)?;
 
-    // 7. CHANGELOG
-    cp(Path::new("./CHANGELOG"), dir)?;
-
     Ok(())
 }
 


### PR DESCRIPTION
### Description of changes: 

The `_msg` parameter of `kani::any_where` has no effect and does not appear in the Kani output. Removing it to make the usage of `any_where` more ergonomic.

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

This is a *breaking* change, and needs to be called out in the release notes.

### Testing:

* How is this change tested? Existing regressions

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
