### PR TITLE
Remove doc build from regular regression

### DIFF
--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -100,14 +100,6 @@ FEATURES_MANIFEST_PATH="$KANI_DIR/tests/cargo-kani/cargo-features-flag/Cargo.tom
 cargo kani --manifest-path "$FEATURES_MANIFEST_PATH" --harness trivial_success
 cargo clean --manifest-path "$FEATURES_MANIFEST_PATH"
 
-# Check that documentation compiles.
-echo "Current disk usage:"
-df -h
-echo "Starting doc tests:"
-cargo doc --workspace --no-deps --exclude std
-echo "Disk usage after documentation build:"
-df -h
-
 echo
 echo "All Kani regression tests completed successfully."
 echo


### PR DESCRIPTION
This check is redundant in our CI since the bookrunner job already builds the documentation. It is also often breaking the regression job, maybe due to some disk requirement.

If we decide that we want this to be part of the regular developer workflow before it pushes a PR, I suggest that we create a separate script that is meant for that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
