### PR TITLE
[minor] Fix number_program_steps benchcomp metric

### DIFF
--- a/tools/benchcomp/benchcomp/parsers/kani_perf.py
+++ b/tools/benchcomp/benchcomp/parsers/kani_perf.py
@@ -95,10 +95,13 @@ def main(root_dir):
                     break
 
     for bench_name, bench_info in benchmarks.items():
-        n_steps = bench_info["metrics"]["number_program_steps"]
-        rm_steps = bench_info["metrics"]["removed_program_steps"]
-        bench_info["metrics"]["number_program_steps"] = n_steps - rm_steps
-        bench_info["metrics"].pop("removed_program_steps", None)
+        try:
+            n_steps = bench_info["metrics"]["number_program_steps"]
+            rm_steps = bench_info["metrics"]["removed_program_steps"]
+            bench_info["metrics"]["number_program_steps"] = n_steps - rm_steps
+            bench_info["metrics"].pop("removed_program_steps", None)
+        except KeyError:
+            pass
 
     return {
         "metrics": get_metrics(),


### PR DESCRIPTION
This ensures that benchcomp does not crash even if no number_program_steps metric was recorded for a kani perf benchmark, perhaps because Kani crashed or timed out.

### Testing:

* How is this change tested?

Ran it locally

* Is this a refactor change?

no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
