### PR TITLE
Enforce negative zero

### DIFF
--- a/tests/ui/concrete-playback/f32/main.rs
+++ b/tests/ui/concrete-playback/f32/main.rs
@@ -18,7 +18,7 @@ pub fn harness() {
         !(f32_1 == f32::NEG_INFINITY
             && f32_2 == f32::MIN
             && f32_3 == -101f32
-            && f32_4 == 0f32
+            && (f32_4 == 0f32 && f32_4.signum() < 0.0)
             && f32_5 == f32::MIN_POSITIVE
             && f32_6 == 101f32
             && f32_7 == f32::MAX

--- a/tests/ui/concrete-playback/f64/main.rs
+++ b/tests/ui/concrete-playback/f64/main.rs
@@ -18,7 +18,7 @@ pub fn harness() {
         !(f64_1 == f64::NEG_INFINITY
             && f64_2 == f64::MIN
             && f64_3 == -101f64
-            && f64_4 == 0f64
+            && (f64_4 == 0f64 && f64_4.signum() < 0.0)
             && f64_5 == f64::MIN_POSITIVE
             && f64_6 == 101f64
             && f64_7 == f64::MAX


### PR DESCRIPTION
### Description of changes: 

Rust has -0.0 == +0.0, so the test could have returned either value. It seems that previous toolchains (or perhaps the choice of solver) produced negative zero by chance. Since we expect that, make sure the test always produces it.

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? Part of CI

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
