### PR TITLE
Fix automatic toolchain update

### DIFF
--- a/.github/workflows/toolchain-upgrade.yml
+++ b/.github/workflows/toolchain-upgrade.yml
@@ -9,8 +9,10 @@ on:
   workflow_dispatch:     # Allow manual dispatching for a custom branch / tag.
 
 permissions:
-  contents: read
+  checks: write
+  contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   create-toolchain-pr:
@@ -31,6 +33,7 @@ jobs:
           current_toolchain_epoch=$(date --date $current_toolchain_date +%s)
           next_toolchain_date=$(date --date "@$(($current_toolchain_epoch + 86400))" +%Y-%m-%d)
           echo "next_toolchain_date=$next_toolchain_date" >> $GITHUB_ENV
+          GH_TOKEN=${{ github.token }}
           if gh issue list -S \
               "Toolchain upgrade to nightly-$next_toolchain_date failed" \
               --json number,title | grep title ; then


### PR DESCRIPTION
### Description of changes: 

1. Adjust permissions that were made overly restrictive in 4b829abfb4af, resulting in an inability to create branches.
2. Ensure `gh` can actually access the repository information by setting `GH_TOKEN`.

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? Will be tested upon merge.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- n/a Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
