### PR TITLE
Remove duplicated CBMC Viewer version string

### DIFF
--- a/kani-dependencies
+++ b/kani-dependencies
@@ -1,4 +1,7 @@
 CBMC_VERSION="5.79.0"
-# If you update this version number, remember to bump it in `src/setup.rs` too
-CBMC_VIEWER_VERSION="3.8"
+CBMC_VIEWER_VERSION=$(
+  grep "cbmc-viewer==" < src/setup.rs |
+  awk -F== '{print $2}' |
+  awk -F '"' '{print $1}'
+)
 KISSAT_VERSION="3.0.0"

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -137,7 +137,6 @@ fn setup_python_deps(kani_dir: &Path, os: &os_info::Info) -> Result<()> {
     println!("[4/5] Installing Kani python dependencies...");
     let pyroot = kani_dir.join("pyroot");
 
-    // TODO: this is a repetition of versions from kani/kani-dependencies
     let pkg_versions = &["cbmc-viewer==3.8"];
 
     if os_hacks::should_apply_ubuntu_18_04_python_hack(os)? {


### PR DESCRIPTION
This ensures that the version string does not need to be updated in two places, either manually or via a release script.

### Testing:

```sh
$ source kani-dependencies
$ echo $CBMC_VIEWER_VERSION                                                           
3.8
```

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
