### PR TITLE
Add scripts to automate dependencies

### DIFF
--- a/scripts/ci/preflight-steps/check-outdated.py
+++ b/scripts/ci/preflight-steps/check-outdated.py
@@ -6,7 +6,13 @@ import subprocess
 def run_cargo_command(command, working_directory):
 
     try:
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True, cwd=working_directory)
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
+            text=True,
+            cwd=working_directory)
         stdout, stderr = process.communicate()
 
         if process.returncode != 0:
@@ -24,6 +30,7 @@ def main():
     target_directory = "kani"
     run_cargo_command("cargo install cargo-outdated", working_directory)
     run_cargo_command("cargo outdated --workspace", working_directory)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/ci/preflight-steps/check-outdated.py
+++ b/scripts/ci/preflight-steps/check-outdated.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+import subprocess
+
+def run_cargo_command(command, working_directory):
+
+    try:
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True, cwd=working_directory)
+        stdout, stderr = process.communicate()
+
+        if process.returncode != 0:
+            print(f"Command '{command}' executed unsuccesfully, in '{working_directory}'.")
+            print(stderr)
+        else:
+            print(f"Command '{command}' executed succesfully, in '{working_directory}'.")
+            print(stdout)
+    except Exception as e:
+        print(f"Error: {str(e)}")
+
+
+def main():
+
+    target_directory = "kani"
+    run_cargo_command("cargo install cargo-outdated", working_directory)
+    run_cargo_command("cargo outdated --workspace", working_directory)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/preflight-steps/dependency_links.py
+++ b/scripts/ci/preflight-steps/dependency_links.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+dependencies_links = {
+    'cbmc': {
+        'dependency_name': 'cbmc',
+        'dependency_string': 'CBMC_VERSION',
+        'org_name': 'diffblue',
+        'link': 'https://github.com/diffblue/cbmc'
+    },
+    'cbmc_viewer': {
+        'dependency_name': 'cbmc-viewer',
+        'dependency_string': 'CBMC_VIEWER_VERSION',
+        'org_name': 'model-checking',
+        'link': 'https://github.com/model-checking/cbmc-viewer'
+    },
+    'kissat': {
+        'dependency_name': 'kissat',
+        'dependency_string': 'KISSAT_VERSION',
+        'org_name': 'arminbiere',
+        'link': 'https://github.com/arminbiere/kissat'
+    }
+}

--- a/scripts/ci/preflight-steps/dependency_updater.py
+++ b/scripts/ci/preflight-steps/dependency_updater.py
@@ -25,13 +25,13 @@ class VersionUpdater:
 
         for line in contents:
             if "CBMC_VERSION" in line:
-                version_number = line.split("=")[1].replace("\n","")
+                version_number = line.split("=")[1].replace("\n", "")
                 self.dependencies["CBMC_VERSION"] = version_number
             elif "CBMC_VIEWER_VERSION" in line:
-                version_number = line.split("=")[1].replace("\n","")
+                version_number = line.split("=")[1].replace("\n", "")
                 self.dependencies["CBMC_VIEWER_VERSION"] = version_number
             elif "KISSAT_VERSION" in line:
-                version_number = line.split("=")[1].replace("\n","")
+                version_number = line.split("=")[1].replace("\n", "")
                 self.dependencies["KISSAT_VERSION"] = version_number
             else:
                 pass
@@ -47,10 +47,10 @@ class VersionUpdater:
             for line in lines:
                 match = re.search(r'(\w+)="\d+(\.\d+)+"', line.strip())
                 if match and match.group(1).strip() == self.dependency["dependency_string"]:
-                    f.write(f'{self.dependency["dependency_string"]}="{self.dependencies[self.dependency["dependency_string"]]}"\n')
+                    f.write(
+                        f'{self.dependency["dependency_string"]}="{self.dependencies[self.dependency["dependency_string"]]}"\n')
                 else:
                     f.write(line)
-
 
     def run_process(self):
         self.read_dependencies()

