### PR TITLE
Upgrade toolchain to 2023-02-05

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
@@ -624,6 +624,17 @@ impl<'tcx> GotocCtx<'tcx> {
         }
     }
 
+    /// Given a projection, generate an lvalue that represents the given variant index.
+    pub fn codegen_variant_lvalue(
+        &mut self,
+        initial_projection: ProjectedPlace<'tcx>,
+        variant_idx: VariantIdx,
+    ) -> ProjectedPlace<'tcx> {
+        debug!(?initial_projection, ?variant_idx, "codegen_variant_lvalue");
+        let downcast = ProjectionElem::Downcast(None, variant_idx);
+        self.codegen_projection(Ok(initial_projection), downcast).unwrap()
+    }
+
     // https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/enum.ProjectionElem.html
     // ConstantIndex
     // [−]

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -9,14 +9,15 @@ use cbmc::goto_program::{Expr, Location, Stmt, Type};
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir;
 use rustc_middle::mir::{
-    AggregateKind, AssertKind, BasicBlock, NonDivergingIntrinsic, Operand, Place, Rvalue,
-    Statement, StatementKind, SwitchTargets, Terminator, TerminatorKind,
+    AssertKind, BasicBlock, NonDivergingIntrinsic, Operand, Place, Statement, StatementKind,
+    SwitchTargets, Terminator, TerminatorKind,
 };
 use rustc_middle::ty;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{Instance, InstanceDef, Ty};
 use rustc_span::Span;
-use rustc_target::abi::{FieldsShape, TagEncoding, Variants};
+use rustc_target::abi::VariantIdx;
+use rustc_target::abi::{FieldsShape, Primitive, TagEncoding, Variants};
 use tracing::{debug, debug_span, trace};
 
 impl<'tcx> GotocCtx<'tcx> {
@@ -48,93 +49,18 @@ impl<'tcx> GotocCtx<'tcx> {
                         .goto_expr
                         .assign(self.codegen_rvalue(r, location).cast_to(Type::c_bool()), location)
                 } else {
-                    match r {
-                        Rvalue::Aggregate(ref k, operands) if rty.is_enum() => {
-                            if let AggregateKind::Adt(_, variant_index, _, _, _) = **k {
-                                let lvalue_expr = unwrap_or_return_codegen_unimplemented_stmt!(
-                                    self,
-                                    self.codegen_place(l)
-                                )
-                                .goto_expr;
-                                self.codegen_enum_assignment(
-                                    lvalue_expr,
-                                    &variant_index,
-                                    &operands,
-                                    rty,
-                                    location,
-                                )
-                            } else {
-                                unreachable!()
-                            }
-                        }
-                        _ => unwrap_or_return_codegen_unimplemented_stmt!(
-                            self,
-                            self.codegen_place(l)
-                        )
+                    unwrap_or_return_codegen_unimplemented_stmt!(self, self.codegen_place(l))
                         .goto_expr
-                        .assign(self.codegen_rvalue(r, location), location),
-                    }
+                        .assign(self.codegen_rvalue(r, location), location)
                 }
             }
             StatementKind::Deinit(place) => self.codegen_deinit(place, location),
             StatementKind::SetDiscriminant { place, variant_index } => {
-                // this requires place points to an enum type.
-                let pt = self.place_ty(place);
-                let layout = self.layout_of(pt);
-                match &layout.variants {
-                    Variants::Single { .. } => Stmt::skip(location),
-                    Variants::Multiple { tag, tag_encoding, .. } => match tag_encoding {
-                        TagEncoding::Direct => {
-                            let discr =
-                                pt.discriminant_for_variant(self.tcx, *variant_index).unwrap();
-                            let discr_t = self.codegen_enum_discr_typ(pt);
-                            // The constant created below may not fit into the type.
-                            // https://github.com/model-checking/kani/issues/996
-                            //
-                            // It doesn't matter if the type comes from `self.codegen_enum_discr_typ(pt)`
-                            // or `discr.ty`. It looks like something is wrong with `discriminat_for_variant`
-                            // because when it tries to codegen `std::cmp::Ordering` (which should produce
-                            // discriminant values -1, 0 and 1) it produces values 255, 0 and 1 with i8 types:
-                            //
-                            // debug!("DISCRIMINANT - val:{:?} ty:{:?}", discr.val, discr.ty);
-                            // DISCRIMINANT - val:255 ty:i8
-                            // DISCRIMINANT - val:0 ty:i8
-                            // DISCRIMINANT - val:1 ty:i8
-                            let discr = Expr::int_constant(discr.val, self.codegen_ty(discr_t));
-                            let place_goto_expr = unwrap_or_return_codegen_unimplemented_stmt!(
-                                self,
-                                self.codegen_place(place)
-                            )
-                            .goto_expr;
-                            self.codegen_discriminant_field(place_goto_expr, pt)
-                                .assign(discr, location)
-                        }
-                        TagEncoding::Niche { untagged_variant, niche_variants, niche_start } => {
-                            if untagged_variant != variant_index {
-                                let value = self.compute_enum_niche_value(
-                                    pt,
-                                    variant_index,
-                                    tag,
-                                    niche_variants,
-                                    niche_start,
-                                );
-                                let place = unwrap_or_return_codegen_unimplemented_stmt!(
-                                    self,
-                                    self.codegen_place(place)
-                                )
-                                .goto_expr;
-                                let offset = match &layout.fields {
-                                    FieldsShape::Arbitrary { offsets, .. } => offsets[0],
-                                    _ => unreachable!("niche encoding must have arbitrary fields"),
-                                };
-                                self.codegen_get_niche(place, offset, value.typ().clone())
-                                    .assign(value, location)
-                            } else {
-                                Stmt::skip(location)
-                            }
-                        }
-                    },
-                }
+                let dest_ty = self.place_ty(place);
+                let dest_expr =
+                    unwrap_or_return_codegen_unimplemented_stmt!(self, self.codegen_place(place))
+                        .goto_expr;
+                self.codegen_set_discriminant(dest_ty, dest_expr, *variant_index, location)
             }
             StatementKind::StorageLive(_) => Stmt::skip(location), // TODO: fix me
             StatementKind::StorageDead(_) => Stmt::skip(location), // TODO: fix me
