### PR TITLE
Update expected file for unstable attr test

### DIFF
--- a/tests/cargo-ui/unstable-attr/invalid/expected
+++ b/tests/cargo-ui/unstable-attr/invalid/expected
@@ -1,4 +1,4 @@
-error: failed to parse `#[kani::unstable]`: missing `feature` field\
+error: failed to parse `#[kani::unstable]`:
 src/lib.rs\
 |\
 | #[kani::unstable(\


### PR DESCRIPTION
### Description of changes: 

Apparently, the error message that is emitted on M1 for this test is slightly different than on other platforms.

On M1:
```
error: failed to parse `#[kani::unstable]`: expected "key = value" pair, but found `feature`
```
On other platforms:
```
error: failed to parse `#[kani::unstable]`: missing `feature` field
```
To make the test work on both platforms, I'm updating the `expected` file to remove the suffix that is different.

This is a mitigation for the Kani 0.30.0 release till we figure out why the message is different.

### Resolved issues:

Mitigates #2530 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
