### PR TITLE
Change ensures into closures

### DIFF
--- a/library/kani/src/contracts.rs
+++ b/library/kani/src/contracts.rs
@@ -57,7 +57,7 @@
 //! This is called a postcondition and it also has access to the arguments and
 //! is expressed in regular Rust code. The same restrictions apply as did for
 //! [`requires`][macro@requires]. In addition to the postcondition is expressed
-//! as a closure where the value returned from the function is passed to this 
+//! as a closure where the value returned from the function is passed to this
 //! closure by reference.
 //!
 //! You may combine as many [`requires`][macro@requires] and

--- a/library/kani/src/contracts.rs
+++ b/library/kani/src/contracts.rs
@@ -51,14 +51,14 @@
 //! approximation of the result of division for instance could be this:
 //!
 //! ```
-//! #[ensures(result <= dividend)]
+//! #[ensures(|result : &u32| *result <= dividend)]
 //! ```
 //!
 //! This is called a postcondition and it also has access to the arguments and
 //! is expressed in regular Rust code. The same restrictions apply as did for
-//! [`requires`][macro@requires]. In addition to the arguments the postcondition
-//! also has access to the value returned from the function in a variable called
-//! `result`.
+//! [`requires`][macro@requires]. In addition to the postcondition is expressed
+//! as a closure where the value returned from the function is passed to this 
+//! closure by reference.
 //!
 //! You may combine as many [`requires`][macro@requires] and
 //! [`ensures`][macro@ensures] attributes on a single function as you please.
@@ -67,7 +67,7 @@
 //!
 //! ```
 //! #[kani::requires(divisor != 0)]
-//! #[kani::ensures(result <= dividend)]
+//! #[kani::ensures(|result : &u32| *result <= dividend)]
 //! fn my_div(dividend: u32, divisor: u32) -> u32 {
 //!   dividend / divisor
 //! }

--- a/library/kani_macros/src/lib.rs
+++ b/library/kani_macros/src/lib.rs
@@ -131,11 +131,11 @@ pub fn requires(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// This is part of the function contract API, for more general information see
 /// the [module-level documentation](../kani/contracts/index.html).
 ///
-/// The contents of the attribute is a condition over the input values to the
-/// annotated function *and* its return value, accessible as a variable called
-/// `result`. All Rust syntax is supported, even calling other functions, but
-/// the computations must be side effect free, e.g. it cannot perform I/O or use
-/// mutable memory.
+/// The contents of the attribute is a closure that captures the input values to
+/// the annotated function and the input to the function is the return value of
+/// the function passed by reference. All Rust syntax is supported, even calling
+/// other functions, but the computations must be side effect free, e.g. it
+/// cannot perform I/O or use mutable memory.
 ///
 /// Kani requires each function that uses a contract (this attribute or
 /// [`requires`][macro@requires]) to have at least one designated

--- a/library/kani_macros/src/sysroot/contracts/bootstrap.rs
+++ b/library/kani_macros/src/sysroot/contracts/bootstrap.rs
@@ -89,9 +89,9 @@ impl<'a> ContractConditionsHandler<'a> {
                     #call_replace(#(#args),*)
                 } else {
                     unsafe { REENTRY = true };
-                    let result = #call_check(#(#also_args),*);
+                    let result_kani_internal = #call_check(#(#also_args),*);
                     unsafe { REENTRY = false };
-                    result
+                    result_kani_internal
                 }
             }
         ));

--- a/library/kani_macros/src/sysroot/contracts/bootstrap.rs
+++ b/library/kani_macros/src/sysroot/contracts/bootstrap.rs
@@ -8,7 +8,10 @@ use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::ItemFn;
 
