### PR TITLE
Revert changes to docker file from #2311

### DIFF
--- a/scripts/ci/Dockerfile.bundle-release-20-04
+++ b/scripts/ci/Dockerfile.bundle-release-20-04
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true \
     PATH="/root/.cargo/bin:${PATH}"
 WORKDIR /tmp/kani
-COPY ./tests ./tests
-COPY  ./Cargo.toml ./Cargo.toml
 COPY ./kani-*-x86_64-unknown-linux-gnu.tar.gz ./kani-latest-x86_64-unknown-linux-gnu.tar.gz
 # Very awkward glob (not regex!) to get `kani-verifier-*` and not `kani-verifier-*.crate`
 COPY ./target/package/kani-verifier-*[^e] ./kani-verifier


### PR DESCRIPTION
### Description of changes: 

It looks like the other changes done by #2311 to the release docker file were not as harmless as I thought. This change reverts them to fix the release action.

### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

I was finally able to verify that the release action succeeds in my fork after making these changes: https://github.com/celinval/kani-dev/actions/runs/4630867852 

### Testing:

* How is this change tested? Tested in my fork

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
