### PR TITLE
Clean up kani-compiler's Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,17 +24,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,15 +284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,7 +416,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
 ]
 
 [[package]]
@@ -444,15 +424,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.3",
-]
 
 [[package]]
 name = "heck"
@@ -560,9 +531,7 @@ dependencies = [
  "kani_metadata",
  "kani_queries",
  "lazy_static",
- "libc",
  "num",
- "object",
  "regex",
  "serde",
  "serde_json",
@@ -824,18 +793,6 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
-dependencies = [
- "crc32fast",
- "hashbrown 0.13.2",
- "indexmap",
- "memchr",
 ]
 
 [[package]]

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -17,14 +17,12 @@ itertools = "0.10"
 kani_queries = {path = "kani_queries"}
 kani_metadata = {path = "../kani_metadata"}
 lazy_static = "1.4.0"
-libc = { version = "0.2", optional = true }
 num = { version = "0.4.0", optional = true }
-object = { version = "0.30.0", default-features = false, features = ["std", "read_core", "write", "archive", "coff", "elf", "macho", "pe"], optional = true }
 regex = "1.7.0"
 serde = { version = "1", optional = true }
-serde_json = { version = "1", optional = true }
-strum = {version = "0.24.0", optional = true}
-strum_macros = {version = "0.24.0", optional = true}
+serde_json = "1"
+strum = "0.24.0"
+strum_macros = "0.24.0"
 shell-words = "1.0.0"
 tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-subscriber = {version = "0.3.8", features = ["env-filter", "json", "fmt"]}
@@ -33,8 +31,7 @@ tracing-tree = "0.2.2"
 # Future proofing: enable backend dependencies using feature.
 [features]
 default = ['cprover']
-cprover = ['cbmc', 'libc', 'num', 'object', 'serde',
-    'serde_json', "strum", "strum_macros"]
+cprover = ['cbmc', 'num', 'serde']
 write_json_symtab = []
 
 [package.metadata.rust-analyzer]


### PR DESCRIPTION
### Description of changes: 

Some cleanup to the `Cargo.toml` of the `kani-compiler` crate:
1. Deleted two unused dependencies: `libc` and `object`
2. Changed three other dependencies to non-optional since they're **not** only used in the `cprover` crate and they're used in `kani_middle` crate which is backend-agnostic: `serde_json`, `strum`, and `strum_macros`.

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Current regressions

* Is this a refactor change? Yes

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
