### PR TITLE
Bump Kani version to 0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.49.0]
+
+### What's Changed
+* Disable removal of storage markers by @zhassan-aws in https://github.com/model-checking/kani/pull/3083
+* Ensure storage markers are kept in std code by @zhassan-aws in https://github.com/model-checking/kani/pull/3080
+* Implement validity checks by @celinval in https://github.com/model-checking/kani/pull/3085
+* Allow modifies clause for verification only by @feliperodri in https://github.com/model-checking/kani/pull/3098
+* Add optional scatterplot to benchcomp output by @tautschnig in https://github.com/model-checking/kani/pull/3077
+* Expand ${var} in benchcomp variant `env` by @karkhaz in https://github.com/model-checking/kani/pull/3090
+* Add `benchcomp filter` command by @karkhaz in https://github.com/model-checking/kani/pull/3105
+* Upgrade Rust toolchain to 2024-03-29 by @zhassan-aws @celinval @adpaco-aws @feliperodri
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.48.0...kani-0.49.0
+
 ## [0.48.0]
 
 ### Major Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "build-kani"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -410,14 +410,14 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "kani"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "home",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -992,7 +992,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "std"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Updated version in all `Cargo.toml` files (via
`find . -name Cargo.toml -exec sed -i 's/version = "0.48.0"/version = "0.49.0"/' {} \;`) and ran `cargo build-dev` to have `Cargo.lock` files updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
