### PR TITLE
Do not download x86 mdbook on aarch64

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -11,15 +11,25 @@ set -eu
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd $SCRIPT_DIR
 
-# Download mdbook release (vs spending time building it via cargo install)
-MDBOOK_VERSION=v0.4.18
-FILE="mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-URL="https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/$FILE"
-EXPECTED_HASH="d276b0e594d5980de6a7917ce74c348f28d3cb8b353ca4eaae344ae8a4c40bea"
-if [ ! -x mdbook ]; then
-    curl -sSL -o "$FILE" "$URL"
-    echo "$EXPECTED_HASH $FILE" | sha256sum -c -
-    tar zxf $FILE
+if [ $(uname -m) = "arm64" ]; then
+  if ! $(which mdbook >/dev/null 2>&1); then
+    echo "Pre-built mdbook binaries for Apple ARM are not available."
+    echo 'Run `cargo install mdbook` and try again.'
+    exit 1
+  fi
+  MDBOOK=mdbook
+else
+  # Download mdbook release (vs spending time building it via cargo install)
+  MDBOOK_VERSION=v0.4.18
+  FILE="mdbook-${MDBOOK_VERSION}-${ARCH}.tar.gz"
+  URL="https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/$FILE"
+  EXPECTED_HASH="d276b0e594d5980de6a7917ce74c348f28d3cb8b353ca4eaae344ae8a4c40bea"
+  if [ ! -x mdbook ]; then
+      curl -sSL -o "$FILE" "$URL"
+      echo "$EXPECTED_HASH $FILE" | sha256sum -c -
+      tar zxf $FILE
+  fi
+  MDBOOK=${SCRIPT_DIR}/mdbook
 fi
 
 # Publish bookrunner report into our documentation
@@ -53,12 +63,12 @@ echo "Building user documentation..."
 # Build the book into ./book/
 mkdir -p book
 mkdir -p book/rfc
-$SCRIPT_DIR/mdbook build
+${MDBOOK} build
 touch book/.nojekyll
 
 echo "Building RFC book..."
 cd $RFC_DIR
-$SCRIPT_DIR/mdbook build -d $KANI_DIR/docs/book/rfc
+${MDBOOK} build -d $KANI_DIR/docs/book/rfc
 
 # Testing of the code in the documentation is done via the usual
 # ./scripts/kani-regression.sh script. A note on running just the

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -21,7 +21,7 @@ if [ $(uname -m) = "arm64" ]; then
 else
   # Download mdbook release (vs spending time building it via cargo install)
   MDBOOK_VERSION=v0.4.18
-  FILE="mdbook-${MDBOOK_VERSION}-${ARCH}.tar.gz"
+  FILE="mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
   URL="https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/$FILE"
   EXPECTED_HASH="d276b0e594d5980de6a7917ce74c348f28d3cb8b353ca4eaae344ae8a4c40bea"
   if [ ! -x mdbook ]; then

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -12,9 +12,9 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd $SCRIPT_DIR
 
 if [ $(uname -m) = "arm64" ]; then
-  if ! $(which mdbook >/dev/null 2>&1); then
-    echo "Pre-built mdbook binaries for Apple ARM are not available."
-    echo 'Run `cargo install mdbook` and try again.'
+  if ! $(which xmdbook >/dev/null 2>&1); then
+    >&2 echo "Pre-built mdbook binaries for Apple ARM are not available."
+    >&2 echo 'Run `cargo install mdbook` and try again.'
     exit 1
   fi
   MDBOOK=mdbook


### PR DESCRIPTION
Users who attempt to build the documentation on Apple ARM will be prompted to install mdbook using cargo if it is not already installed, as pre-built binaries for this platform are not available.

### Testing:

* How is this change tested? Ran it a few times on an M1 laptop, inverting the conditions

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
