### PR TITLE
Minor cleanup for kani-compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,7 +497,6 @@ version = "0.22.0"
 dependencies = [
  "ar",
  "atty",
- "bitflags",
  "clap",
  "cprover_bindings",
  "home",

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 [dependencies]
 ar = { version = "0.9.0", optional = true }
 atty = "0.2.14"
-bitflags = { version = "1.0", optional = true }
 cbmc = { path = "../cprover_bindings", package = "cprover_bindings", optional = true }
 clap = { version = "4.1.3", features = ["cargo"] }
 home = "0.5"
@@ -36,7 +35,7 @@ tracing-tree = "0.2.2"
 # Future proofing: enable backend dependencies using feature.
 [features]
 default = ['cprover']
-cprover = ['ar', 'bitflags', 'cbmc', 'libc', 'num', 'object', 'rustc-demangle', 'serde',
+cprover = ['ar', 'cbmc', 'libc', 'num', 'object', 'rustc-demangle', 'serde',
     'serde_json', "strum", "strum_macros"]
 unsound_experiments = ["kani_queries/unsound_experiments"]
 

--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -12,7 +12,6 @@ use crate::kani_middle::provide;
 use crate::kani_middle::reachability::{
     collect_reachable_items, filter_closures_in_const_crate_items, filter_crate_items,
 };
-use bitflags::_core::any::Any;
 use cbmc::goto_program::Location;
 use cbmc::{InternedString, MachineModel};
 use kani_metadata::CompilerArtifactStub;
@@ -39,6 +38,7 @@ use rustc_session::Session;
 use rustc_span::def_id::DefId;
 use rustc_target::abi::Endian;
 use rustc_target::spec::PanicStrategy;
+use std::any::Any;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fmt::Write;

--- a/kani-compiler/src/kani_compiler.rs
+++ b/kani-compiler/src/kani_compiler.rs
@@ -15,6 +15,7 @@
 //! in order to apply the stubs. For the subsequent runs, we add the stub configuration to
 //! `-C llvm-args`.
 
+#[cfg(feature = "cprover")]
 use crate::codegen_cprover_gotoc::GotocCodegenBackend;
 use crate::kani_middle::stubbing;
 use crate::parser::{self, KaniCompilerParser};


### PR DESCRIPTION
### Description of changes: 

A couple of minor cleanups to the `kani-compiler` crate:
1. Remove unneeded `bitflags` crate: it was used for importing `any::Any`, which is already available as `std::any::Any`.
2. Guard importing of `GotocCodegenBackend` with `cfg(feature = "cprover")` as is done elsewhere

### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regressions

* Is this a refactor change? Yes

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
