### PR TITLE
Don't error out if cleanup fails

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,7 +18,7 @@ runs:
         run: |
           # inspired by https://github.com/easimon/maximize-build-space/blob/master/action.yml
           df -h
-          sudo rm -r /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup
           df -h
 
       - name: Install dependencies


### PR DESCRIPTION
### Description of changes: 

Benchcomp CI is now broken due to #2704. The clean up we are performing is a best effort at this point, but it shouldn't fail the regression if it doesn't work.

### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
