### PR TITLE
Update cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ version = "0.1.0"
 dependencies = [
  "Inflector",
  "pulldown-cmark",
+ "pulldown-cmark-escape",
  "rustdoc",
  "serde",
  "serde_json",
@@ -773,6 +774,12 @@ dependencies = [
  "memchr",
  "unicase",
 ]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d8f9aa0e3cbcfaf8bf00300004ee3b72f74770f9cbac93f6928771f613276b"
 
 [[package]]
 name = "quote"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -67,7 +67,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -77,7 +77,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -218,8 +218,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
 dependencies = [
  "crossterm",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "unicode-width",
 ]
 
@@ -250,7 +250,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -340,7 +340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -402,7 +402,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -452,8 +452,8 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-words",
- "strum",
- "strum_macros",
+ "strum 0.26.1",
+ "strum_macros 0.26.1",
  "tracing",
  "tracing-subscriber",
 ]
@@ -477,8 +477,8 @@ dependencies = [
  "rustc-demangle",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.26.1",
+ "strum_macros 0.26.1",
  "tempfile",
  "toml",
  "tracing",
@@ -512,8 +512,8 @@ dependencies = [
  "clap",
  "cprover_bindings",
  "serde",
- "strum",
- "strum_macros",
+ "strum 0.26.1",
+ "strum_macros 0.26.1",
 ]
 
 [[package]]
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
 ]
@@ -765,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+checksum = "dce76ce678ffc8e5675b22aa1405de0b7037e2fdf8913fea40d1926c6fe1e6e7"
 dependencies = [
  "bitflags 2.4.2",
  "memchr",
@@ -909,7 +909,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1062,10 +1062,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
+name = "strum"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+
+[[package]]
 name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1097,15 +1116,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1140,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1161,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
  "indexmap",
  "serde",
@@ -1319,15 +1337,15 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+checksum = "7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c"
 dependencies = [
  "either",
  "home",
  "once_cell",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1360,15 +1378,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "windows-sys"
@@ -1495,9 +1504,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
 dependencies = [
  "memchr",
 ]

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -19,8 +19,8 @@ num = { version = "0.4.0", optional = true }
 regex = "1.7.0"
 serde = { version = "1", optional = true }
 serde_json = "1"
-strum = "0.25.0"
-strum_macros = "0.25.2"
+strum = "0.26"
+strum_macros = "0.26"
 shell-words = "1.0.0"
 tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-subscriber = {version = "0.3.8", features = ["env-filter", "json", "fmt"]}

--- a/kani-compiler/src/args.rs
+++ b/kani-compiler/src/args.rs
@@ -1,10 +1,10 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
+use strum_macros::{AsRefStr, EnumString, VariantNames};
 use tracing_subscriber::filter::Directive;
 
-#[derive(Debug, Default, Clone, Copy, AsRefStr, EnumString, EnumVariantNames, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, AsRefStr, EnumString, VariantNames, PartialEq, Eq)]
 #[strum(serialize_all = "snake_case")]
 pub enum ReachabilityType {
     /// Start the cross-crate reachability analysis from all harnesses in the local crate.

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -27,13 +27,13 @@ rustc-demangle = "0.1.21"
 pathdiff = "0.2.1"
 rayon = "1.5.3"
 comfy-table = "7.0.1"
-strum = {version = "0.25.0"}
-strum_macros = {version = "0.25.2"}
+strum = {version = "0.26"}
+strum_macros = {version = "0.26"}
 tempfile = "3"
 tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-subscriber = {version = "0.3.8", features = ["env-filter", "json", "fmt"]}
 rand = "0.8"
-which = "5.0.0"
+which = "6"
 
 # A good set of suggested dependencies can be found in rustup:
 # https://github.com/rust-lang/rustup/blob/master/Cargo.toml

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -13,6 +13,6 @@ publish = false
 [dependencies]
 serde = {version = "1", features = ["derive"]}
 cbmc = { path = "../cprover_bindings", package = "cprover_bindings" }
-strum = "0.25.0"
-strum_macros = "0.25.2"
+strum = "0.26"
+strum_macros = "0.26"
 clap = { version = "4.4.11", features = ["derive"] }

--- a/kani_metadata/src/cbmc_solver.rs
+++ b/kani_metadata/src/cbmc_solver.rs
@@ -2,22 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use serde::{Deserialize, Serialize};
-use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
+use strum_macros::{AsRefStr, EnumString, VariantNames};
 
 /// An enum for CBMC solver options. All variants are handled by Kani, except for
 /// the `Binary` one, which it passes as is to CBMC's `--external-sat-solver`
 /// option.
-#[derive(
-    Debug,
-    Clone,
-    AsRefStr,
-    EnumString,
-    EnumVariantNames,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize
-)]
+#[derive(Debug, Clone, AsRefStr, EnumString, VariantNames, PartialEq, Eq, Serialize, Deserialize)]
 #[strum(serialize_all = "snake_case")]
 pub enum CbmcSolver {
     /// CaDiCaL which is available in CBMC as of version 5.77.0

--- a/scripts/setup/ubuntu/install_doc_deps.sh
+++ b/scripts/setup/ubuntu/install_doc_deps.sh
@@ -4,5 +4,5 @@
 
 set -eux
 
-cargo install mdbook-graphviz
+# cargo install mdbook-graphviz
 DEBIAN_FRONTEND=noninteractive sudo apt-get install --no-install-recommends --yes graphviz

--- a/tools/bookrunner/Cargo.toml
+++ b/tools/bookrunner/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 [dependencies]
 Inflector = "0.11.4"
 pulldown-cmark = { version = "0.10", default-features = false }
+pulldown-cmark-escape = { version = "0.10", default-features = false }
 rustdoc = { path = "librustdoc" }
 walkdir = "2.3.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/tools/bookrunner/Cargo.toml
+++ b/tools/bookrunner/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 Inflector = "0.11.4"
-pulldown-cmark = { version = "0.9", default-features = false }
+pulldown-cmark = { version = "0.10", default-features = false }
 rustdoc = { path = "librustdoc" }
 walkdir = "2.3.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/tools/bookrunner/librustdoc/Cargo.toml
+++ b/tools/bookrunner/librustdoc/Cargo.toml
@@ -20,7 +20,7 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
-pulldown-cmark = { version = "0.9", default-features = false }
+pulldown-cmark = { version = "0.10", default-features = false }
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/tools/bookrunner/librustdoc/html/markdown.rs
+++ b/tools/bookrunner/librustdoc/html/markdown.rs
@@ -122,7 +122,7 @@ pub fn find_testable_code<T: doctest::Tester>(
                 tests.add_test(text, block_info, line);
                 prev_offset = offset.start;
             }
-            Event::Start(Tag::Heading(level, _, _)) => {
+            Event::Start(Tag::Heading { level, .. }) => {
                 register_header = Some(level as u32);
             }
             Event::Text(ref s) if register_header.is_some() => {

--- a/tools/bookrunner/src/litani.rs
+++ b/tools/bookrunner/src/litani.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Utilities to interact with the `Litani` build accumulator.
 
-use pulldown_cmark::escape::StrWrite;
+use pulldown_cmark_escape::StrWrite;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -13,4 +13,4 @@ publish = false
 anyhow = "1"
 cargo_metadata = "0.18.0"
 clap = { version = "4.4.11", features=["derive"] }
-which = "5"
+which = "6"


### PR DESCRIPTION
This is to fix recent bookrunner failures, such as https://github.com/model-checking/kani/actions/runs/7813237161/job/21311963018?pr=2996

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
