### PR TITLE
Bump Kani version to 0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.51.0]
+
+## What's Changed
+
+* Do not assume that ZST-typed symbols refer to unique objects by @tautschnig in https://github.com/model-checking/kani/pull/3134
+* Remove kani::Arbitrary from the modifies contract instrumentation by @feliperodri in https://github.com/model-checking/kani/pull/3169
+* Emit source locations whenever possible to ease debugging and coverage reporting by @tautschnig in https://github.com/model-checking/kani/pull/3173
+* Fix cargo audit error by @jaisnan in https://github.com/model-checking/kani/pull/3160
+* Rust toolchain is upgraded to nightly-2024-04-21 by @celinval
+
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.50.0...kani-0.51.0
+
+
 ## [0.50.0]
 
 ### Major Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 ## What's Changed
 
 * Do not assume that ZST-typed symbols refer to unique objects by @tautschnig in https://github.com/model-checking/kani/pull/3134
-* Remove kani::Arbitrary from the modifies contract instrumentation by @feliperodri in https://github.com/model-checking/kani/pull/3169
+* Remove `kani::Arbitrary` from the `modifies` contract instrumentation by @feliperodri in https://github.com/model-checking/kani/pull/3169
 * Emit source locations whenever possible to ease debugging and coverage reporting by @tautschnig in https://github.com/model-checking/kani/pull/3173
 * Fix cargo audit error by @jaisnan in https://github.com/model-checking/kani/pull/3160
 * Rust toolchain upgraded to `nightly-2024-04-21` by @celinval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Do not assume that ZST-typed symbols refer to unique objects by @tautschnig in https://github.com/model-checking/kani/pull/3134
 * Remove `kani::Arbitrary` from the `modifies` contract instrumentation by @feliperodri in https://github.com/model-checking/kani/pull/3169
 * Emit source locations whenever possible to ease debugging and coverage reporting by @tautschnig in https://github.com/model-checking/kani/pull/3173
-* Fix cargo audit error by @jaisnan in https://github.com/model-checking/kani/pull/3160
 * Rust toolchain upgraded to `nightly-2024-04-21` by @celinval
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Remove kani::Arbitrary from the modifies contract instrumentation by @feliperodri in https://github.com/model-checking/kani/pull/3169
 * Emit source locations whenever possible to ease debugging and coverage reporting by @tautschnig in https://github.com/model-checking/kani/pull/3173
 * Fix cargo audit error by @jaisnan in https://github.com/model-checking/kani/pull/3160
-* Rust toolchain is upgraded to nightly-2024-04-21 by @celinval
+* Rust toolchain upgraded to `nightly-2024-04-21` by @celinval
 
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.50.0...kani-0.51.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "build-kani"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -411,14 +411,14 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "kani"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "home",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -992,7 +992,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "std"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
For reference, here is the auto-generated changelog

## What's Changed
* Upgrade toolchain to 2024-04-18 and improve toolchain workflow by @celinval in https://github.com/model-checking/kani/pull/3149
* Automatic toolchain upgrade to nightly-2024-04-19 by @github-actions in https://github.com/model-checking/kani/pull/3150
* Stabilize cover statement and update contracts RFC by @celinval in https://github.com/model-checking/kani/pull/3091
* Automatic toolchain upgrade to nightly-2024-04-20 by @github-actions in https://github.com/model-checking/kani/pull/3154
* Bump tests/perf/s2n-quic from `2d5e891` to `5f88e54` by @dependabot in https://github.com/model-checking/kani/pull/3140
* Automatic cargo update to 2024-04-22 by @github-actions in https://github.com/model-checking/kani/pull/3157
* Automatic toolchain upgrade to nightly-2024-04-21 by @github-actions in https://github.com/model-checking/kani/pull/3158
* Bump tests/perf/s2n-quic from `5f88e54` to `9730578` by @dependabot in https://github.com/model-checking/kani/pull/3159
* Fix cargo audit error by @jaisnan in https://github.com/model-checking/kani/pull/3160
* Fix cbmc-update CI job by @tautschnig in https://github.com/model-checking/kani/pull/3156
* Automatic cargo update to 2024-04-29 by @github-actions in https://github.com/model-checking/kani/pull/3165
* Bump tests/perf/s2n-quic from `9730578` to `1436af7` by @dependabot in https://github.com/model-checking/kani/pull/3166
* Do not assume that ZST-typed symbols refer to unique objects by @tautschnig in https://github.com/model-checking/kani/pull/3134
* Fix copyright check for `expected` tests by @adpaco-aws in https://github.com/model-checking/kani/pull/3170
* Remove kani::Arbitrary from the modifies contract instrumentation by @feliperodri in https://github.com/model-checking/kani/pull/3169
* Automatic cargo update to 2024-05-06 by @github-actions in https://github.com/model-checking/kani/pull/3172
* Bump tests/perf/s2n-quic from `1436af7` to `6dd41e0` by @dependabot in https://github.com/model-checking/kani/pull/3174
* Avoid unnecessary uses of Location::none() by @tautschnig in https://github.com/model-checking/kani/pull/3173


**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.50.0...kani-0.51.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