@@ -274,6 +200,64 @@ impl<'tcx> GotocCtx<'tcx> {
                 loc,
                 "https://github.com/model-checking/kani/issues/2",
             ),
+        }
+    }
+
+    /// Create a statement that sets the variable discriminant to the value that corresponds to the
+    /// variant index.
+    pub fn codegen_set_discriminant(
+        &mut self,
+        dest_ty: Ty<'tcx>,
+        dest_expr: Expr,
+        variant_index: VariantIdx,
+        location: Location,
+    ) -> Stmt {
+        // this requires place points to an enum type.
+        let layout = self.layout_of(dest_ty);
+        match &layout.variants {
+            Variants::Single { .. } => Stmt::skip(location),
+            Variants::Multiple { tag, tag_encoding, .. } => match tag_encoding {
+                TagEncoding::Direct => {
+                    let discr = dest_ty.discriminant_for_variant(self.tcx, variant_index).unwrap();
+                    let discr_t = self.codegen_enum_discr_typ(dest_ty);
+                    // The constant created below may not fit into the type.
+                    // https://github.com/model-checking/kani/issues/996
+                    //
+                    // It doesn't matter if the type comes from `self.codegen_enum_discr_typ(pt)`
+                    // or `discr.ty`. It looks like something is wrong with `discriminat_for_variant`
+                    // because when it tries to codegen `std::cmp::Ordering` (which should produce
+                    // discriminant values -1, 0 and 1) it produces values 255, 0 and 1 with i8 types:
+                    //
+                    // debug!("DISCRIMINANT - val:{:?} ty:{:?}", discr.val, discr.ty);
+                    // DISCRIMINANT - val:255 ty:i8
+                    // DISCRIMINANT - val:0 ty:i8
+                    // DISCRIMINANT - val:1 ty:i8
+                    let discr = Expr::int_constant(discr.val, self.codegen_ty(discr_t));
+                    self.codegen_discriminant_field(dest_expr, dest_ty).assign(discr, location)
+                }
+                TagEncoding::Niche { untagged_variant, niche_variants, niche_start } => {
+                    if *untagged_variant != variant_index {
+                        let offset = match &layout.fields {
+                            FieldsShape::Arbitrary { offsets, .. } => offsets[0],
+                            _ => unreachable!("niche encoding must have arbitrary fields"),
+                        };
+                        let discr_ty = self.codegen_enum_discr_typ(dest_ty);
+                        let discr_ty = self.codegen_ty(discr_ty);
+                        let niche_value = variant_index.as_u32() - niche_variants.start().as_u32();
+                        let niche_value = (niche_value as u128).wrapping_add(*niche_start);
+                        let value = if niche_value == 0
+                            && matches!(tag.primitive(), Primitive::Pointer(_))
+                        {
+                            discr_ty.null()
+                        } else {
+                            Expr::int_constant(niche_value, discr_ty.clone())
+                        };
+                        self.codegen_get_niche(dest_expr, offset, discr_ty).assign(value, location)
+                    } else {
+                        Stmt::skip(location)
+                    }
+                }
+            },
         }
     }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -20,12 +20,11 @@ use rustc_middle::ty::{
 use rustc_middle::ty::{List, TypeFoldable};
 use rustc_span::def_id::DefId;
 use rustc_target::abi::{
-    Abi::Vector, FieldsShape, Integer, LayoutS, Primitive, Scalar, Size, TagEncoding, TyAndLayout,
+    Abi::Vector, FieldsShape, Integer, LayoutS, Primitive, Size, TagEncoding, TyAndLayout,
     VariantIdx, Variants,
 };
 use rustc_target::spec::abi::Abi;
 use std::iter;
-use std::ops::RangeInclusive;
 use tracing::{debug, trace, warn};
 use ty::layout::HasParamEnv;
 
@@ -1569,30 +1568,6 @@ impl<'tcx> GotocCtx<'tcx> {
             self.ensure_struct(mangled_name, pretty_name, |gcx, name| {
                 gcx.codegen_enum_cases(name, pretty_name, adtdef, subst, variants, Size::ZERO)
             })
-        }
-    }
-
-    /// Compute the discriminant expression for an enum that uses niche optimization.
-    ///
-    /// We follow the logic of the SSA and Cranelift back-ends in doing the computation:
-    /// <https://github.com/rust-lang/rust/blob/fab99073b01539ce2664366011c7f3e378e52b7e/compiler/rustc_codegen_ssa/src/mir/place.rs#L455>
-    /// <https://github.com/rust-lang/rust/blob/d37e2f74afd131cda7b08520d37426bfbb622b5c/compiler/rustc_codegen_cranelift/src/discriminant.rs#L52>
-    pub fn compute_enum_niche_value(
-        &mut self,
-        enum_ty: Ty<'tcx>,
-        variant_index: &VariantIdx,
-        tag: &Scalar,
-        niche_variants: &RangeInclusive<VariantIdx>,
-        niche_start: &u128,
-    ) -> Expr {
-        let discr_ty = self.codegen_enum_discr_typ(enum_ty);
-        let discr_ty = self.codegen_ty(discr_ty);
-        let niche_value = variant_index.as_u32() - niche_variants.start().as_u32();
-        let niche_value = (niche_value as u128).wrapping_add(*niche_start);
-        if niche_value == 0 && matches!(tag.primitive(), Primitive::Pointer(_)) {
-            discr_ty.null()
-        } else {
-            Expr::int_constant(niche_value, discr_ty)
         }
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-02-04"
+channel = "nightly-2023-02-05"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/kani/Enum/multiple_never.rs
+++ b/tests/kani/Enum/multiple_never.rs
@@ -1,0 +1,39 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test is to check how Kani handle enums where only one variant is valid.
+#![feature(never_type)]
+
+enum MyResult<Y, N, M> {
+    Yes(Y),
+    No(N),
+    Maybe(M),
+}
+
+fn change_maybe<Y, N, M, O>(orig: MyResult<Y, N, M>, val: O) -> MyResult<Y, N, O> {
+    match orig {
+        MyResult::Yes(y) => MyResult::Yes(y),
+        MyResult::No(n) => MyResult::No(n),
+        MyResult::Maybe(m) => MyResult::Maybe(val),
+    }
+}
+
+fn check() -> Result<u32, !> {
+    let val = Result::<u32, !>::Ok(10)?;
+    Ok(val)
+}
+
+fn checkErr() -> Result<!, u32> {
+    let val = Result::<!, u32>::Err(10)?;
+}
+
+fn checkMaybe() -> MyResult<!, !, u8> {
+    change_maybe(MyResult::<!, !, u32>::Maybe(10), 0)
+}
+
+#[kani::proof]
+pub fn harness_residual() {
+    let _ = checkMaybe();
+    let _ = checkErr();
+    let _ = check();
+}

--- a/tests/kani/Enum/one_two.rs
+++ b/tests/kani/Enum/one_two.rs
@@ -1,0 +1,23 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+enum Niche_Enum {
+    One(bool),
+    Two(bool, bool),
+}
+
+enum Enum {
+    One(u32),
+    Two(u32, u32),
+}
+
+#[kani::proof]
+fn check() {
+    // This will have one operand.
+    let _var = Niche_Enum::One(false);
+    // This will have two operands -- true and false
+    let _var = Niche_Enum::Two(true, false);
+    // This will have one operand.
+    let _var = Enum::One(1);
+    // This will have two operands -- 2 and 3
+    let _var = Enum::Two(2, 3);
+}


### PR DESCRIPTION
### Description of changes: 

Implement AggregateKind::{Adt,Closure,Generator} which are being used when moving toolchains from nightly 2023-02-04 to 2023-02-05 (or any later date).

### Resolved issues:

Attempting to upgrade the toolchain to 2023-02-05.

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? All CI checks pass, which includes two additional tests.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
