### PR TITLE
Fix issue 2589

### DIFF
--- a/kani-compiler/src/kani_middle/reachability.rs
+++ b/kani-compiler/src/kani_middle/reachability.rs
@@ -584,7 +584,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MonoItemsFnCollector<'a, 'tcx> {
 /// This function handles the `Trt::CNST` case where there is one trait (`Trt`)
 /// which defined a constant `CNST` that we failed to resolve. As such we expect
 /// that the trait can be resolved from the constant and that only one generic
-/// parameter, the instantiation of `Trt` is present.
+/// parameter, the instantiation of `Trt`, is present.
 ///
 /// If these expectations are not met we return `None`. We do not know in what
 /// situation that would be the case and if they are even possible.

--- a/kani-compiler/src/kani_middle/reachability.rs
+++ b/kani-compiler/src/kani_middle/reachability.rs
@@ -577,6 +577,15 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MonoItemsFnCollector<'a, 'tcx> {
     }
 }
 
+/// Try to construct a nice error message when const evaluation fails.
+/// 
+/// This function handles the `Trt::CNST` case where there is one trait (`Trt`)
+/// which defined a constant `CNST` that we failed to resolve. As such we expect
+/// that the trait can be resolved from the constant and that only one generic
+/// parameter, the instantiation of `Trt` is present.
+/// 
+/// If these expectations are not met we return `None`. We do not know in what
+/// situation that would be the case and if they are even possible.
 fn graceful_const_resolution_err<'tcx>(
     tcx: TyCtxt<'tcx>,
     mono_const: &UnevaluatedConst<'tcx>,

--- a/kani-compiler/src/kani_middle/reachability.rs
+++ b/kani-compiler/src/kani_middle/reachability.rs
@@ -460,12 +460,14 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MonoItemsFnCollector<'a, 'tcx> {
                     // The `monomorphize` call should have evaluated that constant already.
                     Ok(const_val) => const_val,
                     Err(ErrorHandled::TooGeneric(span)) => {
-                        if let Some(_) = graceful_const_resolution_err(
+                        if graceful_const_resolution_err(
                             self.tcx,
                             &un_eval,
                             span,
                             self.instance.def_id(),
-                        ) {
+                        )
+                        .is_some()
+                        {
                             return;
                         } else {
                             span_bug!(
@@ -578,12 +580,12 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MonoItemsFnCollector<'a, 'tcx> {
 }
 
 /// Try to construct a nice error message when const evaluation fails.
-/// 
+///
 /// This function handles the `Trt::CNST` case where there is one trait (`Trt`)
 /// which defined a constant `CNST` that we failed to resolve. As such we expect
 /// that the trait can be resolved from the constant and that only one generic
 /// parameter, the instantiation of `Trt` is present.
-/// 
+///
 /// If these expectations are not met we return `None`. We do not know in what
 /// situation that would be the case and if they are even possible.
 fn graceful_const_resolution_err<'tcx>(

--- a/tests/expected/issue-2589/issue_2589.expected
+++ b/tests/expected/issue-2589/issue_2589.expected
@@ -1,0 +1,1 @@
+error: Type `std::string::String` does not implement trait `Dummy`. This is likely because `original` is used as a stub but its generic bounds are not being met.

--- a/tests/expected/issue-2589/issue_2589.rs
+++ b/tests/expected/issue-2589/issue_2589.rs
@@ -3,13 +3,11 @@
 //
 // kani-flags: -Z stubbing
 
-
 fn original<T>() {}
 
 trait Dummy {
     const TRUE: bool = true;
 }
-
 
 fn stub<T: Dummy>() {
     // Do nothing.

--- a/tests/kani/Stubbing/issue_2589.rs
+++ b/tests/kani/Stubbing/issue_2589.rs
@@ -1,0 +1,23 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// kani-flags: -Z stubbing
+
+
+fn original<T>() {}
+
+trait Dummy {
+    const TRUE: bool = true;
+}
+
+
+fn stub<T: Dummy>() {
+    // Do nothing.
+    assert!(T::TRUE);
+}
+
+#[kani::proof]
+#[kani::stub(original, stub)]
+fn check_mismatch() {
+    original::<String>();
+}


### PR DESCRIPTION
### Description of changes: 

This addresses #2589 by providing a better error message that contains both the trait that failed to resolve and the type which does not implement it.

Before:

```
error: internal compiler error: kani-compiler/src/kani_middle/reachability.rs:471:29: Unexpected polymorphic constant: Unevaluated(UnevaluatedConst { def: DefId(0:6 ~ issue_2589[1b49]::Dummy::TRUE), args: [Adt(std::string::String, [])], promoted: None }, bool) Unevaluated(UnevaluatedConst { def: DefId(0:6 ~ issue_2589[1b49]::Dummy::TRUE), args: [T/#0], promoted: None }, bool)

thread 'rustc' panicked at /rustc/65ea825f4021eaf77f1b25139969712d65b435a4/compiler/rustc_errors/src/lib.rs:995:33:
Box<dyn Any>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Kani unexpectedly panicked during compilation.
Please file an issue here: https://github.com/model-checking/kani/issues/new?labels=bug&template=bug_report.md

[Kani] no current codegen item.
[Kani] no current codegen location.
error: aborting due to previous error; 1 warning emitted
```

After:

```
error: Type `std::string::String` does not implement trait `Dummy`. This is likely because `original` is used as a stub but its generic bounds are not being met.

error: aborting due to previous error; 1 warning emitted
```

### Resolved issues:

Resolves #2589 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
