### PR TITLE
Upgrade toolchain to 2024-03-11

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -725,7 +725,7 @@ impl<'tcx> GotocCtx<'tcx> {
                             .bytes(),
                         Type::size_t(),
                     ),
-                    NullOp::DebugAssertions => Expr::c_false(),
+                    NullOp::UbCheck(_) => Expr::c_false(),
                 }
             }
             Rvalue::ShallowInitBox(ref operand, content_ty) => {

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -542,6 +542,9 @@ impl<'tcx> GotocCtx<'tcx> {
             ty::Float(k) => match k {
                 FloatTy::F32 => Type::float(),
                 FloatTy::F64 => Type::double(),
+                // `F16` and `F128` are not yet handled.
+                // Tracked here: <https://github.com/model-checking/kani/issues/3069>
+                FloatTy::F16 | FloatTy::F128 => unimplemented!(),
             },
             ty::Adt(def, _) if def.repr().simd() => self.codegen_vector(ty),
             ty::Adt(def, subst) => {
@@ -1346,6 +1349,9 @@ impl<'tcx> GotocCtx<'tcx> {
 
             Primitive::F32 => self.tcx.types.f32,
             Primitive::F64 => self.tcx.types.f64,
+            // `F16` and `F128` are not yet handled.
+            // Tracked here: <https://github.com/model-checking/kani/issues/3069>
+            Primitive::F16 | Primitive::F128 => unimplemented!(),
             Primitive::Pointer(_) => Ty::new_ptr(
                 self.tcx,
                 ty::TypeAndMut { ty: self.tcx.types.u8, mutbl: Mutability::Not },

--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -397,7 +397,7 @@ impl CodegenBackend for GotocCodegenBackend {
                 let path = MaybeTempDir::new(tmp_dir, sess.opts.cg.save_temps);
                 let (metadata, _metadata_position) = create_wrapper_file(
                     sess,
-                    b".rmeta".to_vec(),
+                    ".rmeta".to_string(),
                     codegen_results.metadata.raw_data(),
                 );
                 let metadata = emit_wrapper_file(sess, &metadata, &path, METADATA_FILENAME);

--- a/kani-compiler/src/kani_middle/attributes.rs
+++ b/kani-compiler/src/kani_middle/attributes.rs
@@ -611,9 +611,8 @@ fn parse_modify_values<'a>(
     let mut iter = t.trees();
     std::iter::from_fn(move || {
         let tree = iter.next()?;
-        let wrong_token_err = || {
-            tcx.sess.parse_sess.dcx.span_err(tree.span(), "Unexpected token. Expected identifier.")
-        };
+        let wrong_token_err =
+            || tcx.sess.psess.dcx.span_err(tree.span(), "Unexpected token. Expected identifier.");
         let result = match tree {
             TokenTree::Token(token, _) => {
                 if let TokenKind::Ident(id, _) = &token.kind {
@@ -640,7 +639,7 @@ fn parse_modify_values<'a>(
         match iter.next() {
             None | Some(comma_tok!()) => (),
             Some(not_comma) => {
-                tcx.sess.parse_sess.dcx.span_err(
+                tcx.sess.psess.dcx.span_err(
                     not_comma.span(),
                     "Unexpected token, expected end of attribute or comma",
                 );

--- a/kani-compiler/src/kani_middle/reachability.rs
+++ b/kani-compiler/src/kani_middle/reachability.rs
@@ -515,8 +515,8 @@ fn collect_alloc_items(alloc_id: AllocId) -> Vec<MonoItem> {
 }
 
 #[cfg(debug_assertions)]
+#[allow(dead_code)]
 mod debug {
-    #![allow(dead_code)]
 
     use std::fmt::{Display, Formatter};
     use std::{

--- a/kani-driver/src/assess/mod.rs
+++ b/kani-driver/src/assess/mod.rs
@@ -170,7 +170,7 @@ fn reconstruct_metadata_structure(
         }
         if !package_artifacts.is_empty() {
             let mut merged = crate::metadata::merge_kani_metadata(package_artifacts);
-            merged.crate_name = package.name.clone();
+            merged.crate_name.clone_from(&package.name);
             package_metas.push(merged);
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-03-01"
+channel = "nightly-2024-03-11"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/coverage/unreachable/variant/expected
+++ b/tests/coverage/unreachable/variant/expected
@@ -1,4 +1,4 @@
-coverage/unreachable/variant/main.rs, 15, PARTIAL
+coverage/unreachable/variant/main.rs, 15, FULL
 coverage/unreachable/variant/main.rs, 16, NONE
 coverage/unreachable/variant/main.rs, 17, NONE
 coverage/unreachable/variant/main.rs, 18, FULL

--- a/tools/bookrunner/librustdoc/html/markdown.rs
+++ b/tools/bookrunner/librustdoc/html/markdown.rs
@@ -225,7 +225,7 @@ impl LangString {
         let mut data = LangString::default();
         let mut ignores = vec![];
 
-        data.original = string.to_owned();
+        string.clone_into(&mut data.original);
 
         for token in Self::tokens(string) {
             match token {


### PR DESCRIPTION
Relevant upstream changes:

https://github.com/rust-lang/rust/pull/120675: An intrinsic `Symbol` is now wrapped in a `IntrinsicDef` struct, so the relevant part of the code needed to be updated.
https://github.com/rust-lang/rust/pull/121464: The second argument of the `create_wrapper_file` function changed from a vector to a string.
https://github.com/rust-lang/rust/pull/121662: `NullOp::DebugAssertions` was renamed to `NullOp::UbCheck` and it now has data (currently unused by Kani)
https://github.com/rust-lang/rust/pull/121728: Introduces `F16` and `F128`, so needed to add stubs for them
https://github.com/rust-lang/rust/pull/121969: `parse_sess` was renamed to `psess`, so updated the relevant code.
https://github.com/rust-lang/rust/pull/122059: The `is_val_statically_known` intrinsic is now used in some `core::fmt` code, so had to handle it in (codegen'ed to false).
https://github.com/rust-lang/rust/pull/122233: This added a new `retag_box_to_raw` intrinsic. This is an operation that is primarily relevant for stacked borrows. For Kani, we just return the pointer.



Resolves #3057

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
