### PR TITLE
Bump Kani version to 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,9 @@ or by passing `--solver=<SOLVER>` command line option.
 * Coverage reporting without a need for cbmc-viewer by @adpaco-aws in https://github.com/model-checking/kani/pull/2609
 * Add support to array-based SIMD by @celinval in https://github.com/model-checking/kani/pull/2633
 * Add unchecked/SIMD bitshift checks and disable CBMC flag by @reisnera in https://github.com/model-checking/kani/pull/2630
+* Fix codegen of constant byte slices to address spurious verification failures by @zhassan in https://github.com/model-checking/kani/pull/2663
 * Bump CBMC to v5.89.0 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2662
 * Update Rust toolchain to nightly 2023-08-04 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2661
-
-## New Contributors
-* @reisnera made their first contribution in https://github.com/model-checking/kani/pull/2630
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.33.0...kani-0.34.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,20 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 ## [0.34.0]
 
 ### Breaking Changes
-* Change default solver to CaDiCaL by @celinval in https://github.com/model-checking/kani/pull/2557
+* Change default solver to CaDiCaL ([pull request](https://github.com/model-checking/kani/pull/2557) by @celinval)
 By default, Kani will now run CBMC with CaDiCaL, since this solver has outperformed Minisat in most of our benchmarks.
 User's should still be able to select Minisat (or a different solver) either by using `#[solver]` harness attribute,
 or by passing `--solver=<SOLVER>` command line option.
 
 ## What's Changed
 
-* Allow specifying the scheduling strategy in #[kani_proof] for async functions by @fzaiser in https://github.com/model-checking/kani/pull/1661
-* Support for stubbing out foreign functions by @feliperodri in https://github.com/model-checking/kani/pull/2658
-* Coverage reporting without a need for cbmc-viewer by @adpaco-aws in https://github.com/model-checking/kani/pull/2609
-* Add support to array-based SIMD by @celinval in https://github.com/model-checking/kani/pull/2633
-* Add unchecked/SIMD bitshift checks and disable CBMC flag by @reisnera in https://github.com/model-checking/kani/pull/2630
-* Bump CBMC to v5.89.0 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2662
-* Update Rust toolchain to nightly 2023-08-04 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2661
+* Allow specifying the scheduling strategy in #[kani_proof] for async functions ([pull request](https://github.com/model-checking/kani/pull/1661) by @fzaiser)
+* Support for stubbing out foreign functions ([pull request](https://github.com/model-checking/kani/pull/2658) by @feliperodri)
+* Coverage reporting without a need for cbmc-viewer ([pull request](https://github.com/model-checking/kani/pull/2609) by @adpaco-aws)
+* Add support to array-based SIMD ([pull request](https://github.com/model-checking/kani/pull/2633) by @celinval)
+* Add unchecked/SIMD bitshift checks and disable CBMC flag ([pull request](https://github.com/model-checking/kani/pull/2630) by @reisnera)
+* Bump CBMC to v5.89.0 ([pull request](https://github.com/model-checking/kani/pull/2662) by @remi-delmas-3000)
+* Update Rust toolchain to nightly 2023-08-04 ([pull request](https://github.com/model-checking/kani/pull/2661) by @remi-delmas-3000)
 
 ## New Contributors
 * @reisnera made their first contribution in https://github.com/model-checking/kani/pull/2630

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ or by passing `--solver=<SOLVER>` command line option.
 
 ## What's Changed
 
+* Allow specifying the scheduling strategy in #[kani_proof] for async functions by @fzaiser in https://github.com/model-checking/kani/pull/1661
+* Support for stubbing out foreign functions by @feliperodri in https://github.com/model-checking/kani/pull/2658
+* Coverage reporting without a need for cbmc-viewer by @adpaco-aws in https://github.com/model-checking/kani/pull/2609
+* Add support to array-based SIMD by @celinval in https://github.com/model-checking/kani/pull/2633
+* Add unchecked/SIMD bitshift checks and disable CBMC flag by @reisnera in https://github.com/model-checking/kani/pull/2630
+* Bump CBMC to v5.89.0 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2662
+* Update Rust toolchain to nightly 2023-08-04 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2661
+
+## New Contributors
+* @reisnera made their first contribution in https://github.com/model-checking/kani/pull/2630
+
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.33.0...kani-0.34.0
 
 ## [0.33.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,20 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 ## [0.34.0]
 
 ### Breaking Changes
-* Change default solver to CaDiCaL ([pull request](https://github.com/model-checking/kani/pull/2557) by @celinval)
+* Change default solver to CaDiCaL by @celinval in https://github.com/model-checking/kani/pull/2557
 By default, Kani will now run CBMC with CaDiCaL, since this solver has outperformed Minisat in most of our benchmarks.
 User's should still be able to select Minisat (or a different solver) either by using `#[solver]` harness attribute,
 or by passing `--solver=<SOLVER>` command line option.
 
 ## What's Changed
 
-* Allow specifying the scheduling strategy in #[kani_proof] for async functions ([pull request](https://github.com/model-checking/kani/pull/1661) by @fzaiser)
-* Support for stubbing out foreign functions ([pull request](https://github.com/model-checking/kani/pull/2658) by @feliperodri)
-* Coverage reporting without a need for cbmc-viewer ([pull request](https://github.com/model-checking/kani/pull/2609) by @adpaco-aws)
-* Add support to array-based SIMD ([pull request](https://github.com/model-checking/kani/pull/2633) by @celinval)
-* Add unchecked/SIMD bitshift checks and disable CBMC flag ([pull request](https://github.com/model-checking/kani/pull/2630) by @reisnera)
-* Bump CBMC to v5.89.0 ([pull request](https://github.com/model-checking/kani/pull/2662) by @remi-delmas-3000)
-* Update Rust toolchain to nightly 2023-08-04 ([pull request](https://github.com/model-checking/kani/pull/2661) by @remi-delmas-3000)
+* Allow specifying the scheduling strategy in #[kani_proof] for async functions by @fzaiser in https://github.com/model-checking/kani/pull/1661
+* Support for stubbing out foreign functions by @feliperodri in https://github.com/model-checking/kani/pull/2658
+* Coverage reporting without a need for cbmc-viewer by @adpaco-aws in https://github.com/model-checking/kani/pull/2609
+* Add support to array-based SIMD by @celinval in https://github.com/model-checking/kani/pull/2633
+* Add unchecked/SIMD bitshift checks and disable CBMC flag by @reisnera in https://github.com/model-checking/kani/pull/2630
+* Bump CBMC to v5.89.0 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2662
+* Update Rust toolchain to nightly 2023-08-04 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2661
 
 ## New Contributors
 * @reisnera made their first contribution in https://github.com/model-checking/kani/pull/2630

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -484,14 +484,14 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "kani"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "home",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "cprover_bindings",
  "serde",
@@ -1146,7 +1146,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "std"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Description of changes: 

Updated version in all `Cargo.toml` files (via
`find . -name Cargo.toml -exec sed -i 's/version = "0.33.0"/version = "0.34.0"/' {} \;`) and ran `cargo build-dev` to have `Cargo.lock` files updated.

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? CI

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
