### PR TITLE
Fix dev-documentation broken link

### DIFF
--- a/docs/src/dev-documentation.md
+++ b/docs/src/dev-documentation.md
@@ -9,10 +9,11 @@ we recommend looking into [these issues](https://github.com/model-checking/kani/
 
 In this chapter, we provide documentation that might be helpful for Kani
 developers (including external contributors):
- 1. [Suggested workarounds](./workarounds.md).
+ 1. [Coding conventions](./conventions.md).
  2. [Useful command-line instructions for Kani/CBMC/Git](./cheat-sheets.md).
- 3. [Development setup recommendations for working with `rustc`](./rustc-hacks.md).
- 4. [Guide for testing in Kani](./testing.md).
+ 3. [Development setup recommendations for working with `cbmc`](./cbmc-hacks.md).
+ 4. [Development setup recommendations for working with `rustc`](./rustc-hacks.md).
+ 5. [Guide for testing in Kani](./testing.md).
 
 > **NOTE**: The developer documentation is intended for Kani developers and not
 users. At present, the project is under heavy development and some items


### PR DESCRIPTION
### Description of changes: 

Fix broken link introduced by #1138 and add a link to Coding conventions.

### Resolved issues:

N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Manually checked the documentation in my local build

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
