### PR TITLE
Remove floating-point check for +/-Inf

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -166,7 +166,6 @@ impl KaniSession {
         }
         if self.args.checks.overflow_on() {
             args.push("--div-by-zero-check".into());
-            args.push("--float-overflow-check".into());
             args.push("--nan-check".into());
             // With PR #647 we use Rust's `-C overflow-checks=on` instead of:
             // --unsigned-overflow-check


### PR DESCRIPTION
Kani included by default the flag `--float-overflow-check`, which reports overflow for arithmetic operations over floating-point numbers that result in +/-Inf. This doesn't panic in Rust and it shouldn't be consider a verification failure by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
