### PR TITLE
Migrate function, block and statement modules to StableMIR

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/assert.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/assert.rs
@@ -21,7 +21,6 @@
 use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::goto_program::{Expr, Location, Stmt, Type};
 use cbmc::InternedString;
-use rustc_span::Span;
 use stable_mir::ty::Span as SpanStable;
 use std::convert::AsRef;
 use strum_macros::{AsRefStr, EnumString};
@@ -149,8 +148,8 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     /// Generate a cover statement for code coverage reports.
-    pub fn codegen_coverage(&self, span: Span) -> Stmt {
-        let loc = self.codegen_caller_span(&span);
+    pub fn codegen_coverage(&self, span: SpanStable) -> Stmt {
+        let loc = self.codegen_caller_span_stable(span);
         // Should use Stmt::cover, but currently this doesn't work with CBMC
         // unless it is run with '--cover cover' (see
         // https://github.com/diffblue/cbmc/issues/6613). So for now use

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/block.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/block.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::codegen_cprover_gotoc::GotocCtx;
-use rustc_middle::mir::{BasicBlock, BasicBlockData};
-use stable_mir::mir::BasicBlockIdx;
+use stable_mir::mir::{BasicBlock, BasicBlockIdx};
 use tracing::debug;
 
 pub fn bb_label(bb: BasicBlockIdx) -> String {
@@ -17,20 +16,20 @@ impl<'tcx> GotocCtx<'tcx> {
     ///
     /// This function does not return a value, but mutates state with
     /// `self.current_fn_mut().push_onto_block(...)`
-    pub fn codegen_block(&mut self, bb: BasicBlock, bbd: &BasicBlockData<'tcx>) {
-        debug!(?bb, "Codegen basicblock");
-        let label: String = self.current_fn().find_label(&bb);
+    pub fn codegen_block(&mut self, bb: BasicBlockIdx, bbd: &BasicBlock) {
+        debug!(?bb, "codegen_block");
+        let label = bb_label(bb);
         let check_coverage = self.queries.args().check_coverage;
         // the first statement should be labelled. if there is no statements, then the
         // terminator should be labelled.
         match bbd.statements.len() {
             0 => {
-                let term = bbd.terminator();
+                let term = &bbd.terminator;
                 let tcode = self.codegen_terminator(term);
                 // When checking coverage, the `coverage` check should be
                 // labelled instead.
                 if check_coverage {
-                    let span = term.source_info.span;
+                    let span = term.span;
                     let cover = self.codegen_coverage(span);
                     self.current_fn_mut().push_onto_block(cover.with_label(label));
                     self.current_fn_mut().push_onto_block(tcode);
@@ -44,7 +43,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 // When checking coverage, the `coverage` check should be
                 // labelled instead.
                 if check_coverage {
-                    let span = stmt.source_info.span;
+                    let span = stmt.span;
                     let cover = self.codegen_coverage(span);
                     self.current_fn_mut().push_onto_block(cover.with_label(label));
                     self.current_fn_mut().push_onto_block(scode);
@@ -54,16 +53,16 @@ impl<'tcx> GotocCtx<'tcx> {
 
                 for s in &bbd.statements[1..] {
                     if check_coverage {
-                        let span = s.source_info.span;
+                        let span = s.span;
                         let cover = self.codegen_coverage(span);
                         self.current_fn_mut().push_onto_block(cover);
                     }
                     let stmt = self.codegen_statement(s);
                     self.current_fn_mut().push_onto_block(stmt);
                 }
-                let term = bbd.terminator();
+                let term = &bbd.terminator;
                 if check_coverage {
-                    let span = term.source_info.span;
+                    let span = term.span;
                     let cover = self.codegen_coverage(span);
                     self.current_fn_mut().push_onto_block(cover);
                 }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/foreign_function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/foreign_function.rs
@@ -137,7 +137,7 @@ impl<'tcx> GotocCtx<'tcx> {
     ///
     /// This will behave like `codegen_unimplemented_stmt` but print a message that includes
     /// the name of the function not supported and the calling convention.
-    pub fn codegen_ffi_unsupported(&mut self, instance: Instance<'tcx>, loc: Location) -> Stmt {
+    fn codegen_ffi_unsupported(&mut self, instance: Instance<'tcx>, loc: Location) -> Stmt {
         let fn_name = &self.symbol_name(instance);
         debug!(?fn_name, ?loc, "codegen_ffi_unsupported");
 

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -7,9 +7,9 @@ use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::goto_program::{Expr, Stmt, Symbol};
 use cbmc::InternString;
 use rustc_middle::mir::traversal::reverse_postorder;
-use rustc_middle::mir::{Body, HasLocalDecls, Local};
-use rustc_middle::ty;
 use stable_mir::mir::mono::Instance;
+use stable_mir::mir::{Body, Local};
+use stable_mir::ty::{RigidTy, TyKind};
 use stable_mir::CrateDef;
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
@@ -17,58 +17,42 @@ use tracing::{debug, debug_span};
 
 /// Codegen MIR functions into gotoc
 impl<'tcx> GotocCtx<'tcx> {
-    /// Get the number of parameters that the current function expects.
-    fn get_params_size(&self) -> usize {
-        let sig = self.current_fn().sig();
-        let sig = self.tcx.normalize_erasing_late_bound_regions(ty::ParamEnv::reveal_all(), sig);
-        // we don't call [codegen_function_sig] because we want to get a bit more metainformation.
-        sig.inputs().len()
-    }
-
     /// Declare variables according to their index.
     /// - Index 0 represents the return value.
     /// - Indices [1, N] represent the function parameters where N is the number of parameters.
     /// - Indices that are greater than N represent local variables.
-    fn codegen_declare_variables(&mut self) {
-        let mir = self.current_fn().body_internal();
-        let ldecls = mir.local_decls();
-        let num_args = self.get_params_size();
-        ldecls.indices().enumerate().for_each(|(idx, lc)| {
-            if Some(lc) == mir.spread_arg {
+    fn codegen_declare_variables(&mut self, body: &Body) {
+        let ldecls = body.local_decls();
+        let num_args = body.arg_locals().len();
+        for (lc, ldata) in ldecls {
+            if Some(lc) == body.spread_arg() {
                 // We have already added this local in the function prelude, so
                 // skip adding it again here.
-                return;
+                continue;
             }
             let base_name = self.codegen_var_base_name(&lc);
             let name = self.codegen_var_name(&lc);
-            let ldata = &ldecls[lc];
-            let var_ty = self.monomorphize(ldata.ty);
-            let var_type = self.codegen_ty(var_ty);
-            let loc = self.codegen_span(&ldata.source_info.span);
+            let var_type = self.codegen_ty_stable(ldata.ty);
+            let loc = self.codegen_span_stable(ldata.span);
             // Indices [1, N] represent the function parameters where N is the number of parameters.
             // Except that ZST fields are not included as parameters.
-            let sym = Symbol::variable(
-                name,
-                base_name,
-                var_type,
-                self.codegen_span(&ldata.source_info.span),
-            )
-            .with_is_hidden(!self.is_user_variable(&lc))
-            .with_is_parameter((idx > 0 && idx <= num_args) && !self.is_zst(var_ty));
+            let sym =
+                Symbol::variable(name, base_name, var_type, self.codegen_span_stable(ldata.span))
+                    .with_is_hidden(!self.is_user_variable(&lc))
+                    .with_is_parameter((lc > 0 && lc <= num_args) && !self.is_zst_stable(ldata.ty));
             let sym_e = sym.to_expr();
             self.symbol_table.insert(sym);
 
             // Index 0 represents the return value, which does not need to be
             // declared in the first block
-            if lc.index() < 1 || lc.index() > mir.arg_count {
+            if lc < 1 || lc > body.arg_locals().len() {
                 let init = self.codegen_default_initializer(&sym_e);
                 self.current_fn_mut().push_onto_block(Stmt::decl(sym_e, init, loc));
             }
-        });
+        }
     }
 
     pub fn codegen_function(&mut self, instance: Instance) {
-        self.set_current_fn(instance);
         let name = self.symbol_name_stable(instance);
         let old_sym = self.symbol_table.lookup(&name).unwrap();
 
@@ -77,11 +61,11 @@ impl<'tcx> GotocCtx<'tcx> {
             debug!("Double codegen of {:?}", old_sym);
         } else {
             assert!(old_sym.is_function());
-            // TODO: Remove this clone.
-            let body = self.current_fn().body().clone();
+            let body = instance.body().unwrap();
+            self.set_current_fn(instance, &body);
             self.print_instance(instance, &body);
-            self.codegen_function_prelude();
-            self.codegen_declare_variables();
+            self.codegen_function_prelude(&body);
+            self.codegen_declare_variables(&body);
 
             // Get the order from internal body for now.
             let internal_body = self.current_fn().body_internal();
@@ -92,16 +76,16 @@ impl<'tcx> GotocCtx<'tcx> {
             let stmts = self.current_fn_mut().extract_block();
             let goto_body = Stmt::block(stmts, loc);
             self.symbol_table.update_fn_declaration_with_definition(&name, goto_body);
+            self.reset_current_fn();
         }
-        self.reset_current_fn();
     }
 
     /// Codegen changes required due to the function ABI.
     /// We currently untuple arguments for RustCall ABI where the `spread_arg` is set.
-    fn codegen_function_prelude(&mut self) {
-        let mir = self.current_fn().body_internal();
-        if let Some(spread_arg) = mir.spread_arg {
-            self.codegen_spread_arg(mir, spread_arg);
+    fn codegen_function_prelude(&mut self, body: &Body) {
+        debug!(spread_arg=?body.spread_arg(), "codegen_function_prelude");
+        if let Some(spread_arg) = body.spread_arg() {
+            self.codegen_spread_arg(body, spread_arg);
         }
     }
 
@@ -122,34 +106,27 @@ impl<'tcx> GotocCtx<'tcx> {
     ///
     /// See:
     /// <https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Determine.20untupled.20closure.20args.20from.20Instance.3F>
-    fn codegen_spread_arg(&mut self, mir: &Body<'tcx>, spread_arg: Local) {
-        tracing::debug!(current=?self.current_fn, "codegen_spread_arg");
-        let spread_data = &mir.local_decls()[spread_arg];
-        let tup_ty = self.monomorphize(spread_data.ty);
-        if self.is_zst(tup_ty) {
+    fn codegen_spread_arg(&mut self, body: &Body, spread_arg: Local) {
+        debug!(current=?self.current_fn().name(), "codegen_spread_arg");
+        let spread_data = &body.locals()[spread_arg];
+        let tup_ty = spread_data.ty;
+        if self.is_zst_stable(tup_ty) {
             // No need to spread a ZST since it will be ignored.
             return;
         }
 
-        let loc = self.codegen_span(&spread_data.source_info.span);
+        let loc = self.codegen_span_stable(spread_data.span);
 
         // Get the function signature from MIR, _before_ we untuple
-        let fntyp = self.current_fn().instance().ty(self.tcx, ty::ParamEnv::reveal_all());
-        let sig = match fntyp.kind() {
-            ty::FnPtr(..) | ty::FnDef(..) => fntyp.fn_sig(self.tcx).skip_binder(),
-            // Closures themselves will have their arguments already untupled,
-            // see Zulip link above.
-            ty::Closure(..) => unreachable!(
-                "Unexpected `spread arg` set for closure, got: {:?}, {:?}",
-                fntyp,
-                self.current_fn().readable_name()
-            ),
-            _ => unreachable!(
-                "Expected function type for `spread arg` prelude, got: {:?}, {:?}",
-                fntyp,
-                self.current_fn().readable_name()
-            ),
-        };
+        let instance = self.current_fn().instance_stable();
+        // Closures themselves will have their arguments already untupled,
+        // see Zulip link above.
+        assert!(
+            !instance.ty().kind().is_closure(),
+            "Unexpected spread arg `{}` set for closure `{}`",
+            spread_arg,
+            instance.name()
+        );
 
         // When we codegen the function signature elsewhere, we will codegen the untupled version.
         // We then marshall the arguments into a local variable holding the expected tuple.
@@ -171,7 +148,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // };
         // ```
         // Note how the compiler has reordered the fields to improve packing.
-        let tup_type = self.codegen_ty(tup_ty);
+        let tup_type = self.codegen_ty_stable(tup_ty);
 
         // We need to marshall the arguments into the tuple
         // The arguments themselves have been tacked onto the explicit function paramaters by
@@ -190,21 +167,19 @@ impl<'tcx> GotocCtx<'tcx> {
         // }
         // ```
 
-        let tupe = sig.inputs().last().unwrap();
-        let args = match tupe.kind() {
-            ty::Tuple(args) => *args,
-            _ => unreachable!("a function's spread argument must be a tuple"),
+        let TyKind::RigidTy(RigidTy::Tuple(args)) = tup_ty.kind() else {
+            unreachable!("a function's spread argument must be a tuple")
         };
-        let starting_idx = sig.inputs().len();
+        let starting_idx = spread_arg;
         let marshalled_tuple_fields =
             BTreeMap::from_iter(args.iter().enumerate().map(|(arg_i, arg_t)| {
                 // The components come at the end, so offset by the untupled length.
                 // This follows the naming convention defined in `typ.rs`.
-                let lc = Local::from_usize(arg_i + starting_idx);
+                let lc = arg_i + starting_idx;
                 let (name, base_name) = self.codegen_spread_arg_name(&lc);
-                let sym = Symbol::variable(name, base_name, self.codegen_ty(arg_t), loc)
+                let sym = Symbol::variable(name, base_name, self.codegen_ty_stable(*arg_t), loc)
                     .with_is_hidden(false)
-                    .with_is_parameter(!self.is_zst(arg_t));
+                    .with_is_parameter(!self.is_zst_stable(*arg_t));
                 // The spread arguments are additional function paramaters that are patched in
                 // They are to the function signature added in the `fn_typ` function.
                 // But they were never added to the symbol table, which we currently do here.
@@ -229,12 +204,13 @@ impl<'tcx> GotocCtx<'tcx> {
 
     pub fn declare_function(&mut self, instance: Instance) {
         debug!("declaring {}; {:?}", instance.name(), instance);
-        self.set_current_fn(instance);
+        let body = instance.body().unwrap();
+        self.set_current_fn(instance, &body);
         debug!(krate=?instance.def.krate(), is_std=self.current_fn().is_std(), "declare_function");
         self.ensure(&self.symbol_name_stable(instance), |ctx, fname| {
             Symbol::function(
                 fname,
-                ctx.fn_typ(),
+                ctx.fn_typ(&body),
                 None,
                 instance.name(),
                 ctx.codegen_span_stable(instance.def.span()),

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -138,7 +138,7 @@ impl<'tcx> GotocCtx<'tcx> {
         debug!(?fargs, "codegen_intrinsic");
         debug!(?place, "codegen_intrinsic");
         debug!(?span, "codegen_intrinsic");
-        let sig = instance.fn_sig();
+        let sig = instance.ty().kind().fn_sig().unwrap().skip_binder();
         let ret_ty = sig.output();
         let farg_types = sig.inputs();
         let cbmc_ret_ty = self.codegen_ty_stable(ret_ty);
@@ -414,7 +414,8 @@ impl<'tcx> GotocCtx<'tcx> {
             "cttz" => codegen_count_intrinsic!(cttz, true),
             "cttz_nonzero" => codegen_count_intrinsic!(cttz, false),
             "discriminant_value" => {
-                let ty = pointee_type_stable(instance.fn_sig().inputs()[0]).unwrap();
+                let sig = instance.ty().kind().fn_sig().unwrap().skip_binder();
+                let ty = pointee_type_stable(sig.inputs()[0]).unwrap();
                 let e = self.codegen_get_discriminant(fargs.remove(0).dereference(), ty, ret_ty);
                 self.codegen_expr_to_place_stable(place, e)
             }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs
@@ -566,7 +566,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// sometimes subtly differs from the type that codegen_function_sig returns.
     /// This is tracked in <https://github.com/model-checking/kani/issues/1350>.
     fn codegen_func_symbol(&mut self, instance: Instance) -> (&Symbol, Type) {
-        let funct = self.codegen_function_sig(self.fn_sig_of_instance_stable(instance));
+        let funct = self.codegen_function_sig_stable(self.fn_sig_of_instance_stable(instance));
         let sym = if instance.is_foreign_item() {
             // Get the symbol that represents a foreign instance.
             self.codegen_foreign_fn(instance)

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
@@ -6,13 +6,13 @@
 //! in [GotocCtx::codegen_place] below.
 
 use super::typ::TypeExt;
-use crate::codegen_cprover_gotoc::codegen::ty_stable::{pointee_type, StableConverter};
+use crate::codegen_cprover_gotoc::codegen::ty_stable::pointee_type;
 use crate::codegen_cprover_gotoc::codegen::typ::std_pointee_type;
 use crate::codegen_cprover_gotoc::utils::{dynamic_fat_ptr, slice_fat_ptr};
 use crate::codegen_cprover_gotoc::GotocCtx;
 use crate::unwrap_or_return_codegen_unimplemented;
 use cbmc::goto_program::{Expr, Location, Type};
-use rustc_middle::mir::{Local as LocalInternal, Place as PlaceInternal};
+use rustc_middle::mir::Local as LocalInternal;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_smir::rustc_internal;
 use rustc_target::abi::{TagEncoding, Variants};
@@ -637,10 +637,6 @@ impl<'tcx> GotocCtx<'tcx> {
     ///   build the fat pointer from there.
     /// - For `*(Wrapper<T>)` where `T: Unsized`, the projection's `goto_expr` returns an object,
     ///   and we need to take it's address and build the fat pointer.
-    pub fn codegen_place_ref(&mut self, place: &PlaceInternal<'tcx>) -> Expr {
-        self.codegen_place_ref_stable(&StableConverter::convert_place(self, *place))
-    }
-
     pub fn codegen_place_ref_stable(&mut self, place: &Place) -> Expr {
         let place_ty = self.place_ty_stable(place);
         let projection =
@@ -696,13 +692,6 @@ impl<'tcx> GotocCtx<'tcx> {
             )),
             _ => result,
         }
-    }
-
-    pub fn codegen_place(
-        &mut self,
-        place: &PlaceInternal<'tcx>,
-    ) -> Result<ProjectedPlace, UnimplementedData> {
-        self.codegen_place_stable(&StableConverter::convert_place(self, *place))
     }
 
     /// Given a projection, generate an lvalue that represents the given variant index.

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
@@ -12,7 +12,6 @@ use crate::codegen_cprover_gotoc::utils::{dynamic_fat_ptr, slice_fat_ptr};
 use crate::codegen_cprover_gotoc::GotocCtx;
 use crate::unwrap_or_return_codegen_unimplemented;
 use cbmc::goto_program::{Expr, Location, Type};
-use rustc_middle::mir::Local as LocalInternal;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_smir::rustc_internal;
 use rustc_target::abi::{TagEncoding, Variants};
@@ -390,7 +389,7 @@ impl<'tcx> GotocCtx<'tcx> {
         }
 
         // Otherwise, simply look up the local by the var name.
-        let vname = self.codegen_var_name(&LocalInternal::from(l));
+        let vname = self.codegen_var_name(&l);
         Expr::symbol_expression(vname, self.codegen_ty_stable(local_ty))
     }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/span.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/span.rs
@@ -5,10 +5,8 @@
 
 use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::goto_program::Location;
-use rustc_middle::mir::{Local, VarDebugInfoContents};
 use rustc_smir::rustc_internal;
 use rustc_span::Span;
-use stable_mir::mir::VarDebugInfo;
 use stable_mir::ty::Span as SpanStable;
 
 impl<'tcx> GotocCtx<'tcx> {
@@ -43,14 +41,5 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn codegen_caller_span(&self, span: &Span) -> Location {
         let topmost = span.ctxt().outer_expn().expansion_cause().unwrap_or(*span);
         self.codegen_span(&topmost)
-    }
-
-    pub fn find_debug_info(&self, l: &Local) -> Option<VarDebugInfo> {
-        rustc_internal::stable(self.current_fn().body_internal().var_debug_info.iter().find(
-            |info| match info.value {
-                VarDebugInfoContents::Place(p) => p.local == *l && p.projection.len() == 0,
-                VarDebugInfoContents::Const(_) => false,
-            },
-        ))
     }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/span.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/span.rs
@@ -45,10 +45,6 @@ impl<'tcx> GotocCtx<'tcx> {
         self.codegen_span(&topmost)
     }
 
-    pub fn codegen_span_option(&self, sp: Option<Span>) -> Location {
-        sp.map_or(Location::none(), |x| self.codegen_span(&x))
-    }
-
     pub fn find_debug_info(&self, l: &Local) -> Option<VarDebugInfo> {
         rustc_internal::stable(self.current_fn().body_internal().var_debug_info.iter().find(
             |info| match info.value {

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -130,7 +130,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 "https://github.com/model-checking/kani/issues/692",
             ),
             TerminatorKind::Abort => self.codegen_mimic_unimplemented(
-                "TerminatorKind::UnwindTerminate",
+                "TerminatorKind::Abort",
                 loc,
                 "https://github.com/model-checking/kani/issues/692",
             ),

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -135,8 +135,8 @@ impl<'tcx> GotocCtx<'tcx> {
                 "https://github.com/model-checking/kani/issues/692",
             ),
             TerminatorKind::Return => {
-                let rty = self.current_fn().sig().skip_binder().output();
-                if rty.is_unit() {
+                let rty = self.current_fn().sig().output();
+                if rty.kind().is_unit() {
                     self.codegen_ret_unit()
                 } else {
                     let p = Place::from(RETURN_LOCAL);
@@ -177,7 +177,8 @@ impl<'tcx> GotocCtx<'tcx> {
                 } else if let AssertMessage::MisalignedPointerDereference { .. } = msg {
                     // Misaligned pointer dereference check messages is also a runtime messages.
                     // Generate a generic one here.
-                    "misaligned pointer dereference: address must be a multiple of its type's alignment"
+                    "misaligned pointer dereference: address must be a multiple of its type's \
+                    alignment"
                 } else {
                     // For all other assert kind we can get the static message.
                     msg.description().unwrap()

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -139,16 +139,16 @@ impl<'tcx> GotocCtx<'tcx> {
                 if rty.kind().is_unit() {
                     self.codegen_ret_unit()
                 } else {
-                    let p = Place::from(RETURN_LOCAL);
-                    let v = unwrap_or_return_codegen_unimplemented_stmt!(
+                    let place = Place::from(RETURN_LOCAL);
+                    let place_expr = unwrap_or_return_codegen_unimplemented_stmt!(
                         self,
-                        self.codegen_place_stable(&p)
+                        self.codegen_place_stable(&place)
                     )
                     .goto_expr;
-                    if self.place_ty_stable(&p).kind().is_bool() {
-                        v.cast_to(Type::c_bool()).ret(loc)
+                    if self.place_ty_stable(&place).kind().is_bool() {
+                        place_expr.cast_to(Type::c_bool()).ret(loc)
                     } else {
-                        v.ret(loc)
+                        place_expr.ret(loc)
                     }
                 }
             }
@@ -368,8 +368,8 @@ impl<'tcx> GotocCtx<'tcx> {
                     }
                 }
             }
-            _ => unreachable!(
-                "TerminatorKind::Drop but not InstanceKind::DropGlue should be impossible"
+            kind => unreachable!(
+                "Expected a `InstanceKind::Shim` for `TerminatorKind::Drop`, but found {kind:?}"
             ),
         };
         let goto_target = Stmt::goto(bb_label(*target), loc);

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/ty_stable.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/ty_stable.rs
@@ -8,17 +8,12 @@
 
 use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::goto_program::Type;
-use rustc_middle::mir;
-use rustc_middle::mir::visit::{MutVisitor, NonUseContext, PlaceContext};
-use rustc_middle::mir::{
-    Location, Operand as OperandInternal, Place as PlaceInternal, Rvalue as RvalueInternal,
-};
 use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
-use rustc_middle::ty::{self, Const as ConstInternal, GenericArgsRef, Ty as TyInternal, TyCtxt};
+use rustc_middle::ty::{self};
 use rustc_smir::rustc_internal;
 use stable_mir::mir::mono::Instance;
 use stable_mir::mir::{Local, Operand, Place, Rvalue};
-use stable_mir::ty::{Const, RigidTy, Ty, TyKind};
+use stable_mir::ty::{RigidTy, Ty, TyKind};
 
 impl<'tcx> GotocCtx<'tcx> {
     pub fn place_ty_stable(&self, place: &Place) -> Ty {
@@ -94,6 +89,10 @@ impl<'tcx> GotocCtx<'tcx> {
         let (sz, ty) = rustc_internal::internal(ty).simd_size_and_type(self.tcx);
         (sz, rustc_internal::stable(ty))
     }
+
+    pub fn codegen_enum_discr_typ_stable(&self, ty: Ty) -> Ty {
+        rustc_internal::stable(self.codegen_enum_discr_typ(rustc_internal::internal(ty)))
+    }
 }
 /// If given type is a Ref / Raw ref, return the pointee type.
 pub fn pointee_type(mir_type: Ty) -> Option<Ty> {
@@ -112,83 +111,10 @@ pub fn pretty_ty(ty: Ty) -> String {
     rustc_internal::internal(ty).to_string()
 }
 
-/// Convert internal rustc's structs into StableMIR ones.
-///
-/// The body of a StableMIR instance already comes monomorphized, which is different from rustc's
-/// internal representation. To allow us to migrate parts of the code generation stage with
-/// smaller PRs, we have to instantiate rustc's components when converting them to stable.
-///
-/// Once we finish migrating the entire function code generation, we can remove this code.
-pub struct StableConverter<'a, 'tcx> {
-    gcx: &'a GotocCtx<'tcx>,
-}
-
-impl<'a, 'tcx> StableConverter<'a, 'tcx> {
-    pub fn convert_place(gcx: &'a GotocCtx<'tcx>, mut place: PlaceInternal<'tcx>) -> Place {
-        let mut converter = StableConverter { gcx };
-        converter.visit_place(
-            &mut place,
-            PlaceContext::NonUse(NonUseContext::VarDebugInfo),
-            mir::Location::START,
-        );
-        rustc_internal::stable(place)
-    }
-
-    pub fn convert_rvalue(gcx: &'a GotocCtx<'tcx>, mut operand: RvalueInternal<'tcx>) -> Rvalue {
-        let mut converter = StableConverter { gcx };
-        converter.visit_rvalue(&mut operand, mir::Location::START);
-        rustc_internal::stable(operand)
-    }
-
-    pub fn convert_operand(gcx: &'a GotocCtx<'tcx>, mut operand: OperandInternal<'tcx>) -> Operand {
-        let mut converter = StableConverter { gcx };
-        converter.visit_operand(&mut operand, mir::Location::START);
-        rustc_internal::stable(operand)
-    }
-
-    pub fn convert_constant(gcx: &'a GotocCtx<'tcx>, mut constant: ConstInternal<'tcx>) -> Const {
-        let mut converter = StableConverter { gcx };
-        converter.visit_ty_const(&mut constant, mir::Location::START);
-        rustc_internal::stable(constant)
-    }
-}
-
 pub fn pointee_type_stable(ty: Ty) -> Option<Ty> {
     match ty.kind() {
         TyKind::RigidTy(RigidTy::Ref(_, pointee_ty, _))
         | TyKind::RigidTy(RigidTy::RawPtr(pointee_ty, ..)) => Some(pointee_ty),
         _ => None,
-    }
-}
-
-impl<'a, 'tcx> MutVisitor<'tcx> for StableConverter<'a, 'tcx> {
-    fn tcx(&self) -> TyCtxt<'tcx> {
-        self.gcx.tcx
-    }
-
-    fn visit_ty(&mut self, ty: &mut TyInternal<'tcx>, _: mir::visit::TyContext) {
-        *ty = self.gcx.monomorphize(*ty);
-    }
-
-    fn visit_ty_const(&mut self, ct: &mut ty::Const<'tcx>, _location: mir::Location) {
-        *ct = self.gcx.monomorphize(*ct);
-    }
-
-    fn visit_args(&mut self, args: &mut GenericArgsRef<'tcx>, _: Location) {
-        *args = self.gcx.monomorphize(*args);
-    }
-
-    fn visit_constant(&mut self, constant: &mut mir::ConstOperand<'tcx>, location: mir::Location) {
-        let const_ = self.gcx.monomorphize(constant.const_);
-        let val = match const_.eval(self.gcx.tcx, ty::ParamEnv::reveal_all(), None) {
-            Ok(v) => v,
-            Err(mir::interpret::ErrorHandled::Reported(..)) => return,
-            Err(mir::interpret::ErrorHandled::TooGeneric(..)) => {
-                unreachable!("Failed to evaluate instance constant: {:?}", const_)
-            }
-        };
-        let ty = constant.ty();
-        constant.const_ = mir::Const::Val(val, ty);
-        self.super_constant(constant, location);
     }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -8,7 +8,6 @@ use cbmc::{InternString, InternedString};
 use rustc_ast::ast::Mutability;
 use rustc_hir::{LangItem, Unsafety};
 use rustc_index::IndexVec;
-use rustc_middle::mir::Local;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::print::FmtPrinter;
@@ -25,6 +24,7 @@ use rustc_target::abi::{
     TyAndLayout, VariantIdx, Variants,
 };
 use rustc_target::spec::abi::Abi;
+use stable_mir::mir::Body;
 use std::iter;
 use tracing::{debug, trace, warn};
 
@@ -1288,17 +1288,7 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn codegen_function_sig(&mut self, sig: PolyFnSig<'tcx>) -> Type {
         let sig = self.monomorphize(sig);
         let sig = self.tcx.normalize_erasing_late_bound_regions(ty::ParamEnv::reveal_all(), sig);
-        let params = sig
-            .inputs()
-            .iter()
-            .filter_map(|t| if self.is_zst(*t) { None } else { Some(self.codegen_ty(*t)) })
-            .collect();
-
-        if sig.c_variadic {
-            Type::variadic_code_with_unnamed_parameters(params, self.codegen_ty(sig.output()))
-        } else {
-            Type::code_with_unnamed_parameters(params, self.codegen_ty(sig.output()))
-        }
+        self.codegen_function_sig_stable(rustc_internal::stable(sig))
     }
 
     /// Creates a zero-sized struct for a FnDef.
@@ -1666,39 +1656,39 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     /// the function type of the current instance
-    pub fn fn_typ(&mut self) -> Type {
-        let sig = self.current_fn().sig();
-        let sig = self.tcx.normalize_erasing_late_bound_regions(ty::ParamEnv::reveal_all(), sig);
-        // we don't call [codegen_function_sig] because we want to get a bit more metainformation.
-        let is_vtable_shim =
-            matches!(self.current_fn().instance().def, ty::InstanceDef::VTableShim(..));
+    pub fn fn_typ(&mut self, body: &Body) -> Type {
+        let sig = self.current_fn().sig().clone();
+        let internal_instance = self.current_fn().instance();
+        let is_vtable_shim = matches!(internal_instance.def, ty::InstanceDef::VTableShim(..));
         let mut params: Vec<Parameter> = sig
             .inputs()
             .iter()
             .enumerate()
-            .filter_map(|(i, t)| {
+            .filter_map(|(i, ty)| {
+                debug!(?i, ?ty, "fn_typ");
                 let is_vtable_shim_self = i == 0 && is_vtable_shim;
-                if self.is_zst(*t) && !is_vtable_shim_self {
+                if self.is_zst_stable(*ty) && !is_vtable_shim_self {
                     // We ignore zero-sized parameters.
                     // See https://github.com/model-checking/kani/issues/274 for more details.
                     None
                 } else {
-                    let lc = Local::from_usize(i + 1);
+                    // An arg is the local with index offset by one (return value is always local 0)
+                    let lc = i + 1;
                     let mut ident = self.codegen_var_name(&lc);
 
                     // `spread_arg` indicates that the last argument is tupled
-                    // at the LLVM/codegen level, so we need to declare the indivual
+                    // at the LLVM/codegen level, so we need to declare the individual
                     // components as parameters with a special naming convention
                     // so that we can "retuple" them in the function prelude.
                     // See: compiler/rustc_codegen_llvm/src/gotoc/mod.rs:codegen_function_prelude
-                    if let Some(spread) = self.current_fn().body_internal().spread_arg {
-                        if lc.index() >= spread.index() {
+                    if let Some(spread) = body.spread_arg() {
+                        if lc >= spread {
                             let (name, _) = self.codegen_spread_arg_name(&lc);
                             ident = name;
                         }
                     }
                     Some(
-                        self.codegen_ty(*t)
+                        self.codegen_ty_stable(*ty)
                             .as_parameter(Some(ident.clone().into()), Some(ident.into())),
                     )
                 }
@@ -1719,9 +1709,9 @@ impl<'tcx> GotocCtx<'tcx> {
 
         debug!(?params, signature=?sig, "function_type");
         if sig.c_variadic {
-            Type::variadic_code(params, self.codegen_ty(sig.output()))
+            Type::variadic_code(params, self.codegen_ty_stable(sig.output()))
         } else {
-            Type::code(params, self.codegen_ty(sig.output()))
+            Type::code(params, self.codegen_ty_stable(sig.output()))
         }
     }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/context/current_fn.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/current_fn.rs
@@ -3,7 +3,7 @@
 
 use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::goto_program::Stmt;
-use rustc_middle::mir::{BasicBlock, Body as InternalBody};
+use rustc_middle::mir::Body as InternalBody;
 use rustc_middle::ty::{Instance as InternalInstance, PolyFnSig};
 use rustc_smir::rustc_internal;
 use stable_mir::mir::mono::Instance;
@@ -80,11 +80,6 @@ impl<'tcx> CurrentFnCtx<'tcx> {
         rustc_internal::internal(self.instance)
     }
 
-    /// The crate that function came from
-    pub fn krate(&self) -> String {
-        self.krate.to_string()
-    }
-
     /// The internal MIR for the function we are currently compiling using internal APIs.
     pub fn body_internal(&self) -> &'tcx InternalBody<'tcx> {
         self.mir
@@ -116,9 +111,5 @@ impl CurrentFnCtx<'_> {
     /// Is the current function from the `std` crate?
     pub fn is_std(&self) -> bool {
         self.krate == "std" || self.krate == "core"
-    }
-
-    pub fn find_label(&self, bb: &BasicBlock) -> String {
-        format!("{bb:?}")
     }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/context/current_fn.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/current_fn.rs
@@ -3,12 +3,15 @@
 
 use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::goto_program::Stmt;
+use cbmc::InternedString;
 use rustc_middle::mir::Body as InternalBody;
-use rustc_middle::ty::{Instance as InternalInstance, PolyFnSig};
+use rustc_middle::ty::Instance as InternalInstance;
 use rustc_smir::rustc_internal;
 use stable_mir::mir::mono::Instance;
-use stable_mir::mir::Body;
+use stable_mir::mir::{Body, Local, LocalDecl};
+use stable_mir::ty::FnSig;
 use stable_mir::CrateDef;
+use std::collections::HashMap;
 
 /// This structure represents useful data about the function we are currently compiling.
 #[derive(Debug)]
@@ -17,39 +20,48 @@ pub struct CurrentFnCtx<'tcx> {
     block: Vec<Stmt>,
     /// The codegen instance for the current function
     instance: Instance,
+    /// The current function signature.
+    fn_sig: FnSig,
     /// The crate this function is from
     krate: String,
     /// The MIR for the current instance. This is using the internal representation.
     mir: &'tcx InternalBody<'tcx>,
-    /// The MIR for the current instance.
-    body: Body,
+    /// A list of local declarations used to retrieve MIR component types.
+    locals: Vec<LocalDecl>,
+    /// A list of pretty names for locals that corrspond to user variables.
+    local_names: HashMap<Local, InternedString>,
     /// The symbol name of the current function
     name: String,
     /// A human readable pretty name for the current function
     readable_name: String,
-    /// The signature of the current function
-    sig: PolyFnSig<'tcx>,
     /// A counter to enable creating temporary variables
     temp_var_counter: u64,
 }
 
 /// Constructor
 impl<'tcx> CurrentFnCtx<'tcx> {
-    pub fn new(instance: Instance, gcx: &GotocCtx<'tcx>) -> Self {
+    pub fn new(instance: Instance, gcx: &GotocCtx<'tcx>, body: &Body) -> Self {
         let internal_instance = rustc_internal::internal(instance);
-        let body = instance.body().unwrap();
         let readable_name = instance.name();
         let name =
             if &readable_name == "main" { readable_name.clone() } else { instance.mangled_name() };
+        let locals = body.locals().to_vec();
+        let local_names = body
+            .var_debug_info
+            .iter()
+            .filter_map(|info| info.local().map(|local| (local, (&info.name).into())))
+            .collect::<HashMap<_, _>>();
+        let fn_sig = gcx.fn_sig_of_instance_stable(instance);
         Self {
             block: vec![],
             instance,
+            fn_sig,
             mir: gcx.tcx.instance_mir(internal_instance.def),
             krate: instance.def.krate().name,
-            body,
+            locals,
+            local_names,
             name,
             readable_name,
-            sig: gcx.fn_sig_of_instance(internal_instance),
             temp_var_counter: 0,
         }
     }
@@ -80,6 +92,10 @@ impl<'tcx> CurrentFnCtx<'tcx> {
         rustc_internal::internal(self.instance)
     }
 
+    pub fn instance_stable(&self) -> Instance {
+        self.instance
+    }
+
     /// The internal MIR for the function we are currently compiling using internal APIs.
     pub fn body_internal(&self) -> &'tcx InternalBody<'tcx> {
         self.mir
@@ -96,13 +112,16 @@ impl<'tcx> CurrentFnCtx<'tcx> {
     }
 
     /// The signature of the function we are currently compiling
-    pub fn sig(&self) -> PolyFnSig<'tcx> {
-        self.sig
+    pub fn sig(&self) -> &FnSig {
+        &self.fn_sig
     }
 
-    /// The body of the function.
-    pub fn body(&self) -> &Body {
-        &self.body
+    pub fn locals(&self) -> &[LocalDecl] {
+        &self.locals
+    }
+
+    pub fn local_name(&self, local: Local) -> Option<InternedString> {
+        self.local_names.get(&local).copied()
     }
 }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -35,6 +35,7 @@ use rustc_span::Span;
 use rustc_target::abi::call::FnAbi;
 use rustc_target::abi::{HasDataLayout, TargetDataLayout};
 use stable_mir::mir::mono::Instance;
+use stable_mir::mir::Body;
 use stable_mir::ty::Allocation;
 
 pub struct GotocCtx<'tcx> {
@@ -298,8 +299,8 @@ impl<'tcx> GotocCtx<'tcx> {
 
 /// Mutators
 impl<'tcx> GotocCtx<'tcx> {
-    pub fn set_current_fn(&mut self, instance: Instance) {
-        self.current_fn = Some(CurrentFnCtx::new(instance, self));
+    pub fn set_current_fn(&mut self, instance: Instance, body: &Body) {
+        self.current_fn = Some(CurrentFnCtx::new(instance, self, body));
     }
 
     pub fn reset_current_fn(&mut self) {

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -29,12 +29,12 @@ use rustc_middle::ty::layout::{
     FnAbiError, FnAbiOfHelpers, FnAbiRequest, HasParamEnv, HasTyCtxt, LayoutError, LayoutOfHelpers,
     TyAndLayout,
 };
-use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
-use rustc_smir::rustc_internal;
+use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::source_map::respan;
 use rustc_span::Span;
 use rustc_target::abi::call::FnAbi;
 use rustc_target::abi::{HasDataLayout, TargetDataLayout};
+use stable_mir::mir::mono::Instance;
 use stable_mir::ty::Allocation;
 
 pub struct GotocCtx<'tcx> {
@@ -298,8 +298,8 @@ impl<'tcx> GotocCtx<'tcx> {
 
 /// Mutators
 impl<'tcx> GotocCtx<'tcx> {
-    pub fn set_current_fn(&mut self, instance: Instance<'tcx>) {
-        self.current_fn = Some(CurrentFnCtx::new(rustc_internal::stable(instance), self));
+    pub fn set_current_fn(&mut self, instance: Instance) {
+        self.current_fn = Some(CurrentFnCtx::new(instance, self));
     }
 
     pub fn reset_current_fn(&mut self) {

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/names.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/names.rs
@@ -7,10 +7,10 @@ use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::InternedString;
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::mir::mono::CodegenUnitNameBuilder;
-use rustc_middle::mir::Local;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{Instance, TyCtxt};
 use stable_mir::mir::mono::Instance as InstanceStable;
+use stable_mir::mir::Local;
 use tracing::debug;
 
 impl<'tcx> GotocCtx<'tcx> {
@@ -20,22 +20,22 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     pub fn codegen_var_base_name(&self, l: &Local) -> String {
-        match self.find_debug_info(l) {
-            None => format!("var_{}", l.index()),
-            Some(info) => info.name,
+        match self.current_fn().local_name(*l) {
+            None => format!("var_{l}"),
+            Some(name) => name.to_string(),
         }
     }
 
     pub fn codegen_var_name(&self, l: &Local) -> String {
         let fname = self.current_fn().name();
-        match self.find_debug_info(l) {
-            Some(info) => format!("{fname}::1::var{l:?}::{}", info.name),
-            None => format!("{fname}::1::var{l:?}"),
+        match self.current_fn().local_name(*l) {
+            Some(name) => format!("{fname}::1::var_{l}::{name}"),
+            None => format!("{fname}::1::var_{l}"),
         }
     }
 
     pub fn is_user_variable(&self, var: &Local) -> bool {
-        self.find_debug_info(var).is_some()
+        self.current_fn().local_name(*var).is_some()
     }
 
     // Special naming conventions for parameters that are spread from a tuple

--- a/kani-compiler/src/kani_middle/mod.rs
+++ b/kani-compiler/src/kani_middle/mod.rs
@@ -231,6 +231,7 @@ impl SourceLocation {
 }
 
 /// Get the FnAbi of a given instance with no extra variadic arguments.
+/// TODO: Get rid of this. Use instance.fn_sig() instead.
 pub fn fn_abi<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> &'tcx FnAbi<'tcx, Ty<'tcx>> {
     let helper = CompilerHelpers { tcx };
     helper.fn_abi_of_instance(instance, ty::List::empty())

--- a/kani-compiler/src/kani_middle/mod.rs
+++ b/kani-compiler/src/kani_middle/mod.rs
@@ -232,6 +232,7 @@ impl SourceLocation {
 
 /// Get the FnAbi of a given instance with no extra variadic arguments.
 /// TODO: Get rid of this. Use instance.fn_sig() instead.
+/// <https://github.com/model-checking/kani/issues/1365>
 pub fn fn_abi<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> &'tcx FnAbi<'tcx, Ty<'tcx>> {
     let helper = CompilerHelpers { tcx };
     helper.fn_abi_of_instance(instance, ty::List::empty())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2023-12-15"
+channel = "nightly-2023-12-16"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Migrate these modules to use StableMIR except for calls that depend on the function signature and ABI. Note that we shouldn't really be using function signature as captured here: https://github.com/model-checking/kani/issues/1365. So I suggest that we move to using the FnAbi as soon as we add that to StableMIR.

### Call-out

This change depends on the new nightly due to https://github.com/rust-lang/rust/pull/118927 fix. Keeping it as a draft until it's released.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
