### PR TITLE
Add optional scatterplot to benchcomp output

### DIFF
--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -247,7 +247,7 @@ class dump_markdown_results_table:
 
             {% if scatterplot and metric in d["scaled_metrics"] and d["scaled_variants"][metric]|length == 2 -%}
             ```mermaid
-            %%{init: { "quadrantChart": { "titlePadding": 10, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "quadrantLabelFontSize": 0, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
+            %%{init: { "quadrantChart": { "titlePadding": 15, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "quadrantLabelFontSize": 0, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
             quadrantChart
                 title {{ metric }}
                 x-axis {{ d["scaled_variants"][metric][0] }}

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -257,7 +257,9 @@ class dump_markdown_results_table:
                 quadrant-3 3
                 quadrant-4 4
                 {%- for bench_name, bench_variants in d["scaled_metrics"][metric].items () %}
-                "{{ bench_name }}": [{{ bench_variants[d["scaled_variants"][metric][0]] }}, {{ bench_variants[d["scaled_variants"][metric][1]] }}]
+                {% set v0 = bench_variants[d["scaled_variants"][metric][0]] -%}
+                {% set v1 = bench_variants[d["scaled_variants"][metric][1]] -%}
+                "{{ bench_name }}": [{{ v0|round(3) }}, {{ v1|round(3) }}]
                 {%- endfor %}
             ```
 

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -247,7 +247,7 @@ class dump_markdown_results_table:
 
             {% if scatterplot and metric in d["scaled_metrics"] and d["scaled_variants"][metric]|length == 2 -%}
             ```mermaid
-            %%{init: { "quadrantChart": { "chartWidth": 400, "chartHeight": 400, "pointRadius": 2, "pointLabelFontSize": 3 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } }%%
+            %%{init: { "quadrantChart": { "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
             quadrantChart
                 title {{ metric }}
                 x-axis {{ d["scaled_variants"][metric][0] }}

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -302,7 +302,7 @@ class dump_markdown_results_table:
         # 1.0 is not a permissible value for mermaid, so make sure all scaled
         # results stay below that by use 0.99 as hard-coded value or
         # artificially increasing the range by 10 per cent
-        if min_value is None or min_value == max_value:
+        if min_value == math.inf or min_value == max_value:
             for bench, bench_result in data_for_metric.items():
                 ret["benchmarks"][bench] = {variant: 0.99 for variant in bench_result.keys()}
         else:

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -290,9 +290,9 @@ class dump_markdown_results_table:
                     return None
                 if not isinstance(variant_result, (int, float)):
                     return None
-                if min_value is None or variant_result < min_value:
+                if variant_result < min_value:
                     min_value = variant_result
-                if max_value is None or variant_result > max_value:
+                if variant_result > max_value:
                     max_value = variant_result
         ret = {
                 "benchmarks": {bench: {} for bench in data_for_metric.keys()},

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -247,7 +247,7 @@ class dump_markdown_results_table:
 
             {% if scatterplot and metric in d["scaled_metrics"] and d["scaled_variants"][metric]|length == 2 -%}
             ```mermaid
