### PR TITLE
Update stubbing.md with the right command

### DIFF
--- a/docs/src/reference/stubbing.md
+++ b/docs/src/reference/stubbing.md
@@ -83,7 +83,7 @@ Note that this is a fair assumption to do: `rand::random` is expected to return 
 Now, let's run it through Kani:
 
 ```bash
-cargo kani --enable-unstable --enable-stubbing --harness random_cannot_be_zero
+cargo kani --enable-unstable --enable-stubbing --harness encrypt_then_decrypt_is_identity
 ```
 
 The verification result is composed of a single check: the assertion corresponding to `assert_eq!(data, decrypted_data)`.


### PR DESCRIPTION
The original command invoked a call to a harness that is not relevant. The author probably meant to call the harness in the example `encrypt_then_decrypt_is_identity`.

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
