### PR TITLE
Enable concrete playback for failure of UB checks

### DIFF
--- a/kani-driver/src/concrete_playback/test_generator.rs
+++ b/kani-driver/src/concrete_playback/test_generator.rs
@@ -325,7 +325,7 @@ mod concrete_vals_extractor {
         result_items
             .iter()
             .filter(|prop| {
-                (prop.property_class() == "assertion" && prop.status == CheckStatus::Failure)
+                (prop.property_class() != "unwind" && prop.status == CheckStatus::Failure)
                     || (prop.property_class() == "cover" && prop.status == CheckStatus::Satisfied)
             })
             .map(|property| {

--- a/tests/ui/concrete-playback/ub/null_ptr/expected
+++ b/tests/ui/concrete-playback/ub/null_ptr/expected
@@ -1,0 +1,13 @@
+VERIFICATION:- FAILED
+
+Concrete playback
+```
+#[test]
+fn kani_concrete_playback_null_ptr
+    let concrete_vals: Vec<Vec<u8>> = vec![
+        // 15
+        vec![15, 0, 0, 0],
+    ];
+    kani::concrete_playback_run(concrete_vals, null_ptr);
+}
+```

--- a/tests/ui/concrete-playback/ub/null_ptr/test.rs
+++ b/tests/ui/concrete-playback/ub/null_ptr/test.rs
@@ -1,0 +1,15 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags: -Zconcrete-playback --concrete-playback=print
+
+// This test checks that Kani generates a concrete playback test for UB checks
+// (e.g. dereferencing a null pointer)
+
+#[kani::proof]
+fn null_ptr() {
+    let x = 42;
+    let nd: i32 = kani::any();
+    let ptr: *const i32 = if nd != 15 { &x as *const i32 } else { std::ptr::null() };
+    let _y = unsafe { *ptr };
+}

--- a/tests/ui/concrete-playback/ub/oob_ptr/expected
+++ b/tests/ui/concrete-playback/ub/oob_ptr/expected
@@ -1,0 +1,13 @@
+VERIFICATION:- FAILED
+
+Concrete playback
+```
+#[test]
+fn kani_concrete_playback_oob_ptr
+    let concrete_vals: Vec<Vec<u8>> = vec![
+        // 3ul
+        vec![3, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    kani::concrete_playback_run(concrete_vals, oob_ptr);
+}
+```

--- a/tests/ui/concrete-playback/ub/oob_ptr/test.rs
+++ b/tests/ui/concrete-playback/ub/oob_ptr/test.rs
@@ -1,0 +1,15 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags: -Zconcrete-playback --concrete-playback=print
+
+// This test checks that Kani generates a concrete playback test for UB checks
+// (e.g. dereferencing a pointer that is outside the object bounds)
+
+#[kani::proof]
+fn oob_ptr() {
+    let v = vec![1, 2, 3];
+    // BUG: predicate should use strict less-than, i.e. `*idx < v.len()`
+    let idx: usize = kani::any_where(|idx| *idx <= v.len());
+    let _x = unsafe { *v.get_unchecked(idx) };
+}


### PR DESCRIPTION
### Description of changes: 

Currently, Kani only generates concrete playback tests for checks with the "assertion" property class. This PR enables generating concrete playback tests for other classes of properties as well (e.g. UB checks). Executing those tests normally will likely not result in a failure, but running them with MIRI should show the failure.

### Resolved issues:

Towards #2163 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

#2163 suggests that concrete playback tests that result in UB should be classified separately. This PR doesn't do that yet, hence I didn't mark it as a resolver for #2163.

### Testing:

* How is this change tested? Added two new tests

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
