### PR TITLE
Dump full benchcomp YAML results in CI

### DIFF
--- a/tools/benchcomp/configs/perf-regression.yaml
+++ b/tools/benchcomp/configs/perf-regression.yaml
@@ -28,6 +28,8 @@ run:
       variants: [kani_old, kani_new]
 
 visualize:
+  - type: dump_yaml
+
   - type: error_on_regression
     variant_pairs: [[kani_old, kani_new]]
     checks:


### PR DESCRIPTION
This ensures that users can copy-and-paste the benchcomp results and investigate them locally.


### Call-outs:

In a future commit I think we should print a 'pretty' representation to the CI terminal, and save the YAML file as an artifact to download.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
