### PR TITLE
install_cbmc.sh: build from source on non-x86_64

### DIFF
--- a/scripts/setup/ubuntu/install_cbmc.sh
+++ b/scripts/setup/ubuntu/install_cbmc.sh
@@ -15,7 +15,7 @@ fi
 UBUNTU_VERSION=$(lsb_release -rs)
 MAJOR=${UBUNTU_VERSION%.*}
 
-if [[ "${MAJOR}" -gt "18" ]]
+if [[ "${MAJOR}" -gt "18" ]] && [[ $(uname -m) = "x86_64" ]]
 then
   FILE="ubuntu-${UBUNTU_VERSION}-cbmc-${CBMC_VERSION}-Linux.deb"
   URL="https://github.com/diffblue/cbmc/releases/download/cbmc-${CBMC_VERSION}/$FILE"
@@ -29,7 +29,7 @@ then
   exit 0
 fi
 
-# Binaries are no longer released for 18.04, so build from source
+# There are no binaries for 18.04 or for non-x86_64, so build from source
 
 WORK_DIR=$(mktemp -d)
 git clone \

--- a/scripts/setup/ubuntu/install_cbmc.sh
+++ b/scripts/setup/ubuntu/install_cbmc.sh
@@ -15,7 +15,7 @@ fi
 UBUNTU_VERSION=$(lsb_release -rs)
 MAJOR=${UBUNTU_VERSION%.*}
 
-if [[ "${MAJOR}" -gt "18" ]] && [[ $(uname -m) = "x86_64" ]]
+if [[ "${MAJOR}" -gt "18" ]] && [[ $(dpkg --print-architecture) = "amd64" ]]
 then
   FILE="ubuntu-${UBUNTU_VERSION}-cbmc-${CBMC_VERSION}-Linux.deb"
   URL="https://github.com/diffblue/cbmc/releases/download/cbmc-${CBMC_VERSION}/$FILE"


### PR DESCRIPTION
CBMC only provides binaries for x86_64, but it runs fine on other arches (like aarch64) Build from source in that case

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
