### PR TITLE
Upgrade toolchain to nightly-2024-03-15

### DIFF
--- a/docs/src/getting-started/verification-results/src/main.rs
+++ b/docs/src/getting-started/verification-results/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #[kani::proof]
+#[kani::unwind(4)]
 // ANCHOR: success_example
 fn success_example() {
     let mut sum = 0;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-03-14"
+channel = "nightly-2024-03-15"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/coverage/unreachable/abort/main.rs
+++ b/tests/coverage/unreachable/abort/main.rs
@@ -5,7 +5,7 @@
 
 use std::process;
 
-#[kani::proof]
+#[cfg_attr(kani, kani::proof, kani::unwind(5))]
 fn main() {
     for i in 0..4 {
         if i == 1 {

--- a/tests/expected/abort/main.rs
+++ b/tests/expected/abort/main.rs
@@ -6,6 +6,7 @@
 use std::process;
 
 #[kani::proof]
+#[kani::unwind(5)]
 fn main() {
     for i in 0..4 {
         if i == 1 {

--- a/tests/expected/iterator/main.rs
+++ b/tests/expected/iterator/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #[kani::proof]
+#[kani::unwind(4)]
 fn main() {
     let mut z = 1;
     for i in 1..4 {

--- a/tests/kani/Coroutines/main.rs
+++ b/tests/kani/Coroutines/main.rs
@@ -9,6 +9,7 @@ use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
 
 #[kani::proof]
+#[kani::unwind(3)]
 fn main() {
     let mut add_one = |mut resume: u8| {
         loop {


### PR DESCRIPTION
- Kani can no longer automatically detect loop bounds when using range.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
