### PR TITLE
Bump Kani version to 0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,20 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
-## [0.51.0]
+## [0.52.0]
 
 ## What's Changed
+* New section about linter configuraton checking in the doc by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3198
+* Fix `{,e}println!()` by @GrigorenkoPV in https://github.com/model-checking/kani/pull/3209
+* Contracts for a few core functions by @celinval in https://github.com/model-checking/kani/pull/3107
+* Add simple API for shadow memory by @zhassan-aws in https://github.com/model-checking/kani/pull/3200
+* Upgrade Rust toolchain to 2024-05-28 by @zhassan-aws @remi-delmas-3000 @qinheping
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.51.0...kani-0.52.0
+
+## [0.51.0]
+
+### What's Changed
 
 * Do not assume that ZST-typed symbols refer to unique objects by @tautschnig in https://github.com/model-checking/kani/pull/3134
 * Remove `kani::Arbitrary` from the `modifies` contract instrumentation by @feliperodri in https://github.com/model-checking/kani/pull/3169

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "build-kani"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -405,14 +405,14 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "kani"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani-compiler"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "home",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "kani_macros"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -985,7 +985,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "std"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Updated version in all `Cargo.toml` files (via `find . -name Cargo.toml -exec sed -i 's/version = "0.51.0"/version = "0.52.0"/' {} \;`) and ran `cargo build-dev` to have `Cargo.lock` files updated.

GitHub generated release notes:

 ## What's Changed
* Bump tests/perf/s2n-quic from `6dd41e0` to `bd37960` by @dependabot in https://github.com/model-checking/kani/pull/3178
* Automatic cargo update to 2024-05-13 by @github-actions in https://github.com/model-checking/kani/pull/3177
* Upgrade toolchain to 2024-04-22 by @zhassan-aws in https://github.com/model-checking/kani/pull/3171
* Upgrade toolchain to 2024-05-14 by @zhassan-aws in https://github.com/model-checking/kani/pull/3183
* Automatic toolchain upgrade to nightly-2024-05-15 by @github-actions in https://github.com/model-checking/kani/pull/3185
* Include `--check-cfg=cfg(kani)` in the rust flags to avoid a warning about an unknown `cfg`. by @zhassan-aws in https://github.com/model-checking/kani/pull/3187
* Automatic toolchain upgrade to nightly-2024-05-16 by @github-actions in https://github.com/model-checking/kani/pull/3189
* Perform cargo update because of yanked libc version by @zhassan-aws in https://github.com/model-checking/kani/pull/3192
* Automatic toolchain upgrade to nightly-2024-05-17 by @github-actions in https://github.com/model-checking/kani/pull/3191
* Automatic cargo update to 2024-05-20 by @github-actions in https://github.com/model-checking/kani/pull/3195
* Bump tests/perf/s2n-quic from `bd37960` to `f5d9d74` by @dependabot in https://github.com/model-checking/kani/pull/3196
* New section about linter configuraton checking in the doc. by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3198
* Automatic cargo update to 2024-05-27 by @github-actions in https://github.com/model-checking/kani/pull/3201
* Bump tests/perf/s2n-quic from `f5d9d74` to `d03cc47` by @dependabot in https://github.com/model-checking/kani/pull/3202
* Update Rust toolchain from nightly-2024-05-17 to nightly-2024-05-23 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3199
* Fix `{,e}println!()` by @GrigorenkoPV in https://github.com/model-checking/kani/pull/3209
* Contracts for a few core functions by @celinval in https://github.com/model-checking/kani/pull/3107
* Don't crash benchcomp when rounding non-numeric values by @karkhaz in https://github.com/model-checking/kani/pull/3211
* Update Rust toolchain nightly-2024-05-24 by @qinheping in https://github.com/model-checking/kani/pull/3212
* Upgrade Rust toolchain nightly-2024-05-27  by @qinheping in https://github.com/model-checking/kani/pull/3215
* Automatic toolchain upgrade to nightly-2024-05-28 by @github-actions in https://github.com/model-checking/kani/pull/3217
* Automatic cargo update to 2024-06-03 by @github-actions in https://github.com/model-checking/kani/pull/3220
* Bump tests/perf/s2n-quic from `d03cc47` to `d90729d` by @dependabot in https://github.com/model-checking/kani/pull/3222
* Add simple API for shadow memory by @zhassan-aws in https://github.com/model-checking/kani/pull/3200

 ## New Contributors
* @GrigorenkoPV made their first contribution in https://github.com/model-checking/kani/pull/3209

**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.51.0...kani-0.52.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
