### PR TITLE
CI: Allow use of `node16` for release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   RUST_BACKTRACE: 1
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   build_bundle_macos:


### PR DESCRIPTION
actions/checkout@v3 is causing trouble in the `BuildBundle-Linux` workflow as described in #3321 .

This PR sets `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` to continue using `node16` so we don't find issues with `node20` dependencies in `ubuntu-18.04` jobs. This is the option recommended in this GitHub post: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Resolves #3321 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
