### PR TITLE
Explicitly pass out_file to benchcomp visualizers

### DIFF
--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -6,6 +6,7 @@ import dataclasses
 
 import yaml
 
+import benchcomp
 import benchcomp.visualizers.utils as viz_utils
 
 
@@ -54,15 +55,24 @@ class error_on_regression:
 
 
 
-@dataclasses.dataclass
 class dump_yaml:
-    """Print the YAML-formatted results to stdout
+    """Print the YAML-formatted results to a file.
+
+    The 'out_file' key is mandatory; specify '-' to print to stdout.
 
     Sample configuration:
 
     visualize:
     - type: dump_yaml
+      out_file: '-'
     """
 
+
+    def __init__(self, out_file):
+        self.get_out_file = benchcomp.Outfile(out_file)
+
+
     def __call__(self, results):
-        print(yaml.dump(results, default_flow_style=False))
+        with self.get_out_file() as handle:
+            print(
+                yaml.dump(results, default_flow_style=False), file=handle)

--- a/tools/benchcomp/configs/perf-regression.yaml
+++ b/tools/benchcomp/configs/perf-regression.yaml
@@ -29,6 +29,7 @@ run:
 
 visualize:
   - type: dump_yaml
+    out_file: '/tmp/result.yaml'
 
   - type: error_on_regression
     variant_pairs: [[kani_old, kani_new]]

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -95,7 +95,10 @@ class RegressionTests(unittest.TestCase):
                     }
                 }
             },
-            "visualize": [{"type": "dump_yaml"}],
+            "visualize": [{
+                "type": "dump_yaml",
+                "out_file": "-"
+            }],
         })
         run_bc()
         self.assertEqual(run_bc.proc.returncode, 0, msg=run_bc.stderr)
@@ -423,6 +426,7 @@ class RegressionTests(unittest.TestCase):
                 },
                 "visualize": [{
                     "type": "dump_yaml",
+                    "out_file": "-",
                 }, {
                     "type": "error_on_regression",
                     "variant_pairs": [["passed", "failed"]],
@@ -471,6 +475,7 @@ class RegressionTests(unittest.TestCase):
                 },
                 "visualize": [{
                     "type": "dump_yaml",
+                    "out_file": "-",
                 }],
             })
             run_bc(flags=["--except", "dump_yaml"])


### PR DESCRIPTION
This commit adds an `out_file` to the benchcomp visualizes that emit output (currently just one visualization, dump_yaml). This is to allow different visualizations to be written to different output files, including stdout.

The intention (for a future commit) is that CI will save certain visualizations as artifacts, which users can then download.

### Testing:

* How is this change tested? Ran it locally

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