--- a/scripts/ci/preflight-steps/dependency_updater.py
+++ b/scripts/ci/preflight-steps/dependency_updater.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python3
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+import re
+import requests
+
+class VersionUpdater:
+    def __init__(self, file, dependency):
+        self.file = file
+        self.dependency = dependency
+        self.dependencies = {}
+
+    def get_latest_version(self, org_name, crate_name):
+        url = f"https://github.com/{org_name}/{crate_name}/releases/latest"
+        response = requests.get(url)
+        if response.status_code == 404:
+            raise ValueError(f"Failed to find latest version for crate '{crate_name}' on GitHub.")
+        else:
+            return re.search(r"v?(\d+\.\d+(\.\d+)?(-\S+)?)", response.url).group(1)
+
+    def read_dependencies(self):
+
+        with open(self.file, 'r') as f:
+            contents = f.readlines()
+
+        for line in contents:
+            if "CBMC_VERSION" in line:
+                version_number = line.split("=")[1].replace("\n","")
+                self.dependencies["CBMC_VERSION"] = version_number
+            elif "CBMC_VIEWER_VERSION" in line:
+                version_number = line.split("=")[1].replace("\n","")
+                self.dependencies["CBMC_VIEWER_VERSION"] = version_number
+            elif "KISSAT_VERSION" in line:
+                version_number = line.split("=")[1].replace("\n","")
+                self.dependencies["KISSAT_VERSION"] = version_number
+            else:
+                pass
+
+    def update_dependencies(self):
+        latest_version = self.get_latest_version(self.dependency["org_name"], self.dependency["dependency_name"])
+        self.dependencies[self.dependency["dependency_string"]] = latest_version
+
+    def write_dependencies(self):
+        with open(self.file, 'r') as f:
+            lines = f.readlines()
+        with open(self.file, 'w') as f:
+            for line in lines:
+                match = re.search(r'(\w+)="\d+(\.\d+)+"', line.strip())
+                if match and match.group(1).strip() == self.dependency["dependency_string"]:
+                    f.write(f'{self.dependency["dependency_string"]}="{self.dependencies[self.dependency["dependency_string"]]}"\n')
+                else:
+                    f.write(line)
+
+
+    def run_process(self):
+        self.read_dependencies()
+        self.update_dependencies()
+        self.write_dependencies()

--- a/scripts/ci/preflight-steps/update-cbmc-viewer.py
+++ b/scripts/ci/preflight-steps/update-cbmc-viewer.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+from job_runner import dependencies_links
+from dependency_updater import VersionUpdater
+
+# Set the name of the dependency you want to update
+kani_dependencies_path = "/Users/jaisnan/kani/kani-dependencies"
+
+if __name__ == "__main__":
+    updater = VersionUpdater(kani_dependencies_path, dependencies_links["cbmc_viewer"])
+    updater.run_process()

--- a/scripts/ci/preflight-steps/update-cbmc.py
+++ b/scripts/ci/preflight-steps/update-cbmc.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+from job_runner import dependencies_links
+from dependency_updater import VersionUpdater
+
+# Set the name of the dependency you want to update
+kani_dependencies_path = "/Users/jaisnan/kani/kani-dependencies"
+
+if __name__ == "__main__":
+    updater = VersionUpdater(kani_dependencies_path, dependencies_links["cbmc"])
+    updater.run_process()

--- a/scripts/ci/preflight-steps/update-kani-version.py
+++ b/scripts/ci/preflight-steps/update-kani-version.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+import toml
+import sys
+
+def update_version(file_path, new_version):
+
+    try:
+        # load the toml file
+        with open(file_path, 'r') as f:
+            data = toml.load(f)
+
+        # update the version number
+        data['package']['version'] = new_version
+
+        with open(file_path, 'w') as f:
+            toml.dump(data, f)
+
+        print(f"Version updated succesfully to '{version_number}' in '{file_path}'.")
+    except Exception as e:
+        print(f"Error updating kani version to '{version_number}' in '{file_path}'.")
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python update_versions.py <new_version>")
+        sys.exit(1)
+
+    # The new version number specified by the user
+    new_version = sys.argv[1]
+
+    # The list of Cargo.toml files to update
+    cargo_toml_files = [
+        "Cargo.toml",
+        "cprover_bindings/Cargo.toml",
+        "kani-compiler/Cargo.toml",
+        "kani-compiler/kani_queries/Cargo.toml",
+        "kani-driver/Cargo.toml",
+        "kani_metadata/Cargo.toml",
+        "library/kani/Cargo.toml",
+        "library/kani_macros/Cargo.toml",
+        "library/std/Cargo.toml",
+        "tools/build-kani/Cargo.toml",
+    ]

--- a/scripts/ci/preflight-steps/update-kissat.py
+++ b/scripts/ci/preflight-steps/update-kissat.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+from job_runner import dependencies_links
+from dependency_updater import VersionUpdater
+
+# Set the name of the dependency you want to update
+kani_dependencies_path = "/Users/jaisnan/kani/kani-dependencies"
+
+if __name__ == "__main__":
+    updater = VersionUpdater(kani_dependencies_path, dependencies_links["kissat"])
+    updater.run_process()


### PR DESCRIPTION
### Description of changes: 

These scripts help automate part of the dependency scripts. While initially tested for manual use, it can be developed and used as part of the CD.

### Call-outs:

These scripts only automate the part of the deployment that deal with updating dependencies and updating version numbers. If approved, the rest of the deployment can be added easily (the PR for that is ready to be added).

### Testing:

* How is this change tested? Manually

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
