### PR TITLE
Do not crash when `rustfmt` fails.

### DIFF
--- a/kani-driver/src/concrete_playback/test_generator.rs
+++ b/kani-driver/src/concrete_playback/test_generator.rs
@@ -119,7 +119,8 @@ impl KaniSession {
                 file: file_name,
                 line_range: Some((unit_test_start_line, unit_test_end_line)),
             }];
-            self.run_rustfmt(&file_line_ranges, Some(&path))?;
+            self.run_rustfmt(&file_line_ranges, Some(&path))
+                .unwrap_or_else(|err| println!("WARNING: {}", err));
         }
 
         Ok(())

--- a/tests/script-based-pre/playback_no_rustfmt/bin/rustfmt
+++ b/tests/script-based-pre/playback_no_rustfmt/bin/rustfmt
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# This is a fake `rustfmt` for testing what happens when rustfmt is not found
+# or overridden.
+
+exit 1

--- a/tests/script-based-pre/playback_no_rustfmt/config.yml
+++ b/tests/script-based-pre/playback_no_rustfmt/config.yml
@@ -1,0 +1,4 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: playback_no_rustfmt.sh
+expected: playback_no_rustfmt.expected

--- a/tests/script-based-pre/playback_no_rustfmt/original.rs
+++ b/tests/script-based-pre/playback_no_rustfmt/original.rs
@@ -1,0 +1,27 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Check that Kani correctly adds tests to the cover checks reachable in a harness.
+extern crate kani;
+
+#[cfg(kani)]
+mod verify {
+    use kani::cover;
+    use std::convert::TryFrom;
+    use std::num::NonZeroU8;
+
+    #[kani::proof]
+    fn try_nz_u8() {
+        let val: u8 = kani::any();
+        let result = NonZeroU8::try_from(val);
+        match result {
+            Ok(nz_val) => {
+                cover!(true, "Ok");
+                assert_eq!(nz_val.get(), val);
+            }
+            Err(_) => {
+                cover!(true, "Not ok");
+                assert_eq!(val, 0);
+            }
+        }
+    }
+}

--- a/tests/script-based-pre/playback_no_rustfmt/playback_no_rustfmt.expected
+++ b/tests/script-based-pre/playback_no_rustfmt/playback_no_rustfmt.expected
@@ -1,0 +1,8 @@
+[TEST] Generate test...
+Checking harness verify::try_nz_u8
+
+WARNING: Failed to rustfmt modified source code
+
+[TEST] Run test...
+test result: ok. 2 passed; 0 failed;
+

--- a/tests/script-based-pre/playback_no_rustfmt/playback_no_rustfmt.sh
+++ b/tests/script-based-pre/playback_no_rustfmt/playback_no_rustfmt.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Test that concrete playback -Z concrete-playback executes as expected
+set -o pipefail
+set -o nounset
+
+RS_FILE="modified.rs"
+cp original.rs ${RS_FILE}
+
+# override rustfmt binary to make it crash.
+export PATH=$(pwd)/bin:$PATH
+
+echo "[TEST] Generate test..."
+kani ${RS_FILE} -Z concrete-playback --concrete-playback=inplace
+
+echo "[TEST] Run test..."
+kani playback -Z concrete-playback ${RS_FILE} -- kani_concrete_playback
+
+# Cleanup
+rm ${RS_FILE}


### PR DESCRIPTION
### Description of changes: 

Print warning instead of crashing when `rustfmt` crashes or is missing.

### Resolved issues:

Resolves #1680

### Call-outs:


### Testing:

* How is this change tested? `tests/script-based-pre/playback_no_rustfmt`.

* Is this a refactor change? Nop

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.