### PR TITLE
Delay printing playback harness until after verification status

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -53,8 +53,6 @@ pub struct VerificationResult {
     pub runtime: Duration,
     /// Whether concrete playback generated a test
     pub generated_concrete_test: bool,
-    /// the test case to print for concrete playback.
-    pub maybe_concrete_test_to_print: Option<String>,
 }
 
 impl KaniSession {
@@ -268,7 +266,6 @@ impl VerificationResult {
                 results: Ok(results),
                 runtime,
                 generated_concrete_test: false,
-                maybe_concrete_test_to_print: None,
             }
         } else {
             // We never got results from CBMC - something went wrong (e.g. crash) so it's failure
@@ -279,7 +276,6 @@ impl VerificationResult {
                 results: Err(output.process_status),
                 runtime,
                 generated_concrete_test: false,
-                maybe_concrete_test_to_print: None,
             }
         }
     }
@@ -292,7 +288,6 @@ impl VerificationResult {
             results: Ok(vec![]),
             runtime: Duration::from_secs(0),
             generated_concrete_test: false,
-            maybe_concrete_test_to_print: None,
         }
     }
 
@@ -307,7 +302,6 @@ impl VerificationResult {
             results: Err(42),
             runtime: Duration::from_secs(0),
             generated_concrete_test: false,
-            maybe_concrete_test_to_print: None,
         }
     }
 

--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -53,6 +53,8 @@ pub struct VerificationResult {
     pub runtime: Duration,
     /// Whether concrete playback generated a test
     pub generated_concrete_test: bool,
+    /// the test case to print for concrete playback.
+    pub maybe_concrete_test_to_print: Option<String>,
 }
 
 impl KaniSession {
@@ -266,6 +268,7 @@ impl VerificationResult {
                 results: Ok(results),
                 runtime,
                 generated_concrete_test: false,
+                maybe_concrete_test_to_print: None,
             }
         } else {
             // We never got results from CBMC - something went wrong (e.g. crash) so it's failure
@@ -276,6 +279,7 @@ impl VerificationResult {
                 results: Err(output.process_status),
                 runtime,
                 generated_concrete_test: false,
+                maybe_concrete_test_to_print: None,
             }
         }
     }
@@ -288,6 +292,7 @@ impl VerificationResult {
             results: Ok(vec![]),
             runtime: Duration::from_secs(0),
             generated_concrete_test: false,
+            maybe_concrete_test_to_print: None,
         }
     }
 
@@ -302,6 +307,7 @@ impl VerificationResult {
             results: Err(42),
             runtime: Duration::from_secs(0),
             generated_concrete_test: false,
+            maybe_concrete_test_to_print: None,
         }
     }
 

