### PR TITLE
Auto label PRs that may require extra checks 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,4 +11,6 @@ Z-BenchCI:
   - kani-dependencies
   - kani-driver/src/call-*
   - Cargo.lock
+  - cprover_bindings/**
+  - library/**
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Configuration for auto-labeling PRs
+#
+# Note that we enable dot, so "**" matches all files in a folder
+
+Z-BenchCI:
+  - kani-compiler/**
+  - rust-toolchain.toml
+  - kani-dependencies
+  - kani-driver/src/call-*
+  - Cargo.lock
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,30 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Auto label PRs based on the files that were changed
+#
+# This PR runs on `pull_request_target` because it needs extra write permission.
+#
+# Thus, we keep this workflow minimal, and the only action used here is from a
+# verified publisher.
+#
+# See <https://github.com/actions/labeler/issues/121> for more details.
+
+name: Auto Label
+on: pull_request_target
+
+jobs:
+  auto-label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Kani
+      uses: actions/checkout@v3
+
+    - name: Label PR
+      uses: actions/labeler@v4
+      with:
+        dot: true
+

--- a/.github/workflows/toolchain-upgrade.yml
+++ b/.github/workflows/toolchain-upgrade.yml
@@ -74,7 +74,6 @@ jobs:
           branch: toolchain-${{ env.next_toolchain_date }}
           delete-branch: true
           title: 'Automatic toolchain upgrade to nightly-${{ env.next_toolchain_date }}'
-          labels: Z-BenchCI
           body: >
             Update Rust toolchain from nightly-${{ env.current_toolchain_date }} to
             nightly-${{ env.next_toolchain_date }} without any other source changes.


### PR DESCRIPTION
### Description of changes: 

Add a new workflow that automatically adds the label "Z-BenchCI" to PRs that touch compiler, toolchain, dependencies and driver files that invoke our dependencies.

I also removed the label from the toolchain update job since this workflow will add the label once the PR is created.

### Resolved issues:

#2606

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? I manually tested in my fork: https://github.com/celinval/kani-dev/pull/12

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
