### PR TITLE
Updated labeler GitHub action configuration to v5 format

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,11 +6,8 @@
 # Note that we enable dot, so "**" matches all files in a folder
 
 Z-BenchCI:
-  - kani-compiler/**
-  - rust-toolchain.toml
-  - kani-dependencies
-  - kani-driver/src/call-*
-  - Cargo.lock
-  - cprover_bindings/**
-  - library/**
-
+- any:
+  - changed-files:
+    - any-glob-to-any-file: ['kani-compiler/**', 'kani-driver/src/call-*', 'cprover_bindings/**', 'library/**']
+    - any-glob-to-any-file: ['rust-toolchain.toml', 'Cargo.lock']
+    - any-glob-to-any-file: ['kani-dependencies']


### PR DESCRIPTION
When merging #2917 I overlooked the note that the configuration file format had changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
