### PR TITLE
Upgrade Rust toolchain to `nightly-2024-03-01`

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -415,6 +415,11 @@ impl<'tcx> GotocCtx<'tcx> {
                 loc,
                 "https://github.com/model-checking/kani/issues/374",
             ),
+            "catch_unwind" => self.codegen_unimplemented_stmt(
+                intrinsic,
+                loc,
+                "https://github.com/model-checking/kani/issues/267",
+            ),
             "ceilf32" => codegen_simple_intrinsic!(Ceilf),
             "ceilf64" => codegen_simple_intrinsic!(Ceil),
             "compare_bytes" => self.codegen_compare_bytes(fargs, place, loc),
@@ -584,11 +589,6 @@ impl<'tcx> GotocCtx<'tcx> {
             "transmute" => self.codegen_intrinsic_transmute(fargs, ret_ty, place),
             "truncf32" => codegen_simple_intrinsic!(Truncf),
             "truncf64" => codegen_simple_intrinsic!(Trunc),
-            "try" => self.codegen_unimplemented_stmt(
-                intrinsic,
-                loc,
-                "https://github.com/model-checking/kani/issues/267",
-            ),
             "type_id" => codegen_intrinsic_const!(),
             "type_name" => codegen_intrinsic_const!(),
             "unaligned_volatile_load" => {

--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -4,12 +4,17 @@
 //! Module used to configure a compiler session.
 
 use crate::args::Arguments;
+use rustc_data_structures::sync::Lrc;
+use rustc_errors::emitter::Emitter;
 use rustc_errors::{
-    emitter::Emitter, emitter::HumanReadableErrorType, fallback_fluent_bundle, json::JsonEmitter,
-    ColorConfig, Diagnostic, TerminalUrl,
+    emitter::HumanReadableErrorType, fallback_fluent_bundle, json::JsonEmitter, ColorConfig,
+    DiagInner,
 };
 use rustc_session::config::ErrorOutputType;
 use rustc_session::EarlyDiagCtxt;
+use rustc_span::source_map::FilePathMapping;
+use rustc_span::source_map::SourceMap;
+use std::io;
 use std::io::IsTerminal;
 use std::panic;
 use std::sync::LazyLock;
@@ -49,17 +54,14 @@ static JSON_PANIC_HOOK: LazyLock<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send
             let msg = format!("Kani unexpectedly panicked at {info}.",);
             let fallback_bundle =
                 fallback_fluent_bundle(rustc_driver::DEFAULT_LOCALE_RESOURCES.to_vec(), false);
-            let mut emitter = JsonEmitter::basic(
+            let mut emitter = JsonEmitter::new(
+                Box::new(io::BufWriter::new(io::stderr())),
+                Lrc::new(SourceMap::new(FilePathMapping::empty())),
+                fallback_bundle,
                 false,
                 HumanReadableErrorType::Default(ColorConfig::Never),
-                None,
-                fallback_bundle,
-                None,
-                false,
-                false,
-                TerminalUrl::No,
             );
-            let diagnostic = Diagnostic::new(rustc_errors::Level::Bug, msg);
+            let diagnostic = DiagInner::new(rustc_errors::Level::Bug, msg);
             emitter.emit_diagnostic(diagnostic);
             (*JSON_PANIC_HOOK)(info);
         }));

