### PR TITLE
Fix setup for `aarch64-unknown-linux-gnu` platform

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -194,7 +194,10 @@ fn download_url() -> String {
 fn fail_if_unsupported_target() -> Result<()> {
     // This is basically going to be reduced to a compile-time constant
     match TARGET {
-        "x86_64-unknown-linux-gnu" | "x86_64-apple-darwin" | "aarch64-apple-darwin" => Ok(()),
+        "x86_64-unknown-linux-gnu"
+        | "x86_64-apple-darwin"
+        | "aarch64-unknown-linux-gnu"
+        | "aarch64-apple-darwin" => Ok(()),
         _ => bail!("Kani does not support this platform (Rust target {})", TARGET),
     }
 }


### PR DESCRIPTION
Fixes setup for `aarch64-unknown-linux-gnu` platform by adding its target triple to the list of supported targets in the setup program.

Resolves #2863 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
