### PR TITLE
expect() does not take format strings

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -716,8 +716,8 @@ impl<'tcx> GotocCtx<'tcx> {
             trace!(func=?instance, "codegen_func_symbol");
             let func = self.symbol_name(instance);
             self.symbol_table
-                .lookup(func)
-                .expect("Function `{func}` should've been declared before usage")
+                .lookup(&func)
+                .unwrap_or_else(|| panic!("Function `{func}` should've been declared before usage"))
         };
         (sym, funct)
     }


### PR DESCRIPTION

This would just print 
````
Function `{func}` should've been declared before usage'
````
on panic, it just now occurred to me that `func` is supposed to be content of a var :smile: 