### PR TITLE
Fix `{,e}println!()`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -135,14 +135,14 @@ macro_rules! eprint {
 #[cfg(not(feature = "concrete_playback"))]
 #[macro_export]
 macro_rules! println {
-    () => { };
+    () => { $crate::print!("\n") };
     ($($x:tt)*) => {{ let _ = format_args!($($x)*); }};
 }
 
 #[cfg(not(feature = "concrete_playback"))]
 #[macro_export]
 macro_rules! eprintln {
-    () => { };
+    () => { $crate::eprint!("\n") };
     ($($x:tt)*) => {{ let _ = format_args!($($x)*); }};
 }
 

--- a/tests/kani/Print/no_semicolon.rs
+++ b/tests/kani/Print/no_semicolon.rs
@@ -1,0 +1,17 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// This test checks that the (e)println with no arguments do not require a trailing semicolon
+
+fn println() {
+    println!()
+}
+fn eprintln() {
+    eprintln!()
+}
+
+#[kani::proof]
+fn main() {
+    println();
+    eprintln();
+}


### PR DESCRIPTION
GitHub closed the previous PR (#3205) after I renamed a branch, hooray.

Change the implementation of `println!` & `eprintln!` with no arguments to call `print!("\n")`
 & `eprint!("\n")` respectively instead of producing no tokens. This is what std does. [^println][^eprintln]

 
[^println]: https://github.com/rust-lang/rust/blob/8c127df75fde3d5ad8ef9af664962a7676288b52/library/std/src/macros.rs#L140
[^eprintln]: https://github.com/rust-lang/rust/blob/8c127df75fde3d5ad8ef9af664962a7676288b52/library/std/src/macros.rs#L218

Resolves #3204.

A test included, as per https://github.com/model-checking/kani/pull/3205#issuecomment-2135702685
