### PR TITLE
Toolchain upgrade workflow: fix de-duplicating issues

### DIFF
--- a/.github/workflows/toolchain-upgrade.yml
+++ b/.github/workflows/toolchain-upgrade.yml
@@ -27,13 +27,14 @@ jobs:
           os: ubuntu-22.04
 
       - name: Update toolchain config
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           current_toolchain_date=$(grep ^channel rust-toolchain.toml | sed 's/.*nightly-\(.*\)"/\1/')
           echo "current_toolchain_date=$current_toolchain_date" >> $GITHUB_ENV
           current_toolchain_epoch=$(date --date $current_toolchain_date +%s)
           next_toolchain_date=$(date --date "@$(($current_toolchain_epoch + 86400))" +%Y-%m-%d)
           echo "next_toolchain_date=$next_toolchain_date" >> $GITHUB_ENV
-          GH_TOKEN=${{ github.token }}
           if gh issue list -S \
               "Toolchain upgrade to nightly-$next_toolchain_date failed" \
               --json number,title | grep title ; then


### PR DESCRIPTION
### Description of changes: 

It seems that just setting the `GH_TOKEN` variable wasn't sufficient for `gh` to work properly. (We ended up with #2748 as a duplicate of #2742.) Now following the advice posted in the workflow run.

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? CI

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
