### PR TITLE
Bump Kani version 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 ## What's Changed
 
 * Allow excluding packages from verification with `--exclude` by @adpaco-aws in https://github.com/model-checking/kani/pull/2399
+* Add size_of annotation to help CBMC's allocator by @tautschnig in https://github.com/model-checking/kani/pull/2395
 * Implement `kani::Arbitrary` for `Box<T>` by @adpaco-aws in https://github.com/model-checking/kani/pull/2404
+* Use optimized overflow operation everywhere by @celinval in https://github.com/model-checking/kani/pull/2405
 * Bump CBMC version to 5.82.0 by @adpaco-aws in https://github.com/model-checking/kani/pull/2417
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.26.0...kani-0.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.27.0]
+
+## What's Changed
+
+* Allow excluding packages from verification with `--exclude` by @adpaco-aws in https://github.com/model-checking/kani/pull/2399
+* Implement `kani::Arbitrary` for `Box<T>` by @adpaco-aws in https://github.com/model-checking/kani/pull/2404
+* Bump CBMC version to 5.82.0 by @adpaco-aws in https://github.com/model-checking/kani/pull/2417
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.26.0...kani-0.27.0
+
 ## [0.26.0]
 
 ### What's Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -549,14 +549,14 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "kani"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "ar",
  "atty",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "home",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "cprover_bindings",
  "serde",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "kani_queries"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "strum",
  "strum_macros",
@@ -1233,7 +1233,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "std"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/kani_queries/Cargo.toml
+++ b/kani-compiler/kani_queries/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_queries"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Description of changes: 

* Bumps version of Kani crates to 0.27.0.
* Adds release notes to `CHANGELOG.md`

Please check the changes included in `CHANGELOG.md`, and let me know if you think any other changes should be included. For reference, the initial auto-generated release notes were:
```
## What's Changed
* Run benchcomp unit and regression tests in CI by @karkhaz in https://github.com/model-checking/kani/pull/2382
* Install system-provided autopep8 where available by @tautschnig in https://github.com/model-checking/kani/pull/2397
* Make cargo build-dev produce a proper exit code by @tautschnig in https://github.com/model-checking/kani/pull/2398
* Allow excluding packages from verification with `--exclude` by @adpaco-aws in https://github.com/model-checking/kani/pull/2399
* Dump full benchcomp YAML results in CI by @karkhaz in https://github.com/model-checking/kani/pull/2401
* Add size_of annotation to help CBMC's allocator by @tautschnig in https://github.com/model-checking/kani/pull/2395
* Implement `kani::Arbitrary` for `Box<T>` by @adpaco-aws in https://github.com/model-checking/kani/pull/2404
* Add #VCCs and #program steps benchcomp metrics by @karkhaz in https://github.com/model-checking/kani/pull/2410
* Add --only and --exclude to benchcomp visualize by @karkhaz in https://github.com/model-checking/kani/pull/2409
* Define different function for concrete playback (no user impact) by @celinval in https://github.com/model-checking/kani/pull/2407
* Make bookrunner job use latest pages-deploy-action by @tautschnig in https://github.com/model-checking/kani/pull/2411
* Explicitly pass out_file to benchcomp visualizers by @karkhaz in https://github.com/model-checking/kani/pull/2408
* Add markdown_results_table benchcomp visualization by @karkhaz in https://github.com/model-checking/kani/pull/2413
* Add extra_column to benchcomp markdown visualizer by @karkhaz in https://github.com/model-checking/kani/pull/2415
* Use optimized overflow operation everywhere by @celinval in https://github.com/model-checking/kani/pull/2405
* Bump CBMC version to 5.82.0 by @adpaco-aws in https://github.com/model-checking/kani/pull/2417
* Update dependencies by @adpaco-aws in https://github.com/model-checking/kani/pull/2418


**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.26.0...kani-0.27.0
```

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regression.

* Is this a refactor change? N/A

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
