### PR TITLE
Upgrade `tracing` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.39"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",


### PR DESCRIPTION
Version 0.1.39 of the `tracing` crate was yanked last week, causing the cargo audit CI workflow to throw an error (see [this action run](https://github.com/model-checking/kani/actions/runs/6593068605/job/17914928240) for an example). This PR upgrades `tracing` to version to 0.1.40.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
