### PR TITLE
Upgrade rust toolchain to 2023-09-07

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/span.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/span.rs
@@ -42,18 +42,6 @@ impl<'tcx> GotocCtx<'tcx> {
         self.current_fn().mir().var_debug_info.iter().find(|info| match info.value {
             VarDebugInfoContents::Place(p) => p.local == *l && p.projection.len() == 0,
             VarDebugInfoContents::Const(_) => false,
-            // This variant was added in
-            // https://github.com/rust-lang/rust/pull/102570 and is concerned
-            // with a scalar replacement of aggregates (SROA) MIR optimization
-            // that is only enabled with `--mir-opt-level=3` or higher.
-            // TODO: create a test and figure out if we should return debug info
-            // for this case:
-            // https://github.com/model-checking/kani/issues/1933
-            VarDebugInfoContents::Composite { .. } => {
-                // Fail in debug mode to determine if we ever hit this case
-                debug_assert!(false, "Unhandled VarDebugInfoContents::Composite");
-                false
-            }
         })
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-09-06"
+channel = "nightly-2023-09-07"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
### Description of changes: 

`VarDebugInfoContents::Composite` no longer exists, and therefore had to be removed. We hadn't fully implemented this case, so this is an improvement.

### Resolved issues:

Fixes: #2742

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? CI

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- n/a Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
