### PR TITLE
Remove python 3.6 support and set minimum python required to 3.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
           apt-get install -y \
             build-essential bash-completion curl lsb-release sudo g++ gcc flex \
             bison make patch git python3.7 python3.7-dev python3.7-distutils
+          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
           curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           python3 get-pip.py --force-reinstall
           rm get-pip.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,10 +75,14 @@ jobs:
           apt-get update
           apt-get install -y software-properties-common apt-utils
           add-apt-repository ppa:git-core/ppa
+          add-apt-repository ppa:deadsnakes/ppa
           apt-get update
           apt-get install -y \
             build-essential bash-completion curl lsb-release sudo g++ gcc flex \
-            bison make patch git
+            bison make patch git python3.7 python3.7-dev python3.7-distutils
+          curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          python3 get-pip.py --force-reinstall
+          rm get-pip.py
 
       - name: Checkout Kani
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,9 @@ jobs:
           df -h
 
       # This is required before checkout because the container does not
-      # have Git installed, so cannot run checkout action. The checkout
-      # action requires Git >=2.18, so use the Git maintainers' PPA.
+      # have Git installed, so cannot run checkout action. T
+      # The checkout action requires Git >=2.18 and python 3.7, so use the Git maintainers' PPA.
+      # and the "deadsnakes" PPA, as the default version of python on ubuntu is 3.11.
       - name: Install system dependencies
         run: |
           apt-get update

--- a/docs/src/install-guide.md
+++ b/docs/src/install-guide.md
@@ -14,7 +14,7 @@ GitHub CI workflows, see [GitHub CI Action](./install-github-ci.md).
 
 The following must already be installed:
 
-* **Python version 3.6 or newer** and the package installer `pip`.
+* **Python version 3.7 or newer** and the package installer `pip`.
 * Rust 1.58 or newer installed via `rustup`.
 * `ctags` is required for Kani's `--visualize` option to work correctly. [Universal ctags](https://ctags.io/) is recommended.
 

--- a/scripts/ci/Dockerfile.bundle-test-ubuntu-18-04
+++ b/scripts/ci/Dockerfile.bundle-test-ubuntu-18-04
@@ -16,7 +16,7 @@ RUN apt-get update && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
     apt install --no-install-recommends -y python3.7 python3.7-dev python3.7-distutils curl ctags && \
 
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
 
 RUN curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python3 get-pip.py --force-reinstall && \

--- a/scripts/ci/Dockerfile.bundle-test-ubuntu-18-04
+++ b/scripts/ci/Dockerfile.bundle-test-ubuntu-18-04
@@ -14,7 +14,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update && \
     apt-get install --no-install-recommends -y build-essential software-properties-common && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt install --no-install-recommends -y python3.7 python3.7-dev python3.7-distutils curl ctags && \
+    apt install --no-install-recommends -y python3.7 python3.7-dev python3.7-distutils curl ctags
 
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
 

--- a/scripts/ci/Dockerfile.bundle-test-ubuntu-18-04
+++ b/scripts/ci/Dockerfile.bundle-test-ubuntu-18-04
@@ -10,9 +10,19 @@
 FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true
+
 RUN apt-get update && \
-    apt-get install -y python3 python3-pip curl ctags && \
-    curl -sSf https://sh.rustup.rs | sh -s -- -y
+    apt-get install --no-install-recommends -y build-essential software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt install --no-install-recommends -y python3.7 python3.7-dev python3.7-distutils curl ctags && \
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
+
+RUN curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python3 get-pip.py --force-reinstall && \
+    rm get-pip.py
+
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /tmp/kani

--- a/src/os_hacks.rs
+++ b/src/os_hacks.rs
@@ -131,3 +131,28 @@ fn setup_nixos_patchelf(kani_dir: &Path) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_greater() {
+        assert_eq!(compare_versions("3.7.1", "3.6.3"), Ok(std::cmp::Ordering::Greater));
+    }
+
+    #[test]
+    fn version_less() {
+        assert_eq!(compare_versions("3.7.1", "3.7.3"), Ok(std::cmp::Ordering::Less));
+    }
+
+    #[test]
+    fn version_equal() {
+        assert_eq!(compare_versions("3.6.3", "3.6.3"), Ok(std::cmp::Ordering::Equal));
+    }
+
+    #[test]
+    fn version_different_len() {
+        assert_eq!(compare_versions("4.0", "4.0.0"), Ok(std::cmp::Ordering::Equal));
+    }
+}

--- a/src/os_hacks.rs
+++ b/src/os_hacks.rs
@@ -29,7 +29,7 @@ pub fn check_minimum_python_version(output: &str) -> Result<bool> {
             std::cmp::Ordering::Equal => Ok(true),
             std::cmp::Ordering::Greater => Ok(true),
         },
-        Err(_e) => Ok(false)
+        Err(_e) => Ok(false),
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -164,7 +164,9 @@ fn setup_python_deps(kani_dir: &Path) -> Result<()> {
 
     // Check for minimum version of python=3.7 in the system and bail if not present
     if !os_hacks::check_minimum_python_version(output_python)? {
-        bail!("Python version detected is 3.6 or lower. Please upgrade to Python 3.7 to setup Kani.");
+        bail!(
+            "Python version detected is 3.6 or lower. Please upgrade to Python 3.7 to setup Kani."
+        );
     }
 
     Command::new("python3")


### PR DESCRIPTION
Quoting the other [PR](https://github.com/model-checking/kani/pull/2879): 

An attempt to fix a release build issue due to cbmc-viewer depending on voluptuous which now depends on python 3.7 for type annotations.

This adds a ppa in the dockerfile and github release action for ubuntu 18.04 and installs python 3.7.

Another additional reason to do this is because python 3.6 has reached end of life support:
https://devguide.python.org/versions/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
