### PR TITLE
Avoid two regression test warnings

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -989,7 +989,7 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     /// This is an intrinsic that was added in
-    /// https://github.com/rust-lang/rust/pull/114382 that is essentially the
+    /// <https://github.com/rust-lang/rust/pull/114382> that is essentially the
     /// same as memcmp: it compares two slices up to the specified length.
     /// The implementation is the same as the hook for `memcmp`.
     pub fn codegen_compare_bytes(

--- a/library/kani/src/models/mod.rs
+++ b/library/kani/src/models/mod.rs
@@ -157,7 +157,7 @@ mod test {
     #[test]
     #[should_panic(expected = "Expected size of return type and mask lanes to match")]
     fn test_invalid_generics() {
-        let mask = unsafe { mask32x16::splat(false) };
+        let mask = mask32x16::splat(false);
         assert_eq!(unsafe { kani_intrinsic::simd_bitmask::<_, u16, i32, 2>(mask) }, u16::MAX);
     }
 


### PR DESCRIPTION
* No need for unsafe in this place.
* Wrap a URL in angle brackets to produce better documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
