### PR TITLE
Install system-provided autopep8 where available

### DIFF
--- a/scripts/setup/ubuntu/install_deps.sh
+++ b/scripts/setup/ubuntu/install_deps.sh
@@ -30,7 +30,7 @@ DEPS=(
 
 # Version specific dependencies.
 declare -A VERSION_DEPS
-VERSION_DEPS["20.04"]="universal-ctags python-is-python3"
+VERSION_DEPS["20.04"]="universal-ctags python-is-python3 python3-autopep8"
 VERSION_DEPS["18.04"]="exuberant-ctags"
 
 UBUNTU_VERSION=$(lsb_release -rs)
@@ -47,11 +47,9 @@ sudo apt-get --yes update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes "${DEPS[@]}" ${OTHER_DEPS[@]}
 
 # Add Python package dependencies
-PYTHON_DEPS=(
-  autopep8
-)
-
-python3 -m pip install "${PYTHON_DEPS[@]}"
+if [[ "x$UBUNTU_VERSION" == "x18.04" ]] ; then
+  python3 -m pip install autopep8
+fi
 
 # Get the directory containing this script
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"


### PR DESCRIPTION
### Description of changes: 

Do not unnecessarily use pip on Ubuntu 20.04, and instead reduce the number of possible sources of (networking) problems.

### Resolved issues:

Avoids CI problems as just seen in https://github.com/model-checking/kani/actions/runs/4753895142/jobs/8446041369?pr=2395.

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? Will be tested in CI.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
