### PR TITLE
Update toolchain to `nightly-2023-09-05`

### DIFF
--- a/cprover_bindings/src/irep/to_irep.rs
+++ b/cprover_bindings/src/irep/to_irep.rs
@@ -509,16 +509,16 @@ impl goto_program::Symbol {
                 SymbolValues::None => Irep::nil(),
             },
             location: self.location.to_irep(mm),
-            /// Unique identifier, same as key in symbol table `foo::x`
+            // Unique identifier, same as key in symbol table `foo::x`
             name: self.name,
-            /// Only used by verilog
+            // Only used by verilog
             module: self.module.unwrap_or("".into()),
-            /// Local identifier `x`
+            // Local identifier `x`
             base_name: self.base_name.unwrap_or("".into()),
-            /// Almost always the same as base_name, but with name mangling can be relevant
+            // Almost always the same as `base_name`, but with name mangling can be relevant
             pretty_name: self.pretty_name.unwrap_or("".into()),
-            /// Currently set to C. Consider creating a "rust" mode and using it in cbmc
-            /// https://github.com/model-checking/kani/issues/1
+            // Currently set to C. Consider creating a "rust" mode and using it in cbmc
+            // https://github.com/model-checking/kani/issues/1
             mode: self.mode.to_string().into(),
 
             // global properties

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-09-02"
+channel = "nightly-2023-09-05"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
### Description of changes: 

Manually updates toolchain to `nightly-2023-09-05`. The main change is documentation-related, to avoid the warnings (which get upgraded to compilation errors when running `kani-regression.sh`) that are now produced because of [this change](https://github.com/rust-lang/rust/pull/115478).

### Testing:

* How is this change tested? Existing regression.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
