### PR TITLE
Slightly change playback arguments

### DIFF
--- a/kani-driver/src/args/mod.rs
+++ b/kani-driver/src/args/mod.rs
@@ -965,7 +965,7 @@ mod tests {
 
     #[test]
     fn check_kani_playback() {
-        let input = "kani playback --test dummy file.rs".split_whitespace();
+        let input = "kani playback file.rs -- dummy".split_whitespace();
         let args = StandaloneArgs::try_parse_from(input).unwrap();
         assert_eq!(args.input, None);
         assert!(matches!(args.command, Some(StandaloneSubcommand::Playback(..))));

--- a/kani-driver/src/args/playback_args.rs
+++ b/kani-driver/src/args/playback_args.rs
@@ -36,10 +36,6 @@ pub struct PlaybackArgs {
     #[command(flatten)]
     pub common_opts: CommonArgs,
 
-    /// Specify which test will be executed by the playback args.
-    #[arg(long)]
-    pub test: String,
-
     /// Compile but don't actually run the tests.
     #[arg(long)]
     pub only_codegen: bool,
@@ -48,6 +44,10 @@ pub struct PlaybackArgs {
     /// Control the subcommand output.
     #[arg(long, default_value = "human")]
     pub message_format: MessageFormat,
+
+    /// Arguments to be passed to the test binary.
+    #[arg(num_args(0..), last = true)]
+    pub test_args: Vec<String>,
 }
 
 /// Message formats available for the subcommand.
@@ -105,48 +105,53 @@ mod tests {
 
     #[test]
     fn check_cargo_parse_test_works() {
-        let input = "playback -Z concrete-playback --test TEST_NAME".split_whitespace();
+        let input = "playback -Z concrete-playback -- TEST_NAME".split_whitespace();
         let args = CargoPlaybackArgs::try_parse_from(input.clone()).unwrap();
         args.validate().unwrap();
-        assert_eq!(args.playback.test, "TEST_NAME");
+        assert_eq!(args.playback.test_args, ["TEST_NAME"]);
         // The default value is human friendly.
         assert_eq!(args.playback.message_format, MessageFormat::Human);
     }
 
     #[test]
     fn check_cargo_parse_pkg_works() {
-        let input = "playback -Z concrete-playback --test TEST_NAME -p PKG_NAME".split_whitespace();
+        let input = "playback -Z concrete-playback -p PKG_NAME".split_whitespace();
         let args = CargoPlaybackArgs::try_parse_from(input).unwrap();
         args.validate().unwrap();
-        assert_eq!(args.playback.test, "TEST_NAME");
         assert_eq!(&args.cargo.package, &["PKG_NAME"])
     }
 
     #[test]
     fn check_parse_format_works() {
-        let input = "playback -Z concrete-playback --test TEST_NAME --message-format=json"
-            .split_whitespace();
+        let input = "playback -Z concrete-playback --message-format=json".split_whitespace();
         let args = CargoPlaybackArgs::try_parse_from(input).unwrap();
         args.validate().unwrap();
-        assert_eq!(args.playback.test, "TEST_NAME");
         assert_eq!(args.playback.message_format, MessageFormat::Json)
     }
 
     #[test]
     fn check_kani_parse_test_works() {
-        let input = "playback -Z concrete-playback --test TEST_NAME input.rs".split_whitespace();
+        let input = "playback -Z concrete-playback input.rs -- TEST_NAME".split_whitespace();
         let args = KaniPlaybackArgs::try_parse_from(input).unwrap();
         // Don't validate this since we check if the input file exists.
         //args.validate().unwrap();
-        assert_eq!(args.playback.test, "TEST_NAME");
+        assert_eq!(args.playback.test_args, ["TEST_NAME"]);
         assert_eq!(args.input, PathBuf::from("input.rs"));
         // The default value is human friendly.
         assert_eq!(args.playback.message_format, MessageFormat::Human);
     }
 
     #[test]
+    fn check_kani_parse_extra_args() {
+        let input = "playback -Z concrete-playback input.rs -- TEST_NAME --exact --nocapture"
+            .split_whitespace();
+        let args = KaniPlaybackArgs::try_parse_from(input).unwrap();
+        assert_eq!(args.playback.test_args, ["TEST_NAME", "--exact", "--nocapture"])
+    }
+
+    #[test]
     fn check_kani_no_unstable_fails() {
-        let input = "playback --test TEST_NAME input.rs".split_whitespace();
+        let input = "playback input.rs".split_whitespace();
         let args = KaniPlaybackArgs::try_parse_from(input).unwrap();
         let err = args.validate().unwrap_err();
         assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);

--- a/tests/script-based-pre/cargo_playback_opts/playback_opts.sh
+++ b/tests/script-based-pre/cargo_playback_opts/playback_opts.sh
@@ -8,10 +8,10 @@ pushd sample_crate > /dev/null
 cargo clean
 
 echo "[TEST] Only codegen test..."
-cargo kani playback -Z concrete-playback --test kani_concrete_playback --only-codegen
+cargo kani playback -Z concrete-playback --only-codegen -- kani_concrete_playback
 
 echo "[TEST] Only codegen test..."
-output=$(cargo kani playback -Z concrete-playback --test kani_concrete_playback --only-codegen --message-format=json)
+output=$(cargo kani playback -Z concrete-playback --only-codegen --message-format=json -- kani_concrete_playback)
 executable=$(echo ${output} | jq 'select(.reason == "compiler-artifact") | .executable')
 
 echo "[TEST] Executable"

--- a/tests/script-based-pre/concrete_playback_e2e/playback_e2e.sh
+++ b/tests/script-based-pre/concrete_playback_e2e/playback_e2e.sh
@@ -17,13 +17,13 @@ echo "Run verification..."
 cargo kani
 
 echo "Run ok test..."
-cargo kani playback -Z concrete-playback --test any_is_ok
+cargo kani playback -Z concrete-playback -- any_is_ok
 
 echo "Run error test..."
-cargo kani playback -Z concrete-playback --test any_is_err
+cargo kani playback -Z concrete-playback -- any_is_err
 
 echo "Run all tests..."
-cargo kani playback -Z concrete-playback --test concrete_playback
+cargo kani playback -Z concrete-playback -- concrete_playback
 
 popd
 rm -rf ${OUT_DIR}

--- a/tests/script-based-pre/playback_opts/playback_opts.sh
+++ b/tests/script-based-pre/playback_opts/playback_opts.sh
@@ -12,13 +12,13 @@ echo "[TEST] Generate test..."
 kani ${RS_FILE} -Z concrete-playback --concrete-playback=inplace
 
 echo "[TEST] Only codegen test..."
-kani playback -Z concrete-playback --test kani_concrete_playback --only-codegen ${RS_FILE}
+kani playback -Z concrete-playback --only-codegen ${RS_FILE} -- kani_concrete_playback
 
 echo "[TEST] Run test..."
-kani playback -Z concrete-playback --test kani_concrete_playback ${RS_FILE}
+kani playback -Z concrete-playback ${RS_FILE} -- kani_concrete_playback
 
 echo "[TEST] Json format..."
-kani playback -Z concrete-playback --test kani_concrete_playback ${RS_FILE} --only-codegen --message-format=json
+kani playback -Z concrete-playback ${RS_FILE} --only-codegen --message-format=json -- kani_concrete_playback
 
 # Cleanup
 rm ${RS_FILE}


### PR DESCRIPTION
### Description of changes: 

Remove `--test` and add trailing test arguments to allow us to pass extra arguments to the test binary.

### Resolved issues:

N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:
As I was working in the integration with the VSCode extension, I noticed that it passes arguments to the test binary. Instead of manually adding support to each one of them, just handle them as `cargo test` does and pass them directly.

### Testing:

* How is this change tested? Modified tests

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
