### PR TITLE
const-ify `cover`

### DIFF
--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -146,7 +146,7 @@ pub const fn assert(cond: bool, msg: &'static str) {
 ///
 #[inline(never)]
 #[rustc_diagnostic_item = "KaniCover"]
-pub fn cover(_cond: bool, _msg: &'static str) {}
+pub const fn cover(_cond: bool, _msg: &'static str) {}
 
 /// This creates an symbolic *valid* value of type `T`. You can assign the return value of this
 /// function to a variable that you want to make symbolic.


### PR DESCRIPTION
This allows `kani::cover` to be used in the body of const fns under verification.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
