### PR TITLE
Replace internal reverse_postorder by a stable one

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/block.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/block.rs
@@ -74,6 +74,13 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 }
 
+/// Iterate over the basic blocks in reverse post-order.
+///
+/// The `reverse_postorder` function used before was internal to the compiler and reflected the
+/// internal body representation.
+///
+/// As we introduce transformations on the top of SMIR body, there will be not guarantee of a
+/// 1:1 relationship between basic blocks from internal body and monomorphic body from StableMIR.
 pub fn reverse_postorder(body: &Body) -> impl Iterator<Item = BasicBlockIdx> {
     postorder(body, 0, &mut HashSet::with_capacity(body.blocks.len())).into_iter().rev()
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/function.rs
@@ -3,10 +3,10 @@
 
 //! This file contains functions related to codegenning MIR functions into gotoc
 
+use crate::codegen_cprover_gotoc::codegen::block::reverse_postorder;
 use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::goto_program::{Expr, Stmt, Symbol};
 use cbmc::InternString;
-use rustc_middle::mir::traversal::reverse_postorder;
 use stable_mir::mir::mono::Instance;
 use stable_mir::mir::{Body, Local};
 use stable_mir::ty::{RigidTy, TyKind};
@@ -67,9 +67,7 @@ impl<'tcx> GotocCtx<'tcx> {
             self.codegen_declare_variables(&body);
 
             // Get the order from internal body for now.
-            let internal_body = self.current_fn().body_internal();
-            reverse_postorder(internal_body)
-                .for_each(|(bb, _)| self.codegen_block(bb.index(), &body.blocks[bb.index()]));
+            reverse_postorder(&body).for_each(|bb| self.codegen_block(bb, &body.blocks[bb]));
 
             let loc = self.codegen_span_stable(instance.def.span());
             let stmts = self.current_fn_mut().extract_block();

--- a/kani-compiler/src/codegen_cprover_gotoc/context/current_fn.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/current_fn.rs
@@ -4,7 +4,6 @@
 use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::goto_program::Stmt;
 use cbmc::InternedString;
-use rustc_middle::mir::Body as BodyInternal;
 use rustc_middle::ty::Instance as InstanceInternal;
 use rustc_smir::rustc_internal;
 use stable_mir::mir::mono::Instance;
@@ -21,8 +20,6 @@ pub struct CurrentFnCtx<'tcx> {
     instance: Instance,
     /// The crate this function is from
     krate: String,
-    /// The MIR for the current instance. This is using the internal representation.
-    mir: &'tcx BodyInternal<'tcx>,
     /// The current instance. This is using the internal representation.
     instance_internal: InstanceInternal<'tcx>,
     /// A list of local declarations used to retrieve MIR component types.
@@ -53,7 +50,6 @@ impl<'tcx> CurrentFnCtx<'tcx> {
         Self {
             block: vec![],
             instance,
-            mir: gcx.tcx.instance_mir(instance_internal.def),
             instance_internal,
             krate: instance.def.krate().name,
             locals,
@@ -92,11 +88,6 @@ impl<'tcx> CurrentFnCtx<'tcx> {
 
     pub fn instance_stable(&self) -> Instance {
         self.instance
-    }
-
-    /// The internal MIR for the function we are currently compiling using internal APIs.
-    pub fn body_internal(&self) -> &'tcx BodyInternal<'tcx> {
-        self.mir
     }
 
     /// The name of the function we are currently compiling


### PR DESCRIPTION
The `reverse_postorder` function used before is internal to the compiler and reflects the internal body representation.

Besides that, I would like to introduce transformation on the top of SMIR body, which will break the 1:1 relationship between basic blocks from internal body and monomorphic body from StableMIR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
