### PR TITLE
Change how we enforce deny warnings

### DIFF
--- a/kani-compiler/src/main.rs
+++ b/kani-compiler/src/main.rs
@@ -6,7 +6,6 @@
 //!
 //! Like miri, clippy, and other tools developed on the top of rustc, we rely on the
 //! rustc_private feature and a specific version of rustc.
-#![deny(warnings)]
 #![feature(extern_types)]
 #![recursion_limit = "256"]
 #![feature(box_patterns)]

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -26,8 +26,8 @@ check_kissat_version.sh
 # Formatting check
 ${SCRIPT_DIR}/kani-fmt.sh --check
 
-# Build all packages in the workspace
-cargo build-dev
+# Build all packages in the workspace and ensure no warning is emitted.
+RUSTFLAGS="-D warnings" cargo build-dev
 
 # Unit tests
 cargo test -p cprover_bindings


### PR DESCRIPTION
### Description of changes: 

Enforce that no warning is being added as part of our regression script instead at a crate level. This will also enforce no warnings for all our crates, instead of just kani-compiler as is today.

This makes development a bit easier, since warnings of unused code shows up fairly often when a feature is half implemented. So this allow us to compile and test the code before it's production ready. That said, it is nice to avoid warnings from piling up, so change the check to the regression instead, which should be executed before we create PR / merge changes.

This also aligns with the recommendation from
https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html

### Resolved issues:
N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
