### PR TITLE
Remove empty box creation from contracts impl

### DIFF
--- a/library/kani/src/internal.rs
+++ b/library/kani/src/internal.rs
@@ -76,3 +76,17 @@ impl<'a, T> Pointer<'a> for *mut T {
 pub fn untracked_deref<T>(_: &T) -> T {
     todo!()
 }
+
+/// CBMC contracts currently has a limitation where `free` has to be in scope.
+/// However, if there is no dynamic allocation in the harness, slicing removes `free` from the
+/// scope.
+///
+/// Thus, this function will basically translate into:
+/// ```c
+/// // This is a no-op.
+/// free(NULL);
+/// ```
+#[inline(never)]
+#[doc(hidden)]
+#[rustc_diagnostic_item = "KaniInitContracts"]
+pub fn init_contracts() {}

--- a/library/kani_macros/src/sysroot/contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/contracts/mod.rs
@@ -288,7 +288,7 @@ pub fn proof_for_contract(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[kanitool::proof_for_contract = stringify!(#args)]
         #(#attrs)*
         #vis #sig {
-            let _ = std::boxed::Box::new(0_usize);
+            kani::internal::init_contracts();
             #block
         }
     )


### PR DESCRIPTION
There seems to be an issue in CBMC contracts implementation that it assumes that `free` must have a body. However, slicing can remove `free` body if the harness does not allocate anything.

We used to create an empty Box before to force `free` to be in scope. Instead, just invoke `free(NULL)` which is a no-op.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
