### PR TITLE
Add PR-blocking performance regression run

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -245,3 +245,65 @@ jobs:
           if-no-files-found: error
           # Aggressively short retention: we don't really need these
           retention-days: 3
+
+  perf-benchcomp:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Kani (pull request HEAD)
+        uses: actions/checkout@v3
+        with:
+          path: ./pr
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout Kani (pull request base)
+        uses: actions/checkout@v3
+        with:
+          path: ./base
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Setup Kani Dependencies
+        uses: ./pr/.github/actions/setup
+        with:
+          os: ubuntu-20.04
+          kani_dir: pr
+
+      - name: Build Kani (pull request HEAD)
+        run: pushd pr && cargo build-dev
+
+      - name: Build Kani (pull request base)
+        run: pushd base && cargo build-dev
+
+      - name: Write benchcomp config file
+        run: |
+          pushd pr && cat >benchcomp.yaml <<EOM
+          variants:
+            kani_pr:
+              config:
+                directory: .
+                command_line: PATH=target/kani/bin:$PATH scripts/kani-perf.sh
+            kani_base:
+              config:
+                directory: .    # Run new benchmarks with old Kani
+                command_line: PATH=../base/target/kani/bin:$PATH scripts/kani-perf.sh
+          run:
+            suites:
+              kani_perf:
+                parser:
+                  module: kani_perf
+                variants: [kani_pr, kani_base]
+          visualize:
+            - type: error_on_regression
+              variant_pairs: [[kani_base, kani_pr]]
+              checks:
+                - metric: success
+                  test: "lambda old, new: False if not old else not new"
+                - metric: solver_runtime
+                  test: "lambda old, new: new / old > 1.1"
+                - metric: symex_runtime
+                  test: "lambda old, new: new / old > 1.1"
+                - metric: verification_time
+                  test: "lambda old, new: new / old > 1.1"
+          EOM
+
+      - name: Run benchcomp
+        run: pushd pr && ./tools/benchcomp/bin/benchcomp

--- a/tools/benchcomp/benchcomp/entry/run.py
+++ b/tools/benchcomp/benchcomp/entry/run.py
@@ -56,8 +56,11 @@ class _SingleInvocation:
         env.update(self.env)
 
         if self.copy_benchmarks_dir:
-            shutil.copytree(
-                self.directory, self.working_copy, ignore_dangling_symlinks=True)
+            try:
+                shutil.copytree(
+                    self.directory, self.working_copy, ignore_dangling_symlinks=True)
+            except shutil.Error:
+                pass
 
         try:
             subprocess.run(


### PR DESCRIPTION
This commit adds a CI job that runs the `benchcomp` tool on the
performance regression suite, comparing the HEAD of the pull request to
the branch that the PR targets.

The CI job fails if any performance benchmark is more than 10% slower
when run using the HEAD version of Kani, or if any performance benchmark
fails with the HEAD version while passing with the base.

This fixes #2277.

### Testing: [link to GitHub Action run]

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
