### PR TITLE
Upgrade toolchain and fix test

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-10-10"
+channel = "nightly-2023-10-16"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/coverage/unreachable/contradiction/expected
+++ b/tests/coverage/unreachable/contradiction/expected
@@ -1,6 +1,7 @@
 coverage/unreachable/contradiction/main.rs, 5, FULL
 coverage/unreachable/contradiction/main.rs, 6, FULL
-coverage/unreachable/contradiction/main.rs, 7, PARTIAL
-coverage/unreachable/contradiction/main.rs, 8, NONE
-coverage/unreachable/contradiction/main.rs, 11, FULL
-coverage/unreachable/contradiction/main.rs, 13, FULL
+coverage/unreachable/contradiction/main.rs, 7, FULL
+coverage/unreachable/contradiction/main.rs, 8, PARTIAL
+coverage/unreachable/contradiction/main.rs, 9, NONE
+coverage/unreachable/contradiction/main.rs, 12, FULL
+coverage/unreachable/contradiction/main.rs, 14, FULL

--- a/tests/coverage/unreachable/contradiction/main.rs
+++ b/tests/coverage/unreachable/contradiction/main.rs
@@ -3,9 +3,10 @@
 #[kani::proof]
 fn contradiction() {
     let x: u8 = kani::any();
+    let mut y: u8 = 0;
     if x > 5 {
         if x < 2 {
-            let y = x;
+            y = x;
         }
     } else {
         assert!(x < 10);


### PR DESCRIPTION
Update rust toolchain to 2023-10-16 and update failing test.

The coverage test was failing because the logic was being pruned by rustup. 

Resolves #2817 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
