### PR TITLE
Build CBMC with cadical in nightly cbmc-latest workflow

### DIFF
--- a/.github/workflows/cbmc-latest.yml
+++ b/.github/workflows/cbmc-latest.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Build CBMC
         working-directory: ./cbmc
         run: |
-          cmake -S . -Bbuild -DWITH_JBMC=OFF
-          cmake --build build -- -j 4
+          make -C src minisat2-download cadical-download
+          make -C src -j4 MINISAT2=../../minisat-2.2.1 CADICAL=../../cadical
           # Prepend the bin directory to $PATH
           echo "${GITHUB_WORKSPACE}/cbmc/build/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
### Description of changes: 

Update nightly CBMC latest workflow to build CBMC with cadical. Without this, regressions that run cadical (e.g. https://github.com/model-checking/kani/blob/035225ca362b0a80c807af0f567c3513237cb0ee/tests/ui/solver-attribute/cadical/test.rs) fail.

### Resolved issues:

Fixes nightly CBMC latest regressions.

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

I couldn't get this to work through just adding `-Dsat_impl="minisat2;cadical` to this line:

https://github.com/model-checking/kani/blob/035225ca362b0a80c807af0f567c3513237cb0ee/.github/workflows/cbmc-latest.yml#L48

because the cadical configure step failed on macos-11. This needs investigation.

### Testing:

* How is this change tested? Regressions passed in my fork.

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
