### PR TITLE
Do not run performance benchmarks for tags

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,8 +3,6 @@
 name: Kani Performance Benchmarks
 on:
   push:
-    tags:
-      - kani-*
     branches:
       - 'main'
   pull_request:


### PR DESCRIPTION
### Description of changes: 

Currently, the performance benchmarks also run when pushing `kani-*` tags, which is essentially done each time we're going to publish a new release. In that case, the performance CI job fails with the error:

```
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=2 origin 0000000000000000000000000000000000000000
  Error: fatal: remote error: upload-pack: not our ref 0000000000000000000000000000000000000000
  The process '/usr/bin/git' failed with exit code 128
  Waiting 17 seconds before trying again
```

There's at least two occasions in which I've seen this happen:
 * For the `kani-0.35.0` tag: https://github.com/model-checking/kani/actions/runs/5957239259/job/16159564100
 * For the `kani-0.36.0` tag: https://github.com/model-checking/kani/actions/runs/6110889802/job/16585358347

It doesn't make sense to run performance benchmarks in this case, since the candidate commit will have already triggered a performance benchmarks CI job when it's merged into `main`.

### Resolved issues:

Resolves #2744 

### Testing:

* How is this change tested? N/A (changes to GA workflows cannot be tested)

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