-            %%{init: { "quadrantChart": { "titlePadding": 15, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
+            %%{init: { "quadrantChart": { "titlePadding": 10, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "quadrantLabelFontSize": 0, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
             quadrantChart
                 title {{ metric }}
                 x-axis {{ d["scaled_variants"][metric][0] }}

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -247,7 +247,7 @@ class dump_markdown_results_table:
 
             {% if scatterplot and metric in d["scaled_metrics"] and d["scaled_variants"][metric]|length == 2 -%}
             ```mermaid
-            %%{init: { "quadrantChart": { "titlePadding": 0, "xAxisLabelPadding": 5, "yAxisLabelPadding": 5, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
+            %%{init: { "quadrantChart": { "titlePadding": 20, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
             quadrantChart
                 title {{ metric }}
                 x-axis {{ d["scaled_variants"][metric][0] }}

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -247,7 +247,7 @@ class dump_markdown_results_table:
 
             {% if scatterplot and metric in d["scaled_metrics"] and d["scaled_variants"][metric]|length == 2 -%}
             ```mermaid
-            %%{init: { "quadrantChart": { "titlePadding": 20, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
+            %%{init: { "quadrantChart": { "titlePadding": 15, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
             quadrantChart
                 title {{ metric }}
                 x-axis {{ d["scaled_variants"][metric][0] }}

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -282,8 +282,8 @@ class dump_markdown_results_table:
 
     @staticmethod
     def _compute_scaled_metric(data_for_metric, log_scaling):
-        min_value = None
-        max_value = None
+        min_value = math.inf
+        max_value = -math.inf
         for bench, bench_result in data_for_metric.items():
             for variant, variant_result in bench_result.items():
                 if isinstance(variant_result, (bool, str)):

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -294,14 +294,18 @@ class dump_markdown_results_table:
                 if max_value is None or variant_result > max_value:
                     max_value = variant_result
         ret = {bench: {} for bench in data_for_metric.keys()}
+        # 1.0 is not a permissible value for mermaid, so make sure all scaled
+        # results stay below that by use 0.99 as hard-coded value or
+        # artificially increasing the range by 10 per cent
         if min_value is None or min_value == max_value:
             for bench, bench_result in data_for_metric.items():
-                ret[bench] = {variant: 1.0 for variant in bench_result.keys()}
+                ret[bench] = {variant: 0.99 for variant in bench_result.keys()}
         else:
             if log_scaling:
                 min_value = math.log(min_value, 10)
                 max_value = math.log(max_value, 10)
             value_range = max_value - min_value
+            value_range = value_range * 1.1
             for bench, bench_result in data_for_metric.items():
                 for variant, variant_result in bench_result.items():
                     if log_scaling:

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -257,7 +257,7 @@ class dump_markdown_results_table:
                 quadrant-3 3
                 quadrant-4 4
                 {%- for bench_name, bench_variants in d["scaled_metrics"][metric].items () %}
-                {{ bench_name }}: [{{ bench_variants[d["scaled_variants"][metric][0]] }}, {{ bench_variants[d["scaled_variants"][metric][1]] }}]
+                "{{ bench_name }}": [{{ bench_variants[d["scaled_variants"][metric][0]] }}, {{ bench_variants[d["scaled_variants"][metric][1]] }}]
                 {%- endfor %}
             ```
 

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -262,9 +262,7 @@ class dump_markdown_results_table:
                 "{{ bench_name }}": [{{ v0|round(3) }}, {{ v1|round(3) }}]
                 {%- endfor %}
             ```
-            Scatterplot axis ranges are
-            {{ d["scaled_metrics"][metric]["min_value"] }} (bottom/left) to
-            {{ d["scaled_metrics"][metric]["max_value"] }} (top/right).
+            Scatterplot axis ranges are {{ d["scaled_metrics"][metric]["min_value"] }} (bottom/left) to {{ d["scaled_metrics"][metric]["max_value"] }} (top/right).
 
             {% endif -%}
             | Benchmark | {% for variant in d["variants"][metric] %} {{ variant }} |{% endfor %}

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -247,7 +247,7 @@ class dump_markdown_results_table:
 
             {% if scatterplot and metric in d["scaled_metrics"] and d["scaled_variants"][metric]|length == 2 -%}
             ```mermaid
-            %%{init: { "quadrantChart": { "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
+            %%{init: { "quadrantChart": { "titlePadding": 0, "xAxisLabelPadding": 5, "yAxisLabelPadding": 5, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
             quadrantChart
                 title {{ metric }}
                 x-axis {{ d["scaled_variants"][metric][0] }}

--- a/tools/benchcomp/configs/perf-regression.yaml
+++ b/tools/benchcomp/configs/perf-regression.yaml
@@ -33,6 +33,7 @@ visualize:
 
   - type: dump_markdown_results_table
     out_file: '-'
+    scatterplot: linear
     extra_columns:
 
       # For these two metrics, display the difference between old and new and

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -472,8 +472,8 @@ class RegressionTests(unittest.TestCase):
                         quadrant-2 2
                         quadrant-3 3
                         quadrant-4 4
-                        "bench_1": [0.0, 1.0]
-                        "bench_2": [1.0, 0.0]
+                        "bench_1": [0.0, 0.909]
+                        "bench_2": [0.909, 0.0]
                     ```
 
                     | Benchmark |  variant_1 | variant_2 | ratio |

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -463,7 +463,7 @@ class RegressionTests(unittest.TestCase):
                     ## runtime
 
                     ```mermaid
-                    %%{init: { "quadrantChart": { "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
+                    %%{init: { "quadrantChart": { "titlePadding": 0, "xAxisLabelPadding": 5, "yAxisLabelPadding": 5, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
                     quadrantChart
                         title runtime
                         x-axis variant_1

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -463,7 +463,7 @@ class RegressionTests(unittest.TestCase):
                     ## runtime
 
                     ```mermaid
-                    %%{init: { "quadrantChart": { "chartWidth": 400, "chartHeight": 400, "pointRadius": 2, "pointLabelFontSize": 3 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } }%%
+                    %%{init: { "quadrantChart": { "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
                     quadrantChart
                         title runtime
                         x-axis variant_1

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -463,7 +463,7 @@ class RegressionTests(unittest.TestCase):
                     ## runtime
 
                     ```mermaid
-                    %%{init: { "quadrantChart": { "titlePadding": 0, "xAxisLabelPadding": 5, "yAxisLabelPadding": 5, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
+                    %%{init: { "quadrantChart": { "titlePadding": 20, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
                     quadrantChart
                         title runtime
                         x-axis variant_1

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -463,7 +463,7 @@ class RegressionTests(unittest.TestCase):
                     ## runtime
 
                     ```mermaid
-                    %%{init: { "quadrantChart": { "titlePadding": 10, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "quadrantLabelFontSize": 0, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
+                    %%{init: { "quadrantChart": { "titlePadding": 15, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "quadrantLabelFontSize": 0, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
                     quadrantChart
                         title runtime
                         x-axis variant_1

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -463,7 +463,7 @@ class RegressionTests(unittest.TestCase):
                     ## runtime
 
                     ```mermaid
-                    %%{init: { "quadrantChart": { "titlePadding": 20, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
+                    %%{init: { "quadrantChart": { "titlePadding": 15, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
                     quadrantChart
                         title runtime
                         x-axis variant_1

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -463,7 +463,7 @@ class RegressionTests(unittest.TestCase):
                     ## runtime
 
                     ```mermaid
-                    %%{init: { "quadrantChart": { "titlePadding": 15, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
+                    %%{init: { "quadrantChart": { "titlePadding": 10, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "quadrantLabelFontSize": 0, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
                     quadrantChart
                         title runtime
                         x-axis variant_1

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -458,7 +458,6 @@ class RegressionTests(unittest.TestCase):
             run_bc()
 
             self.assertEqual(run_bc.proc.returncode, 0, msg=run_bc.stderr)
-            self.maxDiff = None
             self.assertEqual(
                 run_bc.stdout, textwrap.dedent("""
                     ## runtime

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -472,8 +472,8 @@ class RegressionTests(unittest.TestCase):
                         quadrant-2 2
                         quadrant-3 3
                         quadrant-4 4
-                        bench_1: [0.0, 1.0]
-                        bench_2: [1.0, 0.0]
+                        "bench_1": [0.0, 1.0]
+                        "bench_2": [1.0, 0.0]
                     ```
 
                     | Benchmark |  variant_1 | variant_2 | ratio |

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -458,6 +458,7 @@ class RegressionTests(unittest.TestCase):
             run_bc()
 
             self.assertEqual(run_bc.proc.returncode, 0, msg=run_bc.stderr)
+            self.maxDiff = None
             self.assertEqual(
                 run_bc.stdout, textwrap.dedent("""
                     ## runtime

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -458,7 +458,6 @@ class RegressionTests(unittest.TestCase):
             run_bc()
 
             self.assertEqual(run_bc.proc.returncode, 0, msg=run_bc.stderr)
-            self.maxDiff = None
             self.assertEqual(
                 run_bc.stdout, textwrap.dedent("""
                     ## runtime
@@ -476,10 +475,7 @@ class RegressionTests(unittest.TestCase):
                         "bench_1": [0.0, 0.909]
                         "bench_2": [0.909, 0.0]
                     ```
-                    Scatterplot axis ranges are
-                    5 (bottom/left) to
-                    10 (top/right).
-
+                    Scatterplot axis ranges are 5 (bottom/left) to 10 (top/right).
 
                     | Benchmark |  variant_1 | variant_2 | ratio |
                     | --- | --- | --- | --- |

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -458,6 +458,7 @@ class RegressionTests(unittest.TestCase):
             run_bc()
 
             self.assertEqual(run_bc.proc.returncode, 0, msg=run_bc.stderr)
+            self.maxDiff = None
             self.assertEqual(
                 run_bc.stdout, textwrap.dedent("""
                     ## runtime
@@ -475,6 +476,10 @@ class RegressionTests(unittest.TestCase):
                         "bench_1": [0.0, 0.909]
                         "bench_2": [0.909, 0.0]
                     ```
+                    Scatterplot axis ranges are
+                    5 (bottom/left) to
+                    10 (top/right).
+
 
                     | Benchmark |  variant_1 | variant_2 | ratio |
                     | --- | --- | --- | --- |

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -436,6 +436,7 @@ class RegressionTests(unittest.TestCase):
                 "visualize": [{
                     "type": "dump_markdown_results_table",
                     "out_file": "-",
+                    "scatterplot": "linear",
                     "extra_columns": {
                         "runtime": [{
                             "column_name": "ratio",
@@ -460,6 +461,20 @@ class RegressionTests(unittest.TestCase):
             self.assertEqual(
                 run_bc.stdout, textwrap.dedent("""
                     ## runtime
+
+                    ```mermaid
+                    %%{init: { "quadrantChart": { "chartWidth": 400, "chartHeight": 400, "pointRadius": 2, "pointLabelFontSize": 3 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } }%%
+                    quadrantChart
+                        title runtime
+                        x-axis variant_1
+                        y-axis variant_2
+                        quadrant-1 1
+                        quadrant-2 2
+                        quadrant-3 3
+                        quadrant-4 4
+                        bench_1: [0.0, 1.0]
+                        bench_2: [1.0, 0.0]
+                    ```
 
                     | Benchmark |  variant_1 | variant_2 | ratio |
                     | --- | --- | --- | --- |


### PR DESCRIPTION
Scatterplots should make it easier to immediately spot performance trends (and indeed any differences) rather than having to process a (large) number of table rows.

Uses mermaid-js to produce markdown-embedded plots that will display on the job summary page. Scatterplots are not directly supported by mermaid-js at this point (xycharts only do line or bar charts), so quadrant plots are employed with various diagram items drawn in white to make them disappear.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
