### PR TITLE
Fix nightly jobs running CBMC latest on the `perf` suite 

### DIFF
--- a/.github/workflows/cbmc-latest.yml
+++ b/.github/workflows/cbmc-latest.yml
@@ -81,8 +81,8 @@ jobs:
       - name: Build CBMC
         working-directory: ./cbmc
         run: |
-          cmake -S . -Bbuild -DWITH_JBMC=OFF
-          cmake --build build -- -j 4
+          make -C src minisat2-download cadical-download
+          make -C src -j4 MINISAT2=../../minisat-2.2.1 CADICAL=../../cadical
           # Prepend the bin directory to $PATH
           echo "${GITHUB_WORKSPACE}/cbmc/build/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
As explained in #2952 , the nightly `perf` runs started failing over the weekend with this error:

```
The input was compiled with an old version of goto-cc; please recompile
error: goto-cc exited with status exit status: 1
```

Changing the build process for CBMC to use `make` instead of `cmake` is enough for the error to go away. [This action run](https://github.com/adpaco-aws/rmc/actions/runs/7254410145) shows how a successful `perf` job with the change in this PR.

Resolves #2952

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
