### PR TITLE
Fix syntax errors in Kissat checking script

### DIFF
--- a/scripts/check_kissat_version.sh
+++ b/scripts/check_kissat_version.sh
@@ -11,16 +11,16 @@ source "${KANI_DIR}/kani-dependencies"
 
 if [ -z "${KISSAT_VERSION:-}" ]; then
   echo "$0: ERROR: KISSAT_VERSION is not set"
-  return 1
+  exit 1
 fi
 cmd="kissat --version"
 if kissat_version=$($cmd); then
   # Perform a lexicographic comparison of the version
   if [[ $kissat_version < $KISSAT_VERSION ]]; then
     echo "ERROR: Kissat version is $kissat_version. Expected at least $KISSAT_VERSION."
-    return 1
+    exit 1
   fi
 else
   echo "ERROR: Couldn't run command '$cmd'"
-  return 1
+  exit 1
 fi


### PR DESCRIPTION
### Description of changes: 

In bash, `return` can only be used within a function. Use `exit` instead.

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? Locally

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
