### PR TITLE
fix expected value for pref_align_of under aarch64/macos

### DIFF
--- a/tests/kani/Intrinsics/ConstEval/pref_align_of.rs
+++ b/tests/kani/Intrinsics/ConstEval/pref_align_of.rs
@@ -48,7 +48,7 @@ fn main() {
         #[cfg(target_os = "linux")]
         assert!(unsafe { pref_align_of::<i16>() } == 4);
         #[cfg(target_os = "macos")]
-        assert!(unsafe { pref_align_of::<i16>() } == 1);
+        assert!(unsafe { pref_align_of::<i16>() } == 2);
         assert!(unsafe { pref_align_of::<i32>() } == 4);
         assert!(unsafe { pref_align_of::<i64>() } == 8);
         assert!(unsafe { pref_align_of::<i128>() } == 16);


### PR DESCRIPTION
### Description of changes: 

Sets the expected value for `pref_align_of ::<i16>` under aarch64/macos to 2 to make tests pass under M1.

### Resolved issues:

n/a

### Related RFC:

### Call-outs:

### Testing:

* How is this change tested?  CI

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
