### PR TITLE
Update CBMC version to 5.94

### DIFF
--- a/kani-dependencies
+++ b/kani-dependencies
@@ -1,4 +1,10 @@
-CBMC_VERSION="5.93.0"
+CBMC_MAJOR="5"
+CBMC_MINOR="94"
+CBMC_VERSION="5.94.0"
+
 # If you update this version number, remember to bump it in `src/setup.rs` too
+CBMC_VIEWER_MAJOR="3"
+CBMC_VIEWER_MINOR="8"
 CBMC_VIEWER_VERSION="3.8"
+
 KISSAT_VERSION="3.1.1"

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -18,9 +18,16 @@ KANI_DIR=$SCRIPT_DIR/..
 # TODO: We should add a more robust mechanism to detect python unexpected behavior.
 export KANI_FAIL_ON_UNEXPECTED_DESCRIPTION="true"
 
-# Required dependencies
-check-cbmc-version.py --major 5 --minor 93
-check-cbmc-viewer-version.py --major 3 --minor 8
+# Gather dependencies version from top `kani-dependencies` file.
+source "${KANI_DIR}/kani-dependencies"
+# Sanity check dependencies values.
+[[ "${CBMC_MAJOR}.${CBMC_MINOR}" == "${CBMC_VERSION%.*}" ]] || \
+    (echo "Conflicting CBMC versions"; exit 1)
+[[ "${CBMC_VIEWER_MAJOR}.${CBMC_VIEWER_MINOR}" == "${CBMC_VIEWER_VERSION}" ]] || \
+    (echo "Conflicting CBMC viewer versions"; exit 1)
+# Check if installed versions are correct.
+check-cbmc-version.py --major ${CBMC_MAJOR} --minor ${CBMC_MINOR}
+check-cbmc-viewer-version.py --major ${CBMC_VIEWER_MAJOR} --minor ${CBMC_VIEWER_MINOR}
 check_kissat_version.sh
 
 # Formatting check


### PR DESCRIPTION
Update CBMC version to 5.94 and change our regression script to read the values from kani-dependencies instead of requiring us to keep two sources of truth.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
