### PR TITLE
Make `codegen_span` stable

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/span.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/span.rs
@@ -3,16 +3,21 @@
 
 //! MIR Span related functions
 
-use crate::{codegen_cprover_gotoc::GotocCtx, kani_middle::SourceLocation};
+use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::goto_program::Location;
 use rustc_middle::mir::{Local, VarDebugInfo, VarDebugInfoContents};
+use rustc_smir::rustc_internal;
 use rustc_span::Span;
 
 impl<'tcx> GotocCtx<'tcx> {
     pub fn codegen_span(&self, sp: &Span) -> Location {
-        let loc = SourceLocation::new(self.tcx, sp);
+        self.stable_codegen_span(&rustc_internal::stable(sp))
+    }
+
+    pub fn stable_codegen_span(&self, sp: &stable_mir::ty::Span) -> Location {
+        let loc = sp.get_lines();
         Location::new(
-            loc.filename,
+            sp.get_filename().to_string(),
             self.current_fn.as_ref().map(|x| x.readable_name().to_string()),
             loc.start_line,
             Some(loc.start_col),

--- a/kani-compiler/src/kani_middle/analysis.rs
+++ b/kani-compiler/src/kani_middle/analysis.rs
@@ -23,31 +23,24 @@ use std::fmt::Display;
 ///  - Number of items per type (Function / Constant / Shims)
 ///  - Number of instructions per type.
 ///  - Total number of MIR instructions.
-pub fn print_stats<'tcx>(tcx: TyCtxt<'tcx>, items: &[InternalMonoItem<'tcx>]) {
-    rustc_internal::run(tcx, || {
-        let items: Vec<MonoItem> = items.iter().map(rustc_internal::stable).collect();
-        let item_types = items.iter().collect::<Counter>();
-        let visitor = items
-            .iter()
-            .filter_map(
-                |mono| {
-                    if let MonoItem::Fn(instance) = mono { Some(instance) } else { None }
-                },
-            )
-            .fold(StatsVisitor::default(), |mut visitor, body| {
-                visitor.visit_body(&body.body().unwrap());
-                visitor
-            });
-        eprintln!("====== Reachability Analysis Result =======");
-        eprintln!("Total # items: {}", item_types.total());
-        eprintln!("Total # statements: {}", visitor.stmts.total());
-        eprintln!("Total # expressions: {}", visitor.exprs.total());
-        eprintln!("\nReachable Items:\n{item_types}");
-        eprintln!("Statements:\n{}", visitor.stmts);
-        eprintln!("Expressions:\n{}", visitor.exprs);
-        eprintln!("-------------------------------------------")
-    })
-    .unwrap();
+pub fn print_stats<'tcx>(_tcx: TyCtxt<'tcx>, items: &[InternalMonoItem<'tcx>]) {
+    let items: Vec<MonoItem> = items.iter().map(rustc_internal::stable).collect();
+    let item_types = items.iter().collect::<Counter>();
+    let visitor = items
+        .iter()
+        .filter_map(|mono| if let MonoItem::Fn(instance) = mono { Some(instance) } else { None })
+        .fold(StatsVisitor::default(), |mut visitor, body| {
+            visitor.visit_body(&body.body().unwrap());
+            visitor
+        });
+    eprintln!("====== Reachability Analysis Result =======");
+    eprintln!("Total # items: {}", item_types.total());
+    eprintln!("Total # statements: {}", visitor.stmts.total());
+    eprintln!("Total # expressions: {}", visitor.exprs.total());
+    eprintln!("\nReachable Items:\n{item_types}");
+    eprintln!("Statements:\n{}", visitor.stmts);
+    eprintln!("Expressions:\n{}", visitor.exprs);
+    eprintln!("-------------------------------------------")
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Follow up pr to https://github.com/model-checking/kani/pull/2871 as `stable_mir::ty::Span` have ability to `get_filename` and `get_lineinfo` we could start adopting it. 