### PR TITLE
Update toolchain to `nightly-2023-11-21`

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -300,7 +300,7 @@ impl<'tcx> GotocCtx<'tcx> {
             var: ty::BoundVar::from_usize(bound_vars.len() - 1),
             kind: ty::BoundRegionKind::BrEnv,
         };
-        let env_region = ty::Region::new_late_bound(self.tcx, ty::INNERMOST, br);
+        let env_region = ty::Region::new_bound(self.tcx, ty::INNERMOST, br);
         let env_ty = self.tcx.closure_env_ty(def_id, args, env_region).unwrap();
 
         let sig = sig.skip_binder();
@@ -341,7 +341,7 @@ impl<'tcx> GotocCtx<'tcx> {
             var: ty::BoundVar::from_usize(bound_vars.len() - 1),
             kind: ty::BoundRegionKind::BrEnv,
         };
-        let env_region = ty::ReLateBound(ty::INNERMOST, br);
+        let env_region = ty::ReBound(ty::INNERMOST, br);
         let env_ty = Ty::new_mut_ref(self.tcx, ty::Region::new_from_kind(self.tcx, env_region), ty);
 
         let pin_did = self.tcx.require_lang_item(LangItem::Pin, None);

--- a/kani-compiler/src/kani_middle/analysis.rs
+++ b/kani-compiler/src/kani_middle/analysis.rs
@@ -35,7 +35,7 @@ pub fn print_stats<'tcx>(tcx: TyCtxt<'tcx>, items: &[InternalMonoItem<'tcx>]) {
                 },
             )
             .fold(StatsVisitor::default(), |mut visitor, body| {
-                visitor.visit_body(&body.body());
+                visitor.visit_body(&body.body().unwrap());
                 visitor
             });
         eprintln!("====== Reachability Analysis Result =======");
@@ -46,7 +46,8 @@ pub fn print_stats<'tcx>(tcx: TyCtxt<'tcx>, items: &[InternalMonoItem<'tcx>]) {
         eprintln!("Statements:\n{}", visitor.stmts);
         eprintln!("Expressions:\n{}", visitor.exprs);
         eprintln!("-------------------------------------------")
-    });
+    })
+    .unwrap();
 }
 
 #[derive(Default)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-11-12"
+channel = "nightly-2023-11-21"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
We got a bit delayed on the nightly, so this PR closes the gap.

The related Rust changes were:
  - https://github.com/rust-lang/rust/pull/117876
  - https://github.com/rust-lang/rust/pull/117688

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.