-use super::{helpers::*, shared::identifier_for_generated_function, ContractConditionsHandler, INTERNAL_RESULT_IDENT};
+use super::{
+    helpers::*, shared::identifier_for_generated_function, ContractConditionsHandler,
+    INTERNAL_RESULT_IDENT,
+};
 
 impl<'a> ContractConditionsHandler<'a> {
     /// The complex case. We are the first time a contract is handled on this function, so

--- a/library/kani_macros/src/sysroot/contracts/check.rs
+++ b/library/kani_macros/src/sysroot/contracts/check.rs
@@ -46,14 +46,14 @@ impl<'a> ContractConditionsHandler<'a> {
                 assert!(matches!(
                     inner.pop(),
                     Some(syn::Stmt::Expr(syn::Expr::Path(pexpr), None))
-                        if pexpr.path.get_ident().map_or(false, |id| id == "result")
+                        if pexpr.path.get_ident().map_or(false, |id| id == "result_kani_internal")
                 ));
 
                 quote!(
                     #arg_copies
                     #(#inner)*
                     #exec_postconditions
-                    result
+                    result_kani_internal
                 )
             }
             ContractConditionsData::Modifies { attr } => {
@@ -96,8 +96,8 @@ impl<'a> ContractConditionsHandler<'a> {
                 quote!(#wrapper_name)
             };
             syn::parse_quote!(
-                let result : #return_type = #wrapper_call(#(#args),*);
-                result
+                let result_kani_internal : #return_type = #wrapper_call(#(#args),*);
+                result_kani_internal
             )
         } else {
             self.annotated_fn.block.stmts.clone()

--- a/library/kani_macros/src/sysroot/contracts/initialize.rs
+++ b/library/kani_macros/src/sysroot/contracts/initialize.rs
@@ -12,7 +12,7 @@ use syn::{spanned::Spanned, visit::Visit, visit_mut::VisitMut, Expr, ItemFn, Sig
 use super::{
     helpers::{chunks_by, is_token_stream_2_comma, matches_path},
     ContractConditionsData, ContractConditionsHandler, ContractConditionsType,
-    ContractFunctionState,
+    ContractFunctionState, INTERNAL_RESULT_IDENT,
 };
 
 impl<'a> TryFrom<&'a syn::Attribute> for ContractFunctionState {
@@ -197,7 +197,7 @@ impl<'a> VisitMut for RenamerResult<'a> {
             i.path
                 .segments
                 .first_mut()
-                .map(|p| if p.ident == *self.0 {p.ident = Ident::new("result_kani_internal",Span::call_site())});
+                .map(|p| if p.ident == *self.0 {p.ident = Ident::new(INTERNAL_RESULT_IDENT,Span::call_site())});
         }
     }
 
@@ -206,7 +206,7 @@ impl<'a> VisitMut for RenamerResult<'a> {
     /// [`Self::visit_expr_path_mut`] is scope-unaware.
     fn visit_pat_ident_mut(&mut self, i: &mut syn::PatIdent) {
         if i.ident == *self.0 {
-            i.ident = Ident::new("result_kani_internal",Span::call_site())
+            i.ident = Ident::new(INTERNAL_RESULT_IDENT,Span::call_site())
         }
     }
 }

--- a/library/kani_macros/src/sysroot/contracts/initialize.rs
+++ b/library/kani_macros/src/sysroot/contracts/initialize.rs
@@ -85,7 +85,7 @@ impl<'a> ContractConditionsHandler<'a> {
                 let mut data: ExprClosure = syn::parse(attr)?;
                 let argument_names = rename_argument_occurrences(&annotated_fn.sig, &mut data);
                 let result: Ident = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
-                let app: Expr = Expr::Verbatim(quote!((#data)(#result)));
+                let app: Expr = Expr::Verbatim(quote!((#data)(&#result)));
                 ContractConditionsData::Ensures { argument_names, attr: app }
             }
             ContractConditionsType::Modifies => {

--- a/library/kani_macros/src/sysroot/contracts/initialize.rs
+++ b/library/kani_macros/src/sysroot/contracts/initialize.rs
@@ -7,8 +7,10 @@ use std::collections::{HashMap, HashSet};
 
 use proc_macro::{Diagnostic, TokenStream};
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
-use syn::{spanned::Spanned, visit::Visit, visit_mut::VisitMut, Expr, ExprClosure, ItemFn, Signature};
 use quote::quote;
+use syn::{
+    spanned::Spanned, visit::Visit, visit_mut::VisitMut, Expr, ExprClosure, ItemFn, Signature,
+};
 
 use super::{
     helpers::{chunks_by, is_token_stream_2_comma, matches_path},
@@ -82,9 +84,9 @@ impl<'a> ContractConditionsHandler<'a> {
                 ContractConditionsData::Requires { attr: syn::parse(attr)? }
             }
             ContractConditionsType::Ensures => {
-                let data : ExprClosure = syn::parse(attr)?;
-                let result : Ident = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
-                let attr : Expr = Expr::Verbatim(quote!((#data)(#result)));
+                let data: ExprClosure = syn::parse(attr)?;
+                let result: Ident = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
+                let attr: Expr = Expr::Verbatim(quote!((#data)(#result)));
                 ContractConditionsData::new_ensures(&annotated_fn.sig, attr)
             }
             ContractConditionsType::Modifies => {

--- a/library/kani_macros/src/sysroot/contracts/initialize.rs
+++ b/library/kani_macros/src/sysroot/contracts/initialize.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 use proc_macro::{Diagnostic, TokenStream};
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
-use syn::{spanned::Spanned, visit::Visit, visit_mut::VisitMut, Expr, ItemFn, Signature};
+use syn::{spanned::Spanned, visit::Visit, visit_mut::VisitMut, Expr, ItemFn, Signature, parse::ParseStream, parse::Parse, Token};
 
 use super::{
     helpers::{chunks_by, is_token_stream_2_comma, matches_path},
@@ -64,6 +64,22 @@ impl ContractFunctionState {
     }
 }
 
+struct EnsuresParseResult {
+    result_name: Ident,
+    attr: Expr,
+}
+
+impl Parse for EnsuresParseResult {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut result_name : Ident = Ident::new("result",Span::call_site());
+        if input.peek2(Token![=>]) {
+            result_name = input.parse()?;
+            let _arrow: Token![=>] = input.parse()?;
+        }
+        Ok(EnsuresParseResult{result_name:result_name, attr:input.parse()?,})
+    }
+}
+
 impl<'a> ContractConditionsHandler<'a> {
     /// Initialize the handler. Constructs the required
     /// [`ContractConditionsType`] depending on `is_requires`.
@@ -81,7 +97,8 @@ impl<'a> ContractConditionsHandler<'a> {
                 ContractConditionsData::Requires { attr: syn::parse(attr)? }
             }
             ContractConditionsType::Ensures => {
-                ContractConditionsData::new_ensures(&annotated_fn.sig, syn::parse(attr)?)
+                let data : EnsuresParseResult = syn::parse(attr)?;
+                ContractConditionsData::new_ensures(&annotated_fn.sig, data.attr, data.result_name)
             }
             ContractConditionsType::Modifies => {
                 ContractConditionsData::new_modifies(attr, &mut output)
@@ -97,8 +114,12 @@ impl ContractConditionsData {
     ///
     /// Renames the [`Ident`]s used in `attr` and stores the translation map in
     /// `argument_names`.
-    fn new_ensures(sig: &Signature, mut attr: Expr) -> Self {
+    fn new_ensures(sig: &Signature, mut attr: Expr, result_name: Ident) -> Self {
         let argument_names = rename_argument_occurrences(sig, &mut attr);
+        
+        let mut ident_rewriter = RenamerResult(&result_name);
+        ident_rewriter.visit_expr_mut(&mut attr);
+
         ContractConditionsData::Ensures { argument_names, attr }
     }
 
@@ -164,6 +185,29 @@ impl<'ast> Visit<'ast> for ArgumentIdentCollector {
     }
     fn visit_receiver(&mut self, _: &'ast syn::Receiver) {
         self.0.insert(Ident::new("self", proc_macro2::Span::call_site()));
+    }
+}
+
+/// renames the ident to the internal result variable
+struct RenamerResult<'a>(&'a Ident);
+
+impl<'a> VisitMut for RenamerResult<'a> {
+    fn visit_expr_path_mut(&mut self, i: &mut syn::ExprPath) {
+        if i.path.segments.len() == 1 {
+            i.path
+                .segments
+                .first_mut()
+                .map(|p| if p.ident == *self.0 {p.ident = Ident::new("result_kani_internal",Span::call_site())});
+        }
+    }
+
+    /// This restores shadowing. Without this we would rename all ident
+    /// occurrences, but not rebinding location. This is because our
+    /// [`Self::visit_expr_path_mut`] is scope-unaware.
+    fn visit_pat_ident_mut(&mut self, i: &mut syn::PatIdent) {
+        if i.ident == *self.0 {
+            i.ident = Ident::new("result_kani_internal",Span::call_site())
+        }
     }
 }
 

--- a/library/kani_macros/src/sysroot/contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/contracts/mod.rs
@@ -243,6 +243,8 @@ mod initialize;
 mod replace;
 mod shared;
 
+const INTERNAL_RESULT_IDENT : &str = "result_kani_internal";
+
 pub fn requires(attr: TokenStream, item: TokenStream) -> TokenStream {
     contract_main(attr, item, ContractConditionsType::Requires)
 }

--- a/library/kani_macros/src/sysroot/contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/contracts/mod.rs
@@ -243,7 +243,7 @@ mod initialize;
 mod replace;
 mod shared;
 
-const INTERNAL_RESULT_IDENT : &str = "result_kani_internal";
+const INTERNAL_RESULT_IDENT: &str = "result_kani_internal";
 
 pub fn requires(attr: TokenStream, item: TokenStream) -> TokenStream {
     contract_main(attr, item, ContractConditionsType::Requires)

--- a/library/kani_macros/src/sysroot/contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/contracts/mod.rs
@@ -159,9 +159,9 @@
 //!         call_replace(fn args...)
 //!     } else {
 //!         unsafe { reentry = true };
-//!         let result = call_check(fn args...);
+//!         let result_kani_internal = call_check(fn args...);
 //!         unsafe { reentry = false };
-//!         result
+//!         result_kani_internal
 //!     }
 //! }
 //! ```
@@ -173,7 +173,7 @@
 //!
 //! ```
 //! #[kani::requires(divisor != 0)]
-//! #[kani::ensures(result <= dividend)]
+//! #[kani::ensures(|result : &u32| *result <= dividend)]
 //! fn div(dividend: u32, divisor: u32) -> u32 {
 //!     dividend / divisor
 //! }
@@ -186,31 +186,35 @@
 //! #[kanitool::replaced_with = "div_replace_965916"]
 //! fn div(dividend: u32, divisor: u32) -> u32 { dividend / divisor }
 //!
-//! #[allow(dead_code)]
-//! #[allow(unused_variables)]
-//! #[kanitool::is_contract_generated(check)]
-//! fn div_check_965916(dividend: u32, divisor: u32) -> u32 {
-//!     let dividend_renamed = kani::internal::untracked_deref(&dividend);
-//!     let divisor_renamed = kani::internal::untracked_deref(&divisor);
-//!     let result = { kani::assume(divisor != 0); { dividend / divisor } };
-//!     kani::assert(result <= dividend_renamed, "result <= dividend");
+//! #[allow(dead_code, unused_variables)]
+//! #[kanitool :: is_contract_generated(check)] fn
+//! div_check_b97df2(dividend : u32, divisor : u32) -> u32
+//! {
+//!     let dividend_renamed = kani::internal::untracked_deref(& dividend);
+//!     let divisor_renamed = kani::internal::untracked_deref(& divisor);
+//!     kani::assume(divisor != 0);
+//!     let result_kani_internal : u32 = div_wrapper_b97df2(dividend, divisor);
+//!     kani::assert(
+//!     (| result : & u32 | *result <= dividend_renamed)(& result_kani_internal),
+//!     stringify!(|result : &u32| *result <= dividend));
 //!     std::mem::forget(dividend_renamed);
 //!     std::mem::forget(divisor_renamed);
-//!     result
+//!     result_kani_internal
 //! }
 //!
-//! #[allow(dead_code)]
-//! #[allow(unused_variables)]
-//! #[kanitool::is_contract_generated(replace)]
-//! fn div_replace_965916(dividend: u32, divisor: u32) -> u32 {
-//!     kani::assert(divisor != 0, "divisor != 0");
-//!     let dividend_renamed = kani::internal::untracked_deref(&dividend);
-//!     let divisor_renamed = kani::internal::untracked_deref(&divisor);
-//!     let result = kani::any();
-//!     kani::assume(result <= dividend_renamed, "result <= dividend");
-//!     std::mem::forget(dividend_renamed);
+//! #[allow(dead_code, unused_variables)]
+//! #[kanitool :: is_contract_generated(replace)] fn
+//! div_replace_b97df2(dividend : u32, divisor : u32) -> u32
+//! {
+//!     let divisor_renamed = kani::internal::untracked_deref(& divisor);
+//!     let dividend_renamed = kani::internal::untracked_deref(& dividend);
+//!     kani::assert(divisor != 0, stringify! (divisor != 0));
+//!     let result_kani_internal : u32 = kani::any_modifies();
+//!     kani::assume(
+//!     (|result : & u32| *result <= dividend_renamed)(&result_kani_internal));
 //!     std::mem::forget(divisor_renamed);
-//!     result
+//!     std::mem::forget(dividend_renamed);
+//!     result_kani_internal
 //! }
 //!
 //! #[allow(dead_code)]
@@ -220,12 +224,12 @@
 //!     static mut REENTRY: bool = false;
 //!
 //!     if unsafe { REENTRY } {
-//!         div_replace_965916(dividend, divisor)
+//!         div_replace_b97df2(dividend, divisor)
 //!     } else {
 //!         unsafe { reentry = true };
-//!         let result = div_check_965916(dividend, divisor);
+//!         let result_kani_internal = div_check_b97df2(dividend, divisor);
 //!         unsafe { reentry = false };
-//!         result
+//!         result_kani_internal
 //!     }
 //! }
 //! ```

--- a/library/kani_macros/src/sysroot/contracts/replace.rs
+++ b/library/kani_macros/src/sysroot/contracts/replace.rs
@@ -3,13 +3,13 @@
 
 //! Logic used for generating the code that replaces a function with its contract.
 
-use proc_macro2::{Ident, TokenStream as TokenStream2};
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
 
 use super::{
     helpers::*,
     shared::{make_unsafe_argument_copies, try_as_result_assign},
-    ContractConditionsData, ContractConditionsHandler,
+    ContractConditionsData, ContractConditionsHandler, INTERNAL_RESULT_IDENT,
 };
 
 impl<'a> ContractConditionsHandler<'a> {
@@ -39,7 +39,8 @@ impl<'a> ContractConditionsHandler<'a> {
     fn ensure_bootstrapped_replace_body(&self) -> (Vec<syn::Stmt>, Vec<syn::Stmt>) {
         if self.is_first_emit() {
             let return_type = return_type_to_type(&self.annotated_fn.sig.output);
-            (vec![syn::parse_quote!(let result_kani_internal : #return_type = kani::any_modifies();)], vec![])
+            let result = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
+            (vec![syn::parse_quote!(let #result : #return_type = kani::any_modifies();)], vec![])
         } else {
             let stmts = &self.annotated_fn.block.stmts;
             let idx = stmts
@@ -70,30 +71,33 @@ impl<'a> ContractConditionsHandler<'a> {
         match &self.condition_type {
             ContractConditionsData::Requires { attr } => {
                 let Self { attr_copy, .. } = self;
+                let result = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
                 quote!(
                     kani::assert(#attr, stringify!(#attr_copy));
                     #(#before)*
                     #(#after)*
-                    result_kani_internal
+                    #result
                 )
             }
             ContractConditionsData::Ensures { attr, argument_names } => {
                 let (arg_copies, copy_clean) = make_unsafe_argument_copies(&argument_names);
+                let result = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
                 quote!(
                     #arg_copies
                     #(#before)*
                     #(#after)*
                     kani::assume(#attr);
                     #copy_clean
-                    result_kani_internal
+                    #result
                 )
             }
             ContractConditionsData::Modifies { attr } => {
+                let result = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
                 quote!(
                     #(#before)*
                     #(*unsafe { kani::internal::Pointer::assignable(#attr) } = kani::any_modifies();)*
                     #(#after)*
-                    result_kani_internal
+                    #result
                 )
             }
         }

--- a/library/kani_macros/src/sysroot/contracts/shared.rs
+++ b/library/kani_macros/src/sysroot/contracts/shared.rs
@@ -114,7 +114,7 @@ macro_rules! try_as_result_assign_pat {
                     ident: result_ident,
                     subpat: None,
                     ..
-                }) if result_ident == "result"
+                }) if result_ident == "result_kani_internal"
             ) => init.$convert(),
             _ => None,
         }

--- a/library/kani_macros/src/sysroot/contracts/shared.rs
+++ b/library/kani_macros/src/sysroot/contracts/shared.rs
@@ -13,7 +13,7 @@ use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
 use syn::Attribute;
 
-use super::{ContractConditionsHandler, ContractFunctionState};
+use super::{ContractConditionsHandler, ContractFunctionState, INTERNAL_RESULT_IDENT};
 
 impl ContractFunctionState {
     /// Do we need to emit the `is_contract_generated` tag attribute on the
@@ -114,7 +114,7 @@ macro_rules! try_as_result_assign_pat {
                     ident: result_ident,
                     subpat: None,
                     ..
-                }) if result_ident == "result_kani_internal"
+                }) if result_ident == INTERNAL_RESULT_IDENT
             ) => init.$convert(),
             _ => None,
         }

--- a/tests/expected/function-contract/arbitrary_ensures_fail.expected
+++ b/tests/expected/function-contract/arbitrary_ensures_fail.expected
@@ -1,6 +1,6 @@
 assertion\
 - Status: FAILURE\
-- Description: "|result| result == x"\
+- Description: "|result : &u32| *result == x"\
 in function max 
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/arbitrary_ensures_fail.expected
+++ b/tests/expected/function-contract/arbitrary_ensures_fail.expected
@@ -1,6 +1,6 @@
 assertion\
 - Status: FAILURE\
-- Description: "result == x"\
+- Description: "|result| result == x"\
 in function max 
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/arbitrary_ensures_fail.rs
+++ b/tests/expected/function-contract/arbitrary_ensures_fail.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(|result| result == x)]
+#[kani::ensures(|result : &u32| *result == x)]
 fn max(x: u32, y: u32) -> u32 {
     if x > y { x } else { y }
 }

--- a/tests/expected/function-contract/arbitrary_ensures_fail.rs
+++ b/tests/expected/function-contract/arbitrary_ensures_fail.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(result == x)]
+#[kani::ensures(|result| result == x)]
 fn max(x: u32, y: u32) -> u32 {
     if x > y { x } else { y }
 }

--- a/tests/expected/function-contract/arbitrary_ensures_pass.expected
+++ b/tests/expected/function-contract/arbitrary_ensures_pass.expected
@@ -1,6 +1,6 @@
 assertion\
 - Status: SUCCESS\
-- Description: "|result| result == x || result == y"\
+- Description: "|result : &u32| *result == x || *result == y"\
 in function max
      
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/arbitrary_ensures_pass.expected
+++ b/tests/expected/function-contract/arbitrary_ensures_pass.expected
@@ -1,6 +1,6 @@
 assertion\
 - Status: SUCCESS\
-- Description: "result == x || result == y"\
+- Description: "|result| result == x || result == y"\
 in function max
      
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/arbitrary_ensures_pass.rs
+++ b/tests/expected/function-contract/arbitrary_ensures_pass.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(|result| result == x || result == y)]
+#[kani::ensures(|result : &u32| *result == x || *result == y)]
 fn max(x: u32, y: u32) -> u32 {
     if x > y { x } else { y }
 }

--- a/tests/expected/function-contract/arbitrary_ensures_pass.rs
+++ b/tests/expected/function-contract/arbitrary_ensures_pass.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(result == x || result == y)]
+#[kani::ensures(|result| result == x || result == y)]
 fn max(x: u32, y: u32) -> u32 {
     if x > y { x } else { y }
 }

--- a/tests/expected/function-contract/arbitrary_requires_fail.rs
+++ b/tests/expected/function-contract/arbitrary_requires_fail.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(result <= dividend)]
+#[kani::ensures(|result| result <= dividend)]
 fn div(dividend: u32, divisor: u32) -> u32 {
     dividend / divisor
 }

--- a/tests/expected/function-contract/arbitrary_requires_fail.rs
+++ b/tests/expected/function-contract/arbitrary_requires_fail.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(|result| result <= dividend)]
+#[kani::ensures(|result : &u32| *result <= dividend)]
 fn div(dividend: u32, divisor: u32) -> u32 {
     dividend / divisor
 }

--- a/tests/expected/function-contract/attribute_complain.rs
+++ b/tests/expected/function-contract/attribute_complain.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#[kani::ensures(true)]
+#[kani::ensures(|result| true)]
 fn always() {}
 
 #[kani::proof_for_contract(always)]

--- a/tests/expected/function-contract/attribute_no_complain.rs
+++ b/tests/expected/function-contract/attribute_no_complain.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#[kani::ensures(true)]
+#[kani::ensures(|result| true)]
 fn always() {}
 
 #[kani::proof]

--- a/tests/expected/function-contract/checking_from_external_mod.expected
+++ b/tests/expected/function-contract/checking_from_external_mod.expected
@@ -1,5 +1,5 @@
 - Status: SUCCESS\
-- Description: "(result == x) | (result == y)"\
+- Description: "|result| (result == x) | (result == y)"\
 in function max
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/checking_from_external_mod.expected
+++ b/tests/expected/function-contract/checking_from_external_mod.expected
@@ -1,5 +1,5 @@
 - Status: SUCCESS\
-- Description: "|result| (result == x) | (result == y)"\
+- Description: "|result : &u32| (*result == x) | (*result == y)"\
 in function max
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/checking_from_external_mod.rs
+++ b/tests/expected/function-contract/checking_from_external_mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(|result| (result == x) | (result == y))]
+#[kani::ensures(|result : &u32| (*result == x) | (*result == y))]
 fn max(x: u32, y: u32) -> u32 {
     if x > y { x } else { y }
 }

--- a/tests/expected/function-contract/checking_from_external_mod.rs
+++ b/tests/expected/function-contract/checking_from_external_mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures((result == x) | (result == y))]
+#[kani::ensures(|result| (result == x) | (result == y))]
 fn max(x: u32, y: u32) -> u32 {
     if x > y { x } else { y }
 }

--- a/tests/expected/function-contract/checking_in_impl.expected
+++ b/tests/expected/function-contract/checking_in_impl.expected
@@ -1,5 +1,5 @@
 - Status: SUCCESS\
-- Description: "(result == self) | (result == y)"\
+- Description: "|result| (result == self) | (result == y)"\
 in function WrappedInt::max
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/checking_in_impl.expected
+++ b/tests/expected/function-contract/checking_in_impl.expected
@@ -1,5 +1,5 @@
 - Status: SUCCESS\
-- Description: "|result| (result == self) | (result == y)"\
+- Description: "|result : &WrappedInt| (*result == self) | (*result == y)"\
 in function WrappedInt::max
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/checking_in_impl.rs
+++ b/tests/expected/function-contract/checking_in_impl.rs
@@ -8,7 +8,7 @@ extern crate kani;
 struct WrappedInt(u32);
 
 impl WrappedInt {
-    #[kani::ensures(|result| (result == self) | (result == y))]
+    #[kani::ensures(|result : &WrappedInt| (*result == self) | (*result == y))]
     fn max(self, y: WrappedInt) -> WrappedInt {
         Self(if self.0 > y.0 { self.0 } else { y.0 })
     }

--- a/tests/expected/function-contract/checking_in_impl.rs
+++ b/tests/expected/function-contract/checking_in_impl.rs
@@ -8,7 +8,7 @@ extern crate kani;
 struct WrappedInt(u32);
 
 impl WrappedInt {
-    #[kani::ensures((result == self) | (result == y))]
+    #[kani::ensures(|result| (result == self) | (result == y))]
     fn max(self, y: WrappedInt) -> WrappedInt {
         Self(if self.0 > y.0 { self.0 } else { y.0 })
     }

--- a/tests/expected/function-contract/fail_on_two.expected
+++ b/tests/expected/function-contract/fail_on_two.expected
@@ -7,6 +7,6 @@ Failed Checks: internal error: entered unreachable code: fail on two
 
 assertion\
 - Status: FAILURE\
-- Description: "result < 3"
+- Description: "|result| result < 3"
 
-Failed Checks: result < 3
+Failed Checks: |result| result < 3

--- a/tests/expected/function-contract/fail_on_two.expected
+++ b/tests/expected/function-contract/fail_on_two.expected
@@ -7,6 +7,6 @@ Failed Checks: internal error: entered unreachable code: fail on two
 
 assertion\
 - Status: FAILURE\
-- Description: "|result| result < 3"
+- Description: "|result : &i32| *result < 3"
 
-Failed Checks: |result| result < 3
+Failed Checks: |result : &i32| *result < 3

--- a/tests/expected/function-contract/fail_on_two.rs
+++ b/tests/expected/function-contract/fail_on_two.rs
@@ -16,7 +16,7 @@
 //! once because the postcondition is violated). If instead the hypothesis (e.g.
 //! contract replacement) is used we'd expect the verification to succeed.
 
-#[kani::ensures(result < 3)]
+#[kani::ensures(|result| result < 3)]
 #[kani::recursion]
 fn fail_on_two(i: i32) -> i32 {
     match i {
@@ -32,7 +32,7 @@ fn harness() {
     let _ = fail_on_two(first);
 }
 
-#[kani::ensures(result < 3)]
+#[kani::ensures(|result| result < 3)]
 #[kani::recursion]
 fn fail_on_two_in_postcondition(i: i32) -> i32 {
     let j = i + 1;

--- a/tests/expected/function-contract/fail_on_two.rs
+++ b/tests/expected/function-contract/fail_on_two.rs
@@ -16,7 +16,7 @@
 //! once because the postcondition is violated). If instead the hypothesis (e.g.
 //! contract replacement) is used we'd expect the verification to succeed.
 
-#[kani::ensures(|result| result < 3)]
+#[kani::ensures(|result : &i32| *result < 3)]
 #[kani::recursion]
 fn fail_on_two(i: i32) -> i32 {
     match i {
@@ -32,7 +32,7 @@ fn harness() {
     let _ = fail_on_two(first);
 }
 
-#[kani::ensures(|result| result < 3)]
+#[kani::ensures(|result : &i32| *result < 3)]
 #[kani::recursion]
 fn fail_on_two_in_postcondition(i: i32) -> i32 {
     let j = i + 1;

--- a/tests/expected/function-contract/gcd_failure_code.expected
+++ b/tests/expected/function-contract/gcd_failure_code.expected
@@ -1,8 +1,8 @@
 assertion\
 - Status: FAILURE\
-- Description: "result != 0 && x % result == 0 && y % result == 0"\
+- Description: "|result| result != 0 && x % result == 0 && y % result == 0"\
 in function gcd
 
-Failed Checks: result != 0 && x % result == 0 && y % result == 0
+Failed Checks: |result| result != 0 && x % result == 0 && y % result == 0
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/gcd_failure_code.expected
+++ b/tests/expected/function-contract/gcd_failure_code.expected
@@ -1,8 +1,8 @@
 assertion\
 - Status: FAILURE\
-- Description: "|result| result != 0 && x % result == 0 && y % result == 0"\
+- Description: "|result : &T| *result != 0 && x % *result == 0 && y % *result == 0"\
 in function gcd
 
-Failed Checks: |result| result != 0 && x % result == 0 && y % result == 0
+Failed Checks: |result : &T| *result != 0 && x % *result == 0 && y % *result == 0
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/gcd_failure_code.rs
+++ b/tests/expected/function-contract/gcd_failure_code.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result : &T| *result != 0 && x % *result == 0 && y % *result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_failure_code.rs
+++ b/tests/expected/function-contract/gcd_failure_code.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_failure_contract.expected
+++ b/tests/expected/function-contract/gcd_failure_contract.expected
@@ -1,8 +1,8 @@
 assertion\
 - Status: FAILURE\
-- Description: "result != 0 && x % result == 1 && y % result == 0"\
+- Description: "|result| result != 0 && x % result == 1 && y % result == 0"\
 in function gcd\
 	 
-Failed Checks: result != 0 && x % result == 1 && y % result == 0
+Failed Checks: |result| result != 0 && x % result == 1 && y % result == 0
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/gcd_failure_contract.expected
+++ b/tests/expected/function-contract/gcd_failure_contract.expected
@@ -1,8 +1,8 @@
 assertion\
 - Status: FAILURE\
-- Description: "|result| result != 0 && x % result == 1 && y % result == 0"\
+- Description: "|result : &T| *result != 0 && x % *result == 1 && y % *result == 0"\
 in function gcd\
 	 
-Failed Checks: |result| result != 0 && x % result == 1 && y % result == 0
+Failed Checks: |result : &T| *result != 0 && x % *result == 1 && y % *result == 0
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/gcd_failure_contract.rs
+++ b/tests/expected/function-contract/gcd_failure_contract.rs
@@ -6,7 +6,7 @@ type T = u8;
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
 // Changed `0` to `1` in `x % result == 0` to mess with this contract
-#[kani::ensures(result != 0 && x % result == 1 && y % result == 0)]
+#[kani::ensures(|result| result != 0 && x % result == 1 && y % result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_failure_contract.rs
+++ b/tests/expected/function-contract/gcd_failure_contract.rs
@@ -5,8 +5,8 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-// Changed `0` to `1` in `x % result == 0` to mess with this contract
-#[kani::ensures(|result| result != 0 && x % result == 1 && y % result == 0)]
+// Changed `0` to `1` in `x % *result == 0` to mess with this contract
+#[kani::ensures(|result : &T| *result != 0 && x % *result == 1 && y % *result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_rec_code_fail.expected
+++ b/tests/expected/function-contract/gcd_rec_code_fail.expected
@@ -1,3 +1,3 @@
-Failed Checks: result != 0 && x % result == 0 && y % result == 0
+Failed Checks: |result| result != 0 && x % result == 0 && y % result == 0
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/gcd_rec_code_fail.expected
+++ b/tests/expected/function-contract/gcd_rec_code_fail.expected
@@ -1,3 +1,3 @@
-Failed Checks: |result| result != 0 && x % result == 0 && y % result == 0
+Failed Checks: |result : &T| *result != 0 && x % *result == 0 && y % *result == 0
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/gcd_rec_code_fail.rs
+++ b/tests/expected/function-contract/gcd_rec_code_fail.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
 #[kani::recursion]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;

--- a/tests/expected/function-contract/gcd_rec_code_fail.rs
+++ b/tests/expected/function-contract/gcd_rec_code_fail.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result : &T| *result != 0 && x % *result == 0 && y % *result == 0)]
 #[kani::recursion]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;

--- a/tests/expected/function-contract/gcd_rec_comparison_pass.expected
+++ b/tests/expected/function-contract/gcd_rec_comparison_pass.expected
@@ -4,6 +4,6 @@ assertion\
 
 assertion\
 - Status: SUCCESS\
-- Description: "|result| result != 0 && x % result == 0 && y % result == 0"
+- Description: "|result : &T| *result != 0 && x % *result == 0 && y % *result == 0"
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/gcd_rec_comparison_pass.expected
+++ b/tests/expected/function-contract/gcd_rec_comparison_pass.expected
@@ -1,9 +1,9 @@
 assertion\
 - Status: SUCCESS\
-- Description: "x != 0 && y != 0"
+- Description: "|result| x != 0 && y != 0"
 
 assertion\
 - Status: SUCCESS\
-- Description: "result != 0 && x % result == 0 && y % result == 0"
+- Description: "|result| result != 0 && x % result == 0 && y % result == 0"
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/gcd_rec_comparison_pass.expected
+++ b/tests/expected/function-contract/gcd_rec_comparison_pass.expected
@@ -1,6 +1,6 @@
 assertion\
 - Status: SUCCESS\
-- Description: "|result| x != 0 && y != 0"
+- Description: "x != 0 && y != 0"
 
 assertion\
 - Status: SUCCESS\

--- a/tests/expected/function-contract/gcd_rec_comparison_pass.rs
+++ b/tests/expected/function-contract/gcd_rec_comparison_pass.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
 #[kani::recursion]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;

--- a/tests/expected/function-contract/gcd_rec_comparison_pass.rs
+++ b/tests/expected/function-contract/gcd_rec_comparison_pass.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result : &T| *result != 0 && x % *result == 0 && y % *result == 0)]
 #[kani::recursion]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;

--- a/tests/expected/function-contract/gcd_rec_contract_fail.expected
+++ b/tests/expected/function-contract/gcd_rec_contract_fail.expected
@@ -1,3 +1,3 @@
-Failed Checks: result != 0 && x % result == 1 && y % result == 0
+Failed Checks: |result| result != 0 && x % result == 1 && y % result == 0
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/gcd_rec_contract_fail.expected
+++ b/tests/expected/function-contract/gcd_rec_contract_fail.expected
@@ -1,3 +1,3 @@
-Failed Checks: |result| result != 0 && x % result == 1 && y % result == 0
+Failed Checks: |result : &T| *result != 0 && x % *result == 1 && y % *result == 0
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/gcd_rec_contract_fail.rs
+++ b/tests/expected/function-contract/gcd_rec_contract_fail.rs
@@ -6,7 +6,7 @@ type T = u8;
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
 // Changed `0` to `1` in `x % result == 0` to mess with this contract
-#[kani::ensures(result != 0 && x % result == 1 && y % result == 0)]
+#[kani::ensures(|result| result != 0 && x % result == 1 && y % result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_rec_contract_fail.rs
+++ b/tests/expected/function-contract/gcd_rec_contract_fail.rs
@@ -6,7 +6,7 @@ type T = u8;
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
 // Changed `0` to `1` in `x % result == 0` to mess with this contract
-#[kani::ensures(|result| result != 0 && x % result == 1 && y % result == 0)]
+#[kani::ensures(|result : &T| *result != 0 && x % *result == 1 && y % *result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_rec_replacement_pass.rs
+++ b/tests/expected/function-contract/gcd_rec_replacement_pass.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result : &T| *result != 0 && x % *result == 0 && y % *result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_rec_replacement_pass.rs
+++ b/tests/expected/function-contract/gcd_rec_replacement_pass.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_rec_simple_pass.expected
+++ b/tests/expected/function-contract/gcd_rec_simple_pass.expected
@@ -4,6 +4,6 @@ assertion\
 
 assertion\
 - Status: SUCCESS\
-- Description: "|result| result != 0 && x % result == 0 && y % result == 0"
+- Description: "|result : &T| *result != 0 && x % *result == 0 && y % *result == 0"
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/gcd_rec_simple_pass.expected
+++ b/tests/expected/function-contract/gcd_rec_simple_pass.expected
@@ -1,9 +1,9 @@
 assertion\
 - Status: SUCCESS\
-- Description: "x != 0 && y != 0"
+- Description: "|result| x != 0 && y != 0"
 
 assertion\
 - Status: SUCCESS\
-- Description: "result != 0 && x % result == 0 && y % result == 0"
+- Description: "|result| result != 0 && x % result == 0 && y % result == 0"
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/gcd_rec_simple_pass.expected
+++ b/tests/expected/function-contract/gcd_rec_simple_pass.expected
@@ -1,6 +1,6 @@
 assertion\
 - Status: SUCCESS\
-- Description: "|result| x != 0 && y != 0"
+- Description: "x != 0 && y != 0"
 
 assertion\
 - Status: SUCCESS\

--- a/tests/expected/function-contract/gcd_rec_simple_pass.rs
+++ b/tests/expected/function-contract/gcd_rec_simple_pass.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
 #[kani::recursion]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;

--- a/tests/expected/function-contract/gcd_rec_simple_pass.rs
+++ b/tests/expected/function-contract/gcd_rec_simple_pass.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result : &T| *result != 0 && x % *result == 0 && y % *result == 0)]
 #[kani::recursion]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;

--- a/tests/expected/function-contract/gcd_replacement_fail.rs
+++ b/tests/expected/function-contract/gcd_replacement_fail.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(result != 0 && x % result == 0)]
+#[kani::ensures(|result| result != 0 && x % result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_replacement_fail.rs
+++ b/tests/expected/function-contract/gcd_replacement_fail.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(|result| result != 0 && x % result == 0)]
+#[kani::ensures(|result : &T| *result != 0 && x % *result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_replacement_pass.rs
+++ b/tests/expected/function-contract/gcd_replacement_pass.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result : &T| *result != 0 && x % *result == 0 && y % *result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_replacement_pass.rs
+++ b/tests/expected/function-contract/gcd_replacement_pass.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_success.expected
+++ b/tests/expected/function-contract/gcd_success.expected
@@ -1,6 +1,6 @@
 assertion\
 - Status: SUCCESS\
-- Description: "result != 0 && x % result == 0 && y % result == 0"\
+- Description: "|result| result != 0 && x % result == 0 && y % result == 0"\
 in function gcd
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/gcd_success.expected
+++ b/tests/expected/function-contract/gcd_success.expected
@@ -1,6 +1,6 @@
 assertion\
 - Status: SUCCESS\
-- Description: "|result| result != 0 && x % result == 0 && y % result == 0"\
+- Description: "|result : &T| *result != 0 && x % *result == 0 && y % *result == 0"\
 in function gcd
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/gcd_success.rs
+++ b/tests/expected/function-contract/gcd_success.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result : &T| *result != 0 && x % *result == 0 && y % *result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/gcd_success.rs
+++ b/tests/expected/function-contract/gcd_success.rs
@@ -5,7 +5,7 @@ type T = u8;
 
 /// Euclid's algorithm for calculating the GCD of two numbers
 #[kani::requires(x != 0 && y != 0)]
-#[kani::ensures(result != 0 && x % result == 0 && y % result == 0)]
+#[kani::ensures(|result| result != 0 && x % result == 0 && y % result == 0)]
 fn gcd(x: T, y: T) -> T {
     let mut max = x;
     let mut min = y;

--- a/tests/expected/function-contract/modifies/check_only_verification.rs
+++ b/tests/expected/function-contract/modifies/check_only_verification.rs
@@ -7,7 +7,7 @@
 
 #[kani::requires(*ptr < 100)]
 #[kani::modifies(ptr)]
-#[kani::ensures(|result| result == 100)]
+#[kani::ensures(|result : &u32| *result == 100)]
 fn modify(ptr: &mut u32) -> u32 {
     *ptr += 1;
     *ptr

--- a/tests/expected/function-contract/modifies/check_only_verification.rs
+++ b/tests/expected/function-contract/modifies/check_only_verification.rs
@@ -7,7 +7,7 @@
 
 #[kani::requires(*ptr < 100)]
 #[kani::modifies(ptr)]
-#[kani::ensures(result == 100)]
+#[kani::ensures(|result| result == 100)]
 fn modify(ptr: &mut u32) -> u32 {
     *ptr += 1;
     *ptr

--- a/tests/expected/function-contract/modifies/expr_pass.rs
+++ b/tests/expected/function-contract/modifies/expr_pass.rs
@@ -7,7 +7,7 @@
 
 #[kani::requires(**ptr < 100)]
 #[kani::modifies(ptr.as_ref())]
-#[kani::ensures(**ptr < 101)]
+#[kani::ensures(|result| **ptr < 101)]
 fn modify(ptr: &mut Box<u32>) {
     *ptr.as_mut() += 1;
 }

--- a/tests/expected/function-contract/modifies/expr_replace_pass.rs
+++ b/tests/expected/function-contract/modifies/expr_replace_pass.rs
@@ -4,7 +4,7 @@
 
 #[kani::requires(**ptr < 100)]
 #[kani::modifies(ptr.as_ref())]
-#[kani::ensures(**ptr == prior + 1)]
+#[kani::ensures(|result| **ptr == prior + 1)]
 fn modify(ptr: &mut Box<u32>, prior: u32) {
     *ptr.as_mut() += 1;
 }

--- a/tests/expected/function-contract/modifies/fail_missing_recursion_attr.rs
+++ b/tests/expected/function-contract/modifies/fail_missing_recursion_attr.rs
@@ -5,7 +5,7 @@
 //! Check whether Kani fails if users forgot to annotate recursive
 //! functions with `#[kani::recursion]` when using function contracts.
 
-#[kani::ensures(result < 3)]
+#[kani::ensures(|result| result < 3)]
 fn fail_on_two(i: i32) -> i32 {
     match i {
         0 => fail_on_two(i + 1),

--- a/tests/expected/function-contract/modifies/fail_missing_recursion_attr.rs
+++ b/tests/expected/function-contract/modifies/fail_missing_recursion_attr.rs
@@ -5,7 +5,7 @@
 //! Check whether Kani fails if users forgot to annotate recursive
 //! functions with `#[kani::recursion]` when using function contracts.
 
-#[kani::ensures(|result| result < 3)]
+#[kani::ensures(|result : &i32| *result < 3)]
 fn fail_on_two(i: i32) -> i32 {
     match i {
         0 => fail_on_two(i + 1),

--- a/tests/expected/function-contract/modifies/field_replace_pass.rs
+++ b/tests/expected/function-contract/modifies/field_replace_pass.rs
@@ -8,7 +8,7 @@ struct S<'a> {
 }
 #[kani::requires(*s.target < 100)]
 #[kani::modifies(s.target)]
-#[kani::ensures(*s.target == prior + 1)]
+#[kani::ensures(|result| *s.target == prior + 1)]
 fn modify(s: S, prior: u32) {
     *s.target += 1;
 }

--- a/tests/expected/function-contract/modifies/global_replace_pass.rs
+++ b/tests/expected/function-contract/modifies/global_replace_pass.rs
@@ -5,7 +5,7 @@
 static mut PTR: u32 = 0;
 
 #[kani::modifies(&mut PTR)]
-#[kani::ensures(PTR == src)]
+#[kani::ensures(|result| PTR == src)]
 unsafe fn modify(src: u32) {
     PTR = src;
 }

--- a/tests/expected/function-contract/modifies/havoc_pass.rs
+++ b/tests/expected/function-contract/modifies/havoc_pass.rs
@@ -3,7 +3,7 @@
 // kani-flags: -Zfunction-contracts
 
 #[kani::modifies(dst)]
-#[kani::ensures(*dst == src)]
+#[kani::ensures(|result| *dst == src)]
 fn copy(src: u32, dst: &mut u32) {
     *dst = src;
 }

--- a/tests/expected/function-contract/modifies/havoc_pass_reordered.rs
+++ b/tests/expected/function-contract/modifies/havoc_pass_reordered.rs
@@ -3,7 +3,7 @@
 // kani-flags: -Zfunction-contracts
 
 // These two are reordered in comparison to `havoc_pass` and we expect the test case to pass still
-#[kani::ensures(*dst == src)]
+#[kani::ensures(|result| *dst == src)]
 #[kani::modifies(dst)]
 fn copy(src: u32, dst: &mut u32) {
     *dst = src;

--- a/tests/expected/function-contract/modifies/mistake_condition_return.expected
+++ b/tests/expected/function-contract/modifies/mistake_condition_return.expected
@@ -1,3 +1,3 @@
-Failed Checks: assertion failed: res == 100
+Failed Checks: assertion failed: |result| res == 100
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/modifies/mistake_condition_return.expected
+++ b/tests/expected/function-contract/modifies/mistake_condition_return.expected
@@ -1,3 +1,3 @@
-Failed Checks: assertion failed: |result| res == 100
+Failed Checks: assertion failed: res == 100
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/modifies/mistake_condition_return.rs
+++ b/tests/expected/function-contract/modifies/mistake_condition_return.rs
@@ -16,8 +16,8 @@
 // However, contract instrumentation will create a separate non-deterministic
 // value to return in this function that can only be constrained by using the
 // `result` keyword. Thus the correct condition would be
-// `#[kani::ensures(result == 100)]`.
-#[kani::ensures(*ptr == 100)]
+// `#[kani::ensures(|result| result == 100)]`.
+#[kani::ensures(|result| *ptr == 100)]
 fn modify(ptr: &mut u32) -> u32 {
     *ptr += 1;
     *ptr

--- a/tests/expected/function-contract/modifies/unique_arguments.rs
+++ b/tests/expected/function-contract/modifies/unique_arguments.rs
@@ -4,8 +4,8 @@
 
 #[kani::modifies(a)]
 #[kani::modifies(b)]
-#[kani::ensures(*a == 1)]
-#[kani::ensures(*b == 2)]
+#[kani::ensures(|result| *a == 1)]
+#[kani::ensures(|result| *b == 2)]
 fn two_pointers(a: &mut u32, b: &mut u32) {
     *a = 1;
     *b = 2;

--- a/tests/expected/function-contract/modifies/vec_pass.expected
+++ b/tests/expected/function-contract/modifies/vec_pass.expected
@@ -15,6 +15,6 @@ in function modify_replace
 
 assertion\
 - Status: SUCCESS\
-- Description: "v[0] == src"
+- Description: "|result| v[0] == src"
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/modifies/vec_pass.rs
+++ b/tests/expected/function-contract/modifies/vec_pass.rs
@@ -4,7 +4,7 @@
 
 #[kani::requires(v.len() > 0)]
 #[kani::modifies(&v[0])]
-#[kani::ensures(v[0] == src)]
+#[kani::ensures(|result| v[0] == src)]
 fn modify(v: &mut Vec<u32>, src: u32) {
     v[0] = src
 }

--- a/tests/expected/function-contract/pattern_use.rs
+++ b/tests/expected/function-contract/pattern_use.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(|result| result <= dividend)]
+#[kani::ensures(|result : &u32| *result <= dividend)]
 fn div((dividend, divisor): (u32, u32)) -> u32 {
     dividend / divisor
 }

--- a/tests/expected/function-contract/pattern_use.rs
+++ b/tests/expected/function-contract/pattern_use.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(result <= dividend)]
+#[kani::ensures(|result| result <= dividend)]
 fn div((dividend, divisor): (u32, u32)) -> u32 {
     dividend / divisor
 }

--- a/tests/expected/function-contract/prohibit-pointers/allowed_const_ptr.rs
+++ b/tests/expected/function-contract/prohibit-pointers/allowed_const_ptr.rs
@@ -4,7 +4,7 @@
 
 #![allow(unreachable_code, unused_variables)]
 
-#[kani::ensures(true)]
+#[kani::ensures(|result| true)]
 fn allowed_pointer(t: *const bool) {}
 
 #[kani::proof_for_contract(allowed_pointer)]

--- a/tests/expected/function-contract/prohibit-pointers/allowed_mut_ref.rs
+++ b/tests/expected/function-contract/prohibit-pointers/allowed_mut_ref.rs
@@ -4,7 +4,7 @@
 
 #![allow(unreachable_code, unused_variables)]
 
-#[kani::ensures(true)]
+#[kani::ensures(|result| true)]
 fn allowed_mut_ref(t: &mut bool) {}
 
 #[kani::proof_for_contract(allowed_mut_ref)]

--- a/tests/expected/function-contract/prohibit-pointers/allowed_mut_return_ref.rs
+++ b/tests/expected/function-contract/prohibit-pointers/allowed_mut_return_ref.rs
@@ -17,7 +17,7 @@ impl<'a> kani::Arbitrary for ArbitraryPointer<&'a mut bool> {
     }
 }
 
-#[kani::ensures(true)]
+#[kani::ensures(|result| true)]
 fn allowed_mut_return_ref<'a>() -> ArbitraryPointer<&'a mut bool> {
     ArbitraryPointer(unsafe { &mut B as &'a mut bool })
 }

--- a/tests/expected/function-contract/prohibit-pointers/allowed_ref.rs
+++ b/tests/expected/function-contract/prohibit-pointers/allowed_ref.rs
@@ -4,7 +4,7 @@
 
 #![allow(unreachable_code, unused_variables)]
 
-#[kani::ensures(true)]
+#[kani::ensures(|result| true)]
 fn allowed_ref(t: &bool) {}
 
 #[kani::proof_for_contract(allowed_ref)]

--- a/tests/expected/function-contract/prohibit-pointers/hidden.rs
+++ b/tests/expected/function-contract/prohibit-pointers/hidden.rs
@@ -6,7 +6,7 @@
 
 struct HidesAPointer(*mut u32);
 
-#[kani::ensures(true)]
+#[kani::ensures(|result| true)]
 fn hidden_pointer(h: HidesAPointer) {}
 
 #[kani::proof_for_contract(hidden_pointer)]

--- a/tests/expected/function-contract/prohibit-pointers/plain_pointer.rs
+++ b/tests/expected/function-contract/prohibit-pointers/plain_pointer.rs
@@ -4,7 +4,7 @@
 
 #![allow(unreachable_code, unused_variables)]
 
-#[kani::ensures(true)]
+#[kani::ensures(|result| true)]
 fn plain_pointer(t: *mut i32) {}
 
 #[kani::proof_for_contract(plain_pointer)]

--- a/tests/expected/function-contract/prohibit-pointers/return_pointer.rs
+++ b/tests/expected/function-contract/prohibit-pointers/return_pointer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(unsafe{ *result == *input })]
+#[kani::ensures(|result| unsafe{ *result == *input })]
 fn return_pointer(input: *const usize) -> *const usize {
     input
 }

--- a/tests/expected/function-contract/prohibit-pointers/return_pointer.rs
+++ b/tests/expected/function-contract/prohibit-pointers/return_pointer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(|result : *const usize| unsafe{ *result == *input })]
+#[kani::ensures(|result : &*const usize| unsafe{ **result == *input })]
 fn return_pointer(input: *const usize) -> *const usize {
     input
 }

--- a/tests/expected/function-contract/prohibit-pointers/return_pointer.rs
+++ b/tests/expected/function-contract/prohibit-pointers/return_pointer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(|result| unsafe{ *result == *input })]
+#[kani::ensures(|result : *const usize| unsafe{ *result == *input })]
 fn return_pointer(input: *const usize) -> *const usize {
     input
 }

--- a/tests/expected/function-contract/simple_ensures_fail.expected
+++ b/tests/expected/function-contract/simple_ensures_fail.expected
@@ -1,8 +1,8 @@
 assertion\
 - Status: FAILURE\
-- Description: "result == x"\
+- Description: "|result| result == x"\
 in function max
 
-Failed Checks: result == x
+Failed Checks: |result| result == x
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/simple_ensures_fail.expected
+++ b/tests/expected/function-contract/simple_ensures_fail.expected
@@ -1,8 +1,8 @@
 assertion\
 - Status: FAILURE\
-- Description: "|result| result == x"\
+- Description: "|result : &u32| *result == x"\
 in function max
 
-Failed Checks: |result| result == x
+Failed Checks: |result : &u32| *result == x
 
 VERIFICATION:- FAILED

--- a/tests/expected/function-contract/simple_ensures_fail.rs
+++ b/tests/expected/function-contract/simple_ensures_fail.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(|result| result == x)]
+#[kani::ensures(|result : &u32| *result == x)]
 fn max(x: u32, y: u32) -> u32 {
     if x > y { x } else { y }
 }

--- a/tests/expected/function-contract/simple_ensures_fail.rs
+++ b/tests/expected/function-contract/simple_ensures_fail.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(result == x)]
+#[kani::ensures(|result| result == x)]
 fn max(x: u32, y: u32) -> u32 {
     if x > y { x } else { y }
 }

--- a/tests/expected/function-contract/simple_ensures_pass.expected
+++ b/tests/expected/function-contract/simple_ensures_pass.expected
@@ -1,6 +1,6 @@
 assertion\
 - Status: SUCCESS\
-- Description: "(result == x) | (result == y)"\
+- Description: "|result| (result == x) | (result == y)"\
 in function max
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/simple_ensures_pass.expected
+++ b/tests/expected/function-contract/simple_ensures_pass.expected
@@ -1,6 +1,6 @@
 assertion\
 - Status: SUCCESS\
-- Description: "|result| (result == x) | (result == y)"\
+- Description: "|result : &u32| (*result == x) | (*result == y)"\
 in function max
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/simple_ensures_pass.rs
+++ b/tests/expected/function-contract/simple_ensures_pass.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(|result| (result == x) | (result == y))]
+#[kani::ensures(|result : &u32| (*result == x) | (*result == y))]
 fn max(x: u32, y: u32) -> u32 {
     if x > y { x } else { y }
 }

--- a/tests/expected/function-contract/simple_ensures_pass.rs
+++ b/tests/expected/function-contract/simple_ensures_pass.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures((result == x) | (result == y))]
+#[kani::ensures(|result| (result == x) | (result == y))]
 fn max(x: u32, y: u32) -> u32 {
     if x > y { x } else { y }
 }

--- a/tests/expected/function-contract/simple_replace_fail.rs
+++ b/tests/expected/function-contract/simple_replace_fail.rs
@@ -3,7 +3,7 @@
 // kani-flags: -Zfunction-contracts
 
 #[kani::requires(divisor != 0)]
-#[kani::ensures(|result| result <= dividend)]
+#[kani::ensures(|result : &u32| *result <= dividend)]
 fn div(dividend: u32, divisor: u32) -> u32 {
     dividend / divisor
 }

--- a/tests/expected/function-contract/simple_replace_fail.rs
+++ b/tests/expected/function-contract/simple_replace_fail.rs
@@ -3,7 +3,7 @@
 // kani-flags: -Zfunction-contracts
 
 #[kani::requires(divisor != 0)]
-#[kani::ensures(result <= dividend)]
+#[kani::ensures(|result| result <= dividend)]
 fn div(dividend: u32, divisor: u32) -> u32 {
     dividend / divisor
 }

--- a/tests/expected/function-contract/simple_replace_pass.rs
+++ b/tests/expected/function-contract/simple_replace_pass.rs
@@ -3,7 +3,7 @@
 // kani-flags: -Zfunction-contracts
 
 #[kani::requires(divisor != 0)]
-#[kani::ensures(|result| result <= dividend)]
+#[kani::ensures(|result : &u32| *result <= dividend)]
 fn div(dividend: u32, divisor: u32) -> u32 {
     dividend / divisor
 }

--- a/tests/expected/function-contract/simple_replace_pass.rs
+++ b/tests/expected/function-contract/simple_replace_pass.rs
@@ -3,7 +3,7 @@
 // kani-flags: -Zfunction-contracts
 
 #[kani::requires(divisor != 0)]
-#[kani::ensures(result <= dividend)]
+#[kani::ensures(|result| result <= dividend)]
 fn div(dividend: u32, divisor: u32) -> u32 {
     dividend / divisor
 }

--- a/tests/expected/function-contract/type_annotation_needed.rs
+++ b/tests/expected/function-contract/type_annotation_needed.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(|result : Option<T>| result.is_some())]
+#[kani::ensures(|result : &Option<T>| result.is_some())]
 fn or_default<T: Default>(opt: Option<T>) -> Option<T> {
     opt.or(Some(T::default()))
 }

--- a/tests/expected/function-contract/type_annotation_needed.rs
+++ b/tests/expected/function-contract/type_annotation_needed.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(result.is_some())]
+#[kani::ensures(|result| result.is_some())]
 fn or_default<T: Default>(opt: Option<T>) -> Option<T> {
     opt.or(Some(T::default()))
 }

--- a/tests/expected/function-contract/type_annotation_needed.rs
+++ b/tests/expected/function-contract/type_annotation_needed.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(|result| result.is_some())]
+#[kani::ensures(|result : Option<T>| result.is_some())]
 fn or_default<T: Default>(opt: Option<T>) -> Option<T> {
     opt.or(Some(T::default()))
 }

--- a/tests/std-checks/core/src/ptr.rs
+++ b/tests/std-checks/core/src/ptr.rs
@@ -9,8 +9,8 @@ pub mod contracts {
     use super::*;
     use kani::{ensures, implies, mem::*, modifies, requires};
 
-    #[ensures(implies!(ptr.is_null() => result.is_none()))]
-    #[ensures(implies!(!ptr.is_null() => result.is_some()))]
+    #[ensures(|result : &Option<NonNull<T>>| implies!(ptr.is_null() => result.is_none()))]
+    #[ensures(|result : &Option<NonNull<T>>| implies!(!ptr.is_null() => result.is_some()))]
     pub fn new<T>(ptr: *mut T) -> Option<NonNull<T>> {
         NonNull::new(ptr)
     }


### PR DESCRIPTION
This change now separates the front facing "result" name and the internal facing "result_kani_internal" ident where the user can specify with the keyword "result" but then the system replaces this with the internal representation.

If the user chooses to use a different variable name than result, this now supports the syntax of
`#[kani::ensures(|result_var| expr)]`
where result_var can be any arbitrary name.

For example, the following test now works:
```
#[kani::ensures(|banana : &u32| *banana == a.wrapping_add(b))]
fn simple_addition(a: u32, b: u32) -> u32 {
    return a.wrapping_add(b);
}
```

In addition, the string "result_kani_internal" is now a global constant and can be updated in a single place if needed.

Resolves #2597 since the user can specify the variable name they want within the ensures binding

An important change is that the result is now a pass by reference instead, so as in the example an `&u32` instead of `u32`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
