### PR TITLE
Disable removal of storage markers

### DIFF
--- a/kani-driver/src/call_single_file.rs
+++ b/kani-driver/src/call_single_file.rs
@@ -123,7 +123,7 @@ impl KaniSession {
                 "-Z",
                 "panic_abort_tests=yes",
                 "-Z",
-                "sanitizer=address",
+                "mir-enable-passes=-RemoveStorageMarkers",
             ]
             .map(OsString::from),
         );


### PR DESCRIPTION
Instead of turning on the address sanitizer to ensure storage markers (`StorageLive` and `StorageDead`) are kept in MIR, directly disable the MIR pass that removes them from MIR (https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20Keeping.20MIR's.20storage.20markers). This is to ensure we don't get additional instrumentation that is not relevant for Kani, and may unnecessarily increase the code size and compilation time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