--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -56,6 +56,7 @@ static JSON_PANIC_HOOK: LazyLock<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send
                 fallback_fluent_bundle(rustc_driver::DEFAULT_LOCALE_RESOURCES.to_vec(), false);
             let mut emitter = JsonEmitter::new(
                 Box::new(io::BufWriter::new(io::stderr())),
+                #[allow(clippy::arc_with_non_send_sync)]
                 Lrc::new(SourceMap::new(FilePathMapping::empty())),
                 fallback_bundle,
                 false,

--- a/kani-driver/src/cbmc_property_renderer.rs
+++ b/kani-driver/src/cbmc_property_renderer.rs
@@ -837,7 +837,7 @@ fn annotate_properties_with_reach_results(
             let prop_match_id =
                 check_marker_pat.captures(description.as_str()).unwrap().get(0).unwrap().as_str();
             // Get the status associated to the ID we captured
-            let reach_status_opt = reach_map.get(&prop_match_id.to_string());
+            let reach_status_opt = reach_map.get(prop_match_id);
             // Update the reachability status of the property
             if let Some(reach_status) = reach_status_opt {
                 prop.reach = Some(*reach_status);

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -13,7 +13,7 @@
 // Used to model simd.
 #![feature(repr_simd)]
 // Features used for tests only.
-#![cfg_attr(test, feature(platform_intrinsics, portable_simd))]
+#![cfg_attr(test, feature(core_intrinsics, portable_simd))]
 // Required for rustc_diagnostic_item
 #![allow(internal_features)]
 

--- a/library/kani/src/models/mod.rs
+++ b/library/kani/src/models/mod.rs
@@ -127,11 +127,8 @@ mod intrinsics {
 #[cfg(test)]
 mod test {
     use super::intrinsics as kani_intrinsic;
+    use std::intrinsics::simd::*;
     use std::{fmt::Debug, simd::*};
-
-    extern "platform-intrinsic" {
-        fn simd_bitmask<T, U>(x: T) -> U;
-    }
 
     /// Test that the `simd_bitmask` model is equivalent to the intrinsic for all true and all false
     /// masks with lanes represented using i16.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-02-25"
+channel = "nightly-2024-02-28"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-02-28"
+channel = "nightly-2024-03-01"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/cargo-kani/assess-artifacts/expected
+++ b/tests/cargo-kani/assess-artifacts/expected
@@ -3,7 +3,7 @@ Analyzed 1 packages
  Unsupported feature |   Crates | Instances
                      | impacted |    of use
 ---------------------+----------+-----------
- try                 |        1 |         2
+ catch_unwind        |        1 |         2
 ============================================
 =========================================
  Reason for failure    | Number of tests

--- a/tests/cargo-kani/assess-workspace-artifacts/expected
+++ b/tests/cargo-kani/assess-workspace-artifacts/expected
@@ -3,7 +3,7 @@ Analyzed 2 packages
  Unsupported feature |   Crates | Instances
                      | impacted |    of use
 ---------------------+----------+-----------
- try                 |        2 |         3
+ catch_unwind        |        2 |         3
 ============================================
 =========================================
  Reason for failure    | Number of tests

--- a/tests/expected/intrinsics/simd-arith-overflows/main.rs
+++ b/tests/expected/intrinsics/simd-arith-overflows/main.rs
@@ -2,18 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! This test ensures we detect overflows in SIMD arithmetic operations
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::{simd_add, simd_mul, simd_sub};
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct i8x2(i8, i8);
-
-extern "platform-intrinsic" {
-    fn simd_add<T>(x: T, y: T) -> T;
-    fn simd_sub<T>(x: T, y: T) -> T;
-    fn simd_mul<T>(x: T, y: T) -> T;
-}
 
 #[kani::proof]
 fn main() {

--- a/tests/expected/intrinsics/simd-cmp-result-type-is-diff-size/main.rs
+++ b/tests/expected/intrinsics/simd-cmp-result-type-is-diff-size/main.rs
@@ -3,7 +3,8 @@
 
 //! Checks that storing the result of a vector operation in a vector of
 //! size different to the operands' sizes causes an error.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_eq;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
@@ -19,14 +20,6 @@ pub struct u64x2(u64, u64);
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct u32x4(u32, u32, u32, u32);
-
-// From <https://github.com/rust-lang/rfcs/blob/master/text/1199-simd-infrastructure.md#comparisons>:
-// > The type checker ensures that `T` and `U` have the same length, and that
-// > `U` is appropriately "boolean"-y.
-// This means that `U` is allowed to be `i64` or `u64`, but not `f64`.
-extern "platform-intrinsic" {
-    fn simd_eq<T, U>(x: T, y: T) -> U;
-}
 
 #[kani::proof]
 fn main() {

--- a/tests/expected/intrinsics/simd-div-div-zero/main.rs
+++ b/tests/expected/intrinsics/simd-div-div-zero/main.rs
@@ -2,16 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Checks that `simd_div` triggers a failure when the divisor is zero.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_div;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i32x2(i32, i32);
-
-extern "platform-intrinsic" {
-    fn simd_div<T>(x: T, y: T) -> T;
-}
 
 #[kani::proof]
 fn test_simd_div() {

--- a/tests/expected/intrinsics/simd-div-rem-overflow/main.rs
+++ b/tests/expected/intrinsics/simd-div-rem-overflow/main.rs
@@ -1,19 +1,14 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// Checks that the `simd_div` and `simd_rem` intrinsics check for integer overflows.
-
-#![feature(repr_simd, platform_intrinsics)]
+//! Checks that the `simd_div` and `simd_rem` intrinsics check for integer overflows.
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::{simd_div, simd_rem};
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i32x2(i32, i32);
-
-extern "platform-intrinsic" {
-    fn simd_div<T>(x: T, y: T) -> T;
-    fn simd_rem<T>(x: T, y: T) -> T;
-}
 
 unsafe fn do_simd_div(dividends: i32x2, divisors: i32x2) -> i32x2 {
     simd_div(dividends, divisors)

--- a/tests/expected/intrinsics/simd-extract-wrong-type/main.rs
+++ b/tests/expected/intrinsics/simd-extract-wrong-type/main.rs
@@ -4,16 +4,13 @@
 //! This test checks that we emit an error when the return type for
 //! `simd_extract` has a type different to the first argument's (i.e., the
 //! vector) base type.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_extract;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x2(i64, i64);
-
-extern "platform-intrinsic" {
-    fn simd_extract<T, U>(x: T, idx: u32) -> U;
-}
 
 #[kani::proof]
 fn main() {

--- a/tests/expected/intrinsics/simd-insert-wrong-type/main.rs
+++ b/tests/expected/intrinsics/simd-insert-wrong-type/main.rs
@@ -4,16 +4,13 @@
 //! This test checks that we emit an error when the third argument for
 //! `simd_insert` (the value to be inserted) has a type different to the first
 //! argument's (i.e., the vector) base type.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_insert;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x2(i64, i64);
-
-extern "platform-intrinsic" {
-    fn simd_insert<T, U>(x: T, idx: u32, b: U) -> T;
-}
 
 #[kani::proof]
 fn main() {

--- a/tests/expected/intrinsics/simd-rem-div-zero/main.rs
+++ b/tests/expected/intrinsics/simd-rem-div-zero/main.rs
@@ -2,16 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Checks that `simd_rem` triggers a failure when the divisor is zero
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_rem;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i32x2(i32, i32);
-
-extern "platform-intrinsic" {
-    fn simd_rem<T>(x: T, y: T) -> T;
-}
 
 #[kani::proof]
 fn test_simd_rem() {

--- a/tests/expected/intrinsics/simd-result-type-is-float/main.rs
+++ b/tests/expected/intrinsics/simd-result-type-is-float/main.rs
@@ -3,7 +3,8 @@
 
 //! Checks that storing the result of a vector comparison in a vector of floats
 //! causes an error.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_eq;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
@@ -24,14 +25,6 @@ pub struct u32x4(u32, u32, u32, u32);
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct f32x2(f32, f32);
-
-// From <https://github.com/rust-lang/rfcs/blob/master/text/1199-simd-infrastructure.md#comparisons>:
-// > The type checker ensures that `T` and `U` have the same length, and that
-// > `U` is appropriately "boolean"-y.
-// This means that `U` is allowed to be `i64` or `u64`, but not `f64`.
-extern "platform-intrinsic" {
-    fn simd_eq<T, U>(x: T, y: T) -> U;
-}
 
 #[kani::proof]
 fn main() {

--- a/tests/expected/intrinsics/simd-shl-shift-negative/main.rs
+++ b/tests/expected/intrinsics/simd-shl-shift-negative/main.rs
@@ -2,16 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Checks that `simd_shl` returns a failure if the shift distance is negative.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_shl;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i32x2(i32, i32);
-
-extern "platform-intrinsic" {
-    fn simd_shl<T>(x: T, y: T) -> T;
-}
 
 #[kani::proof]
 fn test_simd_shl() {

--- a/tests/expected/intrinsics/simd-shl-shift-too-large/main.rs
+++ b/tests/expected/intrinsics/simd-shl-shift-too-large/main.rs
@@ -2,16 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Checks that `simd_shl` returns a failure if the shift distance is too large.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_shl;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i32x2(i32, i32);
-
-extern "platform-intrinsic" {
-    fn simd_shl<T>(x: T, y: T) -> T;
-}
 
 #[kani::proof]
 fn test_simd_shl() {

--- a/tests/expected/intrinsics/simd-shr-shift-negative/main.rs
+++ b/tests/expected/intrinsics/simd-shr-shift-negative/main.rs
@@ -2,16 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Checks that `simd_shr` returns a failure if the shift distance is negative.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_shr;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i32x2(i32, i32);
-
-extern "platform-intrinsic" {
-    fn simd_shr<T>(x: T, y: T) -> T;
-}
 
 #[kani::proof]
 fn test_simd_shr() {

--- a/tests/expected/intrinsics/simd-shr-shift-too-large/main.rs
+++ b/tests/expected/intrinsics/simd-shr-shift-too-large/main.rs
@@ -2,16 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Checks that `simd_shr` returns a failure if the shift distance is too large.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_shr;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i32x2(i32, i32);
-
-extern "platform-intrinsic" {
-    fn simd_shr<T>(x: T, y: T) -> T;
-}
 
 #[kani::proof]
 fn test_simd_shr() {

--- a/tests/expected/intrinsics/simd-shuffle-indexes-out/main.rs
+++ b/tests/expected/intrinsics/simd-shuffle-indexes-out/main.rs
@@ -3,16 +3,13 @@
 
 //! Checks that `simd_shuffle` triggers an out-of-bounds failure when any of the
 //! indexes supplied is greater than the combined size of the input vectors.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_shuffle;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x2(i64, i64);
-
-extern "platform-intrinsic" {
-    fn simd_shuffle<T, U, V>(x: T, y: T, idx: U) -> V;
-}
 
 #[kani::proof]
 fn main() {

--- a/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-size/main.rs
+++ b/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-size/main.rs
@@ -3,7 +3,8 @@
 
 //! Checks that Kani triggers an error when the result type doesn't have the
 //! length expected from a `simd_shuffle` call.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_shuffle;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
@@ -14,10 +15,6 @@ pub struct i64x2(i64, i64);
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x4(i64, i64, i64, i64);
-
-extern "platform-intrinsic" {
-    fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
-}
 
 #[kani::proof]
 fn main() {

--- a/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-type/main.rs
+++ b/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-type/main.rs
@@ -3,7 +3,8 @@
 
 //! Checks that Kani triggers an error when the result type doesn't have the
 //! subtype expected from a `simd_shuffle` call.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_shuffle;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
@@ -14,10 +15,6 @@ pub struct i64x2(i64, i64);
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct f64x2(f64, f64);
-
-extern "platform-intrinsic" {
-    fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
-}
 
 #[kani::proof]
 fn main() {

--- a/tests/kani/Intrinsics/SIMD/Compare/float.rs
+++ b/tests/kani/Intrinsics/SIMD/Compare/float.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Checks that intrinsics for SIMD vectors of signed integers are supported
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::*;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
@@ -18,17 +19,6 @@ pub struct i64x2(i64, i64);
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct i32x2(i32, i32);
-
-// The predicate type U in the functions below must
-// be a SIMD type, otherwise we get a compilation error
-extern "platform-intrinsic" {
-    fn simd_eq<T, U>(x: T, y: T) -> U;
-    fn simd_ne<T, U>(x: T, y: T) -> U;
-    fn simd_lt<T, U>(x: T, y: T) -> U;
-    fn simd_le<T, U>(x: T, y: T) -> U;
-    fn simd_gt<T, U>(x: T, y: T) -> U;
-    fn simd_ge<T, U>(x: T, y: T) -> U;
-}
 
 macro_rules! assert_cmp {
     ($res_cmp: ident, $simd_cmp: ident, $x: expr, $y: expr, $($res: expr),+) => {

--- a/tests/kani/Intrinsics/SIMD/Compare/result_type_is_same_size.rs
+++ b/tests/kani/Intrinsics/SIMD/Compare/result_type_is_same_size.rs
@@ -3,7 +3,8 @@
 
 //! Checks that storing the result of a vector operation in a vector of
 //! size equal to the operands' sizes works.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_eq;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
@@ -19,14 +20,6 @@ pub struct u64x2(u64, u64);
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct u32x2(u32, u32);
-
-// From <https://github.com/rust-lang/rfcs/blob/master/text/1199-simd-infrastructure.md#comparisons>:
-// > The type checker ensures that `T` and `U` have the same length, and that
-// > `U` is appropriately "boolean"-y.
-// This means that `U` is allowed to be `i64` or `u64`, but not `f64`.
-extern "platform-intrinsic" {
-    fn simd_eq<T, U>(x: T, y: T) -> U;
-}
 
 #[kani::proof]
 fn main() {

--- a/tests/kani/Intrinsics/SIMD/Compare/signed.rs
+++ b/tests/kani/Intrinsics/SIMD/Compare/signed.rs
@@ -2,25 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Checks that intrinsics for SIMD vectors of signed integers are supported
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::*;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x2(i64, i64);
-
-// From <https://github.com/rust-lang/rfcs/blob/master/text/1199-simd-infrastructure.md#comparisons>:
-// > The type checker ensures that `T` and `U` have the same length, and that
-// > `U` is appropriately "boolean"-y.
-// This means that `U` is allowed to be `i64` or `u64`, but not `f64`.
-extern "platform-intrinsic" {
-    fn simd_eq<T, U>(x: T, y: T) -> U;
-    fn simd_ne<T, U>(x: T, y: T) -> U;
-    fn simd_lt<T, U>(x: T, y: T) -> U;
-    fn simd_le<T, U>(x: T, y: T) -> U;
-    fn simd_gt<T, U>(x: T, y: T) -> U;
-    fn simd_ge<T, U>(x: T, y: T) -> U;
-}
 
 macro_rules! assert_cmp {
     ($res_cmp: ident, $simd_cmp: ident, $x: expr, $y: expr, $($res: expr),+) => {

--- a/tests/kani/Intrinsics/SIMD/Compare/unsigned.rs
+++ b/tests/kani/Intrinsics/SIMD/Compare/unsigned.rs
@@ -2,25 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Checks that intrinsics for SIMD vectors of unsigned integers are supported
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::*;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct u64x2(u64, u64);
-
-// From <https://github.com/rust-lang/rfcs/blob/master/text/1199-simd-infrastructure.md#comparisons>:
-// > The type checker ensures that `T` and `U` have the same length, and that
-// > `U` is appropriately "boolean"-y.
-// This means that `U` is allowed to be `i64` or `u64`, but not `f64`.
-extern "platform-intrinsic" {
-    fn simd_eq<T, U>(x: T, y: T) -> U;
-    fn simd_ne<T, U>(x: T, y: T) -> U;
-    fn simd_lt<T, U>(x: T, y: T) -> U;
-    fn simd_le<T, U>(x: T, y: T) -> U;
-    fn simd_gt<T, U>(x: T, y: T) -> U;
-    fn simd_ge<T, U>(x: T, y: T) -> U;
-}
 
 macro_rules! assert_cmp {
     ($res_cmp: ident, $simd_cmp: ident, $x: expr, $y: expr, $($res: expr),+) => {

--- a/tests/kani/Intrinsics/SIMD/Construction/main.rs
+++ b/tests/kani/Intrinsics/SIMD/Construction/main.rs
@@ -3,17 +3,13 @@
 
 //! Checks that the `simd_extract` and `simd_insert` intrinsics are supported
 //! and return the expected results.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::{simd_extract, simd_insert};
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x2(i64, i64);
-
-extern "platform-intrinsic" {
-    fn simd_extract<T, U>(x: T, idx: u32) -> U;
-    fn simd_insert<T, U>(x: T, idx: u32, b: U) -> T;
-}
 
 #[kani::proof]
 fn main() {

--- a/tests/kani/Intrinsics/SIMD/Operators/arith.rs
+++ b/tests/kani/Intrinsics/SIMD/Operators/arith.rs
@@ -1,21 +1,15 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This test doesn't work because support for SIMD intrinsics isn't available
-//! at the moment in Kani. Support to be added in
-//! <https://github.com/model-checking/kani/issues/1148>
-#![feature(repr_simd, platform_intrinsics)]
+//! Checks that the SIMD intrinsics `simd_add`, `simd_sub` and
+//! `simd_mul` are supported and return the expected results.
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::{simd_add, simd_mul, simd_sub};
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i8x2(i8, i8);
-
-extern "platform-intrinsic" {
-    fn simd_add<T>(x: T, y: T) -> T;
-    fn simd_sub<T>(x: T, y: T) -> T;
-    fn simd_mul<T>(x: T, y: T) -> T;
-}
 
 macro_rules! verify_no_overflow {
     ($cf: ident, $uf: ident) => {{

--- a/tests/kani/Intrinsics/SIMD/Operators/bitmask.rs
+++ b/tests/kani/Intrinsics/SIMD/Operators/bitmask.rs
@@ -6,16 +6,11 @@
 //! This is done by initializing vectors with the contents of 2-member tuples
 //! with symbolic values. The result of using each of the intrinsics is compared
 //! against the result of using the associated bitwise operator on the tuples.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![feature(generic_const_exprs)]
 #![feature(portable_simd)]
-#![feature(core_intrinsics)]
-
 use std::fmt::Debug;
-
-extern "platform-intrinsic" {
-    fn simd_bitmask<T, U>(x: T) -> U;
-}
+use std::intrinsics::simd::simd_bitmask;
 
 #[repr(simd)]
 #[derive(Clone, Debug)]

--- a/tests/kani/Intrinsics/SIMD/Operators/bitshift.rs
+++ b/tests/kani/Intrinsics/SIMD/Operators/bitshift.rs
@@ -3,7 +3,8 @@
 
 //! Checks that the `simd_shl` and `simd_shr` intrinsics are supported and they
 //! return the expected results.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::{simd_shl, simd_shr};
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
@@ -14,11 +15,6 @@ pub struct i32x2(i32, i32);
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct u32x2(u32, u32);
-
-extern "platform-intrinsic" {
-    fn simd_shl<T>(x: T, y: T) -> T;
-    fn simd_shr<T>(x: T, y: T) -> T;
-}
 
 #[kani::proof]
 fn test_simd_shl() {

--- a/tests/kani/Intrinsics/SIMD/Operators/bitwise.rs
+++ b/tests/kani/Intrinsics/SIMD/Operators/bitwise.rs
@@ -8,7 +8,8 @@
 //! This is done by initializing vectors with the contents of 2-member tuples
 //! with symbolic values. The result of using each of the intrinsics is compared
 //! against the result of using the associated bitwise operator on the tuples.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::{simd_and, simd_or, simd_xor};
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
@@ -50,11 +51,6 @@ pub struct u32x2(u32, u32);
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct u64x2(u64, u64);
 
-extern "platform-intrinsic" {
-    fn simd_and<T>(x: T, y: T) -> T;
-    fn simd_or<T>(x: T, y: T) -> T;
-    fn simd_xor<T>(x: T, y: T) -> T;
-}
 macro_rules! compare_simd_op_with_normal_op {
     ($simd_op: ident, $normal_op: tt, $simd_type: ident) => {
         let tup_x: (_,_) = kani::any();

--- a/tests/kani/Intrinsics/SIMD/Operators/division.rs
+++ b/tests/kani/Intrinsics/SIMD/Operators/division.rs
@@ -3,17 +3,13 @@
 
 //! Checks that the `simd_div` and `simd_rem` intrinsics are supported and they
 //! return the expected results.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::{simd_div, simd_rem};
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i32x2(i32, i32);
-
-extern "platform-intrinsic" {
-    fn simd_div<T>(x: T, y: T) -> T;
-    fn simd_rem<T>(x: T, y: T) -> T;
-}
 
 #[kani::proof]
 fn test_simd_div() {

--- a/tests/kani/Intrinsics/SIMD/Operators/division_float.rs
+++ b/tests/kani/Intrinsics/SIMD/Operators/division_float.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Checks that the `simd_div` intrinsic returns the expected results for floating point numbers.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_div;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
@@ -17,10 +18,6 @@ impl f32x2 {
     fn non_simd_div(self, divisors: Self) -> Self {
         f32x2(self.0 / divisors.0, self.1 / divisors.1)
     }
-}
-
-extern "platform-intrinsic" {
-    fn simd_div<T>(x: T, y: T) -> T;
 }
 
 #[kani::proof]

--- a/tests/kani/Intrinsics/SIMD/Operators/remainder_float_fixme.rs
+++ b/tests/kani/Intrinsics/SIMD/Operators/remainder_float_fixme.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Checks that the `simd_rem` intrinsic returns the expected results for floating point numbers.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_rem;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
@@ -17,10 +18,6 @@ impl f32x2 {
     fn non_simd_rem(self, divisors: Self) -> Self {
         f32x2(self.0 % divisors.0, self.1 % divisors.1)
     }
-}
-
-extern "platform-intrinsic" {
-    fn simd_rem<T>(x: T, y: T) -> T;
 }
 
 #[kani::proof]

--- a/tests/kani/Intrinsics/SIMD/Shuffle/main.rs
+++ b/tests/kani/Intrinsics/SIMD/Shuffle/main.rs
@@ -3,7 +3,8 @@
 
 //! Checks that `simd_shuffle` and `simd_shuffleN` (where `N` is a length) are
 //! supported and return the expected results.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_shuffle;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
@@ -14,10 +15,6 @@ pub struct i64x2(i64, i64);
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x4(i64, i64, i64, i64);
-
-extern "platform-intrinsic" {
-    fn simd_shuffle<T, U, V>(x: T, y: T, idx: U) -> V;
-}
 
 #[kani::proof]
 fn main() {

--- a/tests/kani/SIMD/simd_float_ops_fixme.rs
+++ b/tests/kani/SIMD/simd_float_ops_fixme.rs
@@ -4,13 +4,9 @@
 //! Ensure we can handle SIMD defined in the standard library
 //! FIXME: <https://github.com/model-checking/kani/issues/2631>
 #![allow(non_camel_case_types)]
-#![feature(repr_simd, platform_intrinsics, portable_simd)]
+#![feature(repr_simd, core_intrinsics, portable_simd)]
+use std::intrinsics::simd::simd_add;
 use std::simd::f32x4;
-
-extern "platform-intrinsic" {
-    fn simd_add<T>(x: T, y: T) -> T;
-    fn simd_eq<T, U>(x: T, y: T) -> U;
-}
 
 #[repr(simd)]
 #[derive(Clone, PartialEq, kani::Arbitrary)]


### PR DESCRIPTION
Upgrades the Rust toolchain to `nightly-2024-03-01`. The Rust compiler PRs that triggered changes in this upgrades are:
 * https://github.com/rust-lang/rust/pull/121516
 * https://github.com/rust-lang/rust/pull/121598
 * https://github.com/rust-lang/rust/pull/121489
 * https://github.com/rust-lang/rust/pull/121783

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
