### PR TITLE
cargo update and fix macos CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "0.47.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "clap 4.5.1",
+ "clap 4.5.2",
  "which",
 ]
 
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -481,7 +481,7 @@ dependencies = [
 name = "kani-compiler"
 version = "0.47.0"
 dependencies = [
- "clap 4.5.1",
+ "clap 4.5.2",
  "cprover_bindings",
  "home",
  "itertools",
@@ -492,8 +492,8 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-words",
- "strum 0.26.1",
- "strum_macros 0.26.1",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -504,7 +504,7 @@ version = "0.47.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "clap 4.5.1",
+ "clap 4.5.2",
  "comfy-table",
  "console",
  "glob",
@@ -517,8 +517,8 @@ dependencies = [
  "rustc-demangle",
  "serde",
  "serde_json",
- "strum 0.26.1",
- "strum_macros 0.26.1",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
  "tempfile",
  "toml",
  "tracing",
@@ -550,11 +550,11 @@ dependencies = [
 name = "kani_metadata"
 version = "0.47.0"
 dependencies = [
- "clap 4.5.1",
+ "clap 4.5.2",
  "cprover_bindings",
  "serde",
- "strum 0.26.1",
- "strum_macros 0.26.1",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
@@ -896,7 +896,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -911,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1115,9 +1115,9 @@ checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 
 [[package]]
 name = "strum_macros"
@@ -1134,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1219,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1240,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
 dependencies = [
  "indexmap",
  "serde",

--- a/scripts/setup/macos/install_deps.sh
+++ b/scripts/setup/macos/install_deps.sh
@@ -9,6 +9,10 @@ set -eux
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
 #brew update
 
+# Install Python separately to workround recurring homebrew CI issue.
+# See https://github.com/actions/runner-images/issues/9471 for more details.
+brew install python@3 || brew link --overwrite python@3
+
 # Install dependencies via `brew`
 brew install universal-ctags wget jq
 

--- a/scripts/setup/macos/install_deps.sh
+++ b/scripts/setup/macos/install_deps.sh
@@ -11,7 +11,8 @@ set -eux
 
 # Install Python separately to workround recurring homebrew CI issue.
 # See https://github.com/actions/runner-images/issues/9471 for more details.
-brew install python@3 || brew link --overwrite python@3
+brew install python@3 || true
+brew link --overwrite python@3
 
 # Install dependencies via `brew`
 brew install universal-ctags wget jq

--- a/scripts/setup/macos/install_deps.sh
+++ b/scripts/setup/macos/install_deps.sh
@@ -17,13 +17,6 @@ brew link --overwrite python@3
 # Install dependencies via `brew`
 brew install universal-ctags wget jq
 
-# Add Python package dependencies
-PYTHON_DEPS=(
-  autopep8
-)
-
-python3 -m pip install "${PYTHON_DEPS[@]}"
-
 # Get the directory containing this script
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 


### PR DESCRIPTION
Fix recurring [macos CI issue](https://github.com/actions/runner-images/issues/9471) (see https://github.com/model-checking/kani/actions/runs/8234799856/job/22521976090?pr=3065#step:3:202 for an example of a failing run) and do a `cargo update`. This subsumes https://github.com/model-checking/kani/pull/3065

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
