### PR TITLE
Refactor slow benchcomp regression tests

### DIFF
--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -49,86 +49,6 @@ class RegressionTests(unittest.TestCase):
     def setUp(self):
         self.kani_dir = pathlib.Path(__file__).parent.parent.parent.parent
 
-    def test_kani_perf_fail(self):
-        cmd = (
-            "rm -rf build target &&"
-            "mkdir -p build/tests/perf/Unwind-Attribute/expected &&"
-            "kani tests/kani/Unwind-Attribute/fixme_lib.rs > "
-            "build/tests/perf/Unwind-Attribute/expected/expected.out"
-        )
-        self._run_kani_perf_test(cmd, False)
-
-    def test_kani_perf_success(self):
-        cmd = (
-            "rm -rf build target &&"
-            "mkdir -p build/tests/perf/Arbitrary/expected &&"
-            "kani tests/kani/Arbitrary/arbitrary_impls.rs > "
-            "build/tests/perf/Arbitrary/expected/expected.out"
-        )
-        self._run_kani_perf_test(cmd, True)
-
-    def _run_kani_perf_test(self, command, expected_pass):
-        """Ensure that the kani_perf parser can parse the output of a perf test"""
-
-        # The two variants are identical; we're not actually checking the
-        # returned metrics in this test, only checking that the parser works
-        run_bc = Benchcomp({
-            "variants": {
-                "run_1": {
-                    "config": {
-                        "directory": str(self.kani_dir),
-                        "command_line": command,
-                    },
-                },
-                "run_2": {
-                    "config": {
-                        "directory": str(self.kani_dir),
-                        "command_line": command,
-                    },
-                },
-            },
-            "run": {
-                "suites": {
-                    "suite_1": {
-                        "parser": { "module": "kani_perf" },
-                        "variants": ["run_1", "run_2"]
-                    }
-                }
-            },
-            "visualize": [{
-                "type": "dump_yaml",
-                "out_file": "-"
-            }],
-        })
-        run_bc()
-        self.assertEqual(run_bc.proc.returncode, 0, msg=run_bc.stderr)
-
-        results = yaml.safe_load(run_bc.stdout)
-
-        expected_types = {
-            "solver_runtime": float,
-            "symex_runtime": float,
-            "verification_time": float,
-            "success": bool,
-            "number_program_steps": int,
-            "number_vccs": int,
-        }
-
-        all_succeeded = True
-
-        for _, bench in results["benchmarks"].items():
-            for _, variant in bench["variants"].items():
-
-                all_succeeded &= variant["metrics"]["success"]
-
-                for metric, ttype in expected_types.items():
-                    self.assertIn(metric, variant["metrics"], msg=run_bc.stdout)
-                    self.assertTrue(
-                        isinstance(variant["metrics"][metric], ttype),
-                        msg=run_bc.stdout)
-
-        self.assertEqual(expected_pass, all_succeeded, msg=run_bc.stdout)
-
     def test_error_on_regression_two_benchmarks_previously_failed(self):
         """Ensure that benchcomp terminates with exit of 0 when the "error_on_regression" visualization is configured and one of the benchmarks continues to fail (no regression)."""
 
@@ -607,3 +527,91 @@ class RegressionTests(unittest.TestCase):
                 result["benchmarks"]["suite_1"]["variants"][
                     "env_unset"]["metrics"]["foos"], 0,
                 msg=yaml.dump(result, default_flow_style=False))
+
+
+class ZPerfRegressionTests():
+    def setUp(self):
+        self.kani_dir = pathlib.Path(__file__).parent.parent.parent.parent
+
+
+    def test_kani_perf_fail(self):
+        cmd = (
+            "rm -rf build target &&"
+            "mkdir -p build/tests/perf/Unwind-Attribute/expected &&"
+            "kani tests/kani/Unwind-Attribute/fixme_lib.rs > "
+            "build/tests/perf/Unwind-Attribute/expected/expected.out"
+        )
+        self._run_kani_perf_test(cmd, False)
+
+
+    def test_kani_perf_success(self):
+        cmd = (
+            "rm -rf build target &&"
+            "mkdir -p build/tests/perf/Arbitrary/expected &&"
+            "kani tests/kani/Arbitrary/arbitrary_impls.rs > "
+            "build/tests/perf/Arbitrary/expected/expected.out"
+        )
+        self._run_kani_perf_test(cmd, True)
+
+
+    def _run_kani_perf_test(self, command, expected_pass):
+        """Ensure that the kani_perf parser can parse the output of a perf test"""
+
+        # The two variants are identical; we're not actually checking the
+        # returned metrics in this test, only checking that the parser works
+        run_bc = Benchcomp({
+            "variants": {
+                "run_1": {
+                    "config": {
+                        "directory": str(self.kani_dir),
+                        "command_line": command,
+                    },
+                },
+                "run_2": {
+                    "config": {
+                        "directory": str(self.kani_dir),
+                        "command_line": command,
+                    },
+                },
+            },
+            "run": {
+                "suites": {
+                    "suite_1": {
+                        "parser": { "module": "kani_perf" },
+                        "variants": ["run_1", "run_2"]
+                    }
+                }
+            },
+            "visualize": [{
+                "type": "dump_yaml",
+                "out_file": "-"
+            }],
+        })
+        run_bc()
+        self.assertEqual(run_bc.proc.returncode, 0, msg=run_bc.stderr)
+
+        results = yaml.safe_load(run_bc.stdout)
+
+        expected_types = {
+            "solver_runtime": float,
+            "symex_runtime": float,
+            "verification_time": float,
+            "success": bool,
+            "number_program_steps": int,
+            "number_vccs": int,
+        }
+
+        all_succeeded = True
+
+        for _, bench in results["benchmarks"].items():
+            for _, variant in bench["variants"].items():
+
+                all_succeeded &= variant["metrics"]["success"]
+
+                for metric, ttype in expected_types.items():
+                    self.assertIn(metric, variant["metrics"], msg=run_bc.stdout)
+                    self.assertTrue(
+                        isinstance(variant["metrics"][metric], ttype),
+                        msg=run_bc.stdout)
+
+        self.assertEqual(expected_pass, all_succeeded, msg=run_bc.stdout)


### PR DESCRIPTION
This commit moves the regression tests that run Kani into a separate suite that runs after the other regression tests, so that users get quick feedback about any of the fast tests that fail.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
