### PR TITLE
Upgrade Rust toolchain nightly-2024-05-27 

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -699,7 +699,7 @@ impl<'tcx> GotocCtx<'tcx> {
                             data_cast
                         } else {
                             let vtable_expr =
-                                meta.member("vtable_ptr", &self.symbol_table).cast_to(
+                                meta.member("_vtable_ptr", &self.symbol_table).cast_to(
                                     typ.lookup_field_type("vtable", &self.symbol_table).unwrap(),
                                 );
                             dynamic_fat_ptr(typ, data_cast, vtable_expr, &self.symbol_table)

--- a/kani-compiler/src/kani_middle/resolve.rs
+++ b/kani-compiler/src/kani_middle/resolve.rs
@@ -247,7 +247,7 @@ where
 /// Resolves an external crate name.
 fn resolve_external(tcx: TyCtxt, name: &str) -> Option<DefId> {
     debug!(?name, "resolve_external");
-    tcx.crates(()).iter().find_map(|crate_num| {
+    tcx.used_crates(()).iter().find_map(|crate_num| {
         let crate_name = tcx.crate_name(*crate_num);
         if crate_name.as_str() == name {
             Some(DefId { index: CRATE_DEF_INDEX, krate: *crate_num })

--- a/kani-compiler/src/main.rs
+++ b/kani-compiler/src/main.rs
@@ -10,7 +10,6 @@
 #![recursion_limit = "256"]
 #![feature(box_patterns)]
 #![feature(rustc_private)]
-#![feature(lazy_cell)]
 #![feature(more_qualified_paths)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-05-23"
+channel = "nightly-2024-05-24"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-05-24"
+channel = "nightly-2024-05-27"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
`lazy_cell` became stable: https://github.com/rust-lang/rust/pull/121377.
`vtable_ptr` is renamed to `_vtable_ptr`: https://github.com/rust-lang/rust/commit/d83f3ca8ca.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
