### PR TITLE
Replace release action and avoid `set-output` in our workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         id: versioning
         run: |
           # Output for upload scripts to see
-          echo ::set-output name=version::${{ env.TAG_VERSION }}
+          echo "version=${{ env.TAG_VERSION }}" >> $GITHUB_OUTPUT
           # Validate git tag & Cargo.toml are in sync on version number
           if [[ ${{ env.CRATE_VERSION }} != ${{ env.TAG_VERSION }} ]]; then
             echo "Git tag ${{env.TAG_VERSION}} did not match crate version ${{env.CRATE_VERSION}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,16 +39,15 @@ jobs:
 
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1.12.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: kani-${{ env.TAG_VERSION }}
-          release_name: kani-${{ env.TAG_VERSION }}
+          name: kani-${{ env.TAG_VERSION }}
+          tag: kani-${{ env.TAG_VERSION }}
           body: |
             Kani Rust verifier release bundle version ${{ env.TAG_VERSION }}.
           draft: true
-          prerelease: false
 
   Upload:
     name: Upload


### PR DESCRIPTION
### Description of changes: 

This PR removes the single `set-output` instance in our release workflow (`set-output` will be deprecated according to [this announcement](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)) and replaces the `actions/create-release@v1` action with `ncipollo/release-action@v1.12.0` (the former uses `set-output` as well).

Unfortunately, this doesn't remove all the `set-output` warnings in our workflow. The last ones come from `actions/upload-release-asset@v1`, which is also unmaintained. I didn't find a good replacement, and also didn't want to add more changes to the release workflow until the next release.

### Resolved issues:

Related #2310 

### Call-outs:

This PR removes most `set-output` warnings in our workflow, except for those corresponding to the `actions/upload-release-asset@v1`.
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? See these action runs: [this one](https://github.com/adpaco-aws/rmc/actions/runs/4514719825) corresponds to the first commit, and shows multiple `set-output` warnings. Then, in [this other run](https://github.com/adpaco-aws/rmc/actions/runs/4515007891), I had replaced the action. You can see there are fewer warnings, all corresponding to the `Upload` step. This created [two releases](https://github.com/adpaco-aws/rmc/releases) in my repo which are similar to the ones we produced in the past.

* Is this a refactor change? Yes.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
