### PR TITLE
Free up disk space (again)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,16 +13,11 @@ runs:
   using: composite
   steps:
       - name: Remove unnecessary software to free up disk space
-        if: contains(fromJSON('["ubuntu-18.04","ubuntu-20.04","ubuntu-22.04"]'), inputs.os)
+        if: contains(fromJSON('["ubuntu-20.04","ubuntu-22.04"]'), inputs.os)
         shell: bash
         run: |
           # inspired by https://github.com/easimon/maximize-build-space/blob/master/action.yml
           df -h
-          echo $PATH
-          du -hs /usr/share/dotnet
-          du -hs /usr/local/lib/android
-          ls -la /usr/local
-          du -hs /usr/local/.ghcup
           sudo rm -r /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup
           df -h
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,7 +17,7 @@ runs:
         run: |
           # inspired by https://github.com/easimon/maximize-build-space/blob/master/action.yml
           df -h
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo rm -r /usr/share/dotnet /usr/local/lib/android /opt/ghc
           df -h
 
       - name: Install dependencies

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,12 +19,11 @@ runs:
           # inspired by https://github.com/easimon/maximize-build-space/blob/master/action.yml
           df -h
           echo $PATH
-          ls /
-          ls /opt
-          ls -la /usr/local/.ghcup/bin
-          ls -la /home/runner/.dotnet/tools
-          which ghc
-          sudo rm -r /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          du -hs /usr/share/dotnet
+          du -hs /usr/local/lib/android
+          ls -la /usr/local
+          du -hs /usr/local/.ghcup
+          sudo rm -r /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup
           df -h
 
       - name: Install dependencies

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,6 +21,9 @@ runs:
           echo $PATH
           ls /
           ls /opt
+          ls -la /usr/local/.ghcup/bin
+          ls -la /home/runner/.dotnet/tools
+          which ghc
           sudo rm -r /usr/share/dotnet /usr/local/lib/android /opt/ghc
           df -h
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,10 +13,14 @@ runs:
   using: composite
   steps:
       - name: Remove unnecessary software to free up disk space
+        if: contains(fromJSON('["ubuntu-18.04","ubuntu-20.04","ubuntu-22.04"]'), inputs.os)
         shell: bash
         run: |
           # inspired by https://github.com/easimon/maximize-build-space/blob/master/action.yml
           df -h
+          echo $PATH
+          ls /
+          ls /opt
           sudo rm -r /usr/share/dotnet /usr/local/lib/android /opt/ghc
           df -h
 

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -188,15 +188,19 @@ jobs:
           retention-days: 3
 
   releasebundle-ubuntu:
-    runs-on: macos-latest
+    runs-on: ubuntu-20.04
     container:
       image: ubuntu:18.04
+      volumes:
+        /usr/local:/mnt/host-local
     steps:
       # This is required before checkout because the container does not
       # have Git installed, so cannot run checkout action. The checkout
       # action requires Git >=2.18, so use the Git maintainers' PPA.
       - name: Install system dependencies
         run: |
+          df -h
+          rm -r /mnt/host-local/lib/android /mnt/host-local/.ghcup
           df -h
           apt-get update
           apt-get install -y software-properties-common apt-utils

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -188,7 +188,7 @@ jobs:
           retention-days: 3
 
   releasebundle-ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: macos-latest
     container:
       image: ubuntu:18.04
     steps:
@@ -197,6 +197,7 @@ jobs:
       # action requires Git >=2.18, so use the Git maintainers' PPA.
       - name: Install system dependencies
         run: |
+          df -h
           apt-get update
           apt-get install -y software-properties-common apt-utils
           add-apt-repository ppa:git-core/ppa

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -192,7 +192,7 @@ jobs:
     container:
       image: ubuntu:18.04
       volumes:
-        /usr/local:/mnt/host-local
+        - /usr/local:/mnt/host-local
     steps:
       # This is required before checkout because the container does not
       # have Git installed, so cannot run checkout action. The checkout

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -198,7 +198,7 @@ jobs:
         run: |
           # inspired by https://github.com/easimon/maximize-build-space/blob/master/action.yml
           df -h
-          rm -r /__w/usr/share/dotnet /__w/usr/local/lib/android /__w/usr/local/.ghcup
+          rm -r /mnt/host-local/lib/android /mnt/host-local/.ghcup
           df -h
       # This is required before checkout because the container does not
       # have Git installed, so cannot run checkout action. The checkout

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -194,14 +194,17 @@ jobs:
       volumes:
         - /usr/local:/mnt/host-local
     steps:
+      - name: Remove unnecessary software to free up disk space
+        run: |
+          # inspired by https://github.com/easimon/maximize-build-space/blob/master/action.yml
+          df -h
+          rm -r /__w/usr/share/dotnet /__w/usr/local/lib/android /__w/usr/local/.ghcup
+          df -h
       # This is required before checkout because the container does not
       # have Git installed, so cannot run checkout action. The checkout
       # action requires Git >=2.18, so use the Git maintainers' PPA.
       - name: Install system dependencies
         run: |
-          df -h
-          rm -r /mnt/host-local/lib/android /mnt/host-local/.ghcup
-          df -h
           apt-get update
           apt-get install -y software-properties-common apt-utils
           add-apt-repository ppa:git-core/ppa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,17 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: ubuntu:18.04
+      volumes:
+        - /usr/local:/mnt/host-local
     permissions:
       contents: write
     steps:
+      - name: Remove unnecessary software to free up disk space
+        run: |
+          # inspired by https://github.com/easimon/maximize-build-space/blob/master/action.yml
+          df -h
+          rm -r /mnt/host-local/lib/android /mnt/host-local/.ghcup
+          df -h
       # This is required before checkout because the container does not
       # have Git installed, so cannot run checkout action. The checkout
       # action requires Git >=2.18, so use the Git maintainers' PPA.


### PR DESCRIPTION
### Description of changes: 

Actually free up space as when #2674 tried to remove the wrong directories, which went unnoticed for the use of `rm -rf`. Also makes it work with the container image, which really is the main reason we wanted this: use bind mounts to remove files from the host file system. The `df` output now confirms that we are actually freeing up space.

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? CI

* Is this a refactor change? no

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
