### PR TITLE
Add `kani_core` library placeholder and build logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kani_core"
+version = "0.51.0"
+dependencies = [
+ "kani_macros",
+]
+
+[[package]]
 name = "kani_macros"
 version = "0.51.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
   "kani-driver",
   "kani-compiler",
   "kani_metadata",
+  "library/kani_core",
 ]
 
 # This indicates what package to e.g. build with 'cargo build' without --workspace

--- a/library/kani_core/Cargo.toml
+++ b/library/kani_core/Cargo.toml
@@ -1,0 +1,11 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+[package]
+name = "kani_core"
+version = "0.51.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+kani_macros = { path = "../kani_macros", features = ["no_core"] }

--- a/library/kani_core/src/lib.rs
+++ b/library/kani_core/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This is placeholder for the new `kani_core` library.
+#![feature(no_core)]

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -19,4 +19,7 @@ syn = { version = "2.0.18", features = ["full", "visit-mut", "visit"] }
 
 [package.metadata.rust-analyzer]
 # This package uses rustc crates.
-rustc_private=true
+rustc_private = true
+
+[features]
+no_core = []

--- a/tools/build-kani/src/main.rs
+++ b/tools/build-kani/src/main.rs
@@ -19,7 +19,13 @@ fn main() -> Result<()> {
     let args = parser::ArgParser::parse();
 
     match args.subcommand {
-        parser::Commands::BuildDev(build_parser) => build_lib(&build_bin(&build_parser.args)?),
+        parser::Commands::BuildDev(build_parser) => {
+            let bin_folder = &build_bin(&build_parser.args)?;
+            if !build_parser.skip_libs {
+                build_lib(&bin_folder)?;
+            }
+            Ok(())
+        }
         parser::Commands::Bundle(bundle_parser) => {
             let version_string = bundle_parser.version;
             let kani_string = format!("kani-{version_string}");

--- a/tools/build-kani/src/parser.rs
+++ b/tools/build-kani/src/parser.rs
@@ -17,6 +17,10 @@ pub struct BuildDevParser {
     /// Arguments to be passed down to cargo when building cargo binaries.
     #[clap(value_name = "ARG", allow_hyphen_values = true)]
     pub args: Vec<String>,
+    /// Do not re-build Kani libraries. Only use this if you know there has been no changes to Kani
+    /// libraries or the underlying Rust compiler.
+    #[clap(long)]
+    pub skip_libs: bool,
 }
 
 #[derive(Args, Debug, Eq, PartialEq)]


### PR DESCRIPTION
While at it, I also added a `--skip-libs` to skip rebuilding the Kani libraries and standard library at every `cargo build-dev` execution.

We usually only need to rebuild the libraries when we make changes to them or when we update the Rust toolchain. Rebuilding them can be quite time consuming when you are making changes to Kani.

Towards #3226 #3153

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
