### PR TITLE
C library: declare malloc

### DIFF
--- a/library/kani/kani_lib.c
+++ b/library/kani/kani_lib.c
@@ -8,6 +8,7 @@
 void  free(void *ptr);
 void *memcpy(void *dst, const void *src, size_t n);
 void *calloc(size_t nmemb, size_t size);
+void *malloc(size_t size);
 
 typedef __CPROVER_bool bool;
 


### PR DESCRIPTION
In #1812 we removed standard library includes and instead provided forward declarations of `free`, `calloc`, and `memcpy` -- but seemingly forgot to include `malloc`, which we also use.

This avoids a warning seen when dialling up `goto-cc` verbosity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
