### PR TITLE
Avoid undefined behavior in AnySlice::new()

### DIFF
--- a/library/kani/src/slice.rs
+++ b/library/kani/src/slice.rs
@@ -71,7 +71,7 @@ impl<T, const MAX_SLICE_LENGTH: usize> AnySlice<T, MAX_SLICE_LENGTH> {
             //         *(ptr as *mut T).add(i) = any();
             //     }
             while i < any_slice.slice_len && i < MAX_SLICE_LENGTH {
-                *any_slice.ptr.add(i) = any();
+                std::ptr::write(any_slice.ptr.add(i), any());
                 i += 1;
             }
         }

--- a/tests/kani/Slice/slice-drop.rs
+++ b/tests/kani/Slice/slice-drop.rs
@@ -1,0 +1,25 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Assigning to a memory location via pointer dereferencing causes Drop::drop to be called for the location to which the pointer points.
+// Here, kani::Arbitrary implementation for MyStruct deterministically sets MyStruct.0 to 1.
+// We check whether AnySlice will properly initialize memory making the assertion in drop() to pass.
+
+struct MyStruct(i32);
+
+impl Drop for MyStruct {
+    fn drop(&mut self) {
+        assert!(self.0 == 1);
+    }
+}
+
+impl kani::Arbitrary for MyStruct {
+    fn any() -> Self {
+        MyStruct(1)
+    }
+}
+
+#[kani::proof]
+fn my_proof() {
+    let my_slice = kani::slice::any_slice::<MyStruct, 1>();
+}


### PR DESCRIPTION
Reported by @roypat, thanks!

**Summary**

I tried this code:
```rust
struct MyStruct(i32);

impl Drop for MyStruct {
    fn drop(&mut self) {
        assert!(self.0 == 1);
    }
}

impl kani::Arbitrary for MyStruct {
    fn any() -> Self {
         MyStruct(1)
    }
}

#[kani::proof]
fn my_proof() {
    let my_slice = kani::slice::any_slice::<MyStruct, 1>();
}
```

using the following command line invocation:

```
cargo kani
```

**Kani version:** 0.23.0 (verified to still happen when building from source from main branch)

**I expected to see this happen:** Verification to pass, as the `kani::Arbitrary` implementation for `MyStruct` deterministically sets `MyStruct.0` to 1.

**Instead, this happened:** 
Verification failed with the following output

```
Check 17: <MyStruct as std::ops::Drop>::drop.assertion.1
	 - Status: FAILURE
	 - Description: "assertion failed: self.0 == 1"
	 - Location: src/main.rs:9:9 in function <MyStruct as std::ops::Drop>::drop
```

I have attached the full kani log as an attachment (I'm not sure how to do collapsible codeblocks on SIM-T).

The cause for this unexpected verification failure is the way `kani::slice::any_slice` is implemented. The loop [[1]]

```rs
while i < any_slice.slice_len && i < MAX_SLICE_LENGTH {
    *any_slice.ptr.add(i) = any();
     i += 1;
}
```

initializes memory by dereferencing `any_slice.ptr.add(i)`, which is a pointer to memory allocated by `std::alloc::alloc` [[2]]. This memory is uninitialized. This is not a problem in other languages, but in Rust, assigning to a memory location via pointer dereferencing causes `Drop::drop` to be called for the location to which the pointer points. In this case, this means that uninitialized memory gets dropped (which is why the verification fails: the uninitialized memory that gets dropped is zeroed, and thus `MyStruct.0` will not be 1, as expected). This is in-fact undefined behavior. The proper way to initialize memory is to use `std::ptr::write` or `std::mem::MaybeUninit`. I have locally verified that replacing the line `*any_slice.ptr.add(i) = any()` with `std::ptr::write(any_slice.ptr.add(i), any())` causes the verification of the harness above to pass. 

[1]: https://github.com/model-checking/kani/blob/51954235a245355a2ca5bf472c6595d19546b4cb/library/kani/src/slice.rs#L74
[2]: https://github.com/model-checking/kani/blob/51954235a245355a2ca5bf472c6595d19546b4cb/library/kani/src/slice.rs#L81-L87

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
