### PR TITLE
Upgrade toolchain to 2024-04-18 and improve toolchain workflow

### DIFF
--- a/.github/workflows/toolchain-upgrade.yml
+++ b/.github/workflows/toolchain-upgrade.yml
@@ -30,42 +30,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          current_toolchain_date=$(grep ^channel rust-toolchain.toml | sed 's/.*nightly-\(.*\)"/\1/')
-          echo "current_toolchain_date=$current_toolchain_date" >> $GITHUB_ENV
-          current_toolchain_epoch=$(date --date $current_toolchain_date +%s)
-          next_toolchain_date=$(date --date "@$(($current_toolchain_epoch + 86400))" +%Y-%m-%d)
-          echo "next_toolchain_date=$next_toolchain_date" >> $GITHUB_ENV
-          if gh issue list -S \
-              "Toolchain upgrade to nightly-$next_toolchain_date failed" \
-              --json number,title | grep title ; then
-            echo "next_step=none" >> $GITHUB_ENV
-          elif ! git ls-remote --exit-code origin toolchain-$next_toolchain_date ; then
-            echo "next_step=create_pr" >> $GITHUB_ENV
-            sed -i "/^channel/ s/$current_toolchain_date/$next_toolchain_date/" rust-toolchain.toml
-            git diff
-            git clone --filter=tree:0 https://github.com/rust-lang/rust rust.git
-            cd rust.git
-            current_toolchain_hash=$(curl https://static.rust-lang.org/dist/$current_toolchain_date/channel-rust-nightly-git-commit-hash.txt)
-            echo "current_toolchain_hash=$current_toolchain_hash" >> $GITHUB_ENV
-            next_toolchain_hash=$(curl https://static.rust-lang.org/dist/$next_toolchain_date/channel-rust-nightly-git-commit-hash.txt)
-            echo "next_toolchain_hash=$next_toolchain_hash" >> $GITHUB_ENV
-            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-            echo "git_log<<$EOF" >> $GITHUB_ENV
-            git log --oneline $current_toolchain_hash..$next_toolchain_hash | \
-              sed 's#^#https://github.com/rust-lang/rust/commit/#' >> $GITHUB_ENV
-            echo "$EOF" >> $GITHUB_ENV
-            cd ..
-            rm -rf rust.git
-            if ! cargo build-dev ; then
-              echo "next_step=create_issue" >> $GITHUB_ENV
-            else
-              if ! ./scripts/kani-regression.sh ; then
-                echo "next_step=create_issue" >> $GITHUB_ENV
-              fi
-            fi
-          else
-            echo "next_step=none" >> $GITHUB_ENV
-          fi
+          source scripts/toolchain_update.sh
       - name: Create Pull Request
         if: ${{ env.next_step == 'create_pr' }}
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/toolchain-upgrade.yml
+++ b/.github/workflows/toolchain-upgrade.yml
@@ -31,6 +31,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           source scripts/toolchain_update.sh
+
+      - name: Clean untracked files
+        run: git clean -f
+
       - name: Create Pull Request
         if: ${{ env.next_step == 'create_pr' }}
         uses: peter-evans/create-pull-request@v6

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ no_llvm_build
 /tmp/
 # Created by default with `src/ci/docker/run.sh`
 /obj/
+# Created by kani-compiler
+*.rlib
+*.rmeta
+*.mir
 
 ## Temporary files
 *~

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-04-15"
+channel = "nightly-2024-04-18"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/scripts/toolchain_update.sh
+++ b/scripts/toolchain_update.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+set -eu
+
+current_toolchain_date=$(grep ^channel rust-toolchain.toml | sed 's/.*nightly-\(.*\)"/\1/')
+echo "current_toolchain_date=$current_toolchain_date" >> $GITHUB_ENV
+
+current_toolchain_epoch=$(date --date $current_toolchain_date +%s)
+next_toolchain_date=$(date --date "@$(($current_toolchain_epoch + 86400))" +%Y-%m-%d)
+echo "next_toolchain_date=$next_toolchain_date" >> $GITHUB_ENV
+
+if gh issue list -S \
+  "Toolchain upgrade to nightly-$next_toolchain_date failed" \
+  --json number,title | grep title ; then
+echo "next_step=none" >> $GITHUB_ENV
+
+elif ! git ls-remote --exit-code origin toolchain-$next_toolchain_date ; then
+echo "next_step=create_pr" >> $GITHUB_ENV
+
+# Modify rust-toolchain file
+sed -i "/^channel/ s/$current_toolchain_date/$next_toolchain_date/" rust-toolchain.toml
+
+git diff
+git clone --filter=tree:0 https://github.com/rust-lang/rust rust.git
+cd rust.git
+current_toolchain_hash=$(curl https://static.rust-lang.org/dist/$current_toolchain_date/channel-rust-nightly-git-commit-hash.txt)
+echo "current_toolchain_hash=$current_toolchain_hash" >> $GITHUB_ENV
+
+next_toolchain_hash=$(curl https://static.rust-lang.org/dist/$next_toolchain_date/channel-rust-nightly-git-commit-hash.txt)
+echo "next_toolchain_hash=$next_toolchain_hash" >> $GITHUB_ENV
+
+EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+echo "git_log<<$EOF" >> $GITHUB_ENV
+
+git log --oneline $current_toolchain_hash..$next_toolchain_hash | \
+  sed 's#^#https://github.com/rust-lang/rust/commit/#' >> $GITHUB_ENV
+echo "$EOF" >> $GITHUB_ENV
+
+cd ..
+rm -rf rust.git
+if ! cargo build-dev ; then
+  echo "next_step=create_issue" >> $GITHUB_ENV
+else
+  if ! ./scripts/kani-regression.sh ; then
+    echo "next_step=create_issue" >> $GITHUB_ENV
+  fi
+fi
+else
+  echo "next_step=none" >> $GITHUB_ENV
+fi

--- a/scripts/toolchain_update.sh
+++ b/scripts/toolchain_update.sh
@@ -2,6 +2,15 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
+# This script is part of our CI nightly job to bump the toolchain version.
+# It will potentially update the rust-toolchain.toml file, and run the
+# regression.
+#
+# In order to manually run this script, you will need to do the following:
+#
+# 1. Set $GITHUB_ENV to point to an output file.
+# 2. Install and configure GitHub CLI
+
 set -eu
 
 current_toolchain_date=$(grep ^channel rust-toolchain.toml | sed 's/.*nightly-\(.*\)"/\1/')
@@ -11,42 +20,46 @@ current_toolchain_epoch=$(date --date $current_toolchain_date +%s)
 next_toolchain_date=$(date --date "@$(($current_toolchain_epoch + 86400))" +%Y-%m-%d)
 echo "next_toolchain_date=$next_toolchain_date" >> $GITHUB_ENV
 
+echo "------ Start upgrade ------"
+echo "- current: ${current_toolchain_date}"
+echo "- next: ${next_toolchain_date}"
+echo "---------------------------"
+
 if gh issue list -S \
   "Toolchain upgrade to nightly-$next_toolchain_date failed" \
-  --json number,title | grep title ; then
-echo "next_step=none" >> $GITHUB_ENV
+  --json number,title | grep title
+then
+  echo "Skip update: Found existing issue"
+  echo "next_step=none" >> $GITHUB_ENV
+elif ! git ls-remote --exit-code origin toolchain-$next_toolchain_date
+then
+  echo "next_step=create_pr" >> $GITHUB_ENV
 
-elif ! git ls-remote --exit-code origin toolchain-$next_toolchain_date ; then
-echo "next_step=create_pr" >> $GITHUB_ENV
+  # Modify rust-toolchain file
+  sed -i "/^channel/ s/$current_toolchain_date/$next_toolchain_date/" rust-toolchain.toml
 
-# Modify rust-toolchain file
-sed -i "/^channel/ s/$current_toolchain_date/$next_toolchain_date/" rust-toolchain.toml
+  git diff
+  git clone --filter=tree:0 https://github.com/rust-lang/rust rust.git
+  cd rust.git
+  current_toolchain_hash=$(curl https://static.rust-lang.org/dist/$current_toolchain_date/channel-rust-nightly-git-commit-hash.txt)
+  echo "current_toolchain_hash=$current_toolchain_hash" >> $GITHUB_ENV
 
-git diff
-git clone --filter=tree:0 https://github.com/rust-lang/rust rust.git
-cd rust.git
-current_toolchain_hash=$(curl https://static.rust-lang.org/dist/$current_toolchain_date/channel-rust-nightly-git-commit-hash.txt)
-echo "current_toolchain_hash=$current_toolchain_hash" >> $GITHUB_ENV
+  next_toolchain_hash=$(curl https://static.rust-lang.org/dist/$next_toolchain_date/channel-rust-nightly-git-commit-hash.txt)
+  echo "next_toolchain_hash=$next_toolchain_hash" >> $GITHUB_ENV
 
-next_toolchain_hash=$(curl https://static.rust-lang.org/dist/$next_toolchain_date/channel-rust-nightly-git-commit-hash.txt)
-echo "next_toolchain_hash=$next_toolchain_hash" >> $GITHUB_ENV
+  EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+  echo "git_log<<$EOF" >> $GITHUB_ENV
 
-EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-echo "git_log<<$EOF" >> $GITHUB_ENV
+  git log --oneline $current_toolchain_hash..$next_toolchain_hash | \
+    sed 's#^#https://github.com/rust-lang/rust/commit/#' >> $GITHUB_ENV
+  echo "$EOF" >> $GITHUB_ENV
 
-git log --oneline $current_toolchain_hash..$next_toolchain_hash | \
-  sed 's#^#https://github.com/rust-lang/rust/commit/#' >> $GITHUB_ENV
-echo "$EOF" >> $GITHUB_ENV
-
-cd ..
-rm -rf rust.git
-if ! cargo build-dev ; then
-  echo "next_step=create_issue" >> $GITHUB_ENV
-else
+  cd ..
+  rm -rf rust.git
   if ! ./scripts/kani-regression.sh ; then
     echo "next_step=create_issue" >> $GITHUB_ENV
   fi
-fi
 else
+  echo "Skip update: Found existing branch"
   echo "next_step=none" >> $GITHUB_ENV
 fi


### PR DESCRIPTION
The toolchain upgrade itself didn't require any modification, but it looks like the rust toolchain script includes any untracked files to the PR, which is the root cause of the #3146 CI failure.

Thus, I made the following changes (each one of them in its own commit):
  1. Moved the upgrade step to its own script.
  2. Added a bit of debugging and doc to the script.
  3. Added a new step that cleans the workspace before the PR creation.
  4. Actually update the toolchain.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
