### PR TITLE
Import apply_closure into kani_core

### DIFF
--- a/library/kani_core/src/lib.rs
+++ b/library/kani_core/src/lib.rs
@@ -384,6 +384,13 @@ macro_rules! kani_intrinsics {
             #[doc(hidden)]
             #[rustc_diagnostic_item = "KaniInitContracts"]
             pub fn init_contracts() {}
+
+            /// This should only be used within contracts. The intent is to
+            /// perform type inference on a closure's argument
+            #[doc(hidden)]
+            pub fn apply_closure<T, U: Fn(&T) -> bool>(f: U, x: &T) -> bool {
+                f(x)
+            }
         }
     };
 }


### PR DESCRIPTION
This enables use of `|result|` when verifying the standard library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
