### PR TITLE
Add #VCCs and #program steps benchcomp metrics

### DIFF
--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -105,6 +105,8 @@ class RegressionTests(unittest.TestCase):
             "symex_runtime": float,
             "verification_time": float,
             "success": bool,
+            "number_program_steps": int,
+            "number_vccs": int,
         }
 
         all_succeeded = True


### PR DESCRIPTION
This commit adds two new metrics to the benchcomp "kani perf" parser. These metrics are recorded from each benchmark's output file but not currently checked for regression.

### Testing:

* How is this change tested? Added these metrics to the existing regression test

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
