### PR TITLE
Do not turn trivially diverging loops into assume(false)

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -183,6 +183,7 @@ impl KaniSession {
 
         if self.args.checks.unwinding_on() {
             args.push("--unwinding-assertions".into());
+            args.push("--no-self-loops-to-assumptions".into());
         }
 
         if self.args.extra_pointer_checks {

--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -182,6 +182,7 @@ impl KaniSession {
         }
 
         if self.args.checks.unwinding_on() {
+            // TODO: With CBMC v6 the below can be removed as those are defaults.
             args.push("--unwinding-assertions".into());
             args.push("--no-self-loops-to-assumptions".into());
         }

--- a/tests/expected/function-contract/diverging_loop.expected
+++ b/tests/expected/function-contract/diverging_loop.expected
@@ -1,0 +1,3 @@
+Failed Checks: unwinding assertion loop 0
+
+VERIFICATION:- FAILED

--- a/tests/expected/function-contract/diverging_loop.rs
+++ b/tests/expected/function-contract/diverging_loop.rs
@@ -1,0 +1,11 @@
+#[kani::ensures(result == 1)]
+fn foo() -> i32 {
+    loop {};
+    2
+}
+
+#[kani::proof_for_contract(foo)]
+#[kani::unwind(1)]
+fn check_foo() {
+    let _ = foo();
+}

--- a/tests/expected/function-contract/diverging_loop.rs
+++ b/tests/expected/function-contract/diverging_loop.rs
@@ -1,3 +1,7 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Zfunction-contracts
+
 #[kani::ensures(result == 1)]
 fn foo() -> i32 {
     loop {}

--- a/tests/expected/function-contract/diverging_loop.rs
+++ b/tests/expected/function-contract/diverging_loop.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-#[kani::ensures(result == 1)]
+#[kani::ensures(|result : &i32| *result == 1)]
 fn foo() -> i32 {
     loop {}
     2

--- a/tests/expected/function-contract/diverging_loop.rs
+++ b/tests/expected/function-contract/diverging_loop.rs
@@ -1,6 +1,6 @@
 #[kani::ensures(result == 1)]
 fn foo() -> i32 {
-    loop {};
+    loop {}
     2
 }
 


### PR DESCRIPTION
CBMC's symbolic execution by default turns `while(true) {}` loops into `assume(false)` to counter trivial non-termination of symbolic execution. When unwinding assertions are enabled, however, we should report the non-termination of such loops.

Resolves: #2909

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
