### PR TITLE
Upgrade Rust toolchain to nightly-2023-07-01

### DIFF
--- a/kani-compiler/src/kani_compiler.rs
+++ b/kani-compiler/src/kani_compiler.rs
@@ -33,6 +33,7 @@ use rustc_hir::definitions::DefPathHash;
 use rustc_interface::Config;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::config::{ErrorOutputType, OutputType};
+use rustc_session::EarlyErrorHandler;
 use rustc_span::ErrorGuaranteed;
 use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
@@ -370,6 +371,7 @@ impl Callbacks for KaniCompiler {
     /// During the initialization state, we collect the crate harnesses and prepare for codegen.
     fn after_analysis<'tcx>(
         &mut self,
+        _handler: &EarlyErrorHandler,
         _compiler: &rustc_interface::interface::Compiler,
         rustc_queries: &'tcx rustc_interface::Queries<'tcx>,
     ) -> Compilation {

--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -9,6 +9,8 @@ use rustc_errors::{
     emitter::Emitter, emitter::HumanReadableErrorType, fallback_fluent_bundle, json::JsonEmitter,
     ColorConfig, Diagnostic, TerminalUrl,
 };
+use rustc_session::config::ErrorOutputType;
+use rustc_session::EarlyErrorHandler;
 use std::io::IsTerminal;
 use std::panic;
 use std::str::FromStr;
@@ -71,7 +73,8 @@ pub fn init_session(args: &ArgMatches, json_hook: bool) {
     // Initialize the rustc logger using value from RUSTC_LOG. We keep the log control separate
     // because we cannot control the RUSTC log format unless if we match the exact tracing
     // version used by RUSTC.
-    rustc_driver::init_rustc_env_logger();
+    let handler = EarlyErrorHandler::new(ErrorOutputType::default());
+    rustc_driver::init_rustc_env_logger(&handler);
 
     // Install Kani panic hook.
     if json_hook {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-06-28"
+channel = "nightly-2023-07-01"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-06-26"
+channel = "nightly-2023-06-28"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-06-25"
+channel = "nightly-2023-06-26"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
This PR contains #2615.

If any of the CI checks fail, manual intervention is required. In such a case, review the changes at https://github.com/rust-lang/rust from https://github.com/rust-lang/rust/commit/f7ca9df69549470541fbf542f87a03eb9ed024b6 up to  https://github.com/rust-lang/rust/commit/f4b80cacf93ca216c75f6ae12f4b9dec19eba42f. The log for this commit range is:
https://github.com/rust-lang/rust/commit/f4b80cacf93 Auto merge of #113200 - ferrocene:pa-fix-mir-opt-bless, r=oli-obk
https://github.com/rust-lang/rust/commit/00cc815e573 fix loading target specs in compiletest not working with custom targets
https://github.com/rust-lang/rust/commit/56d507dc92d Auto merge of #109524 - bzEq:aix-embed-llvmbc, r=nagisa
https://github.com/rust-lang/rust/commit/af9df2fd914 Auto merge of #106619 - agausmann:avr-object-file, r=nagisa
https://github.com/rust-lang/rust/commit/b4591cb04c8 Auto merge of #113188 - matthiaskrgr:rollup-j3abaks, r=matthiaskrgr
https://github.com/rust-lang/rust/commit/207b24413c6 Rollup merge of #113177 - estebank:hrlt-sugg, r=compiler-errors
https://github.com/rust-lang/rust/commit/38e6bba9c1c Rollup merge of #113171 - spastorino:new-rpitit-25, r=compiler-errors
https://github.com/rust-lang/rust/commit/c8f50ee1117 Rollup merge of #113165 - compiler-errors:rpitits-foreign-bounds, r=spastorino
https://github.com/rust-lang/rust/commit/0b96b25bdf3 Rollup merge of #113071 - compiler-errors:no-parent-non-lifetime-args-in-apit, r=eholk
https://github.com/rust-lang/rust/commit/6c22e0419f2 Rollup merge of #111403 - y21:suggest-slice-swap, r=compiler-errors
https://github.com/rust-lang/rust/commit/016c306ce64 Rollup merge of #107624 - tgross35:const-cstr-methods, r=dtolnay
https://github.com/rust-lang/rust/commit/97279e91d8d Auto merge of #113162 - matthiaskrgr:rollup-fct3wj7, r=matthiaskrgr
https://github.com/rust-lang/rust/commit/a10406318e0 Properly implement variances_of for RPITIT GAT
https://github.com/rust-lang/rust/commit/8aed93d912e Auto merge of #113116 - nnethercote:codegen-opts, r=oli-obk
https://github.com/rust-lang/rust/commit/7d33094d3aa Use structured suggestion when telling user about `for<'a>`
https://github.com/rust-lang/rust/commit/330727467b8 Auto merge of #112682 - spastorino:new-rpitit-21, r=compiler-errors
https://github.com/rust-lang/rust/commit/b23a5add092 Auto merge of #113059 - Kobzol:ci-concurrency-fix, r=pietroalbini
https://github.com/rust-lang/rust/commit/6f4a51e80e6 Do not generate lifetime_mapping for RPIT no in_trait
https://github.com/rust-lang/rust/commit/4925b57782b Add bidirectional where clauses on RPITIT synthesized GATs
https://github.com/rust-lang/rust/commit/679c5be4057 add `slice::swap` suggestion
https://github.com/rust-lang/rust/commit/d70deac161b Intern OpaqueTy on ItemKind::OpaqueTy
https://github.com/rust-lang/rust/commit/72a32583d1f Reorganize opaque lowering code
https://github.com/rust-lang/rust/commit/33d21e62d07 Do not remove previously added predicates in param_env, extend them instead
https://github.com/rust-lang/rust/commit/373293c3ca0 Extract compute_bidirectional_outlives_predicates fn
https://github.com/rust-lang/rust/commit/0506250f8c3 Encode item bounds for DefKind::ImplTraitPlaceholder
https://github.com/rust-lang/rust/commit/a20a04e5d68 Auto merge of #113108 - compiler-errors:normalize-opaques-with-late-bound-vars-again, r=jackh726
https://github.com/rust-lang/rust/commit/4338683b941 Rollup merge of #113161 - Bryanskiy:err_msg, r=petrochenkov
https://github.com/rust-lang/rust/commit/5d74664a7ea Rollup merge of #113144 - compiler-errors:elaborate-clauses, r=oli-obk
https://github.com/rust-lang/rust/commit/f135815f9b2 Rollup merge of #112795 - He1pa:translation_builtin_macros, r=davidtwco
https://github.com/rust-lang/rust/commit/f00db43e97d Rollup merge of #112300 - Zalathar:run-coverage, r=wesleywiser
https://github.com/rust-lang/rust/commit/93a97c7a2a7 Rollup merge of #112234 - ozkanonur:hotfix, r=jyn514
https://github.com/rust-lang/rust/commit/be0a96fc7da Rollup merge of #112086 - petrochenkov:impambig, r=oli-obk
https://github.com/rust-lang/rust/commit/4696a921830 Rollup merge of #111322 - mirkootter:master, r=davidtwco
https://github.com/rust-lang/rust/commit/35c6a1d0f39 Fix type privacy lints error message
https://github.com/rust-lang/rust/commit/32428ab5f37 CI: do not cancel concurrent builds on the same branch
https://github.com/rust-lang/rust/commit/e69c7306e2b Auto merge of #113151 - RalfJung:miri, r=RalfJung,oli-obk
https://github.com/rust-lang/rust/commit/78f58f96aab Use a valid `target` directory in miri ui tests
https://github.com/rust-lang/rust/commit/4dcce38cda4 resolve: Remove artificial import ambiguity errors
https://github.com/rust-lang/rust/commit/cde54ffc99d refactor `tool_doc!` so that it can accept additional arguments.
https://github.com/rust-lang/rust/commit/a3cea7f1792 update lockfile
https://github.com/rust-lang/rust/commit/de223888735 Auto merge of #113134 - TaKO8Ki:rollup-4hvqzf6, r=TaKO8Ki
https://github.com/rust-lang/rust/commit/feed376e15a Auto merge of #2946 - RalfJung:rustup, r=RalfJung
https://github.com/rust-lang/rust/commit/cca0c810276 Merge from rustc
https://github.com/rust-lang/rust/commit/8d4b2bdf7be Preparing for merge from rustc
https://github.com/rust-lang/rust/commit/0a32ca98318 Auto merge of #113146 - matthiaskrgr:rollup-bxtr51e, r=matthiaskrgr
https://github.com/rust-lang/rust/commit/7a7ffced6a8 Rollup merge of #113143 - joshtriplett:style-guide-narrow-dereference-guidance, r=calebcartwright
https://github.com/rust-lang/rust/commit/c0e37ad1271 Rollup merge of #113140 - joshtriplett:style-guide-example-multi-line-attribute, r=calebcartwright
https://github.com/rust-lang/rust/commit/c4dc70eb31b Rollup merge of #113139 - joshtriplett:style-clarify-let-else, r=calebcartwright
https://github.com/rust-lang/rust/commit/7e1869f9b42 Rollup merge of #113137 - lukas-code:no-moving-references, r=compiler-errors
https://github.com/rust-lang/rust/commit/f35f213d270 Rollup merge of #113054 - Rageking8:make-`rustc_on_unimplemented`-std-agnostic, r=WaffleLapkin
https://github.com/rust-lang/rust/commit/1963688f931 Rollup merge of #112929 - oli-obk:what_if_an_impl_item_just_doesnt_wanna_be_impld, r=compiler-errors
https://github.com/rust-lang/rust/commit/42a495da7ec Rollup merge of #112670 - petrochenkov:typriv, r=eholk
https://github.com/rust-lang/rust/commit/7e786e81b00 Avoid cloning `LocalDecls`.
https://github.com/rust-lang/rust/commit/8d7084d65fc Simplify the `bundles` vectors.
https://github.com/rust-lang/rust/commit/81436ebd55e Use `SmallVec` for the `bundles` vectors.
https://github.com/rust-lang/rust/commit/d20b1a8f6ba Set capacity of the string passed to `push_item_name`.
https://github.com/rust-lang/rust/commit/f2d863fa750 Remove `SmallStr`.
https://github.com/rust-lang/rust/commit/de1914af342 Avoid an unnecessary use of `SmallStr`.
https://github.com/rust-lang/rust/commit/45fcd1d0c5d Use `partition_point` in `SourceMap::lookup_source_file_idx`.
https://github.com/rust-lang/rust/commit/b4c6e19adef Replace a `lookup_debug_loc` call.
https://github.com/rust-lang/rust/commit/a13be655a51 Avoid unnecessary line lookup.
https://github.com/rust-lang/rust/commit/aafc801d691 Make the Elaboratable trait take clauses
https://github.com/rust-lang/rust/commit/025dd3aef08 style-guide: Narrow guidance about references and dereferencing
https://github.com/rust-lang/rust/commit/75726cae373 Auto merge of #112629 - compiler-errors:atb-imply, r=jackh726
https://github.com/rust-lang/rust/commit/4cc80651b84 style-guide: Add an example of formatting a multi-line attribute
https://github.com/rust-lang/rust/commit/5e83ddd2794 don't suggest `move` for borrows that aren't closures
https://github.com/rust-lang/rust/commit/5abeb801b88 syle-guide: Clarify let-else further
https://github.com/rust-lang/rust/commit/cec5ec44b19 Auto merge of #2936 - Vanille-N:unique, r=RalfJung
https://github.com/rust-lang/rust/commit/8a5272cb37e Rollup merge of #113119 - aDotInTheVoid:reduce-viz, r=notriddle
https://github.com/rust-lang/rust/commit/74d69582978 Rollup merge of #113107 - mj10021:issue-113012-fix, r=oli-obk
https://github.com/rust-lang/rust/commit/5871bc84867 Rollup merge of #113100 - GuillaumeGomez:search-result-long-name, r=notriddle
https://github.com/rust-lang/rust/commit/376c944bd2a Rollup merge of #113048 - psumbera:solaris-bootstrap-cfgs, r=ozkanonur
https://github.com/rust-lang/rust/commit/bad06885630 Rollup merge of #112946 - nnethercote:improve-cgu-naming-and-ordering, r=wesleywiser
https://github.com/rust-lang/rust/commit/0671f147333 Unique gets special treatment when -Zmiri-unique-is-unique
https://github.com/rust-lang/rust/commit/5bd28f5eac1 Auto merge of #98867 - cjgillot:metaloop, r=oli-obk
https://github.com/rust-lang/rust/commit/eb76764ea41 Auto merge of #113120 - Dylan-DPC:rollup-cz4qr3o, r=Dylan-DPC
https://github.com/rust-lang/rust/commit/1ffe627f05b Auto merge of #2945 - oli-obk:gha_mk_pr, r=RalfJung
https://github.com/rust-lang/rust/commit/e1b29514503 Try running a sync automatically
https://github.com/rust-lang/rust/commit/11c8dbf9f7f Rollup merge of #113111 - BoxyUwU:boxy_t_types_review, r=compiler-errors
https://github.com/rust-lang/rust/commit/a70842c7d16 Rollup merge of #113094 - GuillaumeGomez:fix-invalid-div-tag-in-head, r=notriddle,fmease
https://github.com/rust-lang/rust/commit/e4e1a995dce Rollup merge of #113019 - ericmarkmartin:warning-for-guard-non-exhaustion, r=fee1-dead
https://github.com/rust-lang/rust/commit/fc2c587cd04 Rollup merge of #112867 - compiler-errors:more-impl-source-nits, r=lcnr
https://github.com/rust-lang/rust/commit/dabcbae5354 Rollup merge of #112236 - cjgillot:interval-kill, r=davidtwco
https://github.com/rust-lang/rust/commit/fa56e01b357 Rollup merge of #111571 - jhpratt:proc-macro-span, r=m-ou-se
https://github.com/rust-lang/rust/commit/13ff41eda36 rustdoc: Reduce internal function visibility.
https://github.com/rust-lang/rust/commit/71362c733f3 remove FIXME and add test
https://github.com/rust-lang/rust/commit/ce5ed5b6ccf add check for ConstKind::Value(_)
https://github.com/rust-lang/rust/commit/8882507bc7d Auto merge of #112708 - flip1995:clippy-freezing-pc-with-ice, r=oli-obk
https://github.com/rust-lang/rust/commit/a716c79c29a Update GUI tests
https://github.com/rust-lang/rust/commit/0c10eb0b6af Fix display of long items in search results
https://github.com/rust-lang/rust/commit/984d29d2606 Auto merge of #2944 - oli-obk:rustup, r=oli-obk
https://github.com/rust-lang/rust/commit/de9dc591645 fmt
https://github.com/rust-lang/rust/commit/7c15779ff18 Rustdoc nit: refer to macro from docs
https://github.com/rust-lang/rust/commit/c10656e8825 Merge from rustc
https://github.com/rust-lang/rust/commit/48294e40e7c Preparing for merge from rustc
https://github.com/rust-lang/rust/commit/96bd0566959 remove cruft
https://github.com/rust-lang/rust/commit/2017a176eb9 use translatable subdiagnostic
https://github.com/rust-lang/rust/commit/e79b1794121 add comment back
https://github.com/rust-lang/rust/commit/fbd1e0252fc add note for non-exhaustive matches with guards
https://github.com/rust-lang/rust/commit/08fd6f719ee Auto merge of #111269 - clubby789:validate-fluent-variables, r=davidtwco
https://github.com/rust-lang/rust/commit/453603a4b52 fix typo
https://github.com/rust-lang/rust/commit/7b4e75b9896 Remove the old `coverage-reports` and `coverage` directories
https://github.com/rust-lang/rust/commit/edd051c31e2 Re-bless the newly-migrated tests
https://github.com/rust-lang/rust/commit/a2c0b388970 Migrate the remaining `run-make/coverage-reports` tests over to `run-coverage`
https://github.com/rust-lang/rust/commit/9d2564a1102 Expand `run-coverage` to support the remaining `coverage-reports` tests
https://github.com/rust-lang/rust/commit/d05653cbe07 Declare a `run-coverage-rustdoc` suite for coverage tests that need `rustdoc`
https://github.com/rust-lang/rust/commit/e0625b4586c Migrate most of the existing coverage tests over to `run-coverage`
https://github.com/rust-lang/rust/commit/22e119bbacd Add a custom `run-coverage` mode to compiletest
https://github.com/rust-lang/rust/commit/a42bbd0eddc Move the `RUSTC_PROFILER_SUPPORT` check into `CachedNeedsConditions`
https://github.com/rust-lang/rust/commit/75d01f8821f Remember whether `failure-status` was explicitly specified
https://github.com/rust-lang/rust/commit/a32cdee4662 Introduce `exec_compiled_test_general`
https://github.com/rust-lang/rust/commit/5b51d9cadb0 Extract a common function for setting up environment vars
https://github.com/rust-lang/rust/commit/d8d09b06815 Declare a `run-coverage` test mode/suite in bootstrap
https://github.com/rust-lang/rust/commit/bb95b7dcd6a Auto merge of #112307 - lcnr:operand-ref, r=compiler-errors
https://github.com/rust-lang/rust/commit/acbab96a8e7 add boxy to t-types review
https://github.com/rust-lang/rust/commit/bfc6ca8207a More tests
https://github.com/rust-lang/rust/commit/75a8f681837 Remove unnecessary DefineOpaqueTypes::Bubble from codegen
https://github.com/rust-lang/rust/commit/983f6b97872 Normalize opaques with escaping bound vars
https://github.com/rust-lang/rust/commit/6b46c996e1d Auto merge of #113105 - matthiaskrgr:rollup-rci0uym, r=matthiaskrgr
https://github.com/rust-lang/rust/commit/acbfb8c3bdb Replace `id` attribute with `name` for `<meta>` tag
https://github.com/rust-lang/rust/commit/4b1d0682a6f Rollup merge of #113103 - cjgillot:normalize-inhabited, r=compiler-errors
https://github.com/rust-lang/rust/commit/d505582ce2e Rollup merge of #113084 - WaffleLapkin:less_map_or, r=Nilstrieb
https://github.com/rust-lang/rust/commit/db11b77bdda Rollup merge of #113020 - AnthonyKalaitzis:add-tests-impl-via-obj-unless-denied, r=compiler-errors
https://github.com/rust-lang/rust/commit/9ec676dd7f2 Rollup merge of #112972 - nbdd0121:mir, r=davidtwco
https://github.com/rust-lang/rust/commit/b6144cd843d Rollup merge of #112692 - jieyouxu:better-err-msg-for-unstable-options, r=davidtwco
https://github.com/rust-lang/rust/commit/448d2a84179 Rollup merge of #112628 - gootorov:box_alloc_partialeq, r=joshtriplett
https://github.com/rust-lang/rust/commit/353dd71d73d Rollup merge of #112454 - ferrocene:pa-compiletest-dynamic-linking, r=davidtwco
https://github.com/rust-lang/rust/commit/1880e83ae36 Rollup merge of #112207 - qwandor:virt_feature, r=davidtwco
https://github.com/rust-lang/rust/commit/de0e7d32fda pass PredicateFilter to compute_bounds
https://github.com/rust-lang/rust/commit/858a861fff3 Make associated type bounds in supertrait position implied
https://github.com/rust-lang/rust/commit/5ea66686467 Auto merge of #113102 - matthiaskrgr:rollup-wpkbsw1, r=matthiaskrgr
https://github.com/rust-lang/rust/commit/6f3f8783517 Normalize types when applying uninhabited predicate.
https://github.com/rust-lang/rust/commit/0faea7728f2 Encode impls in encode_impls.
https://github.com/rust-lang/rust/commit/845fcc19397 Use instrument macro.
https://github.com/rust-lang/rust/commit/fd81e964b8e Retire encode_info_for_items.
https://github.com/rust-lang/rust/commit/22df32264ab Encode Impl separately.
https://github.com/rust-lang/rust/commit/45a9a5460ff Encode Trait info in def-id loop.
https://github.com/rust-lang/rust/commit/1a9d34fd81c Merge assoc_item functions.
https://github.com/rust-lang/rust/commit/3c790b37309 Encode fn_sig separately.
https://github.com/rust-lang/rust/commit/adc3ae24d6a Rollup merge of #113096 - TaKO8Ki:remove-unused-struct, r=oli-obk
https://github.com/rust-lang/rust/commit/4571be358bf Rollup merge of #113093 - WaffleLapkin:become_unuwuable_in_thir, r=Nilstrieb
https://github.com/rust-lang/rust/commit/1dc29bbfd68 Rollup merge of #113089 - floriangru:mut_analyses_followup, r=oli-obk
https://github.com/rust-lang/rust/commit/526326e10de Rollup merge of #113079 - Zalathar:as-operand-id, r=oli-obk
https://github.com/rust-lang/rust/commit/1153aba3ec6 Rollup merge of #113068 - clubby789:bootstrap-user-to-dist, r=jyn514
https://github.com/rust-lang/rust/commit/e992895c1d1 Rollup merge of #112978 - compiler-errors:bad-block-sugg, r=davidtwco
https://github.com/rust-lang/rust/commit/9f2c21c11f0 Rollup merge of #112518 - chenyukang:yukang-fix-112458, r=davidtwco
https://github.com/rust-lang/rust/commit/cef812bd958 Provide more context for `rustc +nightly -Zunstable-options` on stable
https://github.com/rust-lang/rust/commit/3c554f5cb49 Auto merge of #112516 - erikdesjardins:loop, r=davidtwco
https://github.com/rust-lang/rust/commit/b0142f603dd Avoid calling queries during query stack printing
https://github.com/rust-lang/rust/commit/5d3377dd678 Add regression test for OOM issue on EarlyLintPass ICE
https://github.com/rust-lang/rust/commit/8352c02fc29 avoid using `format!("{}", ..)`
https://github.com/rust-lang/rust/commit/662388e17fe Auto merge of #2943 - cbeuw:patch-1, r=oli-obk
https://github.com/rust-lang/rust/commit/1b7efb5ade6 remove an unused struct `ForbiddenNonLifetimeParam`
https://github.com/rust-lang/rust/commit/c91fb780a47 Add trophy
https://github.com/rust-lang/rust/commit/b8e4c54ffb3 Fix invalid HTML DIV tag used in HEAD
https://github.com/rust-lang/rust/commit/35cfac1e2b6 [PATCH] Fix build on Solaris where fd-lock cannot be used.
https://github.com/rust-lang/rust/commit/48544c1b12b Make `rustc_on_unimplemented` std-agnostic
https://github.com/rust-lang/rust/commit/f42f19b6d3d Auto merge of #113078 - saethlin:mention-the-function, r=RalfJung
https://github.com/rust-lang/rust/commit/b56777352c4 Auto merge of #2942 - oli-obk:ui_test_bump, r=RalfJung
https://github.com/rust-lang/rust/commit/3224ea44244 Export AnalysisResults trait in rustc_mir_dataflow
https://github.com/rust-lang/rust/commit/c60fb12a35a `thir`: Add `Become` expression kind
https://github.com/rust-lang/rust/commit/09f05489e34 Add passing & failing test for bultin dyn trait generation
https://github.com/rust-lang/rust/commit/0ba4cdb712e Make `--quiet` actually do something
https://github.com/rust-lang/rust/commit/ef05533c39a Simplify some conditions
https://github.com/rust-lang/rust/commit/95978b302ce Auto merge of #113083 - matthiaskrgr:rollup-anbqpij, r=matthiaskrgr
https://github.com/rust-lang/rust/commit/c396abe1bf0 Rollup merge of #113063 - ehuss:update-books, r=ehuss
https://github.com/rust-lang/rust/commit/3238a97d39c Rollup merge of #113058 - GuillaumeGomez:improve-code-comments, r=notriddle
https://github.com/rust-lang/rust/commit/a144272eeef Rollup merge of #113039 - matthiaskrgr:custom_mir, r=compiler-errors
https://github.com/rust-lang/rust/commit/b5e51db16df Auto merge of #112938 - compiler-errors:clause-3, r=oli-obk
https://github.com/rust-lang/rust/commit/fbb2079a241 Use `CoverageKind::as_operand_id` instead of manually reimplementing it
https://github.com/rust-lang/rust/commit/cdaac8799bd Mention the panic function in CheckAlignment
https://github.com/rust-lang/rust/commit/b9ad9b78a2b Auto merge of #112693 - ericmarkmartin:use-more-placeref, r=spastorino
https://github.com/rust-lang/rust/commit/374173cd996 TypeWellFormedInEnv
https://github.com/rust-lang/rust/commit/fbdef58414a Migrate predicates_of and caller_bounds to Clause
https://github.com/rust-lang/rust/commit/85c4ea0138f bootstrap: rename 'user' profile to 'dist'
https://github.com/rust-lang/rust/commit/2a15bdaaa1e Auto merge of #112969 - CryZe:patch-7, r=Mark-Simulacrum
https://github.com/rust-lang/rust/commit/724f3ff50de migrate lifetime too
https://github.com/rust-lang/rust/commit/26cd5486f89 Account for late-bound vars from parent arg-position impl trait
https://github.com/rust-lang/rust/commit/36fb58e433c Auto merge of #113057 - TaKO8Ki:rollup-071lc9g, r=TaKO8Ki
https://github.com/rust-lang/rust/commit/c6e6ceb078f make custom mir ICE a bit nicer
https://github.com/rust-lang/rust/commit/3d9ba07a0e0 Use constness query to encode constness.
https://github.com/rust-lang/rust/commit/cbe1578690b Encode info for Fn/AssocFn in a single place.
https://github.com/rust-lang/rust/commit/20c46f0ef17 Update books
https://github.com/rust-lang/rust/commit/7fb559353ee CI: do not cancel concurrent builds on the same branch
https://github.com/rust-lang/rust/commit/32f056ce6b9 Add/improve code comments
https://github.com/rust-lang/rust/commit/40e3fcfd59b Rollup merge of #112920 - fmease:rustdoc-fix-112904, r=GuillaumeGomez
https://github.com/rust-lang/rust/commit/c6a4d449775 Rollup merge of #112677 - the8472:remove-unusued-field, r=JohnTitor
https://github.com/rust-lang/rust/commit/6f8c27ae89d Auto merge of #112887 - WaffleLapkin:become_unuwuable_in_hir, r=compiler-errors,Nilstrieb
https://github.com/rust-lang/rust/commit/27e10c5292e Auto merge of #113049 - matthiaskrgr:rollup-41wo5w8, r=matthiaskrgr
https://github.com/rust-lang/rust/commit/5122e88b35d Rollup merge of #113034 - jyn514:ci-progress, r=oli-obk
https://github.com/rust-lang/rust/commit/005d860fc60 Rollup merge of #112979 - NotStirred:translatable_diag/resolve_imports, r=fee1-dead
https://github.com/rust-lang/rust/commit/5d9935a6389 Rollup merge of #112955 - Kobzol:ci-pr-cancel-workflows, r=Mark-Simulacrum
https://github.com/rust-lang/rust/commit/de79f51206f Rollup merge of #112840 - loongarch-rs:update-docs, r=GuillaumeGomez
https://github.com/rust-lang/rust/commit/ac84b664f99 Rollup merge of #112559 - SergioGasquez:master, r=JohnTitor
https://github.com/rust-lang/rust/commit/f6d58eaad3d Rollup merge of #111326 - he32:netbsd-aarch64-be, r=oli-obk
https://github.com/rust-lang/rust/commit/042f6052abf Add some tests around where bounds on associated items and their lack of effect on impls
https://github.com/rust-lang/rust/commit/3917774963a Auto merge of #2941 - oli-obk:ui_test_bump, r=oli-obk
https://github.com/rust-lang/rust/commit/e38576a893b Support `hir::ExprKind::Become` in clippy
https://github.com/rust-lang/rust/commit/ccb71ff424a `hir`: Add `Become` expression kind
https://github.com/rust-lang/rust/commit/732f1270369 Update ui test crate
https://github.com/rust-lang/rust/commit/25b5af1b3a0 Auto merge of #113024 - Jerrody:master, r=thomcc
https://github.com/rust-lang/rust/commit/06c58cb9666 Auto merge of #112884 - klensy:ri-drop-old-clap, r=albertlarsan68
https://github.com/rust-lang/rust/commit/c07c10d1e42 use PlaceRef abstractions more consistently
https://github.com/rust-lang/rust/commit/ae8ffa663c9 Auto merge of #111850 - the8472:external-step-by, r=scottmcm
https://github.com/rust-lang/rust/commit/666b1b68a72 Tweak thread names for CGU processing.
https://github.com/rust-lang/rust/commit/487bdeb519a Improve ordering and naming of CGUs for non-incremental builds.
https://github.com/rust-lang/rust/commit/7f01f030613 Auto merge of #113038 - matthiaskrgr:rollup-sdcfkxa, r=matthiaskrgr
https://github.com/rust-lang/rust/commit/6c7575721ff Rollup merge of #113036 - TaKO8Ki:fix-112094, r=compiler-errors
https://github.com/rust-lang/rust/commit/d7723f41801 Rollup merge of #113031 - JohnTitor:issue-110933, r=compiler-errors
https://github.com/rust-lang/rust/commit/dfd6d708db9 Rollup merge of #113030 - JohnTitor:issue-109071, r=TaKO8Ki
https://github.com/rust-lang/rust/commit/32995d87e62 Rollup merge of #113013 - fmease:rustdoc-decl-line-wrapping-slim-arg-list, r=camelid
https://github.com/rust-lang/rust/commit/aa8a885cc1e Rollup merge of #112976 - dswij:issue-112347, r=compiler-errors
https://github.com/rust-lang/rust/commit/8084f397c67 Auto merge of #113037 - TaKO8Ki:rollup-pqfbxwk, r=TaKO8Ki
https://github.com/rust-lang/rust/commit/abb43958a97 platform-support.md: remove references to not-yet upstreamed targets.
https://github.com/rust-lang/rust/commit/f948ce7362e Rollup merge of #113029 - Kobzol:ci-fork-update, r=Mark-Simulacrum
https://github.com/rust-lang/rust/commit/019f43e6c2b Rollup merge of #113028 - fmease:rustdoc-x-crate-itiap-clean-term, r=notriddle
https://github.com/rust-lang/rust/commit/96ab7e6ed72 Rollup merge of #112281 - jyn514:test-bootstrap-py, r=albertlarsan68
https://github.com/rust-lang/rust/commit/7a07ffdbd88 SUMMARY.md: add entry for NetBSD.
https://github.com/rust-lang/rust/commit/f174547124a Mark the StepBy specialization as unsafe
https://github.com/rust-lang/rust/commit/8a72f35234c StepBy<Range<{int <= usize}>> can be TrustedLen
https://github.com/rust-lang/rust/commit/83722c62b08 accept `ReStatic` for RPITIT
https://github.com/rust-lang/rust/commit/f70a4b9dd3e doccomments for StepBy specializations
https://github.com/rust-lang/rust/commit/1e7f03718b3 fix some bugs
https://github.com/rust-lang/rust/commit/bd36f636cb9 Switch some more Steps to `builder.msg`
https://github.com/rust-lang/rust/commit/db3c3942ea8 Auto merge of #113027 - matthiaskrgr:rollup-mpes684, r=matthiaskrgr
https://github.com/rust-lang/rust/commit/421105b4537 Add a regression test for #110933
https://github.com/rust-lang/rust/commit/abe52cdcc79 Add a regression test for #109071
https://github.com/rust-lang/rust/commit/e8973eac122 Remove `cancel-outdated` action
https://github.com/rust-lang/rust/commit/cb06c973c7e CI: do not run Bump dependencies workflow on forks
https://github.com/rust-lang/rust/commit/247aa06f106 rustdoc: handle assoc const equalities in cross-crate impl-Trait-in-arg-pos
https://github.com/rust-lang/rust/commit/91351ef4867 Add test for futures with HRTB
https://github.com/rust-lang/rust/commit/d2f82a00d00 Rollup merge of #113023 - GuillaumeGomez:migrate-gui-test-color-17, r=notriddle
https://github.com/rust-lang/rust/commit/75f6a7aa00d Rollup merge of #113007 - compiler-errors:dont-structural-resolve-byte-str-pat, r=oli-obk
https://github.com/rust-lang/rust/commit/c51fbb3dd3a Auto merge of #113001 - ChrisDenton:win-arm32-shim, r=thomcc
https://github.com/rust-lang/rust/commit/bb337303612 Always inline primitive data types.
https://github.com/rust-lang/rust/commit/0d03812e242 Auto merge of #113022 - GuillaumeGomez:rollup-vkpzsuw, r=GuillaumeGomez
https://github.com/rust-lang/rust/commit/0979bf74131 Migrate GUI colors test to original CSS color format
https://github.com/rust-lang/rust/commit/a3c147b90b9 Rollup merge of #113018 - asquared31415:test_fix, r=TaKO8Ki
https://github.com/rust-lang/rust/commit/758adf64e77 Rollup merge of #113011 - Nilstrieb:can_access_statics, r=oli-obk
https://github.com/rust-lang/rust/commit/691580f5667 Rollup merge of #112990 - JohnTitor:issue-96699, r=TaKO8Ki
https://github.com/rust-lang/rust/commit/fb98925b8c9 Rollup merge of #112918 - zephaniahong:issue-107077-fix, r=Mark-Simulacrum
https://github.com/rust-lang/rust/commit/b7d60320825 Add translatable diagnostic for import resolution strings
https://github.com/rust-lang/rust/commit/3c5d71a99dd Auto merge of #112476 - chenyukang:yukang-fix-109991, r=compiler-errors
https://github.com/rust-lang/rust/commit/7b9b1277009 Auto merge of #113014 - matthiaskrgr:rollup-dasfmfc, r=matthiaskrgr
https://github.com/rust-lang/rust/commit/9dd655ff91c fix test
https://github.com/rust-lang/rust/commit/33f73c2e939 Do not offer any of the suggestions in emit_coerce_suggestions for expr from destructuring assignment desugaring
https://github.com/rust-lang/rust/commit/48247884c94 Rollup merge of #113009 - ChrisDenton:remove-path, r=workingjubilee
https://github.com/rust-lang/rust/commit/85a7bb47e4d Rollup merge of #113008 - jyn514:new-contributor-improvements, r=clubby789
https://github.com/rust-lang/rust/commit/2ed4368d2fa Rollup merge of #112956 - Amanieu:weak-intrinsics, r=Mark-Simulacrum
https://github.com/rust-lang/rust/commit/8630b1b3f4b Rollup merge of #112950 - tshepang:patch-4, r=Mark-Simulacrum
https://github.com/rust-lang/rust/commit/8816f9ee1ee Rollup merge of #112937 - camelid:align-typenames, r=notriddle,GuillaumeGomez
https://github.com/rust-lang/rust/commit/d23c3347074 rustdoc: get rid of extra line when line-wrapping fn decls with empty arg list
https://github.com/rust-lang/rust/commit/9b97ae1d8c6 rustdoc: Update GUI test
https://github.com/rust-lang/rust/commit/70b6a74c3c4 Add enum for `can_access_statics` boolean
https://github.com/rust-lang/rust/commit/664ffa419eb Don't print "x.ps1"
https://github.com/rust-lang/rust/commit/fa7e965bf0a Give a better error on Windows if python isn't installed
https://github.com/rust-lang/rust/commit/e2eff0d4ab4 Remove unnecessary `path` attribute
https://github.com/rust-lang/rust/commit/e304a1f13b4 Revert "Structurally resolve correctly in check_pat_lit"
https://github.com/rust-lang/rust/commit/dd314f6533c give more helpful suggestions for a missing feature gate test
https://github.com/rust-lang/rust/commit/b556e284962 outline x.py alternate invocations to the dev guide
https://github.com/rust-lang/rust/commit/8af8a95a64c Migrate some rustc_builtin_macros to SessionDiagnostic
https://github.com/rust-lang/rust/commit/8a7399cd459 Move arm32 shim to c.rs
https://github.com/rust-lang/rust/commit/24e67d51a0f Don't test the profile override hack
https://github.com/rust-lang/rust/commit/c643bedf7c9 rustdoc: render gen params & where-clauses of cross-crate assoc tys in impl blocks
https://github.com/rust-lang/rust/commit/ab87f72a22e Add a regression test for #96699
https://github.com/rust-lang/rust/commit/c7af6fb5b8d Test color/verbose/warnings properly
https://github.com/rust-lang/rust/commit/c5820b50c55 Test cargo arguments passed by bootstrap.py
https://github.com/rust-lang/rust/commit/3508cde8159 Allow passing arguments to `bootstrap_test.py`
https://github.com/rust-lang/rust/commit/7d2373e48f9 Fix progress messages for configure in bootstrap_test.py
https://github.com/rust-lang/rust/commit/2cc7782cfd8 Add suggestion for bad block fragment error
https://github.com/rust-lang/rust/commit/5f433f33ed8 Reduce typename width to 6.25rem
https://github.com/rust-lang/rust/commit/19ce326a086 Bless tests
https://github.com/rust-lang/rust/commit/12de5b7ff33 Make typenames a bit wider to support "existential type"
https://github.com/rust-lang/rust/commit/c4fca7202b8 Abbreviate long typenames so they don't get wrapped in results
https://github.com/rust-lang/rust/commit/c462291e0c8 Make `UnwindAction::Continue` explicit in MIR dump
https://github.com/rust-lang/rust/commit/471cd785ccf Update wasi-libc
https://github.com/rust-lang/rust/commit/8969d974377 Add test for invalid variables
https://github.com/rust-lang/rust/commit/4a9f292e500 Expose `compiler-builtins-weak-intrinsics` feature for `-Zbuild-std`
https://github.com/rust-lang/rust/commit/3c2b8b06fc9 Cancel in-progress workflow runs after a push
https://github.com/rust-lang/rust/commit/e7e584b7d9d display pid of process holding lock
https://github.com/rust-lang/rust/commit/6f61f6ba11a DirEntry::file_name: improve explanation
https://github.com/rust-lang/rust/commit/1bc095cd801 add inline annotation to concrete impls
https://github.com/rust-lang/rust/commit/070ce235f2c Specialize StepBy<Range<{integer}>>
https://github.com/rust-lang/rust/commit/a8fa961696f Align search results horizontally for easy scanning
https://github.com/rust-lang/rust/commit/da05ed36836 Remove extra trailing newline
https://github.com/rust-lang/rust/commit/65d60f9f111 drop perform_read_access (always read) in favor of zero_size
https://github.com/rust-lang/rust/commit/878c6ae3901 Auto merge of #2938 - RalfJung:rustup, r=RalfJung
https://github.com/rust-lang/rust/commit/940cd59e39c Merge from rustc
https://github.com/rust-lang/rust/commit/2bd9ade66e2 Preparing for merge from rustc
https://github.com/rust-lang/rust/commit/61590752a29 Remove outdated import in r-a proc macro server.
https://github.com/rust-lang/rust/commit/fd1439ed8b7 change edition to 2021, fix clippy warns
https://github.com/rust-lang/rust/commit/e1c3313d382 rust-installer: drop clap v3, migrate to v4
https://github.com/rust-lang/rust/commit/21d9fd77f4e Delete use of proc_macro_span_shrink from proc-macro2
https://github.com/rust-lang/rust/commit/abd0677d2f5 Merge proc_macro_span_shrink and proc_macro_span
https://github.com/rust-lang/rust/commit/cd1c1b1a9f0 Update to proc-macro2 1.0.57 to unblock proc_macro_span changes
https://github.com/rust-lang/rust/commit/8dc3b8559c1 Fix tests
https://github.com/rust-lang/rust/commit/a1cd8c3a281 Add `Span::{line, column}`
https://github.com/rust-lang/rust/commit/87ec0738ab6 `Span::{before, after}` → `Span::{start, end}`
https://github.com/rust-lang/rust/commit/dc76991d2fa Remove `LineColumn`, `Span::start`, `Span::end`
https://github.com/rust-lang/rust/commit/7d0a5c31f5b yeet upcast_trait_def_id from ImplSourceObjectData
https://github.com/rust-lang/rust/commit/42571c48476 yeet ImplSource::TraitAlias too
https://github.com/rust-lang/rust/commit/db235a07f79 Remove unnecessary call to select_from_obligation
https://github.com/rust-lang/rust/commit/767c4b9ef17 add support for needs-dynamic-linking
https://github.com/rust-lang/rust/commit/04f658f3d3d avoid dynamic linking on targets that do not support dynamic linking
https://github.com/rust-lang/rust/commit/a56c829e747 merge target spec and --print=cfg for compiletest target info
https://github.com/rust-lang/rust/commit/b621c4d6003 Auto merge of #2520 - saethlin:mmap-shim, r=RalfJung
https://github.com/rust-lang/rust/commit/8fc8f13ebd5 Improve organization
https://github.com/rust-lang/rust/commit/69dc7353a15 Make munmap throw unsup errors instead of trying to work
https://github.com/rust-lang/rust/commit/a00405649b5 mmap/munmap/mremamp shims
https://github.com/rust-lang/rust/commit/76092263d92 doc: loongarch: Update maintainers
https://github.com/rust-lang/rust/commit/f7690454117 Auto merge of #2935 - RalfJung:rustup, r=RalfJung
https://github.com/rust-lang/rust/commit/6ea50356480 bless new tests
https://github.com/rust-lang/rust/commit/46973c9c8a7 add FIXME's for a later refactoring
https://github.com/rust-lang/rust/commit/0589cd0f0a9 mir opt: fix subtype handling
https://github.com/rust-lang/rust/commit/46af169ec59 codegen: fix `OperandRef` subtype handling
https://github.com/rust-lang/rust/commit/be33ad88480 fix types in shim building
https://github.com/rust-lang/rust/commit/c5943307ec6 add tests for unsound subtype handling
https://github.com/rust-lang/rust/commit/7cef28657e7 Merge from rustc
https://github.com/rust-lang/rust/commit/e6962992944 Preparing for merge from rustc
https://github.com/rust-lang/rust/commit/001b081cc1b alloc: Allow comparing `Box`s over different allocators
https://github.com/rust-lang/rust/commit/5f81d83ddef Auto merge of #2933 - RalfJung:rustup, r=RalfJung
https://github.com/rust-lang/rust/commit/14155e95b14 Merge from rustc
https://github.com/rust-lang/rust/commit/dfd5037fa5b Preparing for merge from rustc
https://github.com/rust-lang/rust/commit/20a2a24e112 Auto merge of #2932 - RalfJung:comment, r=RalfJung
https://github.com/rust-lang/rust/commit/5c9ad8bda05 comment tweaks
https://github.com/rust-lang/rust/commit/6f771c8f449 Auto merge of #2929 - RalfJung:tls-panic, r=RalfJung
https://github.com/rust-lang/rust/commit/f3b52fdb74f make test work cross-platform
https://github.com/rust-lang/rust/commit/e2d22666e92 add tests for panicky drop in thread_local destructor
https://github.com/rust-lang/rust/commit/c853744f660 Auto merge of #2930 - RalfJung:rustup, r=RalfJung
https://github.com/rust-lang/rust/commit/508675b0fd0 Merge from rustc
https://github.com/rust-lang/rust/commit/8e930fdf695 Preparing for merge from rustc
https://github.com/rust-lang/rust/commit/64ee0f74eb4 remove unused field
https://github.com/rust-lang/rust/commit/98a86ffc9ff privacy: Rename some variables for clarity
https://github.com/rust-lang/rust/commit/95a24c6ed48 privacy: Do not mark items reachable farther than their nominal visibility
https://github.com/rust-lang/rust/commit/17edd1a7790 privacy: Remove `(Non)ShallowEffectiveVis`
https://github.com/rust-lang/rust/commit/d326aed46f6 privacy: Feature gate new type privacy lints
https://github.com/rust-lang/rust/commit/b4b7cd63d74 Auto merge of #2661 - DrMeepster:deref_operand_as, r=oli-obk
https://github.com/rust-lang/rust/commit/52036f5a455 Auto merge of #2928 - oli-obk:rustup, r=oli-obk
https://github.com/rust-lang/rust/commit/24595f5db6c Merge from rustc
https://github.com/rust-lang/rust/commit/36e0c426032 Preparing for merge from rustc
https://github.com/rust-lang/rust/commit/c0aed703be1 docs: 📝 Add missing targets
https://github.com/rust-lang/rust/commit/15a6362e000 Auto merge of #2924 - RalfJung:rustup, r=RalfJung
https://github.com/rust-lang/rust/commit/6ab7af4d415 Merge from rustc
https://github.com/rust-lang/rust/commit/6147833064a Preparing for merge from rustc
https://github.com/rust-lang/rust/commit/85533a3f120 Auto merge of #2922 - Vanille-N:tb-tests, r=RalfJung
https://github.com/rust-lang/rust/commit/0220c0b765e Detect actual span for getting unexpected token from parsing macros
https://github.com/rust-lang/rust/commit/bd0aae92dc7 cg_llvm: use index-based loop in write_operand_repeatedly
https://github.com/rust-lang/rust/commit/be5f6b24d26 box_exclusive_violation
https://github.com/rust-lang/rust/commit/7b79cb1759f Use `c`-prefixed string
https://github.com/rust-lang/rust/commit/5725561e169 Support embedding bitcode on AIX
https://github.com/rust-lang/rust/commit/744ec64c939 fix comment (review change)
https://github.com/rust-lang/rust/commit/12ad6622add add comment regarding `__gxx_wasm_personality_v0`
https://github.com/rust-lang/rust/commit/82730b45214 wasm exception handling
https://github.com/rust-lang/rust/commit/35cdb28c846 add comment
https://github.com/rust-lang/rust/commit/00ce5e8fcab add wasm eh intrinsics
https://github.com/rust-lang/rust/commit/82336c13115 wasm target feature: exception handling
https://github.com/rust-lang/rust/commit/634c21f4de3 Auto merge of #2919 - Vanille-N:tb-diags, r=RalfJung
https://github.com/rust-lang/rust/commit/c87f6d9643a Revert error in doc comment
https://github.com/rust-lang/rust/commit/98c5fce3413 Auto merge of #2918 - Vanille-N:tb-diags, r=RalfJung
https://github.com/rust-lang/rust/commit/7a1cdf71103 Differentiate between explicit accesses and accesses inserted by TB
https://github.com/rust-lang/rust/commit/5d01a6bdd20 Auto merge of #2916 - ehuss:remove-workspace-hack, r=RalfJung
https://github.com/rust-lang/rust/commit/53187d7b164 Remove rustc-workspace-hack
https://github.com/rust-lang/rust/commit/c1a7783a149 Auto merge of #2915 - RalfJung:as_os_str_bytes, r=RalfJung
https://github.com/rust-lang/rust/commit/7444a5030b8 use as_os_str_bytes
https://github.com/rust-lang/rust/commit/96678867375 Auto merge of #2887 - Vanille-N:tb-mut-transmute, r=RalfJung
https://github.com/rust-lang/rust/commit/580e2b30377 Select more TB fail tests
https://github.com/rust-lang/rust/commit/7380a4d7a16 explain windows sync layouts
https://github.com/rust-lang/rust/commit/9d1d651d1d8 add deref_pointer_as
https://github.com/rust-lang/rust/commit/13c20f297f6 deref shim arguments with actual ty instead of declared ty
https://github.com/rust-lang/rust/commit/f10aa7dddc0 Simplify pre-order algorithm.
https://github.com/rust-lang/rust/commit/7269972f733 Add trustzone and virtualization target features for aarch32.
https://github.com/rust-lang/rust/commit/5cb701f3794 Stabilize 'const_cstr_methods'
https://github.com/rust-lang/rust/commit/0a1e42e0e27 platform-support.md: document the various NetBSD targets.
https://github.com/rust-lang/rust/commit/220bb61b331 Fix diagnostics with errors
https://github.com/rust-lang/rust/commit/9b5574f028c Validate fluent variable references with `debug_assertions`
https://github.com/rust-lang/rust/commit/a7158ecfa9a rustc_codegen_ssa: Set e_flags for AVR architecture based on target CPU
https://github.com/rust-lang/rust/commit/6ef377cc41d Add support for NetBSD/aarch64-be (big-endian arm64).
