### PR TITLE
Change intrinsics tests to ensure the call is not removed by the compiler

### DIFF
--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/add_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/add_fail.rs
@@ -9,5 +9,6 @@
 fn main() {
     let a: i32 = kani::any();
     let b: i32 = kani::any();
-    unsafe { std::intrinsics::unchecked_add(a, b) };
+    // Black box this so it doesn't get pruned by the compiler.
+    std::hint::black_box(unsafe { std::intrinsics::unchecked_add(a, b) });
 }

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/div_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/div_fail.rs
@@ -10,5 +10,6 @@
 fn main() {
     let a: i32 = i32::MIN;
     let b: i32 = -1;
-    unsafe { std::intrinsics::unchecked_div(a, b) };
+    // Black box this so it doesn't get pruned by the compiler.
+    std::hint::black_box(unsafe { std::intrinsics::unchecked_div(a, b) });
 }

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/div_zero_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/div_zero_fail.rs
@@ -10,5 +10,6 @@
 fn main() {
     let a: i32 = kani::any();
     let b: i32 = 0;
-    unsafe { std::intrinsics::unchecked_div(a, b) };
+    // Black box this so it doesn't get pruned by the compiler.
+    std::hint::black_box(unsafe { std::intrinsics::unchecked_div(a, b) });
 }

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/mul_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/mul_fail.rs
@@ -9,5 +9,6 @@
 fn main() {
     let a: i32 = kani::any();
     let b: i32 = kani::any();
-    unsafe { std::intrinsics::unchecked_mul(a, b) };
+    // Black box this so it doesn't get pruned by the compiler.
+    std::hint::black_box(unsafe { std::intrinsics::unchecked_mul(a, b) });
 }

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/rem_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/rem_fail.rs
@@ -10,5 +10,6 @@
 fn main() {
     let a: i32 = i32::MIN;
     let b: i32 = -1;
-    unsafe { std::intrinsics::unchecked_rem(a, b) };
+    // Black box this so it doesn't get pruned by the compiler.
+    std::hint::black_box(unsafe { std::intrinsics::unchecked_rem(a, b) });
 }

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/rem_zero_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/rem_zero_fail.rs
@@ -10,5 +10,6 @@
 fn main() {
     let a: i32 = kani::any();
     let b: i32 = 0;
-    unsafe { std::intrinsics::unchecked_rem(a, b) };
+    // Black box this so it doesn't get pruned by the compiler.
+    std::hint::black_box(unsafe { std::intrinsics::unchecked_rem(a, b) });
 }

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/shl_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/shl_fail.rs
@@ -9,5 +9,6 @@
 fn main() {
     let a: u32 = kani::any();
     let b: u32 = kani::any();
-    unsafe { std::intrinsics::unchecked_shl(a, b) };
+    // Black box this so it doesn't get pruned by the compiler.
+    std::hint::black_box(unsafe { std::intrinsics::unchecked_shl(a, b) });
 }

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/shr_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/shr_fail.rs
@@ -9,5 +9,6 @@
 fn main() {
     let a: u32 = kani::any();
     let b: u32 = kani::any();
-    unsafe { std::intrinsics::unchecked_shr(a, b) };
+    // Black box this so it doesn't get pruned by the compiler.
+    std::hint::black_box(unsafe { std::intrinsics::unchecked_shr(a, b) });
 }

--- a/tests/kani/Intrinsics/Math/Arith/Unchecked/sub_fail.rs
+++ b/tests/kani/Intrinsics/Math/Arith/Unchecked/sub_fail.rs
@@ -9,5 +9,6 @@
 fn main() {
     let a: i32 = kani::any();
     let b: i32 = kani::any();
-    unsafe { std::intrinsics::unchecked_sub(a, b) };
+    // Black box this so it doesn't get pruned by the compiler.
+    std::hint::black_box(unsafe { std::intrinsics::unchecked_sub(a, b) });
 }


### PR DESCRIPTION
### Description of changes: 

The tests below started failing as part of the latest toolchain update because the value produced by intrinsics is not used, and the compiler just removes them.

To avoid that to happen, we now wrap those calls with the `black_box` std function to avoid compiler optimizations.

### Resolved issues:

N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Only test changes

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
