### PR TITLE
Upgrade tooclhain to 2024-02-17

### DIFF
--- a/kani-compiler/src/kani_middle/intrinsics.rs
+++ b/kani-compiler/src/kani_middle/intrinsics.rs
@@ -101,8 +101,8 @@ fn resolve_rust_intrinsic<'tcx>(
     func_ty: Ty<'tcx>,
 ) -> Option<(Symbol, GenericArgsRef<'tcx>)> {
     if let ty::FnDef(def_id, args) = *func_ty.kind() {
-        if tcx.is_intrinsic(def_id) {
-            return Some((tcx.item_name(def_id), args));
+        if let Some(symbol) = tcx.intrinsic(def_id) {
+            return Some((symbol, args));
         }
     }
     None

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-02-14"
+channel = "nightly-2024-02-17"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/kani/SizeAndAlignOfDst/main_assert.rs
+++ b/tests/kani/SizeAndAlignOfDst/main_assert.rs
@@ -1,15 +1,11 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// The original harness takes too long so we introduced a simplified version to run in CI.
-// kani-flags: --harness simplified
 
 //! This is a regression test for size_and_align_of_dst computing the
 //! size and alignment of a dynamically-sized type like
 //! Arc<Mutex<dyn Subscriber>>.
 //! We added a simplified version of the original harness from:
 //! <https://github.com/model-checking/kani/issues/426>
-//! This currently fails due to
-//! <https://github.com/model-checking/kani/issues/1781>
 
 use std::sync::Arc;
 use std::sync::Mutex;


### PR DESCRIPTION
Upgrade toolchain to 2024-02-17. Relevant PR:

https://github.com/rust-lang/rust/pull/120500

Resolves https://github.com/model-checking/kani/issues/87

This currently breaks the `std` lib regression. Keeping it as a draft till we figure out a fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.