### PR TITLE
Mitigate invalid `transmute` when checking memory initialization

### DIFF
--- a/kani-compiler/src/kani_middle/transform/check_uninit/uninit_visitor.rs
+++ b/kani-compiler/src/kani_middle/transform/check_uninit/uninit_visitor.rs
@@ -595,15 +595,13 @@ impl<'a> MirVisitor for CheckUninitVisitor<'a> {
                                 reason: "Kani does not support reasoning about memory initialization in presence of mutable raw pointer casts that could cause delayed UB.".to_string(),
                             });
                         }
-                    } else {
-                        if !tys_layout_compatible(&operand_ty, &ty) {
-                            // If transmuting between two types of incompatible layouts, padding
-                            // bytes are exposed, which is UB.
-                            self.push_target(MemoryInitOp::Unsupported {
-                                reason: "Transmuting between types of incompatible layouts."
-                                    .to_string(),
-                            });
-                        }
+                    } else if !tys_layout_compatible(&operand_ty, &ty) {
+                        // If transmuting between two types of incompatible layouts, padding
+                        // bytes are exposed, which is UB.
+                        self.push_target(MemoryInitOp::Unsupported {
+                            reason: "Transmuting between types of incompatible layouts."
+                                .to_string(),
+                        });
                     }
                 }
                 _ => {}

--- a/tests/expected/uninit/delayed-ub-transmute/delayed-ub-transmute.rs
+++ b/tests/expected/uninit/delayed-ub-transmute/delayed-ub-transmute.rs
@@ -1,0 +1,14 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z uninit-checks
+
+/// Checks that Kani rejects mutable pointer casts between types of different padding.
+#[kani::proof]
+fn invalid_value() {
+    unsafe {
+        let mut value: u128 = 0;
+        let ptr: *mut (u8, u32, u64) = std::mem::transmute(&mut value as *mut _);
+        *ptr = (4, 4, 4); // This assignment itself does not cause UB...
+        let c: u128 = value; // ...but this reads a padding value!
+    }
+}

--- a/tests/expected/uninit/delayed-ub-transmute/expected
+++ b/tests/expected/uninit/delayed-ub-transmute/expected
@@ -1,0 +1,5 @@
+Failed Checks: Kani does not support reasoning about memory initialization in presence of mutable raw pointer casts that could cause delayed UB.
+
+VERIFICATION:- FAILED
+
+Complete - 0 successfully verified harnesses, 1 failures, 1 total.

--- a/tests/expected/uninit/transmute-padding/expected
+++ b/tests/expected/uninit/transmute-padding/expected
@@ -1,0 +1,5 @@
+Failed Checks: Transmuting between types of incompatible layouts.
+
+VERIFICATION:- FAILED
+
+Complete - 0 successfully verified harnesses, 1 failures, 1 total.

--- a/tests/expected/uninit/transmute-padding/transmute_padding.rs
+++ b/tests/expected/uninit/transmute-padding/transmute_padding.rs
@@ -1,0 +1,19 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z uninit-checks
+
+// 5 bytes of data + 3 bytes of padding.
+#[repr(C)]
+#[derive(kani::Arbitrary)]
+struct S(u32, u8);
+
+/// Checks that Kani catches an attempt to access padding of a struct using raw pointers.
+#[kani::proof]
+fn check_uninit_padding() {
+    let s = kani::any();
+    access_padding(s);
+}
+
+fn access_padding(s: S) {
+    let _padding: u64 = unsafe { std::mem::transmute(s) }; // ~ERROR: padding bytes are uninitialized, so reading them is UB.
+}

--- a/tests/expected/uninit/transmute-padding/transmute_padding.rs
+++ b/tests/expected/uninit/transmute-padding/transmute_padding.rs
@@ -7,7 +7,7 @@
 #[derive(kani::Arbitrary)]
 struct S(u32, u8);
 
-/// Checks that Kani catches an attempt to access padding of a struct using raw pointers.
+/// Checks that Kani catches an attempt to access padding of a struct using transmute.
 #[kani::proof]
 fn check_uninit_padding() {
     let s = kani::any();


### PR DESCRIPTION
This PR addresses another aspect of #3324, where delayed UB could be caused by transmuting a mutable pointer into the one of incompatible padding. It also adds a check to error whenever transmuting between two types of incompatible padding:

```rust
// 5 bytes of data + 3 bytes of padding.
#[repr(C)]
#[derive(kani::Arbitrary)]
struct S(u32, u8);

/// Checks that Kani catches an attempt to access padding of a struct using transmute.
#[kani::proof]
fn check_uninit_padding() {
    let s = kani::any();
    access_padding(s);
}

fn access_padding(s: S) {
    let _padding: u64 = unsafe { std::mem::transmute(s) }; // ~ERROR: padding bytes are uninitialized, so reading them is UB.
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
