### PR TITLE
Update rust toolchain to nightly-2023-09-19

### DIFF
--- a/kani-compiler/src/kani_middle/reachability.rs
+++ b/kani-compiler/src/kani_middle/reachability.rs
@@ -457,11 +457,9 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MonoItemsFnCollector<'a, 'tcx> {
                 match self.tcx.const_eval_resolve(ParamEnv::reveal_all(), un_eval, None) {
                     // The `monomorphize` call should have evaluated that constant already.
                     Ok(const_val) => const_val,
-                    Err(ErrorHandled::TooGeneric(span)) => span_bug!(
-                        span,
-                        "Unexpected polymorphic constant: {:?}",
-                        literal
-                    ),
+                    Err(ErrorHandled::TooGeneric(span)) => {
+                        span_bug!(span, "Unexpected polymorphic constant: {:?}", literal)
+                    }
                     Err(error) => {
                         warn!(?error, "Error already reported");
                         return;

--- a/kani-compiler/src/kani_middle/reachability.rs
+++ b/kani-compiler/src/kani_middle/reachability.rs
@@ -457,8 +457,8 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MonoItemsFnCollector<'a, 'tcx> {
                 match self.tcx.const_eval_resolve(ParamEnv::reveal_all(), un_eval, None) {
                     // The `monomorphize` call should have evaluated that constant already.
                     Ok(const_val) => const_val,
-                    Err(ErrorHandled::TooGeneric) => span_bug!(
-                        self.body.source_info(location).span,
+                    Err(ErrorHandled::TooGeneric(span)) => span_bug!(
+                        span,
                         "Unexpected polymorphic constant: {:?}",
                         literal
                     ),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-09-18"
+channel = "nightly-2023-09-19"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
### Description of changes: 

Update rust toolchain to nightly-2023-09-19.

Source changes required by the following upstream commits: 

Propagate changes from https://github.com/rust-lang/rust/pull/115748

### Resolved issues:

n/a

### Related RFC:

n/a

### Call-outs:

n/a

### Testing:

* How is this change tested? CI

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
