### PR TITLE
Avoid an unnecssary suffix to the goto filename

### DIFF
--- a/kani-driver/src/util.rs
+++ b/kani-driver/src/util.rs
@@ -157,11 +157,6 @@ pub fn render_command(cmd: &Command) -> OsString {
     str
 }
 
-/// Generate the filename for a specialized harness from the base linked object
-pub fn specialized_harness_name(linked_obj: &Path, harness_filename: &str) -> PathBuf {
-    alter_extension(linked_obj, &format!("for-{harness_filename}.out"))
-}
-
 /// Print a warning message. This will add a "warning:" tag before the message and style accordingly.
 pub fn warning(msg: &str) {
     let warning = console::style("warning:").bold().yellow();
@@ -228,22 +223,5 @@ mod tests {
         assert_eq!(render_command(&c1), OsString::from("a b \"/c d/\""));
         c1.env("PARAM", "VALUE");
         assert_eq!(render_command(&c1), OsString::from("PARAM=\"VALUE\" a b \"/c d/\""));
-    }
-
-    #[test]
-    fn check_specialized_harness_name() {
-        // It's important that the filenames produced end in `.out` as we produce
-        // `--gen-c` filenames with `alter_extension` and we previously had a bug where
-        // `for-harness` was the "extension" being removed, and all filenames collided.
-
-        // cargo kani typically produced a file name like this
-        let h1 = PathBuf::from("./cbmc-linked.out");
-        assert_eq!(specialized_harness_name(&h1, "main"), Path::new("./cbmc-linked.for-main.out"));
-        assert_eq!(specialized_harness_name(&h1, "hs_n"), Path::new("./cbmc-linked.for-hs_n.out"));
-
-        // kani typically produces a file name like this
-        let h2 = PathBuf::from("./rs-file.out");
-        assert_eq!(specialized_harness_name(&h2, "main"), Path::new("./rs-file.for-main.out"));
-        assert_eq!(specialized_harness_name(&h2, "hs_n"), Path::new("./rs-file.for-hs_n.out"));
     }
 }

--- a/tests/kani/LongNames/test.rs
+++ b/tests/kani/LongNames/test.rs
@@ -1,0 +1,17 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test checks that Kani handles harnesses with long name, e.g. due to
+//! nested modules
+//! The test is from https://github.com/model-checking/kani/issues/2468
+
+mod a_really_long_module_name {
+    mod yet_another_really_long_module_name {
+        mod one_more_really_long_module_name {
+            #[kani::proof]
+            fn a_really_long_harness_name() {
+                assert_eq!(1, 1);
+            }
+        }
+    }
+}

--- a/tests/script-based-pre/check-output/check-output.sh
+++ b/tests/script-based-pre/check-output/check-output.sh
@@ -34,15 +34,15 @@ rm -rf *.c
 kani --gen-c --enable-unstable singlefile.rs >& kani.log || \
     { ret=$?; echo "== Failed to run Kani"; cat kani.log; rm kani.log; exit 1; }
 rm -f kani.log
-if ! [ -e singlefile_main.for-main.c ]
+if ! [ -e singlefile_main.c ]
 then
-    echo "Error: no GotoC file generated. Expected: singlefile_main.for-main.c"
+    echo "Error: no GotoC file generated. Expected: singlefile_main.c"
     exit 1
 fi
 
-if ! [ -e singlefile_main.for-main.demangled.c ]
+if ! [ -e singlefile_main.demangled.c ]
 then
-    echo "Error: no demangled GotoC file generated. Expected singlefile_main.for-main.demangled.c."
+    echo "Error: no demangled GotoC file generated. Expected singlefile_main.demangled.c."
     exit 1
 fi
 
@@ -57,9 +57,9 @@ declare -a PATTERNS=(
 )
 
 for val in "${PATTERNS[@]}"; do
-    if ! grep -Fq "$val" singlefile_main.for-main.demangled.c;
+    if ! grep -Fq "$val" singlefile_main.demangled.c;
     then
-        echo "Error: demangled file singlefile_main.for-main.demangled.c did not contain expected pattern '$val'."
+        echo "Error: demangled file singlefile_main.demangled.c did not contain expected pattern '$val'."
         exit 1
     fi
 done
@@ -75,17 +75,17 @@ cargo kani --target-dir build --gen-c --enable-unstable >& kani.log || \
 rm -f kani.log
 cd build/kani/${TARGET}/debug/deps/
 
-mangled=$(ls multifile*.for-main.c)
+mangled=$(ls multifile*_main.c)
 if ! [ -e "${mangled}" ]
 then
-    echo "Error: no GotoC file found. Expected: build/${TARGET}/debug/deps/multifile*.for-main.c"
+    echo "Error: no GotoC file found. Expected: build/kani/${TARGET}/debug/deps/multifile*_main.c"
     exit 1
 fi
 
-demangled=$(ls multifile*.for-main.demangled.c)
+demangled=$(ls multifile*_main.demangled.c)
 if ! [ -e "${demangled}" ]
 then
-    echo "Error: no demangled GotoC file found. Expected build/${TARGET}/debug/deps/multifile*.for-main.demangled.c."
+    echo "Error: no demangled GotoC file found. Expected build/kani/${TARGET}/debug/deps/multifile*_main.demangled.c."
     exit 1
 fi
 


### PR DESCRIPTION
### Description of changes: 

With #2439, codegen now produces a separate goto file for each harness. Thus, adding a `.for-<harness-name>` suffix to the name of each goto file is no longer necessary. This PR removes the appending of the `.for-<harness-name>` to avoid unnecessarily long filenames.

### Resolved issues:

Resolves #2468 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Added one test

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
