### PR TITLE
Add disk space output to debug occasional test failures

### DIFF
--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -101,8 +101,12 @@ cargo kani --manifest-path "$FEATURES_MANIFEST_PATH" --harness trivial_success
 cargo clean --manifest-path "$FEATURES_MANIFEST_PATH"
 
 # Check that documentation compiles.
+echo "Current disk usage:"
+df -h
 echo "Starting doc tests:"
 cargo doc --workspace --no-deps --exclude std
+echo "Disk usage after documentation build:"
+df -h
 
 echo
 echo "All Kani regression tests completed successfully."


### PR DESCRIPTION
Despite freeing up disk space early on, we saw occasional failures like https://github.com/model-checking/kani/actions/runs/7030685174/job/19130721957 that look like running out of disk space.

This change should be reverted once we have diagnosed the problem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
