### PR TITLE
Use same perf tests for benchcomp in CI

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -303,6 +303,9 @@ jobs:
       - name: Build Kani (old variant)
         run: pushd old && cargo build-dev
 
+      - name: Copy benchmarks form new to old
+        run: rm -rf ./old/tests/perf ; cp -r ./new/tests/perf ./old/tests/
+
       - name: Run benchcomp
         run: |
           new/tools/benchcomp/bin/benchcomp \


### PR DESCRIPTION
### Description of changes: 

The current benchcomp compares the two versions (pre/post-PR commits) of Kani on the corresponding two versions of benchmarks. It make no sense to compare their performance if the commit modified the performance benchmarks.

In this PR, we copy the post-PR benchmarks to the pre-PR folder to make sure benchcomp always run on the same set of benchmarks.

Here is the CI run result with this commit 
https://github.com/qinheping/kani/actions/runs/4879281724/jobs/8705705561?pr=3
comparing to the current workflow
https://github.com/model-checking/kani/actions/runs/4866466752/jobs/8678021607?pr=2422

### Resolved issues:

Resolves #2424 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:


<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
