### PR TITLE
Bump CBMC Viewer to 3.9

### DIFF
--- a/kani-dependencies
+++ b/kani-dependencies
@@ -4,7 +4,7 @@ CBMC_VERSION="5.95.1"
 
 # If you update this version number, remember to bump it in `src/setup.rs` too
 CBMC_VIEWER_MAJOR="3"
-CBMC_VIEWER_MINOR="8"
-CBMC_VIEWER_VERSION="3.8"
+CBMC_VIEWER_MINOR="9"
+CBMC_VIEWER_VERSION="3.9"
 
 KISSAT_VERSION="3.1.1"

--- a/scripts/setup/macos/install_deps.sh
+++ b/scripts/setup/macos/install_deps.sh
@@ -4,10 +4,10 @@
 
 set -eux
 
-# Github promises weekly build image updates, so we can skip the update step and
+# Github promises weekly build image updates, so we could skip the update step and
 # worst case we should only be 1-2 weeks behind upstream brew.
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
-#brew update
+brew update
 
 # Install Python separately to workround recurring homebrew CI issue.
 # See https://github.com/actions/runner-images/issues/9471 for more details.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -189,7 +189,7 @@ fn setup_python_deps(kani_dir: &Path) -> Result<()> {
     let pyroot = kani_dir.join("pyroot");
 
     // TODO: this is a repetition of versions from kani/kani-dependencies
-    let pkg_versions = &["cbmc-viewer==3.8"];
+    let pkg_versions = &["cbmc-viewer==3.9"];
 
     Command::new("python3")
         .args(["-m", "pip", "install", "--target"])


### PR DESCRIPTION
This is in preparation of updating to CBMC 6, which emits some properties in ways that CBMC Viewer 3.8 did not adequately parse.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
