### PR TITLE
Function Contracts: remove instances of _renamed

### DIFF
--- a/library/kani_macros/src/sysroot/contracts/check.rs
+++ b/library/kani_macros/src/sysroot/contracts/check.rs
@@ -34,14 +34,12 @@ impl<'a> ContractConditionsHandler<'a> {
                 )
             }
             ContractConditionsData::Ensures { attr } => {
-                let (arg_copies, copy_clean, ensures_clause) =
-                    build_ensures(&self.annotated_fn.sig, attr);
+                let (remembers, ensures_clause) = build_ensures(attr);
 
                 // The code that enforces the postconditions and cleans up the shallow
                 // argument copies (with `mem::forget`).
                 let exec_postconditions = quote!(
                     kani::assert(#ensures_clause, stringify!(#attr_copy));
-                    #copy_clean
                 );
 
                 assert!(matches!(
@@ -52,7 +50,7 @@ impl<'a> ContractConditionsHandler<'a> {
 
                 let result = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
                 quote!(
-                    #arg_copies
+                    #remembers
                     #(#inner)*
                     #exec_postconditions
                     #result

--- a/library/kani_macros/src/sysroot/contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/contracts/mod.rs
@@ -242,8 +242,7 @@
 //! state. Each occurrence of `old` is lifted, so is is necessary that
 //! each lifted occurrence is closed with respect to the function arguments.
 //! The results of these old computations are placed into
-//! `remember_kani_internal_XXX` variables of incrementing index to avoid
-//! collisions of variable names. Consider the following example:
+//! `remember_kani_internal_XXX` variables which are hashed. Consider the following example:
 //!
 //! ```
 //! #[kani::ensures(|result| old(*ptr + 1) == *ptr)]
@@ -265,49 +264,72 @@
 //! This expands to
 //!
 //! ```
+//! #[kanitool::checked_with = "modify_recursion_wrapper_633496"]
+//! #[kanitool::replaced_with = "modify_replace_633496"]
+//! #[kanitool::inner_check = "modify_wrapper_633496"]
+//! fn modify(ptr: &mut u32) { { *ptr += 1; } }
+//! #[allow(dead_code, unused_variables, unused_mut)]
+//! #[kanitool::is_contract_generated(recursion_wrapper)]
+//! fn modify_recursion_wrapper_633496(arg0: &mut u32) {
+//!     static mut REENTRY: bool = false;
+//!     if unsafe { REENTRY } {
+//!             modify_replace_633496(arg0)
+//!         } else {
+//!            unsafe { REENTRY = true };
+//!            let result_kani_internal = modify_check_633496(arg0);
+//!            unsafe { REENTRY = false };
+//!            result_kani_internal
+//!        }
+//! }
 //! #[allow(dead_code, unused_variables, unused_mut)]
 //! #[kanitool::is_contract_generated(check)]
 //! fn modify_check_633496(ptr: &mut u32) {
 //!     let _wrapper_arg_1 =
 //!         unsafe { kani::internal::Pointer::decouple_lifetime(&ptr) };
 //!     kani::assume(*ptr < 100);
-//!     let remember_kani_internal_1 = *ptr + 1;
-//!     let ptr_renamed = kani::internal::untracked_deref(&ptr);
-//!     let remember_kani_internal_0 = *ptr + 1;
-//!     let ptr_renamed = kani::internal::untracked_deref(&ptr);
+//!     let remember_kani_internal_92cc419d8aca576c = *ptr + 1;
+//!     let remember_kani_internal_92cc419d8aca576c = *ptr + 1;
 //!     let result_kani_internal: () = modify_wrapper_633496(ptr, _wrapper_arg_1);
 //!     kani::assert((|result|
-//!                     (remember_kani_internal_0) ==
-//!                         *ptr_renamed)(&result_kani_internal),
+//!                     (remember_kani_internal_92cc419d8aca576c) ==
+//!                         *ptr)(&result_kani_internal),
 //!         "|result| old(*ptr + 1) == *ptr");
-//!     std::mem::forget(ptr_renamed);
 //!     kani::assert((|result|
-//!                     (remember_kani_internal_1) ==
-//!                         *ptr_renamed)(&result_kani_internal),
+//!                     (remember_kani_internal_92cc419d8aca576c) ==
+//!                         *ptr)(&result_kani_internal),
 //!         "|result| old(*ptr + 1) == *ptr");
-//!     std::mem::forget(ptr_renamed);
 //!     result_kani_internal
 //! }
 //! #[allow(dead_code, unused_variables, unused_mut)]
 //! #[kanitool::is_contract_generated(replace)]
 //! fn modify_replace_633496(ptr: &mut u32) {
 //!     kani::assert(*ptr < 100, "*ptr < 100");
-//!     let remember_kani_internal_1 = *ptr + 1;
-//!     let ptr_renamed = kani::internal::untracked_deref(&ptr);
-//!     let remember_kani_internal_0 = *ptr + 1;
-//!     let ptr_renamed = kani::internal::untracked_deref(&ptr);
+//!     let remember_kani_internal_92cc419d8aca576c = *ptr + 1;
+//!     let remember_kani_internal_92cc419d8aca576c = *ptr + 1;
 //!     let result_kani_internal: () = kani::any_modifies();
-//!     *unsafe { kani::internal::Pointer::assignable(ptr) } =
-//!         kani::any_modifies();
+//!     *unsafe {
+//!                 kani::internal::Pointer::assignable(kani::internal::untracked_deref(&(ptr)))
+//!             } = kani::any_modifies();
 //!     kani::assume((|result|
-//!                     (remember_kani_internal_0) ==
-//!                         *ptr_renamed)(&result_kani_internal));
-//!     std::mem::forget(ptr_renamed);
+//!                     (remember_kani_internal_92cc419d8aca576c) ==
+//!                         *ptr)(&result_kani_internal));
 //!     kani::assume((|result|
-//!                     (remember_kani_internal_1) ==
-//!                         *ptr_renamed)(&result_kani_internal));
-//!     std::mem::forget(ptr_renamed);
+//!                     (remember_kani_internal_92cc419d8aca576c) ==
+//!                         *ptr)(&result_kani_internal));
 //!     result_kani_internal
+//! }
+//! #[kanitool::modifies(_wrapper_arg_1)]
+//! #[allow(dead_code, unused_variables, unused_mut)]
+//! #[kanitool::is_contract_generated(wrapper)]
+//! fn modify_wrapper_633496<'_wrapper_arg_1,
+//!     WrapperArgType1>(ptr: &mut u32, _wrapper_arg_1: &WrapperArgType1) {
+//!     *ptr += 1;
+//! }
+//! #[allow(dead_code)]
+//! #[kanitool::proof_for_contract = "modify"]
+//! fn main() {
+//!     kani::internal::init_contracts();
+//!     { let mut i = kani::any(); modify(&mut i); }
 //! }
 //! ```
 

--- a/library/kani_macros/src/sysroot/contracts/replace.rs
+++ b/library/kani_macros/src/sysroot/contracts/replace.rs
@@ -80,15 +80,13 @@ impl<'a> ContractConditionsHandler<'a> {
                 )
             }
             ContractConditionsData::Ensures { attr } => {
-                let (arg_copies, copy_clean, ensures_clause) =
-                    build_ensures(&self.annotated_fn.sig, attr);
+                let (remembers, ensures_clause) = build_ensures(attr);
                 let result = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
                 quote!(
-                    #arg_copies
+                    #remembers
                     #(#before)*
                     #(#after)*
                     kani::assume(#ensures_clause);
-                    #copy_clean
                     #result
                 )
             }
@@ -96,7 +94,7 @@ impl<'a> ContractConditionsHandler<'a> {
                 let result = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
                 quote!(
                     #(#before)*
-                    #(*unsafe { kani::internal::Pointer::assignable(#attr) } = kani::any_modifies();)*
+                    #(*unsafe { kani::internal::Pointer::assignable(kani::internal::untracked_deref(&(#attr))) } = kani::any_modifies();)*
                     #(#after)*
                     #result
                 )

--- a/tests/expected/function-contract/modifies/field_replace_pass.rs
+++ b/tests/expected/function-contract/modifies/field_replace_pass.rs
@@ -9,7 +9,7 @@ struct S<'a> {
 #[kani::requires(*s.target < 100)]
 #[kani::modifies(s.target)]
 #[kani::ensures(|result| *s.target == prior + 1)]
-fn modify(s: S, prior: u32) {
+fn modify(s: &mut S, prior: u32) {
     *s.target += 1;
 }
 
@@ -20,8 +20,8 @@ fn main() {
     let i_copy = i;
     let mut distraction = kani::any();
     let distraction_copy = distraction;
-    let s = S { distraction: &mut distraction, target: &mut i };
-    modify(s, i_copy);
+    let mut s = S { distraction: &mut distraction, target: &mut i };
+    modify(&mut s, i_copy);
     kani::assert(i == i_copy + 1, "Increment");
     kani::assert(distraction == distraction_copy, "Unchanged");
 }


### PR DESCRIPTION
The current method for creating the modifies wrapper requires changing the `ensures` clause to have `_renamed` variables which are unsafe copies of the original function arguments. This causes issues with regards to some possible tests as in #3239.

This change removes the `_renamed` variables and instead simply changes the modifies clauses within the replace to unsafely dereference the pointer to modify the contents of it unsafely, condensing all instances of unsafe Rust into a single location.

Resolves #3239
Resolves #3026
May affect #3027. In my attempt to run this example with slight modification to fit the current implementation, I got the error `CBMC appears to have run out of memory. You may want to rerun your proof in an environment with additional memory or use stubbing to reduce the size of the code the verifier reasons about.` This suggests that the compilation is working appropriately but the test case is just too large for CBMC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
