### PR TITLE
Benchcomp scatterplots: quote axis labels

### DIFF
--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -250,8 +250,8 @@ class dump_markdown_results_table:
             %%{init: { "quadrantChart": { "titlePadding": 15, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "quadrantLabelFontSize": 0, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
             quadrantChart
                 title {{ metric }}
-                x-axis {{ d["scaled_variants"][metric][0] }}
-                y-axis {{ d["scaled_variants"][metric][1] }}
+                x-axis "{{ d["scaled_variants"][metric][0] }}"
+                y-axis "{{ d["scaled_variants"][metric][1] }}"
                 quadrant-1 1
                 quadrant-2 2
                 quadrant-3 3

--- a/tools/benchcomp/test/test_regression.py
+++ b/tools/benchcomp/test/test_regression.py
@@ -466,8 +466,8 @@ class RegressionTests(unittest.TestCase):
                     %%{init: { "quadrantChart": { "titlePadding": 15, "xAxisLabelPadding": 20, "yAxisLabelPadding": 20, "quadrantLabelFontSize": 0, "pointRadius": 2, "pointLabelFontSize": 2 }, "themeVariables": { "quadrant1Fill": "#FFFFFF", "quadrant2Fill": "#FFFFFF", "quadrant3Fill": "#FFFFFF", "quadrant4Fill": "#FFFFFF", "quadrant1TextFill": "#FFFFFF", "quadrant2TextFill": "#FFFFFF", "quadrant3TextFill": "#FFFFFF", "quadrant4TextFill": "#FFFFFF", "quadrantInternalBorderStrokeFill": "#FFFFFF" } } }%%
                     quadrantChart
                         title runtime
-                        x-axis variant_1
-                        y-axis variant_2
+                        x-axis "variant_1"
+                        y-axis "variant_2"
                         quadrant-1 1
                         quadrant-2 2
                         quadrant-3 3


### PR DESCRIPTION
Mermaid does not accept `@` characters in axis labels when the labels aren't in quotes. (Seen when trying to run CBMC's upcoming benchcomp suite.) Note: the title must not be quoted, else the quotes themselves will be rendered.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
