### PR TITLE
Fix benchcomp path to Kani binary

### DIFF
--- a/tools/benchcomp/configs/perf-regression.yaml
+++ b/tools/benchcomp/configs/perf-regression.yaml
@@ -10,13 +10,13 @@ variants:
   kani_new:
     config:
       directory: new
-      command_line: PATH=$(realpath new/scripts):$PATH scripts/kani-perf.sh
+      command_line: scripts/kani-perf.sh
       env:
         RUST_TEST_THREADS: "1"
   kani_old:
     config:
       directory: old
-      command_line: PATH=$(realpath old/scripts):$PATH scripts/kani-perf.sh
+      command_line: scripts/kani-perf.sh
       env:
         RUST_TEST_THREADS: "1"
 


### PR DESCRIPTION
This commit fixes an error in setting the $PATH variable in the benchcomp perf regression config file. The script was working by accident because kani-perf.sh uses its own logic to find the Kani directory.

### Testing:

* How is this change tested? I tried running it with an intentionally-missing kani in one of the variants to ensure that it worked. (Previously the correct Kani was being used anyway, but this test ensures that the new behavior is correct)

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ x My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
