### PR TITLE
Allow verification for "input rejected" case

### DIFF
--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -297,6 +297,13 @@ mod test {
                 "Default .cases should be 256. Check: src/test_runner/config.rs"
             );
         }
+
+        #[test]
+        fn reject_input(nil in &Just(()) ) {
+            if nil == () {
+                return Err(TestCaseError::reject("input rejected."))
+            }
+        }
     }
 
     proptest! {

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -231,6 +231,9 @@ impl TestRunner {
         test: impl Fn(S::Value) -> TestCaseResult,
     ) -> TestRunResult<S> {
         let tree = strategy.new_tree(self).unwrap();
+
+        // run harness and assert that (1) it succeeds or (2) the
+        // input was invalid.
         assert!(matches!(
             test(tree.current()),
             Ok(_) | Err(TestCaseError::Reject(_))

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -231,7 +231,7 @@ impl TestRunner {
         test: impl Fn(S::Value) -> TestCaseResult,
     ) -> TestRunResult<S> {
         let tree = strategy.new_tree(self).unwrap();
-        test(tree.current()).unwrap();
+        assert!(matches!(test(tree.current()), Ok(_) | Err(TestCaseError::Reject(_))));
         Ok(())
     }
 

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -231,7 +231,10 @@ impl TestRunner {
         test: impl Fn(S::Value) -> TestCaseResult,
     ) -> TestRunResult<S> {
         let tree = strategy.new_tree(self).unwrap();
-        assert!(matches!(test(tree.current()), Ok(_) | Err(TestCaseError::Reject(_))));
+        assert!(matches!(
+            test(tree.current()),
+            Ok(_) | Err(TestCaseError::Reject(_))
+        ));
         Ok(())
     }
 


### PR DESCRIPTION
### Description of changes: 

This change fixes a bug in propproof where it would count "input rejected" as a verification fail. This should not be a verification failure because "input rejected" is a early quit.

### Resolved issues:

Resolves #2550 

### Call-outs:
- draft, need to rebase

### Testing:

* How is this change tested? `test_runner::runner::test::reject_input`

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
