### PR TITLE
Fix docker build step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,7 @@ jobs:
             echo "Git tag ${{env.TAG_VERSION}} did not match crate version ${{env.CRATE_VERSION}}"
             exit 1
           fi
+          echo "version=${{ env.TAG_VERSION }}" >> $GITHUB_OUTPUT
 
       - name: Download MacOS bundle
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Output the tagged version in the `versioning` step of the release workflow to avoid a failure in the posterior docker build step (see #2851 for more details).

This has been tested in my fork, where:
 1. Pushing the `kani-0.40.0` without any changes generated the same failure [in this run](https://github.com/adpaco-aws/rmc/actions/runs/6738081085/job/18317679294)
 2. Committing the change in this PR and pushing the `kani-0.40.0` again resulted in a successful build [in this run](https://github.com/adpaco-aws/rmc/actions/runs/6738159804/job/18317924214)
 3. The tagged image can be downloaded from my fork, as seen [here](https://github.com/adpaco-aws/rmc/pkgs/container/kani-ubuntu-20.04).

Resolves #2851 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
