### PR TITLE
Fix symtab json file removal and reduce regression scope

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -45,12 +45,14 @@ jobs:
           os: ubuntu-20.04
 
       - name: Build Kani
-        run: cargo build-dev
+        run: cargo build-dev -- --features write_json_symtab
 
-      - name: Execute Kani regression
-        env:
-          KANI_ENABLE_WRITE_JSON_SYMTAB: 1
-        run: ./scripts/kani-regression.sh
+      - name: Run tests
+        run: |
+          cargo run -p compiletest --quiet -- --suite kani --mode kani --quiet --no-fail-fast
+          cargo run -p compiletest --quiet -- --suite expected --mode expected --quiet --no-fail-fast
+          cargo run -p compiletest --quiet -- --suite cargo-kani --mode cargo-kani --quiet --no-fail-fast
+
 
   benchcomp-tests:
     runs-on: ubuntu-20.04

--- a/kani-driver/src/project.rs
+++ b/kani-driver/src/project.rs
@@ -129,12 +129,12 @@ impl Project {
                 let goto = Artifact::try_new(&goto_path, Goto)?;
 
                 // All other harness artifacts that may have been generated as part of the build.
-                artifacts.extend([TypeMap, VTableRestriction, PrettyNameMap].iter().filter_map(
-                    |typ| {
+                artifacts.extend(
+                    [SymTab, TypeMap, VTableRestriction, PrettyNameMap].iter().filter_map(|typ| {
                         let artifact = Artifact::try_from(&symtab_out, *typ).ok()?;
                         Some(artifact)
-                    },
-                ));
+                    }),
+                );
                 artifacts.push(symtab_out);
                 artifacts.push(goto);
             }

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -27,11 +27,7 @@ check_kissat_version.sh
 ${SCRIPT_DIR}/kani-fmt.sh --check
 
 # Build all packages in the workspace
-if [[ "" != "${KANI_ENABLE_WRITE_JSON_SYMTAB-}" ]]; then
-  cargo build-dev -- --features write_json_symtab
-else
-  cargo build-dev
-fi
+cargo build-dev
 
 # Unit tests
 cargo test -p cprover_bindings
@@ -69,11 +65,8 @@ for testp in "${TESTS[@]}"; do
       --quiet --no-fail-fast
 done
 
-# Don't run std regression if using JSON symtab to avoid OOM issues.
-if [[ -z "${KANI_ENABLE_WRITE_JSON_SYMTAB-}" ]]; then
-    # Check codegen for the standard library
-    time "$SCRIPT_DIR"/std-lib-regression.sh
-fi
+# Check codegen for the standard library
+time "$SCRIPT_DIR"/std-lib-regression.sh
 
 # We rarely benefit from re-using build artifacts in the firecracker test,
 # and we often end up with incompatible leftover artifacts:


### PR DESCRIPTION
### Description of changes: 

This fixes a regression introduced in #2439 when write symtab json is enabled. We still need to take that into consideration and remove them if needed.

This change also simplifies the write symtab json regression to avoid the out of disk space issue we've been seeing since #2439.

### Resolved issues:

N/A

### Related RFC:

N/A.

### Call-outs:

IMHO, we should consider removing support for the symtab json option given how much slower and costly it is. Besides, we haven't had any major problem with the goto approach that justifies keeping this code lingering.

Until then, we still want to have some test coverage in our regression, but keeping a full regression is costly and just not worth it at this point. Another possible way to fix the out of disk issue would be to clean the build folder after each test suite, but this would be a much more invasive change to our scripts.

### Testing:

* How is this change tested? CI

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
