### PR TITLE
Upgrade version number to 0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Change `expect()` from taking formatted strings to use `unwrap_or_else()` by @matthiaskrgr in https://github.com/model-checking/kani/pull/2865
 * Fix setup for `aarch64-unknown-linux-gnu` platform by @adpaco-aws in https://github.com/model-checking/kani/pull/2864
 * Do not override `std` library during playback by @celinval in https://github.com/model-checking/kani/pull/2852
-* Rust toolchain upgraded to `nightly-2023-11-11` by @zhassan-aws in https://github.com/model-checking/kani/pull/2858
+* Rust toolchain upgraded to `nightly-2023-11-11` by @zhassan-aws
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.40.0...kani-0.41.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,17 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## [0.41.0]
 
-## What's Changed
-* Fix setup for `aarch64-unknown-linux-gnu` platform by @adpaco-aws in https://github.com/model-checking/kani/pull/2864
-* Do not override `std` library during playback by @celinval in https://github.com/model-checking/kani/pull/2852
-* Fix docker build step in release workflow by @adpaco-aws in https://github.com/model-checking/kani/pull/2854
-* Fix path-dependent failures in `assess-artifacts` test by @adpaco-aws in https://github.com/model-checking/kani/pull/2849
-* Automatic toolchain upgrade to nightly-2023-11-11 by @github-actions in https://github.com/model-checking/kani/pull/2870
-
-**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.40.0...kani-0.41.0
-
 ### Breaking Changes
 
 * Set minimum python to 3.7 in docker container and release action by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2879
 * Delete `any_slice` which has been deprecated since Kani 0.38.0. by @zhassan-aws in https://github.com/model-checking/kani/pull/2860
+
+### What's Changed
+* Fix setup for `aarch64-unknown-linux-gnu` platform by @adpaco-aws in https://github.com/model-checking/kani/pull/2864
+* Do not override `std` library during playback by @celinval in https://github.com/model-checking/kani/pull/2852
+* Automatic toolchain upgrade to nightly-2023-11-11 by @github-actions in https://github.com/model-checking/kani/pull/2870
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.40.0...kani-0.41.0
 
 ## [0.40.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Delete `any_slice` which has been deprecated since Kani 0.38.0. by @zhassan-aws in https://github.com/model-checking/kani/pull/2860
 
 ### What's Changed
+
+* Make `cover` const by @jswrenn in https://github.com/model-checking/kani/pull/2867
+* Change `expect()` from taking formatted strings to use `unwrap_or_else()` by @matthiaskrgr in https://github.com/model-checking/kani/pull/2865
 * Fix setup for `aarch64-unknown-linux-gnu` platform by @adpaco-aws in https://github.com/model-checking/kani/pull/2864
 * Do not override `std` library during playback by @celinval in https://github.com/model-checking/kani/pull/2852
-* Automatic toolchain upgrade to nightly-2023-11-11 by @github-actions in https://github.com/model-checking/kani/pull/2870
+* Update Rust toolchain to 2023-11-06 by @zhassan-aws in https://github.com/model-checking/kani/pull/2858
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.40.0...kani-0.41.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,18 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## [0.41.0]
 
+## What's Changed
+* Fix setup for `aarch64-unknown-linux-gnu` platform by @adpaco-aws in https://github.com/model-checking/kani/pull/2864
+* Do not override `std` library during playback by @celinval in https://github.com/model-checking/kani/pull/2852
+* Fix docker build step in release workflow by @adpaco-aws in https://github.com/model-checking/kani/pull/2854
+* Fix path-dependent failures in `assess-artifacts` test by @adpaco-aws in https://github.com/model-checking/kani/pull/2849
+* Automatic toolchain upgrade to nightly-2023-11-11 by @github-actions in https://github.com/model-checking/kani/pull/2870
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.40.0...kani-0.41.0
+
 ### Breaking Changes
 
+* Set minimum python to 3.7 in docker container and release action by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2879
 * Delete `any_slice` which has been deprecated since Kani 0.38.0. by @zhassan-aws in https://github.com/model-checking/kani/pull/2860
 
 ## [0.40.0]
@@ -65,7 +75,7 @@ https://github.com/model-checking/kani/compare/kani-0.38.0...kani-0.39.0
 * Fix expected value for `pref_align_of` under aarch64/macos by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2782
 * Bump CBMC version to 5.92.0 by @zhassan-aws in https://github.com/model-checking/kani/pull/2771
 * Upgrade to Kissat 3.1.1 by @zhassan-aws in https://github.com/model-checking/kani/pull/2756
-* Rust toolchain upgraded to `nightly-2023-09-19` by @remi-delmas-3000 @tautschnig 
+* Rust toolchain upgraded to `nightly-2023-09-19` by @remi-delmas-3000 @tautschnig
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.36.0...kani-0.37.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Change `expect()` from taking formatted strings to use `unwrap_or_else()` by @matthiaskrgr in https://github.com/model-checking/kani/pull/2865
 * Fix setup for `aarch64-unknown-linux-gnu` platform by @adpaco-aws in https://github.com/model-checking/kani/pull/2864
 * Do not override `std` library during playback by @celinval in https://github.com/model-checking/kani/pull/2852
-* Update Rust toolchain to 2023-11-06 by @zhassan-aws in https://github.com/model-checking/kani/pull/2858
+* Rust toolchain upgraded to `nightly-2023-11-11` by @zhassan-aws in https://github.com/model-checking/kani/pull/2858
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.40.0...kani-0.41.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -440,14 +440,14 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "kani"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "home",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1050,7 +1050,7 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "std"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Upgrade version number to 0.41.0

The CHANGELOG changes are:

```
# What's Changed
* Fix setup for `aarch64-unknown-linux-gnu` platform by @adpaco-aws in https://github.com/model-checking/kani/pull/2864
* Do not override `std` library during playback by @celinval in https://github.com/model-checking/kani/pull/2852
* Fix docker build step in release workflow by @adpaco-aws in https://github.com/model-checking/kani/pull/2854
* Fix path-dependent failures in `assess-artifacts` test by @adpaco-aws in https://github.com/model-checking/kani/pull/2849
* Automatic toolchain upgrade to nightly-2023-11-11 by @github-actions in https://github.com/model-checking/kani/pull/2870

**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.40.0...kani-0.41.0

### Breaking Changes

* Set minimum python to 3.7 in docker container and release action by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/2879
* Delete `any_slice` which has been deprecated since Kani 0.38.0. by @zhassan-aws in https://github.com/model-checking/kani/pull/2860
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
