### PR TITLE
Update README.md - fix link locations for badge images in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](./kani-logo.png)
-![Kani regression](https://github.com/model-checking/kani/actions/workflows/kani.yml/badge.svg)
-![Nightly: CBMC Latest](https://github.com/model-checking/kani/actions/workflows/cbmc-latest.yml/badge.svg)
+[![Kani regression](https://github.com/model-checking/kani/actions/workflows/kani.yml/badge.svg)](https://github.com/model-checking/kani/actions/workflows/kani.yml)
+[![Nightly: CBMC Latest](https://github.com/model-checking/kani/actions/workflows/cbmc-latest.yml/badge.svg)](https://github.com/model-checking/kani/actions/workflows/cbmc-latest.yml)
 
 The Kani Rust Verifier is a bit-precise model checker for Rust.
 


### PR DESCRIPTION
### Description of changes: 

Fixing badge links in README so that the links go to the CI-results instead of the badge image.

Previously the badges just linked to images of themselves. Now they go somewhere useful. 

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented - **Not Applicable**
- [ ] Regression or unit tests are included, or existing tests cover the modified code - **Not Applicable**
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
