### PR TITLE
(Re)introduce `Invariant` trait

### DIFF
--- a/library/kani/src/arbitrary.rs
+++ b/library/kani/src/arbitrary.rs
@@ -1,8 +1,8 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This module introduces the Arbitrary trait as well as implementation for primitive types and
-//! other std containers.
+//! This module introduces the `Arbitrary` trait as well as implementation for
+//! primitive types and other std containers.
 
 use std::{
     marker::{PhantomData, PhantomPinned},
@@ -66,7 +66,7 @@ trivial_arbitrary!(i64);
 trivial_arbitrary!(i128);
 trivial_arbitrary!(isize);
 
-// We do not constraint floating points values per type spec. Users must add assumptions to their
+// We do not constrain floating points values per type spec. Users must add assumptions to their
 // verification code if they want to eliminate NaN, infinite, or subnormal.
 trivial_arbitrary!(f32);
 trivial_arbitrary!(f64);

--- a/library/kani/src/invariant.rs
+++ b/library/kani/src/invariant.rs
@@ -15,22 +15,6 @@ where
     fn is_safe(&self) -> bool;
 }
 
-impl Invariant for bool {
-    #[inline(always)]
-    fn is_safe(&self) -> bool {
-        let value = *self as u8;
-        value < 2
-    }
-}
-
-impl Invariant for char {
-    #[inline(always)]
-    fn is_safe(&self) -> bool {
-        let value = *self as u32;
-        value <= 0xD7FF || (0xE000..=0x10FFFF).contains(&value)
-    }
-}
-
 /// Any value is considered safe for the type
 macro_rules! trivial_invariant {
     ( $type: ty ) => {
@@ -64,3 +48,5 @@ trivial_invariant!(f32);
 trivial_invariant!(f64);
 
 trivial_invariant!(());
+trivial_invariant!(bool);
+trivial_invariant!(char);

--- a/library/kani/src/invariant.rs
+++ b/library/kani/src/invariant.rs
@@ -1,0 +1,13 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This module introduces the Invariant trait.
+
+/// This trait should be used to specify and check type safety invariants for a
+/// type.
+pub trait Invariant
+where
+    Self: Sized,
+{
+    fn is_valid(&self) -> bool;
+}

--- a/library/kani/src/invariant.rs
+++ b/library/kani/src/invariant.rs
@@ -1,13 +1,66 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This module introduces the Invariant trait.
+//! This module introduces the `Invariant` trait as well as its implementation
+//! for primitive types.
 
 /// This trait should be used to specify and check type safety invariants for a
 /// type.
+///
+/// Note: Type safety might be checked automatically by Kani in the future.
 pub trait Invariant
 where
     Self: Sized,
 {
     fn is_safe(&self) -> bool;
 }
+
+impl Invariant for bool {
+    #[inline(always)]
+    fn is_safe(&self) -> bool {
+        let value = *self as u8;
+        value < 2
+    }
+}
+
+impl Invariant for char {
+    #[inline(always)]
+    fn is_safe(&self) -> bool {
+        let value = *self as u32;
+        value <= 0xD7FF || (0xE000..=0x10FFFF).contains(&value)
+    }
+}
+
+/// The given type can be represented by an unconstrained symbolic value of size_of::<T>.
+macro_rules! trivial_invariant {
+    ( $type: ty ) => {
+        impl Invariant for $type {
+            #[inline(always)]
+            fn is_safe(&self) -> bool {
+                true
+            }
+        }
+    };
+}
+
+trivial_invariant!(u8);
+trivial_invariant!(u16);
+trivial_invariant!(u32);
+trivial_invariant!(u64);
+trivial_invariant!(u128);
+trivial_invariant!(usize);
+
+trivial_invariant!(i8);
+trivial_invariant!(i16);
+trivial_invariant!(i32);
+trivial_invariant!(i64);
+trivial_invariant!(i128);
+trivial_invariant!(isize);
+
+// We do not constrain the safety invariant for floating points types.
+// Users can create a new type wrapping the floating point type and define an
+// invariant that checks for NaN, infinite, or subnormal values.
+trivial_invariant!(f32);
+trivial_invariant!(f64);
+
+trivial_invariant!(());

--- a/library/kani/src/invariant.rs
+++ b/library/kani/src/invariant.rs
@@ -21,8 +21,13 @@
 /// invariants only need to be upheld at the boundaries to safe code.
 ///
 /// Safety invariants are particularly interesting for user-defined types, and
-/// the `Invariant` trait allows you to check them with Kani. For example,
-/// let's say you're creating a type that represents a date:
+/// the `Invariant` trait allows you to check them with Kani.
+///
+/// It can also be used in tests. It's a programmatic way to specify (in Rust)
+/// properties over your data types. Since it's written in Rust, it can be used
+/// for static and dynamic checking.
+///
+/// For example, let's say you're creating a type that represents a date:
 ///
 /// ```rust
 /// #[derive(kani::Arbitrary)]

--- a/library/kani/src/invariant.rs
+++ b/library/kani/src/invariant.rs
@@ -5,9 +5,54 @@
 //! for primitive types.
 
 /// This trait should be used to specify and check type safety invariants for a
-/// type.
+/// type. For type invariants, we refer to the definitions in the Rust's Unsafe
+/// Code Guidelines Reference:
+/// <https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#validity-and-safety-invariant>
 ///
-/// Note: Type safety might be checked automatically by Kani in the future.
+/// In summary, the reference distinguishes two kinds of type invariants:
+///  - *Validity invariant*: An invariant that all data must uphold any time
+///  it's accessed or copied in a typed manner. This invariant is exploited by
+///  the compiler to perform optimizations.
+///  - *Safety invariant*: An invariant that safe code may assume all data to
+///  uphold. This invariant can be temporarily violated by unsafe code, but must
+///  always be upheld when interfacing with unknown safe code.
+///
+/// Therefore, validity invariants must be upheld at all times, while safety
+/// invariants only need to be upheld at the boundaries to safe code.
+///
+/// Safety invariants are particularly interesting for user-defined types, and
+/// the `Invariant` trait allows you to check them with Kani. For example,
+/// let's say you're creating a type that represents a date:
+///
+/// ```rust
+/// #[derive(kani::Arbitrary)]
+/// pub struct MyDate {
+///   day: u8,
+///   month: u8,
+///   year: i64,
+/// }
+/// ```
+/// You can specify its safety invariant as:
+/// ```rust
+/// impl kani::Invariant for MyDate {
+///   fn is_safe(&self) -> bool {
+///     self.month > 0
+///       && self.month <= 12
+///       && self.day > 0
+///       && self.day <= days_in_month(self.year, self.month)
+///   }
+/// }
+/// ```
+/// And use it to check that your APIs are safe:
+/// ```rust
+/// #[kani::proof]
+/// fn check_increase_date() {
+///   let mut date: MyDate = kani::any();
+///   // Increase date by one day
+///   increase_date(date, 1);
+///   assert!(date.is_safe());
+/// }
+/// ```
 pub trait Invariant
 where
     Self: Sized,

--- a/library/kani/src/invariant.rs
+++ b/library/kani/src/invariant.rs
@@ -11,11 +11,11 @@
 ///
 /// In summary, the reference distinguishes two kinds of type invariants:
 ///  - *Validity invariant*: An invariant that all data must uphold any time
-///  it's accessed or copied in a typed manner. This invariant is exploited by
-///  the compiler to perform optimizations.
+///    it's accessed or copied in a typed manner. This invariant is exploited by
+///    the compiler to perform optimizations.
 ///  - *Safety invariant*: An invariant that safe code may assume all data to
-///  uphold. This invariant can be temporarily violated by unsafe code, but must
-///  always be upheld when interfacing with unknown safe code.
+///    uphold. This invariant can be temporarily violated by unsafe code, but
+///    must always be upheld when interfacing with unknown safe code.
 ///
 /// Therefore, validity invariants must be upheld at all times, while safety
 /// invariants only need to be upheld at the boundaries to safe code.

--- a/library/kani/src/invariant.rs
+++ b/library/kani/src/invariant.rs
@@ -9,5 +9,5 @@ pub trait Invariant
 where
     Self: Sized,
 {
-    fn is_valid(&self) -> bool;
+    fn is_safe(&self) -> bool;
 }

--- a/library/kani/src/invariant.rs
+++ b/library/kani/src/invariant.rs
@@ -31,7 +31,7 @@ impl Invariant for char {
     }
 }
 
-/// The given type can be represented by an unconstrained symbolic value of size_of::<T>.
+/// Any value is considered safe for the type
 macro_rules! trivial_invariant {
     ( $type: ty ) => {
         impl Invariant for $type {

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -35,9 +35,9 @@ pub mod internal;
 mod models;
 
 pub use arbitrary::Arbitrary;
-pub use invariant::Invariant;
 #[cfg(feature = "concrete_playback")]
 pub use concrete_playback::concrete_playback_run;
+pub use invariant::Invariant;
 
 #[cfg(not(feature = "concrete_playback"))]
 /// NOP `concrete_playback` for type checking during verification mode.

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -23,6 +23,7 @@ pub mod arbitrary;
 #[cfg(feature = "concrete_playback")]
 mod concrete_playback;
 pub mod futures;
+pub mod invariant;
 pub mod mem;
 pub mod slice;
 pub mod tuple;
@@ -34,6 +35,7 @@ pub mod internal;
 mod models;
 
 pub use arbitrary::Arbitrary;
+pub use invariant::Invariant;
 #[cfg(feature = "concrete_playback")]
 pub use concrete_playback::concrete_playback_run;
 

--- a/tests/kani/Invariant/invariant_impls.rs
+++ b/tests/kani/Invariant/invariant_impls.rs
@@ -1,0 +1,62 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Check the `Invariant` implementations that we include in the Kani library
+//! with respect to the underlying type invariants.
+extern crate kani;
+use kani::Invariant;
+
+#[kani::proof]
+#[kani::should_panic]
+fn check_unsafe_char() {
+    let unsafe_char = unsafe { char::from_u32_unchecked(0x110000) };
+    assert!(unsafe_char.is_safe());
+}
+
+#[kani::proof]
+fn check_safe_char() {
+    let safe_char: char = kani::any();
+    assert!(safe_char.is_safe());
+}
+
+#[kani::proof]
+#[kani::should_panic]
+fn check_unsafe_bool() {
+    let unsafe_bool: bool = unsafe { std::mem::transmute(2_u8) };
+    assert!(unsafe_bool.is_safe());
+}
+
+#[kani::proof]
+fn check_safe_bool() {
+    let safe_bool: bool = kani::any();
+    assert!(safe_bool.is_safe());
+}
+
+macro_rules! check_safe_type {
+    ( $type: ty ) => {
+        let value: $type = kani::any();
+        assert!(value.is_safe());
+    };
+}
+
+#[kani::proof]
+fn check_safe_impls() {
+    check_safe_type!(u8);
+    check_safe_type!(u16);
+    check_safe_type!(u32);
+    check_safe_type!(u64);
+    check_safe_type!(u128);
+    check_safe_type!(usize);
+
+    check_safe_type!(i8);
+    check_safe_type!(i16);
+    check_safe_type!(i32);
+    check_safe_type!(i64);
+    check_safe_type!(i128);
+    check_safe_type!(isize);
+
+    check_safe_type!(f32);
+    check_safe_type!(f64);
+
+    check_safe_type!(());
+}

--- a/tests/kani/Invariant/invariant_impls.rs
+++ b/tests/kani/Invariant/invariant_impls.rs
@@ -6,32 +6,6 @@
 extern crate kani;
 use kani::Invariant;
 
-#[kani::proof]
-#[kani::should_panic]
-fn check_unsafe_char() {
-    let unsafe_char = unsafe { char::from_u32_unchecked(0x110000) };
-    assert!(unsafe_char.is_safe());
-}
-
-#[kani::proof]
-fn check_safe_char() {
-    let safe_char: char = kani::any();
-    assert!(safe_char.is_safe());
-}
-
-#[kani::proof]
-#[kani::should_panic]
-fn check_unsafe_bool() {
-    let unsafe_bool: bool = unsafe { std::mem::transmute(2_u8) };
-    assert!(unsafe_bool.is_safe());
-}
-
-#[kani::proof]
-fn check_safe_bool() {
-    let safe_bool: bool = kani::any();
-    assert!(safe_bool.is_safe());
-}
-
 macro_rules! check_safe_type {
     ( $type: ty ) => {
         let value: $type = kani::any();
@@ -59,4 +33,6 @@ fn check_safe_impls() {
     check_safe_type!(f64);
 
     check_safe_type!(());
+    check_safe_type!(bool);
+    check_safe_type!(char);
 }

--- a/tests/kani/Invariant/percentage.rs
+++ b/tests/kani/Invariant/percentage.rs
@@ -12,6 +12,25 @@ use kani::Invariant;
 #[derive(kani::Arbitrary)]
 struct Percentage(u8);
 
+impl Percentage {
+    pub fn try_new(val: u8) -> Result<Self, String> {
+        if val <= 100 {
+            Ok(Self(val))
+        } else {
+            Err(String::from("error: invalid percentage value"))
+        }
+    }
+
+    pub fn value(&self) -> u8 {
+        self.0
+    }
+
+    pub fn increase(&self, other: u8) -> Percentage {
+        let amount = self.0 + other;
+        Percentage::try_new(amount.min(100)).unwrap()
+    }
+}
+
 impl kani::Invariant for Percentage {
     fn is_safe(&self) -> bool {
         self.0 <= 100
@@ -22,7 +41,7 @@ impl kani::Invariant for Percentage {
 fn check_assume_safe() {
     let percentage: Percentage = kani::any();
     kani::assume(percentage.is_safe());
-    assert!(percentage.0 <= 100);
+    assert!(percentage.value() <= 100);
 }
 
 #[kani::proof]
@@ -30,4 +49,14 @@ fn check_assume_safe() {
 fn check_assert_safe() {
     let percentage: Percentage = kani::any();
     assert!(percentage.is_safe());
+}
+
+#[kani::proof]
+fn check_increase_safe() {
+    let percentage: Percentage = kani::any();
+    kani::assume(percentage.is_safe());
+    let amount = kani::any();
+    kani::assume(amount <= 100);
+    let new_percentage = percentage.increase(amount);
+    assert!(new_percentage.is_safe());
 }

--- a/tests/kani/Invariant/percentage.rs
+++ b/tests/kani/Invariant/percentage.rs
@@ -1,0 +1,33 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Check that the `Invariant` implementation behaves as expected when used on a
+//! custom type.
+
+extern crate kani;
+use kani::Invariant;
+
+// We use the default `Arbitrary` implementation, which allows values that
+// shouldn't be considered safe for the `Percentage` type.
+#[derive(kani::Arbitrary)]
+struct Percentage(u8);
+
+impl kani::Invariant for Percentage {
+    fn is_safe(&self) -> bool {
+        self.0 <= 100
+    }
+}
+
+#[kani::proof]
+fn check_assume_safe() {
+    let percentage: Percentage = kani::any();
+    kani::assume(percentage.is_safe());
+    assert!(percentage.0 <= 100);
+}
+
+#[kani::proof]
+#[kani::should_panic]
+fn check_assert_safe() {
+    let percentage: Percentage = kani::any();
+    assert!(percentage.is_safe());
+}


### PR DESCRIPTION
This PR reintroduces the `Invariant` trait as a mechanism for the specification of type safety invariants. The trait is defined in the Kani library where we also provide `Invariant` implementations for primitive types.

In contrast to the previous `Invariant` trait, this version doesn't require the `Arbitrary` bound (i.e., it has the same requirements as `Arbitrary`). This way, the user isn't required to provide an `Arbitrary` implementation in addition to the `Invariant` one.

Related #3095 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
