### PR TITLE
Upgrade Rust toolchin to 2023-08-07

### DIFF
--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -9,6 +9,7 @@
 // This is required for the optimized version of `any_array()`
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
+#![allow(internal_features)]
 
 pub mod arbitrary;
 #[cfg(feature = "concrete_playback")]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-08-04"
+channel = "nightly-2023-08-07"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/cargo-kani/vecdeque-cve/src/harness.rs
+++ b/tests/cargo-kani/vecdeque-cve/src/harness.rs
@@ -10,6 +10,7 @@
 #![feature(core_intrinsics)]
 #![feature(ptr_internals)]
 #![feature(rustc_allow_const_fn_unstable)]
+#![allow(internal_features)]
 
 #[cfg(disable_debug_asserts)]
 macro_rules! debug_assert {

--- a/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-size/main.rs
+++ b/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-size/main.rs
@@ -16,7 +16,7 @@ pub struct i64x2(i64, i64);
 pub struct i64x4(i64, i64, i64, i64);
 
 extern "platform-intrinsic" {
-    fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
+    fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 
 #[kani::proof]
@@ -24,7 +24,7 @@ fn main() {
     let y = i64x2(0, 1);
     let z = i64x2(1, 2);
     const I: [u32; 4] = [1, 2, 1, 2];
-    let x: i64x2 = unsafe { simd_shuffle4(y, z, I) };
+    let x: i64x2 = unsafe { simd_shuffle(y, z, I) };
     // ^^^^ The code above fails to type-check in Rust with the error:
     // ```
     // error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: expected return type of length 4, found `i64x2` with length 2

--- a/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-type/main.rs
+++ b/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-type/main.rs
@@ -16,7 +16,7 @@ pub struct i64x2(i64, i64);
 pub struct f64x2(f64, f64);
 
 extern "platform-intrinsic" {
-    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
+    fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 
 #[kani::proof]
@@ -24,7 +24,7 @@ fn main() {
     let y = i64x2(0, 1);
     let z = i64x2(1, 2);
     const I: [u32; 2] = [1, 2];
-    let x: f64x2 = unsafe { simd_shuffle2(y, z, I) };
+    let x: f64x2 = unsafe { simd_shuffle(y, z, I) };
     // ^^^^ The code above fails to type-check in Rust with the error:
     // ```
     // error[E0511]: invalid monomorphization of `simd_shuffle2` intrinsic: expected return element type `i64` (element of input `i64x2`), found `f64x2` with element type `f64`

--- a/tests/kani/Intrinsics/SIMD/Shuffle/main.rs
+++ b/tests/kani/Intrinsics/SIMD/Shuffle/main.rs
@@ -17,8 +17,6 @@ pub struct i64x4(i64, i64, i64, i64);
 
 extern "platform-intrinsic" {
     fn simd_shuffle<T, U, V>(x: T, y: T, idx: U) -> V;
-    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
-    fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
 }
 
 #[kani::proof]
@@ -35,7 +33,7 @@ fn main() {
         let y = i64x2(0, 1);
         let z = i64x2(1, 2);
         const I: [u32; 2] = [1, 2];
-        let x: i64x2 = unsafe { simd_shuffle2(y, z, I) };
+        let x: i64x2 = unsafe { simd_shuffle(y, z, I) };
         assert!(x.0 == 1);
         assert!(x.1 == 1);
     }
@@ -43,7 +41,7 @@ fn main() {
         let a = i64x4(1, 2, 3, 4);
         let b = i64x4(5, 6, 7, 8);
         const I: [u32; 4] = [1, 3, 5, 7];
-        let c: i64x4 = unsafe { simd_shuffle4(a, b, I) };
+        let c: i64x4 = unsafe { simd_shuffle(a, b, I) };
         assert!(c == i64x4(2, 4, 6, 8));
     }
 }

--- a/tools/bookrunner/librustdoc/doctest.rs
+++ b/tools/bookrunner/librustdoc/doctest.rs
@@ -5,7 +5,7 @@
 use rustc_ast as ast;
 use rustc_data_structures::sync::Lrc;
 use rustc_driver::DEFAULT_LOCALE_RESOURCES;
-use rustc_errors::{ColorConfig, TerminalUrl};
+use rustc_errors::ColorConfig;
 use rustc_span::edition::Edition;
 use rustc_span::source_map::SourceMap;
 use rustc_span::symbol::sym;
@@ -81,33 +81,11 @@ pub fn make_test(
 
             let fallback_bundle =
                 rustc_errors::fallback_fluent_bundle(DEFAULT_LOCALE_RESOURCES.to_vec(), false);
-            supports_color = EmitterWriter::stderr(
-                ColorConfig::Auto,
-                None,
-                None,
-                fallback_bundle.clone(),
-                false,
-                false,
-                Some(80),
-                false,
-                false,
-                TerminalUrl::No,
-            )
-            .supports_color();
+            supports_color = EmitterWriter::stderr(ColorConfig::Auto, fallback_bundle.clone())
+                .diagnostic_width(Some(80))
+                .supports_color();
 
-            let emitter = EmitterWriter::new(
-                Box::new(io::sink()),
-                None,
-                None,
-                fallback_bundle,
-                false,
-                false,
-                false,
-                None,
-                false,
-                false,
-                TerminalUrl::No,
-            );
+            let emitter = EmitterWriter::new(Box::new(io::sink()), fallback_bundle);
 
             // FIXME(misdreavus): pass `-Z treat-err-as-bug` to the doctest parser
             let handler = Handler::with_emitter(Box::new(emitter));


### PR DESCRIPTION
### Description of changes: 

Advance the Rust toolchain version by 3 days. Further than that requires a bit more work.

Here are the relevant upstream commits:

https://github.com/rust-lang/rust/commit/5830ca216d Add internal_features lint: This required explicitly allowing `internal_features` in the Kani library as well as the `vecdeque-cve` test.
https://github.com/rust-lang/rust/commit/4457ef2c6d Forbid old-style simd_shuffleN intrinsics
https://github.com/rust-lang/rust/commit/0e7ec9683d Use builder pattern instead of lots of arguments for EmitterWriter::new
https://github.com/rust-lang/rust/commit/29de70da1b Replace the many arguments of EmitterWriter::stderr with builder methods

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Current regressions

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
