### PR TITLE
Add `async-lib` unstable flag to slow tokio test

### DIFF
--- a/tests/slow/tokio-proofs/Cargo.toml
+++ b/tests/slow/tokio-proofs/Cargo.toml
@@ -19,3 +19,6 @@ tokio-util = { version = "0.7.3", features = ["io"] }
 async-stream = "0.3.3"
 # mockall = "0.11.1"
 # async-stream = "0.3"
+
+[kani.unstable]
+async-lib = true


### PR DESCRIPTION
### Description of changes: 

@tautschnig reported that our nightly regression has been failing since #1659 was merged because the only test in there requires the `-Z async-lib` unstable flag:
```
error: Use of unstable feature `async-lib`: experimental async support
   |
note: the function `kani::block_on` is unstable:
  --> /home/runner/work/kani/kani/library/kani/src/futures.rs:21:1
   |
21 | pub fn block_on<T>(mut fut: impl Future<Output = T>) -> T {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: see issue 2559 for more information
   = help: use `-Z async-lib` to enable using this function.

error: aborting due to previous error; 113 warnings emitted
```

This PR adds the flag to the `Cargo.toml` file of the test. Testing the fix locally worked.

### Testing:

* How is this change tested? Manually ran `./scripts/kani-slow-tests.sh` and got:
```
    Finished dev [unoptimized + debuginfo] target(s) in 0.29s

running 1 test
test [cargo-kani] slow/tokio-proofs/expected has been running for over 60 seconds
test [cargo-kani] slow/tokio-proofs/expected ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 119.57s


Kani slow tests completed successfully.
```

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
