### PR TITLE
Remove atty and tracing-tree, update hermit-abi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
 name = "bookrunner"
 version = "0.1.0"
 dependencies = [
@@ -185,7 +191,7 @@ checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "once_cell",
  "strsim",
@@ -321,7 +327,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -428,6 +434,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -457,7 +472,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -585,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -845,7 +860,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -917,7 +932,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,6 @@ dependencies = [
  "strum_macros",
  "tracing",
  "tracing-subscriber",
- "tracing-tree",
 ]
 
 [[package]]
@@ -560,7 +559,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "tracing-tree",
  "which",
 ]
 
@@ -1363,18 +1361,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "tracing-tree"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9742d8df709837409dbb22aa25dd7769c260406f20ff48a2320b80a4a6aed0"
-dependencies = [
- "nu-ansi-term",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,27 +428,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "home"
@@ -470,24 +452,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -997,13 +967,12 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,17 +88,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,7 +518,6 @@ dependencies = [
 name = "kani-compiler"
 version = "0.31.0"
 dependencies = [
- "atty",
  "clap",
  "cprover_bindings",
  "home",
@@ -553,7 +541,6 @@ name = "kani-driver"
 version = "0.31.0"
 dependencies = [
  "anyhow",
- "atty",
  "cargo_metadata",
  "clap",
  "comfy-table",
@@ -1384,7 +1371,6 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f9742d8df709837409dbb22aa25dd7769c260406f20ff48a2320b80a4a6aed0"
 dependencies = [
- "atty",
  "nu-ansi-term",
  "tracing-core",
  "tracing-log",

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-atty = "0.2.14"
 cbmc = { path = "../cprover_bindings", package = "cprover_bindings", optional = true }
 clap = { version = "4.1.3", features = ["cargo"] }
 home = "0.5"

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -24,7 +24,6 @@ strum_macros = "0.24.0"
 shell-words = "1.0.0"
 tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-subscriber = {version = "0.3.8", features = ["env-filter", "json", "fmt"]}
-tracing-tree = "0.2.2"
 
 # Future proofing: enable backend dependencies using feature.
 [features]

--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -14,7 +14,6 @@ use std::panic;
 use std::str::FromStr;
 use std::sync::LazyLock;
 use tracing_subscriber::{filter::Directive, layer::SubscriberExt, EnvFilter, Registry};
-use tracing_tree::HierarchicalLayer;
 
 /// Environment variable used to control this session log tracing.
 const LOG_ENV_VAR: &str = "KANI_LOG";
@@ -111,13 +110,10 @@ fn hier_logs(args: &ArgMatches, filter: EnvFilter) {
     let use_colors = std::io::stdout().is_terminal() || args.get_flag(parser::COLOR_OUTPUT);
     let subscriber = Registry::default().with(filter);
     let subscriber = subscriber.with(
-        HierarchicalLayer::default()
+        tracing_subscriber::fmt::layer()
             .with_writer(std::io::stderr)
-            .with_indent_lines(true)
             .with_ansi(use_colors)
-            .with_targets(true)
-            .with_verbose_exit(true)
-            .with_indent_amount(4),
+            .with_target(true),
     );
     tracing::subscriber::set_global_default(subscriber).unwrap();
 }

--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -9,6 +9,7 @@ use rustc_errors::{
     emitter::Emitter, emitter::HumanReadableErrorType, fallback_fluent_bundle, json::JsonEmitter,
     ColorConfig, Diagnostic, TerminalUrl,
 };
+use std::io::IsTerminal;
 use std::panic;
 use std::str::FromStr;
 use std::sync::LazyLock;
@@ -107,7 +108,7 @@ fn json_logs(filter: EnvFilter) {
 
 /// Configure global logger to use a hierarchical view.
 fn hier_logs(args: &ArgMatches, filter: EnvFilter) {
-    let use_colors = atty::is(atty::Stream::Stdout) || args.get_flag(parser::COLOR_OUTPUT);
+    let use_colors = std::io::stdout().is_terminal() || args.get_flag(parser::COLOR_OUTPUT);
     let subscriber = Registry::default().with(filter);
     let subscriber = subscriber.with(
         HierarchicalLayer::default()

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -31,7 +31,6 @@ strum = {version = "0.24.0"}
 strum_macros = {version = "0.24.0"}
 tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-subscriber = {version = "0.3.8", features = ["env-filter", "json", "fmt"]}
-tracing-tree = "0.2.2"
 rand = "0.8"
 which = "4.4.0"
 

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -15,7 +15,6 @@ publish = false
 kani_metadata = { path = "../kani_metadata" }
 cargo_metadata = "0.15.0"
 anyhow = "1"
-atty = "0.2.14"
 console = "0.15.1"
 once_cell = "1.13.0"
 serde = { version = "1", features = ["derive"] }

--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -1,14 +1,14 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use anyhow::{bail, Context, Result};
-use cargo_metadata::diagnostic::{Diagnostic, DiagnosticLevel};
-use cargo_metadata::{Message, Metadata, MetadataCommand, Package, Target};
 use crate::args::VerificationArgs;
 use crate::call_single_file::to_rustc_arg;
 use crate::project::Artifact;
 use crate::session::KaniSession;
 use crate::util;
+use anyhow::{bail, Context, Result};
+use cargo_metadata::diagnostic::{Diagnostic, DiagnosticLevel};
+use cargo_metadata::{Message, Metadata, MetadataCommand, Package, Target};
 use kani_metadata::{ArtifactType, CompilerArtifactStub};
 use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Display};

--- a/kani-driver/src/session.rs
+++ b/kani-driver/src/session.rs
@@ -14,7 +14,6 @@ use std::time::Instant;
 use strum_macros::Display;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
-use tracing_tree::HierarchicalLayer;
 
 /// Environment variable used to control this session log tracing.
 /// This is the same variable used to control `kani-compiler` logs. Note that you can still control
@@ -372,13 +371,10 @@ fn init_logger(args: &VerificationArgs) {
     let use_colors = std::io::stdout().is_terminal();
     let subscriber = Registry::default().with(filter);
     let subscriber = subscriber.with(
-        HierarchicalLayer::default()
+        tracing_subscriber::fmt::layer()
             .with_writer(std::io::stderr)
-            .with_indent_lines(true)
             .with_ansi(use_colors)
-            .with_targets(true)
-            .with_verbose_exit(true)
-            .with_indent_amount(4),
+            .with_target(true),
     );
     tracing::subscriber::set_global_default(subscriber).unwrap();
 }

--- a/kani-driver/src/session.rs
+++ b/kani-driver/src/session.rs
@@ -1,10 +1,11 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::args::common::Verbosity;
-use crate::args::VerificationArgs;
-use crate::util::render_command;
 use anyhow::{bail, Context, Result};
+use crate::args::VerificationArgs;
+use crate::args::common::Verbosity;
+use crate::util::render_command;
+use std::io::IsTerminal;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
@@ -368,7 +369,7 @@ fn init_logger(args: &VerificationArgs) {
     };
 
     // Use a hierarchical view for now.
-    let use_colors = atty::is(atty::Stream::Stdout);
+    let use_colors = std::io::stdout().is_terminal();
     let subscriber = Registry::default().with(filter);
     let subscriber = subscriber.with(
         HierarchicalLayer::default()

--- a/kani-driver/src/session.rs
+++ b/kani-driver/src/session.rs
@@ -1,10 +1,10 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use anyhow::{bail, Context, Result};
-use crate::args::VerificationArgs;
 use crate::args::common::Verbosity;
+use crate::args::VerificationArgs;
 use crate::util::render_command;
+use anyhow::{bail, Context, Result};
 use std::io::IsTerminal;
 use std::io::Write;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
### Description of changes: 

This removes dependency on `atty`, and `tracing-tree` (which depends on `atty`). This is in response to this security advisory:

https://rustsec.org/advisories/RUSTSEC-2021-0145

`atty` is removed by switching to `std::io::IsTerminal`. `tracing-tree` is removed by replacing `HierarchicalLayer` with a regular `tracing_subscriber::fmt::layer` that directs to stderr.

The PR also updates hermit-abi to 0.3.2 from 0.3.1, in response to 0.3.1 being yanked.

### Resolved issues:

Resolves #2580

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

The removal of `tracing-tree` is intended to be temporary, until they remove their dependency on `atty`.

### Testing:

* How is this change tested?

I built it...

* Is this a refactor change?

No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
