### PR TITLE
Contracts: Preventing "_renamed" from being visible to the user via reshadowing

### DIFF
--- a/library/kani_macros/src/sysroot/contracts/check.rs
+++ b/library/kani_macros/src/sysroot/contracts/check.rs
@@ -34,11 +34,13 @@ impl<'a> ContractConditionsHandler<'a> {
                 )
             }
             ContractConditionsData::Ensures { argument_names, attr } => {
-                let (arg_copies, copy_clean) = make_unsafe_argument_copies(&argument_names);
+                let (arg_copies, copy_rename, copy_clean) =
+                    make_unsafe_argument_copies(&argument_names);
 
                 // The code that enforces the postconditions and cleans up the shallow
                 // argument copies (with `mem::forget`).
                 let exec_postconditions = quote!(
+                    #copy_rename
                     kani::assert(#attr, stringify!(#attr_copy));
                     #copy_clean
                 );

--- a/library/kani_macros/src/sysroot/contracts/initialize.rs
+++ b/library/kani_macros/src/sysroot/contracts/initialize.rs
@@ -154,7 +154,4 @@ impl<'ast> Visit<'ast> for ArgumentIdentCollector {
         self.0.insert(i.ident.clone());
         syn::visit::visit_pat_ident(self, i)
     }
-    fn visit_receiver(&mut self, _: &'ast syn::Receiver) {
-        self.0.insert(Ident::new("self", proc_macro2::Span::call_site()));
-    }
 }

--- a/library/kani_macros/src/sysroot/contracts/replace.rs
+++ b/library/kani_macros/src/sysroot/contracts/replace.rs
@@ -80,12 +80,14 @@ impl<'a> ContractConditionsHandler<'a> {
                 )
             }
             ContractConditionsData::Ensures { attr, argument_names } => {
-                let (arg_copies, copy_clean) = make_unsafe_argument_copies(&argument_names);
+                let (arg_copies, copy_rename, copy_clean) =
+                    make_unsafe_argument_copies(&argument_names);
                 let result = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
                 quote!(
                     #arg_copies
                     #(#before)*
                     #(#after)*
+                    #copy_rename
                     kani::assume(#attr);
                     #copy_clean
                     #result

--- a/library/kani_macros/src/sysroot/contracts/shared.rs
+++ b/library/kani_macros/src/sysroot/contracts/shared.rs
@@ -82,10 +82,11 @@ pub fn make_unsafe_argument_copies(
     let also_also_arg_names = renaming_map.values();
     let arg_values = renaming_map.keys();
     let also_arg_values = renaming_map.keys();
+    let also_also_arg_values = renaming_map.keys();
     (
         quote!(#(let #arg_names = kani::internal::untracked_deref(&#arg_values);)*),
-        quote!(#(let #also_arg_values = #also_arg_names;)*),
-        quote!(#(std::mem::forget(#also_also_arg_names);)*),
+        quote!(#(let #also_arg_values = kani::internal::untracked_deref(&#also_arg_names);)*),
+        quote!(#(std::mem::forget(#also_also_arg_names); std::mem::forget(#also_also_arg_values);)*),
     )
 }
 

--- a/library/kani_macros/src/sysroot/contracts/shared.rs
+++ b/library/kani_macros/src/sysroot/contracts/shared.rs
@@ -73,16 +73,19 @@ pub fn identifier_for_generated_function(
 /// `requires` and `ensures` clauses and later clean them up.
 ///
 /// This function creates the code necessary to both make the copies (first
-/// tuple elem) and to clean them (second tuple elem).
+/// tuple elem), to rebind them (second tuple elem), and to clean them (third tuple elem).
 pub fn make_unsafe_argument_copies(
     renaming_map: &HashMap<Ident, Ident>,
-) -> (TokenStream2, TokenStream2) {
+) -> (TokenStream2, TokenStream2, TokenStream2) {
     let arg_names = renaming_map.values();
     let also_arg_names = renaming_map.values();
+    let also_also_arg_names = renaming_map.values();
     let arg_values = renaming_map.keys();
+    let also_arg_values = renaming_map.keys();
     (
         quote!(#(let #arg_names = kani::internal::untracked_deref(&#arg_values);)*),
-        quote!(#(std::mem::forget(#also_arg_names);)*),
+        quote!(#(let #also_arg_values = #also_arg_names;)*),
+        quote!(#(std::mem::forget(#also_also_arg_names);)*),
     )
 }
 


### PR DESCRIPTION
Currently, the ensures macro is expanded by taking the user provided expression and renaming all the function arguments to "arg_renamed". We attempt to hide the renaming by having the produced  kani::assert(renamed,"original") have the original version of the expression as a string for the error message.

However, this abstraction is occasionally broken when the "renamed" expression doesn't type check properly, and the error message propagated to the user features the renamed expression instead of the original one, causing the kind of confusion in #3026.

Instead of changing the input expression, it is possible to rebind the arguments back into their original form in the same way that they were renamed. This pull request introduce a new let binding to do so and remove the VisitMut that replaces the variables in the input expression.

Resolves #3026

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
