### PR TITLE
Add --no-copy flag to benchcomp run

### DIFF
--- a/tools/benchcomp/benchcomp/cmd_args.py
+++ b/tools/benchcomp/benchcomp/cmd_args.py
@@ -131,6 +131,13 @@ def _get_args_dict():
                         "help":
                             "symbolically link D to the output directory "
                             "(default: %(default)s)",
+                    }, {
+                        "flags": ["--no-copy"],
+                        "action": "store_false",
+                        "dest": "copy_benchmarks_dir",
+                        "help":
+                            "do not make a fresh copy of the benchmark "
+                            "directories before running each variant",
                     }],
                 },
                 "collate": {


### PR DESCRIPTION
This flag makes benchcomp not create a fresh copy of each benchmark directory before running each variant. The default behaviour is to make a new copy each time, to avoid built artefacts from silently being skipped, and to ensure that patches apply cleanly. Users can use this flag when benchmark runs are guaranteed to be idempotent, to avoid waiting for benchmark suites to be copied to a fresh directory.

### Call-outs:

Should --no-copy actually be the default behaviour?

### Testing:

* How is this change tested? I ran it

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
