### PR TITLE
Do not use panic abort strategy for playback

### DIFF
--- a/kani-driver/src/session.rs
+++ b/kani-driver/src/session.rs
@@ -280,7 +280,7 @@ pub fn lib_folder() -> Result<PathBuf> {
 
 /// Return the path for the folder where the pre-compiled rust libraries are located.
 pub fn lib_playback_folder() -> Result<PathBuf> {
-    Ok(base_folder()?.join("lib-playback"))
+    Ok(base_folder()?.join("playback/lib"))
 }
 
 /// Return the base folder for the entire kani installation.


### PR DESCRIPTION
### Description of changes: 

The VSCode debugger isn't working when we build the std library without unwind support. Build with unwind instead.

### Resolved issues:

#2488 

### Related RFC:


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
