### PR TITLE
Upgrade Rust toolchain to nightly-2023-6-26

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-06-25"
+channel = "nightly-2023-06-26"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
### Description of changes: 

If any of the CI checks fail, manual intervention is required. In such a case, review the changes at https://github.com/rust-lang/rust from https://github.com/rust-lang/rust/commit/f7ca9df69549470541fbf542f87a03eb9ed024b6 up to https://github.com/rust-lang/rust/commit/8084f397c6710e4748994dd1488b1f399283d469. The log for this commit range is:
  https://github.com/rust-lang/rust/commit/8084f397c6 Auto merge of #113037 - TaKO8Ki:rollup-pqfbxwk, r=TaKO8Ki
  https://github.com/rust-lang/rust/commit/f948ce7362 Rollup merge of #113029 - Kobzol:ci-fork-update, r=Mark-Simulacrum
  https://github.com/rust-lang/rust/commit/019f43e6c2 Rollup merge of #113028 - fmease:rustdoc-x-crate-itiap-clean-term, r=notriddle
  https://github.com/rust-lang/rust/commit/96ab7e6ed7 Rollup merge of #112281 - jyn514:test-bootstrap-py, r=albertlarsan68
  https://github.com/rust-lang/rust/commit/1e7f03718b fix some bugs
  https://github.com/rust-lang/rust/commit/db3c3942ea Auto merge of #113027 - matthiaskrgr:rollup-mpes684, r=matthiaskrgr
  https://github.com/rust-lang/rust/commit/cb06c973c7 CI: do not run Bump dependencies workflow on forks
  https://github.com/rust-lang/rust/commit/247aa06f10 rustdoc: handle assoc const equalities in cross-crate impl-Trait-in-arg-pos
  https://github.com/rust-lang/rust/commit/d2f82a00d0 Rollup merge of #113023 - GuillaumeGomez:migrate-gui-test-color-17, r=notriddle
  https://github.com/rust-lang/rust/commit/75f6a7aa00 Rollup merge of #113007 - compiler-errors:dont-structural-resolve-byte-str-pat, r=oli-obk
  https://github.com/rust-lang/rust/commit/c51fbb3dd3 Auto merge of #113001 - ChrisDenton:win-arm32-shim, r=thomcc
  https://github.com/rust-lang/rust/commit/0d03812e24 Auto merge of #113022 - GuillaumeGomez:rollup-vkpzsuw, r=GuillaumeGomez
  https://github.com/rust-lang/rust/commit/0979bf7413 Migrate GUI colors test to original CSS color format
  https://github.com/rust-lang/rust/commit/a3c147b90b Rollup merge of #113018 - asquared31415:test_fix, r=TaKO8Ki
  https://github.com/rust-lang/rust/commit/758adf64e7 Rollup merge of #113011 - Nilstrieb:can_access_statics, r=oli-obk
  https://github.com/rust-lang/rust/commit/691580f566 Rollup merge of #112990 - JohnTitor:issue-96699, r=TaKO8Ki
  https://github.com/rust-lang/rust/commit/fb98925b8c Rollup merge of #112918 - zephaniahong:issue-107077-fix, r=Mark-Simulacrum
  https://github.com/rust-lang/rust/commit/3c5d71a99d Auto merge of #112476 - chenyukang:yukang-fix-109991, r=compiler-errors
  https://github.com/rust-lang/rust/commit/7b9b127700 Auto merge of #113014 - matthiaskrgr:rollup-dasfmfc, r=matthiaskrgr
  https://github.com/rust-lang/rust/commit/9dd655ff91 fix test
  https://github.com/rust-lang/rust/commit/33f73c2e93 Do not offer any of the suggestions in emit_coerce_suggestions for expr from destructuring assignment desugaring
  https://github.com/rust-lang/rust/commit/48247884c9 Rollup merge of #113009 - ChrisDenton:remove-path, r=workingjubilee
  https://github.com/rust-lang/rust/commit/85a7bb47e4 Rollup merge of #113008 - jyn514:new-contributor-improvements, r=clubby789
  https://github.com/rust-lang/rust/commit/2ed4368d2f Rollup merge of #112956 - Amanieu:weak-intrinsics, r=Mark-Simulacrum
  https://github.com/rust-lang/rust/commit/8630b1b3f4 Rollup merge of #112950 - tshepang:patch-4, r=Mark-Simulacrum
  https://github.com/rust-lang/rust/commit/8816f9ee1e Rollup merge of #112937 - camelid:align-typenames, r=notriddle,GuillaumeGomez
  https://github.com/rust-lang/rust/commit/9b97ae1d8c rustdoc: Update GUI test
  https://github.com/rust-lang/rust/commit/70b6a74c3c Add enum for `can_access_statics` boolean
  https://github.com/rust-lang/rust/commit/664ffa419e Don't print "x.ps1"
  https://github.com/rust-lang/rust/commit/fa7e965bf0 Give a better error on Windows if python isn't installed
  https://github.com/rust-lang/rust/commit/e2eff0d4ab Remove unnecessary `path` attribute
  https://github.com/rust-lang/rust/commit/e304a1f13b Revert "Structurally resolve correctly in check_pat_lit"
  https://github.com/rust-lang/rust/commit/dd314f6533 give more helpful suggestions for a missing feature gate test
  https://github.com/rust-lang/rust/commit/b556e28496 outline x.py alternate invocations to the dev guide
  https://github.com/rust-lang/rust/commit/8a7399cd45 Move arm32 shim to c.rs
  https://github.com/rust-lang/rust/commit/24e67d51a0 Don't test the profile override hack
  https://github.com/rust-lang/rust/commit/ab87f72a22 Add a regression test for #96699
  https://github.com/rust-lang/rust/commit/c7af6fb5b8 Test color/verbose/warnings properly
  https://github.com/rust-lang/rust/commit/c5820b50c5 Test cargo arguments passed by bootstrap.py
  https://github.com/rust-lang/rust/commit/3508cde815 Allow passing arguments to `bootstrap_test.py`
  https://github.com/rust-lang/rust/commit/7d2373e48f Fix progress messages for configure in bootstrap_test.py
  https://github.com/rust-lang/rust/commit/5f433f33ed Reduce typename width to 6.25rem
  https://github.com/rust-lang/rust/commit/12de5b7ff3 Make typenames a bit wider to support "existential type"
  https://github.com/rust-lang/rust/commit/c4fca7202b Abbreviate long typenames so they don't get wrapped in results
  https://github.com/rust-lang/rust/commit/4a9f292e50 Expose `compiler-builtins-weak-intrinsics` feature for `-Zbuild-std`
  https://github.com/rust-lang/rust/commit/e7e584b7d9 display pid of process holding lock
  https://github.com/rust-lang/rust/commit/6f61f6ba11 DirEntry::file_name: improve explanation
  https://github.com/rust-lang/rust/commit/a8fa961696 Align search results horizontally for easy scanning
