### PR TITLE
Update s2n-quic submodule weekly through dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    allow:
+      - dependency-name: "tests/perf/s2n-quic"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Use dependabot to update the `s2n-quic` submodule weekly (every Monday). This is to avoid having to do this effort manually, and to guarantee that none of the `s2n-quic` proofs break due to changes in Kani.

I've tested this in my own fork, and it seemed to work correctly:

https://github.com/zhassan-aws/kani/network/updates/19481419/jobs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
