### PR TITLE
Add tests checking if Kani detects dangling pointer dereference inside println macro

### DIFF
--- a/tests/expected/dangling-ptr-println/main.expected
+++ b/tests/expected/dangling-ptr-println/main.expected
@@ -1,0 +1,29 @@
+Checking harness unsafe_block...
+
+Status: FAILURE\
+Description: "dereference failure: pointer invalid"\
+in function unsafe_block
+
+VERIFICATION:- FAILED
+
+Checking harness general_unsafe...
+
+Status: FAILURE\
+Description: "dereference failure: pointer invalid"\
+in function general_unsafe
+
+VERIFICATION:- FAILED
+
+Checking harness local_unsafe...
+
+Status: FAILURE\
+Description: "dereference failure: dead object"\
+in function local_unsafe
+
+VERIFICATION:- FAILED
+
+Summary:
+Verification failed for - unsafe_block
+Verification failed for - general_unsafe
+Verification failed for - local_unsafe
+Complete - 0 successfully verified harnesses, 3 failures, 3 total.

--- a/tests/expected/dangling-ptr-println/main.rs
+++ b/tests/expected/dangling-ptr-println/main.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Z ptr-to-ref-cast-checks
 
-// These tests check that Kani correctly detects dangling pointer dereference inside println macro.
+//! These tests check that Kani correctly detects dangling pointer dereference inside println macro.
+//! Related issue: <https://github.com/model-checking/kani/issues/3235>.
 
 fn reference_dies() -> *mut i32 {
     let mut x: i32 = 2;

--- a/tests/expected/dangling-ptr-println/main.rs
+++ b/tests/expected/dangling-ptr-println/main.rs
@@ -1,0 +1,30 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z ptr-to-ref-cast-checks
+
+// These tests check that Kani correctly detects dangling pointer dereference inside println macro.
+
+fn reference_dies() -> *mut i32 {
+    let mut x: i32 = 2;
+    &mut x as *mut i32
+}
+
+#[kani::proof]
+fn local_unsafe() {
+    let x = reference_dies();
+    println!("My pointer, {}", unsafe { *x });
+}
+
+#[kani::proof]
+unsafe fn general_unsafe() {
+    let x = reference_dies();
+    println!("My pointer, {}", *x);
+}
+
+#[kani::proof]
+fn unsafe_block() {
+    let x = reference_dies();
+    unsafe {
+        println!("{}", *x);
+    }
+}


### PR DESCRIPTION
Extract tests from the discussion in #3235.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
