### PR TITLE
Bump Kani version to 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.29.0]
+
+### What's Changed
+* Fix symtab json file removal and reduce regression scope ([pull request](https://github.com/model-checking/kani/pull/2447) by @celinval)
+* Fix regression on concrete playback inplace ([pull request](https://github.com/model-checking/kani/pull/2454) by @celinval)
+* Update rust toolchain to 2023-04-29 ([pull request](https://github.com/model-checking/kani/pull/2452) by @zhassan-aws)
+* Update stubbing.md with the right command ([pull request](https://github.com/model-checking/kani/pull/2460) by @jaisnan)
+* Create a playback command to make it easier to run Kani generated tests ([pull request](https://github.com/model-checking/kani/pull/2464) by @celinval)
+* Fix static variable initialization when they have the same value ([pull request](https://github.com/model-checking/kani/pull/2469) by @celinval)
+* Add jq to deps ([pull request](https://github.com/model-checking/kani/pull/2471) by @zhassan-aws)
+* Update concrete playback documentation ([pull request](https://github.com/model-checking/kani/pull/2465) by @celinval)
+* Improve assess and regression time ([pull request](https://github.com/model-checking/kani/pull/2478) by @celinval)
+* Fix playback with build scripts ([pull request](https://github.com/model-checking/kani/pull/2477) by @celinval)
+* Delay printing playback harness until after verification status ([pull request](https://github.com/model-checking/kani/pull/2480) by @YoshikiTakashima)
+* Bump CBMC version to 5.84.0 ([pull request](https://github.com/model-checking/kani/pull/2483) by @tautschn)
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.28.0...kani-0.29.0
+
 ## [0.28.0]
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,17 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## [0.29.0]
 
-### What's Changed
+### Major Changes
+* Create a playback command to make it easier to run Kani generated tests ([pull request](https://github.com/model-checking/kani/pull/2464) by @celinval)
+
+### What Else has Changed
 * Fix symtab json file removal and reduce regression scope ([pull request](https://github.com/model-checking/kani/pull/2447) by @celinval)
 * Fix regression on concrete playback inplace ([pull request](https://github.com/model-checking/kani/pull/2454) by @celinval)
-* Update rust toolchain to 2023-04-29 ([pull request](https://github.com/model-checking/kani/pull/2452) by @zhassan-aws)
-* Update stubbing.md with the right command ([pull request](https://github.com/model-checking/kani/pull/2460) by @jaisnan)
-* Create a playback command to make it easier to run Kani generated tests ([pull request](https://github.com/model-checking/kani/pull/2464) by @celinval)
 * Fix static variable initialization when they have the same value ([pull request](https://github.com/model-checking/kani/pull/2469) by @celinval)
-* Add jq to deps ([pull request](https://github.com/model-checking/kani/pull/2471) by @zhassan-aws)
-* Update concrete playback documentation ([pull request](https://github.com/model-checking/kani/pull/2465) by @celinval)
 * Improve assess and regression time ([pull request](https://github.com/model-checking/kani/pull/2478) by @celinval)
 * Fix playback with build scripts ([pull request](https://github.com/model-checking/kani/pull/2477) by @celinval)
 * Delay printing playback harness until after verification status ([pull request](https://github.com/model-checking/kani/pull/2480) by @YoshikiTakashima)
+* Update rust toolchain to 2023-04-29 ([pull request](https://github.com/model-checking/kani/pull/2452) by @zhassan-aws)
 * Bump CBMC version to 5.84.0 ([pull request](https://github.com/model-checking/kani/pull/2483) by @tautschn)
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.28.0...kani-0.29.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -514,14 +514,14 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "kani"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "atty",
  "clap",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "home",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "cprover_bindings",
  "serde",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "kani_queries"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "strum",
  "strum_macros",
@@ -1182,7 +1182,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "std"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/kani_queries/Cargo.toml
+++ b/kani-compiler/kani_queries/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_queries"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Description of changes: 

Mark current revision as release 0.29.0.

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? CI

* Is this a refactor change? no

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
