### PR TITLE
De-duplicate same input injections for the same harness.

### DIFF
--- a/kani-driver/src/concrete_playback/test_generator.rs
+++ b/kani-driver/src/concrete_playback/test_generator.rs
@@ -41,13 +41,14 @@ impl KaniSession {
                     harness.pretty_name
                 )
             } else {
-                let unit_tests: Vec<UnitTest> = harness_values
+                let mut unit_tests: Vec<UnitTest> = harness_values
                     .iter()
                     .map(|concrete_vals| {
                         let pretty_name = harness.get_harness_name_unqualified();
                         format_unit_test(&pretty_name, &concrete_vals)
                     })
                     .collect();
+                unit_tests.dedup_by(|a, b| a.name == b.name);
                 match playback_mode {
                     ConcretePlaybackMode::Print => {
                         for generated_unit_test in unit_tests.iter() {

--- a/tests/script-based-pre/playback_zero_size/original.rs
+++ b/tests/script-based-pre/playback_zero_size/original.rs
@@ -5,5 +5,7 @@
 #[kani::proof]
 fn any_is_ok() {
     let unit: () = kani::any();
+    let unit2: () = kani::any();
     kani::cover!(unit == ());
+    kani::cover!(unit2 == ());
 }

--- a/tests/script-based-pre/playback_zero_size/playback_zst.expected
+++ b/tests/script-based-pre/playback_zero_size/playback_zst.expected
@@ -2,4 +2,4 @@
 Checking harness any_is_ok
 
 [TEST] Run test...
-test result: ok. 1 passed; 0 failed;
+test result: ok. 2 passed; 0 failed;

--- a/tests/script-based-pre/playback_zero_size/playback_zst.expected
+++ b/tests/script-based-pre/playback_zero_size/playback_zst.expected
@@ -2,4 +2,4 @@
 Checking harness any_is_ok
 
 [TEST] Run test...
-test result: ok. 2 passed; 0 failed;
+test result: ok. 1 passed; 0 failed;


### PR DESCRIPTION
### Description of changes:

Deduplicate playback harnesses for the same Kani harness when the
inputs are the same.

### Resolved issues:

Resolves #2509

### Call-outs:

- Feel free to request a separate test case. I was originally planning
  to use this test case in #2496, but hit this bug. So the same test
  case is upgraded with 2 ZSTs.

### Testing:

* How is this change tested? `tests/script-based-pre/playback_zero_size/`

* Is this a refactor change? Yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.