--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -66,8 +66,7 @@ impl KaniSession {
 
         let start_time = Instant::now();
 
-        let verification_results = if self.args.output_format == crate::args::OutputFormat::Old
-        {
+        let verification_results = if self.args.output_format == crate::args::OutputFormat::Old {
             if self.run_terminal(cmd).is_err() {
                 VerificationResult::mock_failure()
             } else {

--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -66,7 +66,7 @@ impl KaniSession {
 
         let start_time = Instant::now();
 
-        let mut verification_results = if self.args.output_format == crate::args::OutputFormat::Old
+        let verification_results = if self.args.output_format == crate::args::OutputFormat::Old
         {
             if self.run_terminal(cmd).is_err() {
                 VerificationResult::mock_failure()
@@ -93,7 +93,6 @@ impl KaniSession {
             VerificationResult::from(output, harness.attributes.should_panic, start_time)
         };
 
-        self.gen_and_add_concrete_playback(harness, &mut verification_results)?;
         Ok(verification_results)
     }
 

--- a/kani-driver/src/concrete_playback/test_generator.rs
+++ b/kani-driver/src/concrete_playback/test_generator.rs
@@ -43,19 +43,17 @@ impl KaniSession {
                     let generated_unit_test = format_unit_test(&pretty_name, &concrete_vals);
                     match playback_mode {
                         ConcretePlaybackMode::Print => {
-                            verification_result.maybe_concrete_test_to_print = Some(
-                                format!(
-                                    "Concrete playback unit test for `{}`:
+                            verification_result.maybe_concrete_test_to_print = Some(format!(
+                                "Concrete playback unit test for `{}`:
 ```rust
 {}
 ```
 INFO: To automatically add the concrete playback unit test `{}` to the src code, \
 run Kani with `--concrete-playback=inplace`.",
-                                    &harness.pretty_name,
-                                    &generated_unit_test.code.join("\n"),
-                                    &generated_unit_test.name,
-                                )
-                            );
+                                &harness.pretty_name,
+                                &generated_unit_test.code.join("\n"),
+                                &generated_unit_test.name,
+                            ));
                         }
                         ConcretePlaybackMode::InPlace => {
                             if !self.args.common_args.quiet {

--- a/kani-driver/src/concrete_playback/test_generator.rs
+++ b/kani-driver/src/concrete_playback/test_generator.rs
@@ -43,17 +43,16 @@ impl KaniSession {
                     let generated_unit_test = format_unit_test(&pretty_name, &concrete_vals);
                     match playback_mode {
                         ConcretePlaybackMode::Print => {
-                            verification_result.maybe_concrete_test_to_print = Some(format!(
-                                "Concrete playback unit test for `{}`:
-```rust
-{}
-```
-INFO: To automatically add the concrete playback unit test `{}` to the src code, \
-run Kani with `--concrete-playback=inplace`.",
+                            println!(
+                                "Concrete playback unit test for `{}`:\n```\n{}\n```",
                                 &harness.pretty_name,
-                                &generated_unit_test.code.join("\n"),
-                                &generated_unit_test.name,
-                            ));
+                                &generated_unit_test.code.join("\n")
+                            );
+                            println!(
+                                "INFO: To automatically add the concrete playback unit test `{}` to the \
+                        src code, run Kani with `--concrete-playback=inplace`.",
+                                &generated_unit_test.name
+                            );
                         }
                         ConcretePlaybackMode::InPlace => {
                             if !self.args.common_args.quiet {

--- a/kani-driver/src/concrete_playback/test_generator.rs
+++ b/kani-driver/src/concrete_playback/test_generator.rs
@@ -43,15 +43,18 @@ impl KaniSession {
                     let generated_unit_test = format_unit_test(&pretty_name, &concrete_vals);
                     match playback_mode {
                         ConcretePlaybackMode::Print => {
-                            println!(
-                                "Concrete playback unit test for `{}`:\n```\n{}\n```",
-                                &harness.pretty_name,
-                                &generated_unit_test.code.join("\n")
-                            );
-                            println!(
-                                "INFO: To automatically add the concrete playback unit test `{}` to the \
-                        src code, run Kani with `--concrete-playback=inplace`.",
-                                &generated_unit_test.name
+                            verification_result.maybe_concrete_test_to_print = Some(
+                                format!(
+                                    "Concrete playback unit test for `{}`:
+```rust
+{}
+```
+INFO: To automatically add the concrete playback unit test `{}` to the src code, \
+run Kani with `--concrete-playback=inplace`.",
+                                    &harness.pretty_name,
+                                    &generated_unit_test.code.join("\n"),
+                                    &generated_unit_test.name,
+                                )
                             );
                         }
                         ConcretePlaybackMode::InPlace => {

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -97,7 +97,9 @@ impl KaniSession {
                 println!(
                     "{}{}",
                     result.render(&self.args.output_format, harness.attributes.should_panic),
-                    result.maybe_concrete_test_to_print.as_ref()
+                    result
+                        .maybe_concrete_test_to_print
+                        .as_ref()
                         .map(|message| format!("\n\n{}", message))
                         .unwrap_or("".to_string())
                 );

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -95,13 +95,8 @@ impl KaniSession {
             // When output is old, we also don't have real results to print.
             if !self.args.common_args.quiet && self.args.output_format != OutputFormat::Old {
                 println!(
-                    "{}{}",
-                    result.render(&self.args.output_format, harness.attributes.should_panic),
-                    result
-                        .maybe_concrete_test_to_print
-                        .as_ref()
-                        .map(|message| format!("\n\n{}", message))
-                        .unwrap_or("".to_string())
+                    "{}",
+                    result.render(&self.args.output_format, harness.attributes.should_panic)
                 );
             }
 

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -89,7 +89,7 @@ impl KaniSession {
             // Strictly speaking, we're faking success here. This is more "no error"
             Ok(VerificationResult::mock_success())
         } else {
-            let result = self.with_timer(|| self.run_cbmc(binary, harness), "run_cbmc")?;
+            let mut result = self.with_timer(|| self.run_cbmc(binary, harness), "run_cbmc")?;
 
             // When quiet, we don't want to print anything at all.
             // When output is old, we also don't have real results to print.
@@ -99,7 +99,7 @@ impl KaniSession {
                     result.render(&self.args.output_format, harness.attributes.should_panic)
                 );
             }
-
+            self.gen_and_add_concrete_playback(harness, &mut result)?;
             Ok(result)
         }
     }

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -95,8 +95,11 @@ impl KaniSession {
             // When output is old, we also don't have real results to print.
             if !self.args.common_args.quiet && self.args.output_format != OutputFormat::Old {
                 println!(
-                    "{}",
-                    result.render(&self.args.output_format, harness.attributes.should_panic)
+                    "{}{}",
+                    result.render(&self.args.output_format, harness.attributes.should_panic),
+                    result.maybe_concrete_test_to_print.as_ref()
+                        .map(|message| format!("\n\n{}", message))
+                        .unwrap_or("".to_string())
                 );
             }
 

--- a/tests/ui/concrete-playback/message-order/expected
+++ b/tests/ui/concrete-playback/message-order/expected
@@ -2,7 +2,7 @@ VERIFICATION:- SUCCESSFUL
 
 
 Concrete playback unit test for `dummy`:
-```rust
+```
 #[test]
 fn kani_concrete_playback_dummy
     let concrete_vals: Vec<Vec<u8>> = vec![

--- a/tests/ui/concrete-playback/message-order/expected
+++ b/tests/ui/concrete-playback/message-order/expected
@@ -1,0 +1,14 @@
+VERIFICATION:- SUCCESSFUL
+
+
+Concrete playback unit test for `dummy`:
+```rust
+#[test]
+fn kani_concrete_playback_dummy
+    let concrete_vals: Vec<Vec<u8>> = vec![
+        // 32778
+        vec![10, 128, 0, 0],
+    ];
+    kani::concrete_playback_run(concrete_vals, dummy);
+}
+```

--- a/tests/ui/concrete-playback/message-order/main.rs
+++ b/tests/ui/concrete-playback/message-order/main.rs
@@ -1,0 +1,9 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags: --concrete-playback=print --harness dummy -Z concrete-playback
+
+#[kani::proof]
+fn dummy() {
+    kani::cover!(kani::any::<u32>() != 10);
+}


### PR DESCRIPTION
### Description of changes: 

Delay printing of harness until the verification status message is printed.

### Resolved issues:

Resolves #2462

### Call-outs:

Again, not familiar with testing this feature, so feel free to suggest any improvements on that front.

### Testing:

* How is this change tested? `tests/ui/concrete-playback/message-order`

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
