### PR TITLE
[Boogie Backend] Add SMT bit-vector builtin operations

### DIFF
--- a/kani-compiler/src/codegen_boogie/compiler_interface.rs
+++ b/kani-compiler/src/codegen_boogie/compiler_interface.rs
@@ -171,7 +171,7 @@ impl BoogieCodegenBackend {
         if !tcx.sess.opts.unstable_opts.no_codegen && tcx.sess.opts.output_types.should_codegen() {
             let mut pb = boogie_file.to_path_buf();
             pb.set_extension("bpl");
-            println!("Writing Boogie file to {}", pb.display());
+            info!("Writing Boogie file to {}", pb.display());
             let file = File::create(&pb).unwrap();
             let mut writer = BufWriter::new(file);
             bcx.write(&mut writer).unwrap();

--- a/kani-compiler/src/codegen_boogie/compiler_interface.rs
+++ b/kani-compiler/src/codegen_boogie/compiler_interface.rs
@@ -171,7 +171,7 @@ impl BoogieCodegenBackend {
         if !tcx.sess.opts.unstable_opts.no_codegen && tcx.sess.opts.output_types.should_codegen() {
             let mut pb = boogie_file.to_path_buf();
             pb.set_extension("bpl");
-            info!("Writing Boogie file to {}", pb.display());
+            println!("Writing Boogie file to {}", pb.display());
             let file = File::create(&pb).unwrap();
             let mut writer = BufWriter::new(file);
             bcx.write(&mut writer).unwrap();

--- a/kani-compiler/src/codegen_boogie/compiler_interface.rs
+++ b/kani-compiler/src/codegen_boogie/compiler_interface.rs
@@ -171,7 +171,7 @@ impl BoogieCodegenBackend {
         if !tcx.sess.opts.unstable_opts.no_codegen && tcx.sess.opts.output_types.should_codegen() {
             let mut pb = boogie_file.to_path_buf();
             pb.set_extension("bpl");
-            debug!("Writing Boogie file to {}", pb.display());
+            println!("Writing Boogie file to {}", pb.display());
             let file = File::create(&pb).unwrap();
             let mut writer = BufWriter::new(file);
             bcx.write(&mut writer).unwrap();

--- a/kani-compiler/src/codegen_boogie/context/mod.rs
+++ b/kani-compiler/src/codegen_boogie/context/mod.rs
@@ -6,5 +6,6 @@
 
 mod boogie_ctx;
 mod kani_intrinsic;
+mod smt_builtins;
 
 pub use boogie_ctx::BoogieCtx;

--- a/kani-compiler/src/codegen_boogie/context/smt_builtins.rs
+++ b/kani-compiler/src/codegen_boogie/context/smt_builtins.rs
@@ -1,0 +1,85 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use boogie_ast::boogie_program::{Function, Parameter, Type};
+
+/// SMT bit-vector builtin operations, i.e. operations that SMT solvers (e.g.
+/// Z3) understand
+/// See https://smtlib.cs.uiowa.edu/logics-all.shtml for more details
+#[derive(Debug, Clone, PartialEq, Eq, strum_macros::AsRefStr, strum_macros::EnumIter)]
+pub(crate) enum SmtBvBuiltin {
+    // Predicates:
+    #[strum(serialize = "$BvUnsignedLessThan")]
+    UnsignedLessThan,
+    #[strum(serialize = "$BvSignedLessThan")]
+    SignedLessThan,
+    #[strum(serialize = "$BvUnsignedGreaterThan")]
+    UnsignedGreaterThan,
+    #[strum(serialize = "$BvSignedGreaterThan")]
+    SignedGreaterThan,
+
+    // Binary operators:
+    #[strum(serialize = "$BvAdd")]
+    Add,
+    #[strum(serialize = "$BvOr")]
+    Or,
+    #[strum(serialize = "$BvAnd")]
+    And,
+    #[strum(serialize = "$BvShl")]
+    Shl,
+    #[strum(serialize = "$BvShr")]
+    Shr,
+}
+
+impl SmtBvBuiltin {
+    /// The name of the SMT function corresponding to this bit-vector operation
+    pub fn smt_op_name(&self) -> &'static str {
+        match self {
+            SmtBvBuiltin::UnsignedLessThan => "bvult",
+            SmtBvBuiltin::SignedLessThan => "bvslt",
+            SmtBvBuiltin::UnsignedGreaterThan => "bvugt",
+            SmtBvBuiltin::SignedGreaterThan => "bvsgt",
+            SmtBvBuiltin::Add => "bvadd",
+            SmtBvBuiltin::Or => "bvor",
+            SmtBvBuiltin::And => "bvand",
+            SmtBvBuiltin::Shl => "bvshl",
+            SmtBvBuiltin::Shr => "bvlshr",
+        }
+    }
+
+    /// Whether the builtin is a predicate (i.e. it returns a boolean)
+    pub fn is_predicate(&self) -> bool {
+        match self {
+            SmtBvBuiltin::UnsignedLessThan
+            | SmtBvBuiltin::SignedLessThan
+            | SmtBvBuiltin::UnsignedGreaterThan
+            | SmtBvBuiltin::SignedGreaterThan => true,
+            SmtBvBuiltin::Or
+            | SmtBvBuiltin::And
+            | SmtBvBuiltin::Add
+            | SmtBvBuiltin::Shl
+            | SmtBvBuiltin::Shr => false,
+        }
+    }
+}
+
+/// Create a Boogie function for the given SMT bit-vector builtin
+/// The function has no body, and is annotated with the SMT annotation
+/// `:bvbuiltin "smt_name"` where `smt_name` is the SMT name of the bit-vector
+/// builtin
+pub(crate) fn smt_builtin_binop(
+    bv_builtin: &SmtBvBuiltin,
+    smt_name: &str,
+    is_predicate: bool,
+) -> Function {
+    let tp_name = String::from("T");
+    let tp = Type::parameter(tp_name.clone());
+    Function::new(
+        bv_builtin.as_ref().to_string(), // e.g. $BvOr
+        vec![tp_name],
+        vec![Parameter::new("lhs".into(), tp.clone()), Parameter::new("rhs".into(), tp.clone())],
+        if is_predicate { Type::Bool } else { tp },
+        None,
+        vec![format!(":bvbuiltin \"{}\"", smt_name)],
+    )
+}

--- a/tests/expected/boogie/hello/test__RNvCshNorBqfmMTU_4test19check_boogie_option.symtab.bpl
+++ b/tests/expected/boogie/hello/test__RNvCshNorBqfmMTU_4test19check_boogie_option.symtab.bpl
@@ -1,0 +1,5 @@
+// Procedures:
+procedure _RNvCshNorBqfmMTU_4test19check_boogie_option() 
+{
+  return;
+}

--- a/tests/expected/boogie/hello/test__RNvCshNorBqfmMTU_4test19check_boogie_option.symtab.bpl
+++ b/tests/expected/boogie/hello/test__RNvCshNorBqfmMTU_4test19check_boogie_option.symtab.bpl
@@ -1,5 +1,0 @@
-// Procedures:
-procedure _RNvCshNorBqfmMTU_4test19check_boogie_option() 
-{
-  return;
-}


### PR DESCRIPTION
Define SMT bit-vector builtin operations (e.g. `bvult`, `bvadd`, `bvand`, etc.) as functions in the preamble and codegen MIR binary operations as calls to those functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
