### PR TITLE
Bump Kani version to 0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.47.0]
+
+### What's Changed
+* Upgrade toolchain to 2024-02-14 by @zhassan-aws in https://github.com/model-checking/kani/pull/3036
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.46.0...kani-0.47.0
+
 ## [0.46.0]
 
 ## What's Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -428,14 +428,14 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "kani"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "home",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1034,7 +1034,7 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "std"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## What's Changed
* Upgrade toolchain to 2024-02-14 by @zhassan-aws in https://github.com/model-checking/kani/pull/3036

**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.46.0...kani-0.47.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
