### PR TITLE
Improve expected test runner

### DIFF
--- a/tools/compiletest/src/runtest.rs
+++ b/tools/compiletest/src/runtest.rs
@@ -395,7 +395,12 @@ impl<'test> TestCx<'test> {
     /// the expected output in `expected` file.
     fn run_expected_test(&self) {
         let proc_res = self.run_kani();
-        let expected_path = self.testpaths.file.parent().unwrap().join("expected");
+        let dot_expected_path = self.testpaths.file.with_extension("expected");
+        let expected_path = if dot_expected_path.exists() {
+            dot_expected_path
+        } else {
+            self.testpaths.file.parent().unwrap().join("expected")
+        };
         self.verify_output(&proc_res, &expected_path);
     }
 
@@ -475,35 +480,22 @@ impl<'test> TestCx<'test> {
                 consecutive_lines.clear();
             }
         }
-        None
+        // Someone may add a `\` to the last line (probably by accident) but
+        // that would mean this test would succeed without actually testing so
+        // we add a check here again.
+        (!consecutive_lines.is_empty() && !TestCx::contains(str, &consecutive_lines))
+            .then_some(consecutive_lines)
     }
 
     /// Check if there is a set of consecutive lines in `str` where each line
     /// contains a line from `lines`
     fn contains(str: &[&str], lines: &[&str]) -> bool {
-        let mut i = str.iter();
-        while let Some(output_line) = i.next() {
-            if output_line.contains(&lines[0]) {
-                // Check if the rest of the lines in `lines` are contained in
-                // the subsequent lines in `str`
-                let mut matches = true;
-                // Clone the iterator so that we keep i unchanged
-                let mut j = i.clone();
-                for line in lines.iter().skip(1) {
-                    if let Some(output_line) = j.next() {
-                        if output_line.contains(line) {
-                            continue;
-                        }
-                    }
-                    matches = false;
-                    break;
-                }
-                if matches {
-                    return true;
-                }
-            }
-        }
-        false
+        // Does *any* subslice of length `lines.len()` satisfy the containment of
+        // *all* `lines`
+        // `trim()` added to ignore trailing and preceding whitespace
+        str.windows(lines.len()).any(|subslice| {
+            subslice.iter().zip(lines).all(|(output, expected)| output.contains(expected.trim()))
+        })
     }
 
     fn create_stamp(&self) {


### PR DESCRIPTION
### Description of changes: 

This improves the test runner for expected tests in four ways

1. A single directory can now contain multiple "expected" test. For each such `<testname>.rs` file it expects to find a `<testname>.expected` file. Otherwise it reverts to the old behavior (the change is backwards compatible)
2. It fixes an issue where adding a `\` to the last line in the `expected` file would make the test vacuously pass.
3. Whitespace on the expected test lines are now ignored (with `trim`) which is especially easy to introduce by accident on continued lines, e.g. adding ` \` (space + slash) instead of `\` (slash)
4. It refactors the actual test for expected lines to a tight iterator composition that uses `windows` which executes the check more efficiently (since indices too close to the end are not considered) but in my opinion also makes it easier to read than the big loop and less error prone.

### Testing:

* How is this change tested? By running the test suite.

* Is this a refactor change? Partially

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix (not really sorry but the individual changes seem too small to break up)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
