### PR TITLE
Limit --exclude to workspace packages

### DIFF
--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -319,6 +319,8 @@ fn packages_to_verify<'b>(
             .map(|pkg_name| metadata.packages.iter().find(|pkg| pkg.name == *pkg_name).unwrap())
             .collect()
     } else if !args.cargo.exclude.is_empty() {
+        // should be ensured by argument validation
+        assert!(args.cargo.workspace);
         validate_package_names(&args.cargo.exclude, &metadata.packages)?;
         metadata
             .workspace_packages()

--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -320,7 +320,11 @@ fn packages_to_verify<'b>(
             .collect()
     } else if !args.cargo.exclude.is_empty() {
         validate_package_names(&args.cargo.exclude, &metadata.packages)?;
-        metadata.packages.iter().filter(|pkg| !args.cargo.exclude.contains(&pkg.name)).collect()
+        metadata
+            .workspace_packages()
+            .into_iter()
+            .filter(|pkg| !args.cargo.exclude.contains(&pkg.name))
+            .collect()
     } else {
         match (args.cargo.workspace, metadata.root_package()) {
             (true, _) | (_, None) => metadata.workspace_packages(),


### PR DESCRIPTION
Previously, --exclude would start from the set of all packages referenced in a workspace, i.e., the workspace's packages plus any dependencies. Without --exclude, we would at most look at all the workspace's packages, so --exclude would result in possibly verifying a larger set of packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
