### PR TITLE
Automatically create toolchain update PRs

### DIFF
--- a/.github/workflows/toolchain-upgrade.yml
+++ b/.github/workflows/toolchain-upgrade.yml
@@ -1,0 +1,40 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+name: Attempt toolchain update
+
+on:
+  schedule:
+    - cron: "42 */4 * * *" # Run this every four hours at minute 42 (random choice)
+  workflow_dispatch:     # Allow manual dispatching for a custom branch / tag.
+
+jobs:
+  create-toolchain-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Kani
+        uses: actions/checkout@v3
+
+      - name: Update toolchain config
+        run: |
+          current_toolchain_date=$(grep ^channel rust-toolchain.toml | sed 's/.*nightly-\(.*\)"/\1/')
+          echo "current_toolchain_date=$current_toolchain_date" >> $GITHUB_ENV
+          current_toolchain_epoch=$(date --date $current_toolchain_date +%s)
+          next_toolchain_date=$(date --date "@$(($current_toolchain_epoch + 86400))" +%Y-%m-%d)
+          echo "next_toolchain_date=$next_toolchain_date" >> $GITHUB_ENV
+          sed -i "/^channel/ s/$current_toolchain_date/$next_toolchain_date/" rust-toolchain.toml
+          git diff
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: Upgrade Rust toolchain to nightly-${{ env.next_toolchain_date }}
+          branch: toolchain-${{ env.next_toolchain_date }}
+          delete-branch: true
+          title: 'Automatic toolchain upgrade to nightly-${{ env.next_toolchain_date }}'
+          body: |
+            Update Rust toolchain from nightly-${{ env.current_toolchain_date }} to
+            nightly-${{ envv.next_toolchain_date }} without any other source changes.
+
+            Thiis is an automatically generated pull request. If any of the CI checks fail,
+            manual intervention is required. In such a case, review the changes at
+            https://github.com/rust-lang/rust.


### PR DESCRIPTION
### Description of changes: 

This workflow will attempt to move the toolchain nightly pointer by one day every four hours. In doing so it will create a pull request for just this change. Once that PR is merged, further runs of this workflow will then try to move the pointer even further. (And, thus, running the workflow multiple times a day gives us a chance to catch up.)

This PR supersedes https://github.com/model-checking/kani/pull/2318, which was wrongly backed by a branch in the main repo.

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? Tested in my fork, see https://github.com/tautschnig/kani/pull/4 for a first example.

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
