### PR TITLE
Bump Kani version to 0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.44.0]
+
+### What's Changed
+
+* Rust toolchain upgraded to 2024-01-08 rust toolchain by @adpaco-aws, @celinval, @zhassan-aws
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.43.0...kani-0.44.0
+
 ## [0.43.0]
 
 ###  What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ### What's Changed
 
-* Rust toolchain upgraded to 2024-01-08 rust toolchain by @adpaco-aws, @celinval, @zhassan-aws
+* Rust toolchain upgraded to `nightly-2024-01-08` by @adpaco-aws @celinval @zhassan-aws
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.43.0...kani-0.44.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -438,14 +438,14 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "kani"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "home",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1039,7 +1039,7 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "std"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
These are the auto-generated release notes for comparison purposes:

## What's Changed
* Automate cargo update without dependabot by @tautschnig in https://github.com/model-checking/kani/pull/2942
* Update nightly toolchain to toolchain-2023-12-15 by @celinval in https://github.com/model-checking/kani/pull/2948
* Automatic cargo update to 2023-12-18 by @github-actions in https://github.com/model-checking/kani/pull/2951
* Migrate function, block and statement modules to StableMIR by @celinval in https://github.com/model-checking/kani/pull/2947
* Update Rust toolchain to `nightly-2023-12-18` by @adpaco-aws in https://github.com/model-checking/kani/pull/2953
* Update the rust toolchain to 2023-12-20 by @celinval in https://github.com/model-checking/kani/pull/2961
* Migrate foreign function, compiler-interface and kani-middle modules to use StableMIR by @celinval in https://github.com/model-checking/kani/pull/2959
* Build CBMC with `cmake` in all "CBMC latest" jobs by @adpaco-aws in https://github.com/model-checking/kani/pull/2965
* Automatic cargo update to 2024-01-01 by @github-actions in https://github.com/model-checking/kani/pull/2964
* Automatic cargo update to 2024-01-08 by @github-actions in https://github.com/model-checking/kani/pull/2968
* Upgrade to 2024-01-08 rust toolchain by @zhassan-aws in https://github.com/model-checking/kani/pull/2969


**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.43.0...kani-0.44.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
