### PR TITLE
Make cargo build-dev produce a proper exit code

### DIFF
--- a/tools/build-kani/src/main.rs
+++ b/tools/build-kani/src/main.rs
@@ -19,10 +19,7 @@ fn main() -> Result<()> {
     let args = parser::ArgParser::parse();
 
     match args.subcommand {
-        parser::Commands::BuildDev(build_parser) => {
-            build_lib();
-            build_bin(&build_parser.args);
-        }
+        parser::Commands::BuildDev(build_parser) => build_lib().and(build_bin(&build_parser.args)),
         parser::Commands::Bundle(bundle_parser) => {
             let version_string = bundle_parser.version;
             let kani_string = format!("kani-{version_string}");
@@ -45,10 +42,10 @@ fn main() -> Result<()> {
             std::fs::remove_dir_all(dir)?;
 
             println!("\nSuccessfully built release bundle: {bundle_name}");
+
+            Ok(())
         }
     }
-
-    Ok(())
 }
 
 /// Ensures everything is good to go before we begin to build the release bundle.
@@ -70,10 +67,9 @@ fn prebundle(dir: &Path) -> Result<()> {
     }
 
     // Before we begin, ensure Kani is built successfully in release mode.
-    build_bin(&["--release"]);
-    // And that libraries have been built too.
-    build_lib();
-    Ok(())
+    build_bin(&["--release"])
+        // And that libraries have been built too.
+        .and(build_lib())
 }
 
 /// Copy Kani files into `dir`


### PR DESCRIPTION
### Description of changes: 

Build failures of Kani-related components did not result in a non-zero exit code.

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? Tested locally, see https://github.com/model-checking/kani/actions/runs/4753845746/jobs/8445926203 for an example that I had not previously noticed in my local builds.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
