### PR TITLE
Revert "Bump actions/labeler from 4 to 5 (#2917)"

### DIFF
--- a/.github/workflows/extra_jobs.yml
+++ b/.github/workflows/extra_jobs.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Label PR
       id: labeler
-      uses: actions/labeler@v5
+      uses: actions/labeler@v4
       with:
         dot: true
 


### PR DESCRIPTION
This reverts commit c59c557c1b8e1a6b65b44aa2cea770e8e2fa0866. See #2922.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
