### PR TITLE
Minor edits for all RFCs

### DIFF
--- a/rfc/src/rfcs/0001-mir-linker.md
+++ b/rfc/src/rfcs/0001-mir-linker.md
@@ -1,4 +1,4 @@
-- **Feature Name:** MIR Linker (mir_linker)
+- **Feature Name:** MIR Linker (`mir_linker`)
 - **RFC Tracking Issue**: <https://github.com/model-checking/kani/issues/1588>
 - **RFC PR:** <https://github.com/model-checking/kani/pull/1600>
 - **Status:** Stable

--- a/rfc/src/rfcs/0002-function-stubbing.md
+++ b/rfc/src/rfcs/0002-function-stubbing.md
@@ -1,9 +1,11 @@
-- **Feature Name:** Function and method stubbing (`function_stubbing`)
+- **Feature Name:** Function and method stubbing (`function-stubbing`)
 - **Feature Request Issue:** <https://github.com/model-checking/kani/issues/1695>
 - **RFC PR:** <https://github.com/model-checking/kani/pull/1723> 
-- **Status:** Under Review
+- **Status:** Unstable
 - **Version:** 1
 - **Proof-of-concept:** <https://github.com/aaronbembenek-aws/kani/tree/mir_transform>
+
+-------------------
 
 ## Summary
 

--- a/rfc/src/rfcs/0003-cover-statement.md
+++ b/rfc/src/rfcs/0003-cover-statement.md
@@ -1,9 +1,10 @@
-- **Feature Name:** Cover statement `cover_statement`
+- **Feature Name:** Cover statement (`cover-statement`)
 - **Feature Request Issue:** <https://github.com/model-checking/kani/issues/696>
 - **RFC PR:** <https://github.com/model-checking/kani/pull/1906>
-- **Status:** Under Review
+- **Status:** Unstable
 - **Version:** 0
-- **Proof-of-concept:** *Optional field. If you have implemented a proof of concept, add a link here*
+
+-------------------
 
 ## Summary
 

--- a/rfc/src/rfcs/0004-loop-contract-synthesis.md
+++ b/rfc/src/rfcs/0004-loop-contract-synthesis.md
@@ -1,9 +1,11 @@
-- **Feature Name:** Loop-contract synthesis
+- **Feature Name:** Loop-contract synthesis (`loop-contract-synthesis`)
 - **Feature Request Issue:** <https://github.com/model-checking/kani/issues/2214>
 - **RFC PR:** <https://github.com/model-checking/kani/pull/2215>
 - **Status:** Under Review
 - **Version:** 0
 - **Proof-of-concept:** <https://github.com/qinheping/kani/tree/kani-synthesizer>
+
+-------------------
 
 ## Summary
 

--- a/rfc/src/rfcs/0005-should-panic-attr.md
+++ b/rfc/src/rfcs/0005-should-panic-attr.md
@@ -1,9 +1,11 @@
-- **Feature Name:** The `kani::should_panic` attribute (`should-panic-attr`)*
+- **Feature Name:** The `kani::should_panic` attribute (`should-panic-attr`)
 - **Feature Request Issue:** <https://github.com/model-checking/kani/issues/600>
 - **RFC PR:** <https://github.com/model-checking/kani/pull/2272>
-- **Status:** Under Review
+- **Status:** Unstable
 - **Version:** 0
 - **Proof-of-concept:** <https://github.com/model-checking/kani/pull/2315>
+
+-------------------
 
 ## Summary
 

--- a/rfc/src/rfcs/0006-unstable-api.md
+++ b/rfc/src/rfcs/0006-unstable-api.md
@@ -1,7 +1,7 @@
 - **Feature Name:** Unstable APIs (`unstable-api`)
 - **RFC Tracking Issue**: <https://github.com/model-checking/kani/issues/2279>
 - **RFC PR:** <https://github.com/model-checking/kani/pull/2281>
-- **Status:** Under Review
+- **Status:** Unstable
 - **Version:** 0
 
 -------------------

--- a/rfc/src/template.md
+++ b/rfc/src/template.md
@@ -6,6 +6,8 @@
   Start with 0.*
 - **Proof-of-concept:** *Optional field. If you have implemented a proof of concept, add a link here*
 
+-------------------
+
 ## Summary
 
 Short description of the feature, i.e.: the elevator pitch. What is this feature about?


### PR DESCRIPTION
### Description of changes: 

I noticed that @celinval 's RFCs contain an horizontal separator (e.g., [this one](https://model-checking.github.io/kani/rfc/rfcs/0001-mir-linker.html)) and I liked how it looks. So I'm proposing we add it to our template and already-merged RFCs.

In addition, this PR includes other minor fixes (missing RFC identifiers, status, etc.). 

### Call-outs:

When talking about the status, I'm not sure if `cover-statement` and `should-panic-attr` should be marked as "Stable", since they currently don't require any unstable-related option to enable them, but are relatively new to Kani (that's why I marked them as "Unstable").

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? N/A

* Is this a refactor change? N/A

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
