### PR TITLE
Prepare CBMC v6+ build on Ubuntu 18.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,10 +104,14 @@ jobs:
           apt-get install -y software-properties-common apt-utils
           add-apt-repository ppa:git-core/ppa
           add-apt-repository ppa:deadsnakes/ppa
+          add-apt-repository ppa:ubuntu-toolchain-r/test
           apt-get update
           apt-get install -y \
-            build-essential bash-completion curl lsb-release sudo g++ gcc flex \
+            build-essential bash-completion curl lsb-release sudo g++-9 gcc-9 flex \
             bison make patch git python3.7 python3.7-dev python3.7-distutils
+          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 110 \
+            --slave /usr/bin/g++ g++ /usr/bin/g++-9
+          ln -sf cpp-9 /usr/bin/cpp
           update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
           curl -s https://bootstrap.pypa.io/pip/3.7/get-pip.py -o get-pip.py
           python3 get-pip.py --force-reinstall

--- a/scripts/setup/ubuntu/install_cbmc.sh
+++ b/scripts/setup/ubuntu/install_cbmc.sh
@@ -42,7 +42,8 @@ pushd "${WORK_DIR}"
 mkdir build
 git submodule update --init
 
-cmake -S . -Bbuild -DWITH_JBMC=OFF -Dsat_impl="minisat2;cadical"
+cmake -S . -Bbuild -DWITH_JBMC=OFF -Dsat_impl="minisat2;cadical" \
+  -DBUILD_SHARED_LIBS=OFF -DCMAKE_EXE_LINKER_FLAGS=-static
 make -C build -j$(nproc)
 cpack -G DEB --config build/CPackConfig.cmake
 sudo dpkg -i ./cbmc-*.deb


### PR DESCRIPTION
Use PPA with GCC-9 to build CBMC v6+ on Ubuntu 18.04 (to have full C++17 support) and build static binaries so that they can still be used on systems that might have libstdc++ from said PPA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
