### PR TITLE
Support for stubbing out foreign functions

### DIFF
--- a/kani-compiler/src/kani_middle/provide.rs
+++ b/kani-compiler/src/kani_middle/provide.rs
@@ -55,7 +55,9 @@ fn run_kani_mir_passes<'tcx>(
     body: &'tcx Body<'tcx>,
 ) -> &'tcx Body<'tcx> {
     tracing::debug!(?def_id, "Run Kani transformation passes");
-    stubbing::transform(tcx, def_id, body)
+    let mut transformed_body = stubbing::transform(tcx, def_id, body);
+    stubbing::transform_extern_functions(tcx, &mut transformed_body);
+    tcx.arena.alloc(transformed_body)
 }
 
 /// Runs a reachability analysis before running the default

--- a/kani-compiler/src/kani_middle/provide.rs
+++ b/kani-compiler/src/kani_middle/provide.rs
@@ -56,7 +56,7 @@ fn run_kani_mir_passes<'tcx>(
 ) -> &'tcx Body<'tcx> {
     tracing::debug!(?def_id, "Run Kani transformation passes");
     let mut transformed_body = stubbing::transform(tcx, def_id, body);
-    stubbing::transform_extern_functions(tcx, &mut transformed_body);
+    stubbing::transform_foreign_functions(tcx, &mut transformed_body);
     tcx.arena.alloc(transformed_body)
 }
 

