### PR TITLE
Handle errors thrown from benchcomp column exprs

### DIFF
--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -358,7 +358,20 @@ class dump_markdown_results_table:
             for bench, variants in benches.items():
                 tmp_variants = dict(variants)
                 for column in columns:
-                    variants[column["column_name"]] = column["text"](tmp_variants)
+                    if "column_name" not in column:
+                        logging.error(
+                            "A column specification for metric %s did not "
+                            "contain a column_name field. Each column should "
+                            "have a column name and column text", metric)
+                        sys.exit(1)
+                    try:
+                        variants[column["column_name"]] = column["text"](tmp_variants)
+                    except BaseException:
+                        # This may be reached when evaluating the column text
+                        # throws an exception. The column text is written in a
+                        # YAML file and is typically a simple lambda so can't
+                        # contain sophisticated error handling.
+                        variants[column["column_name"]] = "**<ERROR>**"
 
 
     @staticmethod

--- a/tools/benchcomp/benchcomp/visualizers/__init__.py
+++ b/tools/benchcomp/benchcomp/visualizers/__init__.py
@@ -371,7 +371,7 @@ class dump_markdown_results_table:
                         # throws an exception. The column text is written in a
                         # YAML file and is typically a simple lambda so can't
                         # contain sophisticated error handling.
-                        variants[column["column_name"]] = "**<ERROR>**"
+                        variants[column["column_name"]] = "**ERROR**"
 
 
     @staticmethod


### PR DESCRIPTION
Prior to this commit, errors thrown when evaluating the text of a benchcomp extra column would crash benchcomp. This could happen, for example, if a column tries to compare an old variant with a new one, but no data for the old variant exists, as seen in this run:

https://github.com/model-checking/kani/actions/runs/8700040930/job/23859607740

Forcing the user to do error handling in the column text would make the text even more unwieldy than it already is, so this commit makes the column text evaluate to **<ERROR>** if an exception is raised during evaluation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
