### PR TITLE
Bump Kani version to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -487,14 +487,14 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "kani"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "ar",
  "atty",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "home",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cprover_bindings",
  "serde",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "kani_queries"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "strum",
  "strum_macros",
@@ -1171,7 +1171,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "std"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/kani_queries/Cargo.toml
+++ b/kani-compiler/kani_queries/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_queries"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Description of changes: 

Bump Kani version to `0.24.0`.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
