### PR TITLE
Remove unneeded unwinds from unbounded benchmarks

### DIFF
--- a/tests/kani/AsyncAwait/main.rs
+++ b/tests/kani/AsyncAwait/main.rs
@@ -14,7 +14,6 @@ use std::{
 fn main() {}
 
 #[kani::proof]
-#[kani::unwind(2)]
 async fn test_async_proof_harness() {
     let async_block_result = async { 42 }.await;
     let async_fn_result = async_fn().await;
@@ -22,7 +21,6 @@ async fn test_async_proof_harness() {
 }
 
 #[kani::proof]
-#[kani::unwind(2)]
 pub async fn test_async_proof_harness_pub() {
     let async_block_result = async { 42 }.await;
     let async_fn_result = async_fn().await;
@@ -30,7 +28,6 @@ pub async fn test_async_proof_harness_pub() {
 }
 
 #[kani::proof]
-#[kani::unwind(2)]
 fn test_async_await() {
     // Test using the `block_on` implementation in Kani's library
     kani::block_on(async {

--- a/tests/kani/Drop/drop_after_moving_across_channel.rs
+++ b/tests/kani/Drop/drop_after_moving_across_channel.rs
@@ -18,7 +18,6 @@ impl Drop for DropSetCELLToOne {
     }
 }
 
-#[kani::unwind(1)]
 #[kani::proof]
 fn main() {
     {

--- a/tests/kani/Generator/rustc-generator-tests/conditional-drop.rs
+++ b/tests/kani/Generator/rustc-generator-tests/conditional-drop.rs
@@ -35,7 +35,6 @@ fn test2() -> bool {
 }
 
 #[kani::proof]
-#[kani::unwind(4)]
 fn main() {
     t1();
     t2();

--- a/tests/kani/Generator/rustc-generator-tests/live-upvar-across-yield.rs
+++ b/tests/kani/Generator/rustc-generator-tests/live-upvar-across-yield.rs
@@ -14,7 +14,6 @@ use std::ops::Generator;
 use std::pin::Pin;
 
 #[kani::proof]
-#[kani::unwind(2)]
 fn main() {
     let b = |_| 3;
     let mut a = || {

--- a/tests/kani/Generator/rustc-generator-tests/moved-locals.rs
+++ b/tests/kani/Generator/rustc-generator-tests/moved-locals.rs
@@ -79,7 +79,6 @@ fn overlap_x_and_y() -> impl Generator<Yield = (), Return = ()> {
 }
 
 #[kani::proof]
-#[kani::unwind(129)]
 fn main() {
     let mut generator = move_before_yield();
     assert_eq!(

--- a/tests/kani/Generator/rustc-generator-tests/niche-in-generator.rs
+++ b/tests/kani/Generator/rustc-generator-tests/niche-in-generator.rs
@@ -20,7 +20,6 @@ use std::mem::size_of_val;
 fn take<T>(_: T) {}
 
 #[kani::proof]
-#[kani::unwind(2)]
 fn main() {
     let x = false;
     let mut gen1 = || {

--- a/tests/kani/Generator/rustc-generator-tests/static-generator.rs
+++ b/tests/kani/Generator/rustc-generator-tests/static-generator.rs
@@ -14,7 +14,6 @@ use std::ops::{Generator, GeneratorState};
 use std::pin::Pin;
 
 #[kani::proof]
-#[kani::unwind(2)]
 fn main() {
     let mut generator = static || {
         let a = true;

--- a/tests/kani/Generator/rustc-generator-tests/yield-in-box.rs
+++ b/tests/kani/Generator/rustc-generator-tests/yield-in-box.rs
@@ -15,7 +15,6 @@ use std::ops::GeneratorState;
 use std::pin::Pin;
 
 #[kani::proof]
-#[kani::unwind(2)]
 fn main() {
     let x = 0i32;
     || {

--- a/tests/kani/PointerComparison/ptr_comparison.rs
+++ b/tests/kani/PointerComparison/ptr_comparison.rs
@@ -102,7 +102,6 @@ fn check_slice_len() {
 
 // Check comparison of box.
 #[cfg_attr(kani, kani::proof)]
-#[cfg_attr(kani, kani::unwind(4))]
 fn check_box_comparison() {
     let obj = Box::new([0u16, 10]);
     let first: *const [u16] = &obj[1..2];


### PR DESCRIPTION
### Description of changes: 

There are unreachable loops in the code snippet compiled from generator `resume`. For example, in the goto program compiled from the benchmark `moved_locals.rs`:
```
     8: ASSERT false // KANI_CHECK_ID_moved_locals.c1d95029::moved_locals_3
        // 716 file /Users/qinhh/Repos/kani/qinheping/tests/kani/Generator/rustc-generator-tests/moved-locals.rs line 71 column 5 function overlap_x_and_y::{closure#0}
        ASSERT 0 ≠ 0 // [KANI_CHECK_ID_moved_locals.c1d95029::moved_locals_3] generator resumed after completion
        // 717 file /Users/qinhh/Repos/kani/qinheping/tests/kani/Generator/rustc-generator-tests/moved-locals.rs line 71 column 5 function overlap_x_and_y::{closure#0}
        ASSUME 0 ≠ 0
        // 718 file /Users/qinhh/Repos/kani/qinheping/tests/kani/Generator/rustc-generator-tests/moved-locals.rs line 71 column 5 function overlap_x_and_y::{closure#0}
        GOTO 8
```
The jump-back instruction `GOTO 8` is unreachable as it is after `ASSUME 0 ≠ 0`.

However, such unreachable loops can actually be correctly handle by CBMC. So we can remove the unwinding numbers from the benchmarks modified in this PR.


### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
