### PR TITLE
Add run_command benchcomp visualization

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -35,7 +35,6 @@
   - [Performance comparisons](./performance-comparisons.md)
     - [`benchcomp` command line](./benchcomp-cli.md)
     - [`benchcomp` configuration file](./benchcomp-conf.md)
-    - [Custom visualizations](./benchcomp-viz.md)
     - [Custom parsers](./benchcomp-parse.md)
 
 - [Limitations](./limitations.md)

--- a/docs/src/benchcomp-conf.md
+++ b/docs/src/benchcomp-conf.md
@@ -1,7 +1,7 @@
 # `benchcomp` configuration file
 
 `benchcomp`'s operation is controlled through a YAML file---`benchcomp.yaml` by default or a file passed to the `-c/--config` option.
-This page describes the file's schema and lists the different parsers and visualizations that are available.
+This page lists the different visualizations that are available.
 
 
 ## Built-in visualizations

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -41,13 +41,15 @@ class run_command:
             proc = subprocess.Popen(
                 self.command, shell=True, text=True, stdin=subprocess.PIPE)
             _, _ = proc.communicate(input=results)
-        except subprocess.CalledProcessError as exc:
-            logging.warning(
-                "visualization command '%s' exited with code %d",
-                self.command, exc.returncode)
         except (OSError, subprocess.SubprocessError) as exe:
             logging.error(
                 "visualization command '%s' failed: %s", self.command, str(exe))
+            viz_utils.EXIT_CODE = 1
+        if proc.returncode:
+            logging.error(
+                "visualization command '%s' exited with code %d",
+                self.command, proc.returncode)
+            viz_utils.EXIT_CODE = 1
 
 
 

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -17,7 +17,7 @@ import benchcomp.visualizers.utils as viz_utils
 
 @dataclasses.dataclass
 class run_command:
-    """Run an executable command, passing the result as a JSON file on stdin.
+    """Run an executable command, passing the performance metrics as JSON on stdin.
 
     This allows you to write your own visualization, which reads a result file
     on stdin and does something with it, e.g. writing out a graph or other

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -10,6 +10,7 @@ import subprocess
 import tempfile
 import textwrap
 import unittest
+import uuid
 
 import yaml
 
@@ -733,6 +734,108 @@ class RegressionTests(unittest.TestCase):
                 run_bc.proc.returncode, 0, msg=run_bc.stderr)
 
             with open(run_bc.working_directory / "result.yaml") as handle:
+                result = yaml.safe_load(handle)
+
+            for item in ["benchmarks", "metrics"]:
+                self.assertIn(item, result)
+
+
+    def test_run_command_visualization(self):
+        """Ensure that the run_command visualization can execute a command"""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_file = pathlib.Path(tmp) / str(uuid.uuid4())
+            run_bc = Benchcomp({
+                "variants": {
+                    "v1": {
+                        "config": {
+                            "command_line": "true",
+                            "directory": tmp,
+                        }
+                    },
+                    "v2": {
+                        "config": {
+                            "command_line": "true",
+                            "directory": tmp,
+                        }
+                    }
+                },
+                "run": {
+                    "suites": {
+                        "suite_1": {
+                            "parser": {
+                                "command": """
+                                    echo '{
+                                        "benchmarks": {},
+                                        "metrics": {}
+                                    }'
+                                """
+                            },
+                            "variants": ["v2", "v1"]
+                        }
+                    }
+                },
+                "visualize": [{
+                    "type": "run_command",
+                    "command": f"cat - > {out_file}"
+                }],
+            })
+            run_bc()
+            self.assertEqual(
+                run_bc.proc.returncode, 0, msg=run_bc.stderr)
+
+            with open(out_file) as handle:
+                result = yaml.safe_load(handle)
+
+            for item in ["benchmarks", "metrics"]:
+                self.assertIn(item, result)
+
+
+    def test_run_failing_command_visualization(self):
+        """Ensure that benchcomp terminates normally even when run_command visualization doesn't"""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_file = pathlib.Path(tmp) / str(uuid.uuid4())
+            run_bc = Benchcomp({
+                "variants": {
+                    "v1": {
+                        "config": {
+                            "command_line": "true",
+                            "directory": tmp,
+                        }
+                    },
+                    "v2": {
+                        "config": {
+                            "command_line": "true",
+                            "directory": tmp,
+                        }
+                    }
+                },
+                "run": {
+                    "suites": {
+                        "suite_1": {
+                            "parser": {
+                                "command": """
+                                    echo '{
+                                        "benchmarks": {},
+                                        "metrics": {}
+                                    }'
+                                """
+                            },
+                            "variants": ["v2", "v1"]
+                        }
+                    }
+                },
+                "visualize": [{
+                    "type": "run_command",
+                    "command": f"cat - > {out_file}; false"
+                }],
+            })
+            run_bc()
+            self.assertEqual(
+                run_bc.proc.returncode, 0, msg=run_bc.stderr)
+
+            with open(out_file) as handle:
                 result = yaml.safe_load(handle)
 
             for item in ["benchmarks", "metrics"]:

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -792,7 +792,7 @@ class RegressionTests(unittest.TestCase):
 
 
     def test_run_failing_command_visualization(self):
-        """Ensure that benchcomp terminates normally even when run_command visualization doesn't"""
+        """Ensure that benchcomp terminates with a non-zero return code when run_command visualization fails"""
 
         with tempfile.TemporaryDirectory() as tmp:
             out_file = pathlib.Path(tmp) / str(uuid.uuid4())
@@ -832,11 +832,5 @@ class RegressionTests(unittest.TestCase):
                 }],
             })
             run_bc()
-            self.assertEqual(
+            self.assertNotEqual(
                 run_bc.proc.returncode, 0, msg=run_bc.stderr)
-
-            with open(out_file) as handle:
-                result = yaml.safe_load(handle)
-
-            for item in ["benchmarks", "metrics"]:
-                self.assertIn(item, result)


### PR DESCRIPTION
This allows users to write their own custom visualization script to run after running the benchmarks. Prior to this commit, visualizations had to be checked into the Kani repository.

When `run_command` is specified as a visualization, benchcomp runs the specified command and passes the result of the run as a JSON file on stdin. The command can then process the result however it likes.

This resolves #2518.

### Testing:

* How is this change tested?

2 new regression tests

* Is this a refactor change?

no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
