### PR TITLE
NOP concrete playback to type check during verification mode.

### DIFF
--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -21,6 +21,10 @@ pub mod vec;
 pub use arbitrary::Arbitrary;
 #[cfg(feature = "concrete_playback")]
 pub use concrete_playback::concrete_playback_run;
+#[cfg(not(feature = "concrete_playback"))]
+/// NOP `concrete_playback` for type checking during verification mode.
+pub fn concrete_playback_run<F: Fn()>(_: Vec<Vec<u8>>, _: F) {}
+
 pub use futures::block_on;
 
 /// Creates an assumption that will be valid after this statement run. Note that the assumption

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -23,7 +23,9 @@ pub use arbitrary::Arbitrary;
 pub use concrete_playback::concrete_playback_run;
 #[cfg(not(feature = "concrete_playback"))]
 /// NOP `concrete_playback` for type checking during verification mode.
-pub fn concrete_playback_run<F: Fn()>(_: Vec<Vec<u8>>, _: F) {}
+pub fn concrete_playback_run<F: Fn()>(_: Vec<Vec<u8>>, _: F) {
+    unreachable!("Concrete playback does not work during verification")
+}
 
 pub use futures::block_on;
 

--- a/tests/cargo-kani/concrete-playback-in-verification-mode/Cargo.toml
+++ b/tests/cargo-kani/concrete-playback-in-verification-mode/Cargo.toml
@@ -1,0 +1,10 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+[package]
+name = "playback-test"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+
+[workspace]

--- a/tests/cargo-kani/concrete-playback-in-verification-mode/src/main.rs
+++ b/tests/cargo-kani/concrete-playback-in-verification-mode/src/main.rs
@@ -1,0 +1,14 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+#[kani::proof]
+fn main() {
+    assert!(1 == 1);
+}
+
+#[test]
+/// Purpose of this is to check if Kani can comple this code in
+/// verification mode when `kani::concrete_playback_run` is in the
+/// code,
+fn _playback_type_checks() {
+    kani::concrete_playback_run(vec![], test_sum);
+}

--- a/tests/cargo-kani/simple-lib/src/lib.rs
+++ b/tests/cargo-kani/simple-lib/src/lib.rs
@@ -22,4 +22,9 @@ mod kani_tests {
         let p = Pair::new(a, b);
         assert!(p.sum() == a.wrapping_add(b));
     }
+
+    #[test]
+    fn _playback_type_checks() {
+        kani::concrete_playback_run(vec![], test_sum);
+    }
 }

--- a/tests/cargo-kani/simple-lib/src/lib.rs
+++ b/tests/cargo-kani/simple-lib/src/lib.rs
@@ -22,9 +22,4 @@ mod kani_tests {
         let p = Pair::new(a, b);
         assert!(p.sum() == a.wrapping_add(b));
     }
-
-    #[test]
-    fn _playback_type_checks() {
-        kani::concrete_playback_run(vec![], test_sum);
-    }
 }


### PR DESCRIPTION
### Description of changes: 

This PR adds a NOP concrete playback function so that code inserted by the concrete playback feature that uses `concrete_playback` function still type checks during verification. Previously, this function was not available during verification, causing type fails during verification after playback code was injected.

### Resolved issues:

Resolves #2475 

### Related RFC:

### Call-outs:

@YoshikiTakashima is not sure where the tests should go given that we want to test behavior when the kani is not in playback mode.

### Testing:

* How is this change tested? `tests/cargo-kani/simple-lib`

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
