### PR TITLE
Make bookrunner job use latest pages-deploy-action

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -132,7 +132,7 @@ jobs:
       # When we're pushed to main branch, only then actually publish the docs.
       - name: Publish Documentation
         if: ${{ github.event_name == 'push' && startsWith('refs/heads/main', github.ref) }}
-        uses: JamesIves/github-pages-deploy-action@v4.3.3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: docs/book/


### PR DESCRIPTION
### Description of changes: 


GitHub reports that we are using deprecated Node.js version 12. Fix this by not depending on a particular minor version, but instead using whatever the latest instance of major version 4 (current 4.4.1).

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? Will run in CI.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
