### PR TITLE
Benchcomp visualize: fix missing import

### DIFF
--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -4,6 +4,7 @@
 
 import dataclasses
 import json
+import logging
 import subprocess
 import textwrap
 


### PR DESCRIPTION
logging is required when handling errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
