### PR TITLE
Fix TestLocalToolchain jobs for release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Get toolchain version used to setup kani
         run: |
           tar zxvf ${{ matrix.prev_job.bundle }}
-          DATE=$(cat ./kani-latest/rust-toolchain-version | cut -d'-' -f2,3,4)
+          DATE=$(cat ./kani-${{ matrix.prev_job.version }}/rust-toolchain-version | cut -d'-' -f2,3,4)
           echo "Nightly date: $DATE"
           echo "DATE=$DATE" >> $GITHUB_ENV
 


### PR DESCRIPTION
Upon pushing a release tag, we use the numeric version instead of "latest", which made `kani-latest` a non-existent folder. See https://github.com/model-checking/kani/actions/runs/8574249138 for such an example. Use the `version` variable instead, which will be set to "latest" or the numeric version as appropriate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
