### PR TITLE
Upgrade Rust toolchain to nightly-2023-02-18

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/static_var.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/static_var.rs
@@ -28,7 +28,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let pretty_name = Instance::new(def_id, InternalSubsts::empty()).to_string();
         debug!(?symbol_name, ?pretty_name, "declare_static {}", item);
 
-        let typ = self.codegen_ty(self.tcx.type_of(def_id));
+        let typ = self.codegen_ty(self.tcx.type_of(def_id).subst_identity());
         let span = self.tcx.def_span(def_id);
         let location = self.codegen_span(&span);
         let symbol = Symbol::static_variable(symbol_name.clone(), symbol_name, typ, location)

--- a/kani-compiler/src/kani_middle/provide.rs
+++ b/kani-compiler/src/kani_middle/provide.rs
@@ -6,10 +6,10 @@
 
 use crate::kani_middle::reachability::{collect_reachable_items, filter_crate_items};
 use crate::kani_middle::stubbing;
+use crate::kani_middle::ty::query::query_provided::collect_and_partition_mono_items;
 use kani_queries::{QueryDb, UserInput};
 use rustc_hir::def_id::DefId;
 use rustc_interface;
-use rustc_middle::ty::query::query_stored::collect_and_partition_mono_items;
 use rustc_middle::{
     mir::Body,
     ty::{query::ExternProviders, query::Providers, TyCtxt},

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-02-17"
+channel = "nightly-2023-02-18"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
### Description of changes: 

Upstream PRs that require local changes:

- Switch to EarlyBinder for type_of query https://github.com/rust-lang/rust/pull/107753
- Factor query arena allocation out from query caches https://github.com/rust-lang/rust/pull/107833

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? CI

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