--- a/kani-compiler/src/kani_middle/stubbing/transform.rs
+++ b/kani-compiler/src/kani_middle/stubbing/transform.rs
@@ -66,7 +66,7 @@ impl<'tcx> MutVisitor<'tcx> for ForeignFunctionTransformer<'tcx> {
 
     fn visit_operand(&mut self, operand: &mut Operand<'tcx>, _location: Location) {
         let func_ty = operand.ty(&self.local_decls, self.tcx);
-        if let ty::FnDef(reachable_function, generics) = *func_ty.kind() {
+        if let ty::FnDef(reachable_function, arguments) = *func_ty.kind() {
             if self.tcx.is_foreign_item(reachable_function) {
                 if let Some(stub) = self.stub_map.get(&reachable_function) {
                     let Operand::Constant(function_definition) = operand else {
@@ -74,7 +74,7 @@ impl<'tcx> MutVisitor<'tcx> for ForeignFunctionTransformer<'tcx> {
                     };
                     function_definition.literal = ConstantKind::from_value(
                         ConstValue::ZeroSized,
-                        self.tcx.type_of(stub).subst(self.tcx, generics),
+                        self.tcx.type_of(stub).instantiate(self.tcx, arguments),
                     );
                 }
             }

--- a/kani-compiler/src/kani_middle/stubbing/transform.rs
+++ b/kani-compiler/src/kani_middle/stubbing/transform.rs
@@ -69,7 +69,9 @@ impl<'tcx> MutVisitor<'tcx> for ForeignFunctionTransformer<'tcx> {
         if let ty::FnDef(reachable_function, generics) = *func_ty.kind() {
             if self.tcx.is_foreign_item(reachable_function) {
                 if let Some(stub) = self.stub_map.get(&reachable_function) {
-                    let Operand::Constant(function_definition) = operand else { return; };
+                    let Operand::Constant(function_definition) = operand else {
+                        return;
+                    };
                     function_definition.literal = ConstantKind::from_value(
                         ConstValue::ZeroSized,
                         self.tcx.type_of(stub).subst(self.tcx, generics),

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,11 +1,11 @@
-*.goto
+# Temporary files and folders
 *.json
-
-# Temporary folders
-rmet*/
 kani_concrete_playback
+rmet*/
+target/
 
 # Binary artifacts
+*.goto
 *out
 smoke
 check_tests

--- a/tests/kani/Stubbing/extern_c.rs
+++ b/tests/kani/Stubbing/extern_c.rs
@@ -27,6 +27,18 @@ mod stubs {
     }
 }
 
+fn dig_depper(input : c_int) {
+    unsafe {
+        type FunctionPointerType = unsafe extern "C" fn(c_int) -> c_longlong;
+        let ptr: FunctionPointerType = libc::sysconf;
+        assert_eq!(ptr(input) as usize, 10);
+    }
+}
+
+fn deeper_call() {
+    dig_depper(libc::_SC_PAGESIZE)
+}
+
 #[kani::proof]
 #[kani::stub(libc::strlen, stubs::strlen)]
 #[kani::stub(libc::sysconf, stubs::sysconf)]
@@ -35,4 +47,5 @@ fn harness() {
     let str_ptr: *const i8 = &*str;
     assert_eq!(unsafe { libc::strlen(str_ptr) }, 4);
     assert_eq!(unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize, 10);
+    deeper_call();
 }

--- a/tests/kani/Stubbing/extern_c.rs
+++ b/tests/kani/Stubbing/extern_c.rs
@@ -1,0 +1,38 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// kani-flags: --harness harness --enable-unstable --enable-stubbing
+//
+//! Check support for stubbing out extern C functions.
+
+#![feature(rustc_private)]
+extern crate libc;
+
+use libc::c_char;
+use libc::c_int;
+use libc::c_longlong;
+use libc::size_t;
+
+#[allow(dead_code)] // Avoid warning when using stubs.
+#[allow(unused_variables)]
+mod stubs {
+    use super::*;
+
+    pub unsafe extern "C" fn strlen(cs: *const c_char) -> size_t {
+        4
+    }
+
+    pub unsafe extern "C" fn sysconf(_input: c_int) -> c_longlong {
+        10
+    }
+}
+
+#[kani::proof]
+#[kani::stub(libc::strlen, stubs::strlen)]
+#[kani::stub(libc::sysconf, stubs::sysconf)]
+fn harness() {
+    let str: Box<i8> = Box::new(4);
+    let str_ptr: *const i8 = &*str;
+    assert_eq!(unsafe { libc::strlen(str_ptr) }, 4);
+    assert_eq!(unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize, 10);
+}

--- a/tests/kani/Stubbing/extern_c.rs
+++ b/tests/kani/Stubbing/extern_c.rs
@@ -27,7 +27,7 @@ mod stubs {
     }
 }
 
-fn dig_depper(input : c_int) {
+fn dig_deeper(input: c_int) {
     unsafe {
         type FunctionPointerType = unsafe extern "C" fn(c_int) -> c_longlong;
         let ptr: FunctionPointerType = libc::sysconf;
@@ -36,7 +36,7 @@ fn dig_depper(input : c_int) {
 }
 
 fn deeper_call() {
-    dig_depper(libc::_SC_PAGESIZE)
+    dig_deeper(libc::_SC_PAGESIZE)
 }
 
 #[kani::proof]
@@ -48,4 +48,6 @@ fn harness() {
     assert_eq!(unsafe { libc::strlen(str_ptr) }, 4);
     assert_eq!(unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize, 10);
     deeper_call();
+    let new_ptr = libc::strlen;
+    assert_eq!(unsafe { new_ptr(str_ptr) }, 4);
 }

--- a/tests/kani/Stubbing/foreign_functions.rs
+++ b/tests/kani/Stubbing/foreign_functions.rs
@@ -1,9 +1,9 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
-// kani-flags: --harness harness --enable-unstable --enable-stubbing
+// kani-flags: --enable-unstable --enable-stubbing
 //
-//! Check support for stubbing out extern C functions.
+//! Check support for stubbing out foreign functions.
 
 #![feature(rustc_private)]
 extern crate libc;
@@ -39,15 +39,38 @@ fn deeper_call() {
     dig_deeper(libc::_SC_PAGESIZE)
 }
 
+fn function_pointer_call(function_pointer: unsafe extern "C" fn(c_int) -> c_longlong) {
+    assert_eq!(unsafe { function_pointer(libc::_SC_PAGESIZE) } as usize, 10);
+}
+
 #[kani::proof]
 #[kani::stub(libc::strlen, stubs::strlen)]
-#[kani::stub(libc::sysconf, stubs::sysconf)]
-fn harness() {
+fn standard() {
     let str: Box<i8> = Box::new(4);
     let str_ptr: *const i8 = &*str;
     assert_eq!(unsafe { libc::strlen(str_ptr) }, 4);
-    assert_eq!(unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize, 10);
-    deeper_call();
+}
+
+#[kani::proof]
+#[kani::stub(libc::strlen, stubs::strlen)]
+fn function_pointer_standard() {
+    let str: Box<i8> = Box::new(4);
+    let str_ptr: *const i8 = &*str;
     let new_ptr = libc::strlen;
     assert_eq!(unsafe { new_ptr(str_ptr) }, 4);
+}
+
+#[kani::proof]
+#[kani::stub(libc::sysconf, stubs::sysconf)]
+fn function_pointer_with_layers() {
+    deeper_call();
+}
+
+#[kani::proof]
+#[kani::stub(libc::sysconf, stubs::sysconf)]
+fn function_pointer_as_parameter() {
+    type FunctionPointerType = unsafe extern "C" fn(c_int) -> c_longlong;
+    let function_pointer: FunctionPointerType = libc::sysconf;
+    function_pointer_call(function_pointer);
+    function_pointer_call(libc::sysconf);
 }


### PR DESCRIPTION
### Description of changes: 

Support for stubbing out foreign functions.

### Resolved issues:

Resolves https://github.com/model-checking/kani/issues/2587.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

N/A.

### Testing:

* How is this change tested? Regression tests.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
