### PR TITLE
Include rust git logs in toolchain update PRs

### DIFF
--- a/.github/workflows/toolchain-upgrade.yml
+++ b/.github/workflows/toolchain-upgrade.yml
@@ -24,6 +24,19 @@ jobs:
           echo "next_toolchain_date=$next_toolchain_date" >> $GITHUB_ENV
           sed -i "/^channel/ s/$current_toolchain_date/$next_toolchain_date/" rust-toolchain.toml
           git diff
+          git clone --filter=tree:0 https://github.com/rust-lang/rust rust.git
+          cd rust.git
+          current_toolchain_hash=$(curl https://static.rust-lang.org/dist/$current_toolchain_date/channel-rust-nightly-git-commit-hash.txt)
+          echo "current_toolchain_hash=$current_toolchain_hash" >> $GITHUB_ENV
+          next_toolchain_hash=$(curl https://static.rust-lang.org/dist/$next_toolchain_date/channel-rust-nightly-git-commit-hash.txt)
+          echo "next_toolchain_hash=$next_toolchain_hash" >> $GITHUB_ENV
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "git_log<<$EOF" >> $GITHUB_ENV
+          git log --oneline $current_toolchain_hash..$next_toolchain_hash | \
+            sed 's#^#https://github.com/rust-lang/rust/commit/#' >> $GITHUB_ENV
+          echo "$EOF" >> $GITHUB_ENV
+          cd ..
+          rm -rf rust.git
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
@@ -31,10 +44,15 @@ jobs:
           branch: toolchain-${{ env.next_toolchain_date }}
           delete-branch: true
           title: 'Automatic toolchain upgrade to nightly-${{ env.next_toolchain_date }}'
-          body: |
+          body: >
             Update Rust toolchain from nightly-${{ env.current_toolchain_date }} to
             nightly-${{ env.next_toolchain_date }} without any other source changes.
 
-            Thiis is an automatically generated pull request. If any of the CI checks fail,
+            This is an automatically generated pull request. If any of the CI checks fail,
             manual intervention is required. In such a case, review the changes at
-            https://github.com/rust-lang/rust.
+            https://github.com/rust-lang/rust from
+            https://github.com/rust-lang/rust/commit/${{ env.current_toolchain_hash }} up to
+            https://github.com/rust-lang/rust/commit/${{ env.next_toolchain_hash }}. The log
+            for this commit range is:
+
+            ${{ env.git_log }}


### PR DESCRIPTION
### Description of changes: 

Fetch the commit hashes that nightly builds correspond to and construct a git log for the changes between two nightly releases. This should simplify tracking down which upstream changes may cause our builds or tests to break.

See https://github.com/tautschnig/kani/pull/11 for an example of what the result looks like.

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? Tested in my fork (see above link).

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
