### PR TITLE
Fix `{,e}println!()`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -135,14 +135,14 @@ macro_rules! eprint {
 #[cfg(not(feature = "concrete_playback"))]
 #[macro_export]
 macro_rules! println {
-    () => { };
+    () => { $crate::print!("\n") };
     ($($x:tt)*) => {{ let _ = format_args!($($x)*); }};
 }
 
 #[cfg(not(feature = "concrete_playback"))]
 #[macro_export]
 macro_rules! eprintln {
-    () => { };
+    () => { $crate::eprint!("\n") };
     ($($x:tt)*) => {{ let _ = format_args!($($x)*); }};
 }
 


### PR DESCRIPTION
Change the implementation of `println!` & `eprintln!` with no arguments to call `print!("\n")`
 & `eprint!("\n")` respectively instead of producing no tokens. This is what std does. [^println][^eprintln]
 
[^println]: https://github.com/rust-lang/rust/blob/8c127df75fde3d5ad8ef9af664962a7676288b52/library/std/src/macros.rs#L140
[^eprintln]: https://github.com/rust-lang/rust/blob/8c127df75fde3d5ad8ef9af664962a7676288b52/library/std/src/macros.rs#L218

Probably resolves #320. Haven't tested, sorry. It might also make sense to add a test for this.
