### PR TITLE
Do not run perf tests in parallel

### DIFF
--- a/scripts/kani-perf.sh
+++ b/scripts/kani-perf.sh
@@ -27,7 +27,7 @@ done
 suite="perf"
 mode="cargo-kani-test"
 echo "Check compiletest suite=$suite mode=$mode"
-cargo run -p compiletest -- --suite $suite --mode $mode --no-fail-fast
+RUST_TEST_THREADS=1 cargo run -p compiletest -- --suite $suite --mode $mode --no-fail-fast
 exit_code=$?
 
 echo "Cleaning up..."


### PR DESCRIPTION
Currently, perf tests (whether run through benchcomp or separately) use the available parallelism of the machine. This sometimes causes memouts when multiple memory-hungry tests run in parallel, causing failures in CI. This PR forces perf regressions to always use a single thread regardless of the available parallelism. While this may cause them to take longer to complete, they should:
1. Tame the spurious memouts occurring in CI
2. Reduce the runtime variability in benchcomp results

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
