### PR TITLE
Fix build-dev cache

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,7 @@
 # Command aliases
 [alias]
 # Build kani with development configuration.
-build-dev = "run -p build-kani -- build-dev"
+build-dev = "run --target-dir target/tools -p build-kani -- build-dev"
 # Build kani release bundle.
 bundle = "run -p build-kani -- bundle"
 


### PR DESCRIPTION
### Description of changes: 

After updating our dependencies, running `cargo build-dev` always trigger the recompilation of a few dependencies as well as `kani-driver` and `kani-compiler`.

This seems to be caused by [this change](https://github.com/bytecodealliance/rustix/pull/544) on `rustix` dependency.

The problem here is that we share the same build folder for our tools and our binaries. But they build with slightly different cargo arguments, and this package decided to make their build script very sensitive to changes to their environment

To overcome this, force `cargo build-dev` to use a different folder for the tools build.

### Resolved issues:


### Related RFC:

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? I manually ran the `cargo build-dev` multiple times.

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
