### PR TITLE
Automate cargo update without dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      cargo:
-        update-types:
-          - "minor"
-          - "patch"

--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -1,0 +1,47 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+name: Attempt cargo update
+
+on:
+  schedule:
+    - cron: "30 3 * * Mon" # Run this every Monday at 03:30 UTC
+  workflow_dispatch:     # Allow manual dispatching for a custom branch / tag.
+
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-cargo-update-pr:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Kani
+        uses: actions/checkout@v3
+
+      - name: Setup Kani Dependencies
+        uses: ./.github/actions/setup
+        with:
+          os: ubuntu-22.04
+
+      - name: Run cargo update
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          today=$(date +%Y-%m-%d)
+          echo "today=$today" >> $GITHUB_ENV
+          if ! git ls-remote --exit-code origin cargo-update-$today ; then
+            cargo update
+            cargo build-dev
+            git diff
+          fi
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Upgrade cargo dependencies to ${{ env.today }}
+          branch: cargo-update-${{ env.today }}
+          delete-branch: true
+          title: 'Automatic cargo update to ${{ env.today }}'
+          body: >
+            Dependency upgrade resulting from `cargo update`.


### PR DESCRIPTION
Automatically create pull requests from the result of running `cargo update` every Monday morning. This should avoid the need for manual PRs to update Cargo.lock, which seemingly dependabot wouldn't take care of. We now only use dependabot to update github actions.

This revives what I had initially proposed in #2895 in light of #2940.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
