### PR TITLE
Codegen the arguments to Kani intrinsics inside the functions that handle the intrinsics

### DIFF
--- a/kani-compiler/src/codegen_boogie/context/boogie_ctx.rs
+++ b/kani-compiler/src/codegen_boogie/context/boogie_ctx.rs
@@ -339,7 +339,6 @@ impl<'a, 'tcx> FunctionCtx<'a, 'tcx> {
         span: Span,
     ) -> Stmt {
         debug!(?func, ?args, ?destination, ?span, "codegen_funcall");
-        let fargs = self.codegen_funcall_args(args);
         let funct = self.operand_ty(func);
         // TODO: Only Kani intrinsics are handled currently
         match &funct.kind() {
@@ -355,12 +354,13 @@ impl<'a, 'tcx> FunctionCtx<'a, 'tcx> {
                     return self.codegen_kani_intrinsic(
                         intrinsic,
                         instance,
-                        fargs,
+                        args,
                         *destination,
                         *target,
                         Some(span),
                     );
                 }
+                let _fargs = self.codegen_funcall_args(args);
                 todo!()
             }
             _ => todo!(),
@@ -383,7 +383,7 @@ impl<'a, 'tcx> FunctionCtx<'a, 'tcx> {
             .collect()
     }
 
-    fn codegen_operand(&self, o: &Operand<'tcx>) -> Expr {
+    pub(crate) fn codegen_operand(&self, o: &Operand<'tcx>) -> Expr {
         trace!(operand=?o, "codegen_operand");
         // A MIR operand is either a constant (literal or `const` declaration)
         // or a place (being moved or copied for this operation).


### PR DESCRIPTION
This is a refactor change: currently, the functions that codegen Kani intrinsics (asserts, assumes, etc.) take the arguments to the intrinsics as Boogie expressions (`boogie_ast::boogie_program::Expr`). In other words, the MIR arguments (`rustc_middle::mir::syntax::Operand`) are converted to Boogie expressions before passing them to the functions.

This PR changes the functions to take the MIR arguments directly, and perform the codegen into Boogie expressions inside the functions. This allows those functions to query any information in the MIR `Operand`, that is not available after codegen to Boogie expressions.

Note: it may make sense to do the same change for the Goto backend to avoid having to pattern match on the expressions (e.g. https://github.com/model-checking/kani/blob/2aca488ba9d64d2aaeae3b7774acf367bea42be9/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs#L74), and instead get the information needed from the MIR operand directly.

Resolves #ISSUE-NUMBER

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
