### PR TITLE
Add a test that deallocates a stack variable

### DIFF
--- a/tests/expected/dealloc/stack/expected
+++ b/tests/expected/dealloc/stack/expected
@@ -1,0 +1,4 @@
+Status: FAILURE\
+Description: "free argument must be dynamic object"
+
+VERIFICATION:- FAILED

--- a/tests/expected/dealloc/stack/test.rs
+++ b/tests/expected/dealloc/stack/test.rs
@@ -1,0 +1,17 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::alloc::{dealloc, Layout};
+
+// This test checks that Kani flags the deallocation of a stack-allocated
+// variable
+
+#[kani::proof]
+fn check_dealloc_stack() {
+    let mut x = 6;
+    let layout = Layout::new::<i32>();
+    let p = &mut x as *mut i32;
+    unsafe {
+        dealloc(p as *mut u8, layout);
+    }
+}


### PR DESCRIPTION
### Description of changes: 

Add a new test to our regressions that checks that Kani properly flags the deallocation of a stack variable as a failure.

I did a quick grep, and didn't find a similar test with that has this check failing.

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
