### PR TITLE
Bump Kani version to 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,38 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 ## [0.37.0]
 
 ### Major Changes
+
 * Delete obsolete stubs for `Vec` and related options ([pull request](https://github.com/model-checking/kani/pull/2770) by @zhassan-aws) 
 
+## What's Changed
+
+* Function Contracts: Support for defining and checking `requires` and `ensures` clauses by @JustusAdam in https://github.com/model-checking/kani/pull/2655
+* Do not run performance benchmarks for tags by @adpaco-aws in https://github.com/model-checking/kani/pull/2745
+* Upgrade rust toolchain to 2023-09-07 by @tautschnig in https://github.com/model-checking/kani/pull/2743
+* Toolchain upgrade workflow: fix de-duplicating issues by @tautschnig in https://github.com/model-checking/kani/pull/2749
+* Update RFC process by @celinval in https://github.com/model-checking/kani/pull/2716
+* Remove build files generated with `cargo doc` command by @adpaco-aws in https://github.com/model-checking/kani/pull/2750
+* Automatic toolchain upgrade to nightly-2023-09-08 by @github-actions in https://github.com/model-checking/kani/pull/2752
+* Automatic toolchain upgrade to nightly-2023-09-09 by @github-actions in https://github.com/model-checking/kani/pull/2755
+* Fixing the Footnotes and Feature Flag on the Function Contracts RFC by @JustusAdam in https://github.com/model-checking/kani/pull/2754
+* Upgrade to Kissat 3.1.1 by @zhassan-aws in https://github.com/model-checking/kani/pull/2756
+* Fix hashset perf test by @zhassan-aws in https://github.com/model-checking/kani/pull/2758
+* Add support for the ARM64 Linux platform by @adpaco-aws in https://github.com/model-checking/kani/pull/2757
+* Automatic toolchain upgrade to nightly-2023-09-10 by @github-actions in https://github.com/model-checking/kani/pull/2760
+* Automatic toolchain upgrade to nightly-2023-09-11 by @github-actions in https://github.com/model-checking/kani/pull/2764
+* Force any_vec capacity to match length by @celinval in https://github.com/model-checking/kani/pull/2765
+* Fix syntax errors in Kissat checking script by @tautschnig in https://github.com/model-checking/kani/pull/2769
+* Update Rust toolchain to 2023-09-15 by @tautschnig in https://github.com/model-checking/kani/pull/2768
+* Add range demo example by @zhassan-aws in https://github.com/model-checking/kani/pull/2772
+* Bump CBMC version by @zhassan-aws in https://github.com/model-checking/kani/pull/2771
+* Automatic toolchain upgrade to nightly-2023-09-16 by @github-actions in https://github.com/model-checking/kani/pull/2773
+* Automatic toolchain upgrade to nightly-2023-09-17 by @github-actions in https://github.com/model-checking/kani/pull/2774
+* Automatic toolchain upgrade to nightly-2023-09-18 by @github-actions in https://github.com/model-checking/kani/pull/2775
+* Update rust toolchain to nightly-2023-09-19 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2778
+* Minor version update of deps using cargo update by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2779
+* Major version updates by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2780
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.36.0...kani-0.37.0
 ## [0.36.0]
 
 ## What's Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -473,14 +473,14 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "kani"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "home",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1136,7 +1136,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "std"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Description of changes: 

## What's Changed
* Function Contracts: Support for defining and checking `requires` and `ensures` clauses by @JustusAdam in https://github.com/model-checking/kani/pull/2655
* Do not run performance benchmarks for tags by @adpaco-aws in https://github.com/model-checking/kani/pull/2745
* Upgrade rust toolchain to 2023-09-07 by @tautschnig in https://github.com/model-checking/kani/pull/2743
* Toolchain upgrade workflow: fix de-duplicating issues by @tautschnig in https://github.com/model-checking/kani/pull/2749
* Update RFC process by @celinval in https://github.com/model-checking/kani/pull/2716
* Remove build files generated with `cargo doc` command by @adpaco-aws in https://github.com/model-checking/kani/pull/2750
* Automatic toolchain upgrade to nightly-2023-09-08 by @github-actions in https://github.com/model-checking/kani/pull/2752
* Automatic toolchain upgrade to nightly-2023-09-09 by @github-actions in https://github.com/model-checking/kani/pull/2755
* Fixing the Footnotes and Feature Flag on the Function Contracts RFC by @JustusAdam in https://github.com/model-checking/kani/pull/2754
* Upgrade to Kissat 3.1.1 by @zhassan-aws in https://github.com/model-checking/kani/pull/2756
* Fix hashset perf test by @zhassan-aws in https://github.com/model-checking/kani/pull/2758
* Add support for the ARM64 Linux platform by @adpaco-aws in https://github.com/model-checking/kani/pull/2757
* Automatic toolchain upgrade to nightly-2023-09-10 by @github-actions in https://github.com/model-checking/kani/pull/2760
* Automatic toolchain upgrade to nightly-2023-09-11 by @github-actions in https://github.com/model-checking/kani/pull/2764
* Force any_vec capacity to match length by @celinval in https://github.com/model-checking/kani/pull/2765
* Fix syntax errors in Kissat checking script by @tautschnig in https://github.com/model-checking/kani/pull/2769
* Update Rust toolchain to 2023-09-15 by @tautschnig in https://github.com/model-checking/kani/pull/2768
* Add range demo example by @zhassan-aws in https://github.com/model-checking/kani/pull/2772
* Delete obsolete stubs for Vec and related options by @zhassan-aws in https://github.com/model-checking/kani/pull/2770
* Bump CBMC version by @zhassan-aws in https://github.com/model-checking/kani/pull/2771
* Automatic toolchain upgrade to nightly-2023-09-16 by @github-actions in https://github.com/model-checking/kani/pull/2773
* Automatic toolchain upgrade to nightly-2023-09-17 by @github-actions in https://github.com/model-checking/kani/pull/2774
* Automatic toolchain upgrade to nightly-2023-09-18 by @github-actions in https://github.com/model-checking/kani/pull/2775
* Update rust toolchain to nightly-2023-09-19 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2778
* minor version update of deps using cargo update by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2779
* major version updates by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2780


**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.36.0...kani-0.37.0
### Resolved issues:

N/A

### Related RFC:

n/a 
### Call-outs:


### Testing:

* How is this change tested? CI

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
