### PR TITLE
Fix link to `assess-scan-on-repos.sh` in document

### DIFF
--- a/docs/src/repo-crawl.md
+++ b/docs/src/repo-crawl.md
@@ -82,12 +82,12 @@ will refer to the name as `$CONTAINER_NAME` from now on.
 
 ## Running the List of Repositories
 In this step we will download the list of repositories using a script
-[kani-run-on-repos.sh](../../scripts/exps/kani-run-on-repos.sh)
+[assess-scan-on-repos.sh](../../scripts/exps/assess-scan-on-repos.sh)
 
 Make sure to have Kani ready to run. For that, see the [build instructions](cheat-sheets.md#build).
 
 From the repository root, you can run the script with
-`./scripts/exps/kani-run-on-repos.sh $URL_LIST_FILE` where
+`./scripts/exps/assess-scan-on-repos.sh $URL_LIST_FILE` where
 `$URL_LIST_FILE` points to a line-delimited list of URLs you want to
 run Kani on. Repositories that give warnings or errors can be grepping
 for with "STDERR Warnings" and "Error exit in" respectively.


### PR DESCRIPTION
### Description of changes: 

The link to the script of running the list of repositories in Kani document is outdated.

### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
