### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/cargo-kani/vecdeque-cve/reserve_available_capacity_is_no_op.expected
+++ b/tests/cargo-kani/vecdeque-cve/reserve_available_capacity_is_no_op.expected
@@ -1,16 +1,16 @@
-fixed::VecDeque::<u8>::handle_capacity_increase.assertion.7\
+fixed::VecDeque::<u8>::handle_capacity_increase.assertion\
 Status: UNREACHABLE\
 Description: "assertion failed: self.head < self.tail"
 
-fixed::VecDeque::<u8>::handle_capacity_increase.assertion.8\
+fixed::VecDeque::<u8>::handle_capacity_increase.assertion\
 Status: UNREACHABLE\
 Description: "assertion failed: self.head < self.cap()"
 
-fixed::VecDeque::<u8>::handle_capacity_increase.assertion.9\
+fixed::VecDeque::<u8>::handle_capacity_increase.assertion\
 Status: UNREACHABLE\
 Description: "assertion failed: self.tail < self.cap()"
 
-fixed::VecDeque::<u8>::handle_capacity_increase.assertion.10\
+fixed::VecDeque::<u8>::handle_capacity_increase.assertion\
 Status: UNREACHABLE\
 Description: "assertion failed: self.cap().count_ones() == 1"
 

--- a/tests/expected/object-bits/insufficient/main.rs
+++ b/tests/expected/object-bits/insufficient/main.rs
@@ -1,15 +1,11 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-
-// Checks for error message with an --object-bits value that is too small
-
 // kani-flags: --default-unwind 30 --enable-unstable --cbmc-args --object-bits 5
+//! Checks for error message with an --object-bits value that is too small
+//! Use linked list to ensure that each member represents a new object.
 
 #[kani::proof]
 fn main() {
-    let mut arr: [i32; 100] = kani::Arbitrary::any_array();
-    for i in 0..30 {
-        arr[i] = kani::any();
-    }
-    assert!(arr[0] > arr[0] - arr[99]);
+    let arr: [i32; 18] = kani::Arbitrary::any_array();
+    std::hint::black_box(std::collections::LinkedList::from(arr));
 }

--- a/tests/ui/should-panic-attribute/expected-panics/expected
+++ b/tests/ui/should-panic-attribute/expected-panics/expected
@@ -1,4 +1,4 @@
- ** 2 of 2 failed\
+ ** 2 of 2 failed
 Failed Checks: panicked on the `if` branch!
 Failed Checks: panicked on the `else` branch!
 VERIFICATION:- SUCCESSFUL (encountered one or more panics as expected)


### PR DESCRIPTION
### Description of changes: 

This PR fixes a few flaky tests that started to fail in the ongoing toolchain update (#2551)
 - The object bits test itself doesn't create that many objects since an array is represented as the same allocated object. Use LinkedList instead.
 - Do not rely on property number.
 - Do not rely on the order that failed checks is printed.

### Resolved issues:

N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? N/A

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
