### PR TITLE
Bump version to 0.36.0 and add release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.36.0]
+
+## What's Changed
+
+* Enable `-Z stubbing` and error out instead of ignoring stub by @celinval in https://github.com/model-checking/kani/pull/2678
+* Enable concrete playback for failure of UB checks by @zhassan-aws in https://github.com/model-checking/kani/pull/2727
+* Bump CBMC version to 5.91.0 by @adpaco-aws in https://github.com/model-checking/kani/pull/2733
+* Rust toolchain upgraded to `nightly-2023-09-06` by @celinval @jaisnan @adpaco-aws
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.35.0...kani-0.36.0
+
 ## [0.35.0]
 
 ## What's Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -473,14 +473,14 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "kani"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "home",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "cprover_bindings",
  "serde",
@@ -1135,7 +1135,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "std"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Description of changes: 

Bump version to 0.36.0 and add release notes.

The original (auto-generated) release notes were:

```
## What's Changed
* Don't error out if cleanup fails by @celinval in https://github.com/model-checking/kani/pull/2708
* Update to today's toolchain (2023-08-24) by @celinval in https://github.com/model-checking/kani/pull/2711
* RFC Function Contracts by @JustusAdam in https://github.com/model-checking/kani/pull/2620
* Automatic toolchain upgrade to nightly-2023-08-25 by @github-actions in https://github.com/model-checking/kani/pull/2713
* Add a test that deallocates a stack variable by @zhassan-aws in https://github.com/model-checking/kani/pull/2717
* Use the clap `derive` API for the command line arguments of `kani-compiler` by @JustusAdam in https://github.com/model-checking/kani/pull/2689
* Enable `-Z stubbing` and error out instead of ignore stub by @celinval in https://github.com/model-checking/kani/pull/2678
* Update to today's toolchain (sept-01) by @jaisnan in https://github.com/model-checking/kani/pull/2726
* Enable concrete playback for failure of UB checks by @zhassan-aws in https://github.com/model-checking/kani/pull/2727
* Automatic toolchain upgrade to nightly-2023-09-02 by @github-actions in https://github.com/model-checking/kani/pull/2728
* Automatic toolchain upgrade improvements by @tautschnig in https://github.com/model-checking/kani/pull/2722
* Fix automatic toolchain update by @tautschnig in https://github.com/model-checking/kani/pull/2729
* Bump CBMC version to 5.91.0 by @adpaco-aws in https://github.com/model-checking/kani/pull/2733
* Update toolchain to `nightly-2023-09-05` by @adpaco-aws in https://github.com/model-checking/kani/pull/2734
* Automatic toolchain upgrade to nightly-2023-09-06 by @github-actions in https://github.com/model-checking/kani/pull/2736
* Bump dependencies for release 0.36.0 by @adpaco-aws in https://github.com/model-checking/kani/pull/2738


**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.35.0...kani-0.36.0
```

### Testing:

* How is this change tested? N/A

* Is this a refactor change? N/A

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
