### PR TITLE
Remove build files generated with `cargo doc` command

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -87,5 +87,9 @@ ${MDBOOK} build -d $KANI_DIR/docs/book/rfc
 echo "Building rustdocs..."
 cd $KANI_DIR
 RUSTFLAGS="--cfg=kani" cargo doc -p kani --no-deps --target-dir docs/book/crates
+# We remove build files to avoid false positives in secret scanning alerts.
+# More details in: https://github.com/model-checking/kani/issues/2735
+echo "Removing build files from rustdocs..."
+rm -r docs/book/crates/debug
 
 echo "Finished documentation build successfully."


### PR DESCRIPTION
### Description of changes: 

Remove build files to avoid false positives in secret scanning alerts (more details in #2735) in `scripts/build-docs.sh`.

### Resolved issues:

Resolves #2735 

### Call-outs:

We could instead add an extra step to the `kani.yml` workflow to do the same. That'd allow us to keep build files when we build the docs locally. But I think that's a rare scenario, and I'd rather keep this in the doc-building script which is already doing similar things.
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Locally.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
