### PR TITLE
Add missing functionalities to kani_core

### DIFF
--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -7,11 +7,10 @@
 // Used for rustc_diagnostic_item.
 // Note: We could use a kanitool attribute instead.
 #![feature(rustc_attrs)]
-// This is required for the optimized version of `any_array()`
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
 // Used to model simd.
 #![feature(repr_simd)]
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
 // Features used for tests only.
 #![cfg_attr(test, feature(core_intrinsics, portable_simd))]
 // Required for `rustc_diagnostic_item` and `core_intrinsics`
@@ -20,6 +19,9 @@
 #![feature(ptr_metadata)]
 #![feature(f16)]
 #![feature(f128)]
+
+// Allow us to use `kani::` to access crate features.
+extern crate self as kani;
 
 pub mod arbitrary;
 #[cfg(feature = "concrete_playback")]
@@ -48,6 +50,7 @@ pub use invariant::Invariant;
 pub fn concrete_playback_run<F: Fn()>(_: Vec<Vec<u8>>, _: F) {
     unreachable!("Concrete playback does not work during verification")
 }
+
 pub use futures::{block_on, block_on_with_spawn, spawn, yield_now, RoundRobin};
 
 /// Creates an assumption that will be valid after this statement run. Note that the assumption
@@ -246,21 +249,21 @@ pub fn any_where<T: Arbitrary, F: FnOnce(&T) -> bool>(f: F) -> T {
 /// Note that SIZE_T must be equal the size of type T in bytes.
 #[inline(never)]
 #[cfg(not(feature = "concrete_playback"))]
-pub(crate) unsafe fn any_raw_internal<T, const SIZE_T: usize>() -> T {
+pub(crate) unsafe fn any_raw_internal<T: Copy>() -> T {
     any_raw_inner::<T>()
 }
 
 #[inline(never)]
 #[cfg(feature = "concrete_playback")]
-pub(crate) unsafe fn any_raw_internal<T, const SIZE_T: usize>() -> T {
-    concrete_playback::any_raw_internal::<T, SIZE_T>()
+pub(crate) unsafe fn any_raw_internal<T: Copy>() -> T {
+    concrete_playback::any_raw_internal::<T>()
 }
 
 /// This low-level function returns nondet bytes of size T.
 #[rustc_diagnostic_item = "KaniAnyRaw"]
 #[inline(never)]
 #[allow(dead_code)]
-fn any_raw_inner<T>() -> T {
+fn any_raw_inner<T: Copy>() -> T {
     kani_intrinsic()
 }
 

--- a/library/kani/src/vec.rs
+++ b/library/kani/src/vec.rs
@@ -6,7 +6,6 @@ use crate::{any, any_where, Arbitrary};
 pub fn any_vec<T, const MAX_LENGTH: usize>() -> Vec<T>
 where
     T: Arbitrary,
-    [(); std::mem::size_of::<[T; MAX_LENGTH]>()]:,
 {
     let real_length: usize = any_where(|sz| *sz <= MAX_LENGTH);
     match real_length {
@@ -26,7 +25,6 @@ where
 pub fn exact_vec<T, const EXACT_LENGTH: usize>() -> Vec<T>
 where
     T: Arbitrary,
-    [(); std::mem::size_of::<[T; EXACT_LENGTH]>()]:,
 {
     let boxed_array: Box<[T; EXACT_LENGTH]> = Box::new(any());
     <[T]>::into_vec(boxed_array)

--- a/library/kani_core/src/lib.rs
+++ b/library/kani_core/src/lib.rs
@@ -60,6 +60,7 @@ macro_rules! kani_lib {
 /// such as core in rust's std library itself.
 ///
 /// TODO: Use this inside kani library so that we dont have to maintain two copies of the same intrinsics.
+#[allow(clippy::crate_in_macro_def)]
 #[macro_export]
 macro_rules! kani_intrinsics {
     ($core:tt) => {
@@ -180,7 +181,7 @@ macro_rules! kani_intrinsics {
         /// under all possible `NonZeroU8` input values, i.e., all possible `u8` values except zero.
         ///
         /// ```rust
-        /// let inputA = kani::any::<std::num::NonZeroU8>();
+        /// let inputA = kani::any::<core::num::NonZeroU8>();
         /// fn_under_verification(inputA);
         /// ```
         ///
@@ -247,21 +248,21 @@ macro_rules! kani_intrinsics {
         /// Note that SIZE_T must be equal the size of type T in bytes.
         #[inline(never)]
         #[cfg(not(feature = "concrete_playback"))]
-        pub(crate) unsafe fn any_raw_internal<T, const SIZE_T: usize>() -> T {
+        pub(crate) unsafe fn any_raw_internal<T: Copy>() -> T {
             any_raw_inner::<T>()
         }
 
         #[inline(never)]
         #[cfg(feature = "concrete_playback")]
-        pub(crate) unsafe fn any_raw_internal<T, const SIZE_T: usize>() -> T {
-            concrete_playback::any_raw_internal::<T, SIZE_T>()
+        pub(crate) unsafe fn any_raw_internal<T: Copy>() -> T {
+            concrete_playback::any_raw_internal::<T>()
         }
 
         /// This low-level function returns nondet bytes of size T.
         #[rustc_diagnostic_item = "KaniAnyRaw"]
         #[inline(never)]
         #[allow(dead_code)]
-        pub fn any_raw_inner<T>() -> T {
+        pub fn any_raw_inner<T: Copy>() -> T {
             kani_intrinsic()
         }
 
@@ -269,7 +270,7 @@ macro_rules! kani_intrinsics {
         /// supported by Kani display.
         ///
         /// During verification this will get replaced by `assert(false)`. For concrete executions, we just
-        /// invoke the regular `std::panic!()` function. This function is used by our standard library
+        /// invoke the regular `core::panic!()` function. This function is used by our standard library
         /// overrides, but not the other way around.
         #[inline(never)]
         #[rustc_diagnostic_item = "KaniPanic"]
@@ -294,6 +295,8 @@ macro_rules! kani_intrinsics {
         }
 
         pub mod internal {
+            use crate::kani::Arbitrary;
+            use core::ptr;
 
             /// Helper trait for code generation for `modifies` contracts.
             ///
@@ -301,7 +304,7 @@ macro_rules! kani_intrinsics {
             #[doc(hidden)]
             pub trait Pointer<'a> {
                 /// Type of the pointed-to data
-                type Inner;
+                type Inner: ?Sized;
 
                 /// Used for checking assigns contracts where we pass immutable references to the function.
                 ///
@@ -309,56 +312,52 @@ macro_rules! kani_intrinsics {
                 /// argument, for instance one of type `&mut _`, in the `modifies` clause which would move it.
                 unsafe fn decouple_lifetime(&self) -> &'a Self::Inner;
 
-                /// used for havocking on replecement of a `modifies` clause.
-                unsafe fn assignable(self) -> &'a mut Self::Inner;
+                unsafe fn assignable(self) -> *mut Self::Inner;
             }
 
-            impl<'a, 'b, T> Pointer<'a> for &'b T {
+            impl<'a, 'b, T: ?Sized> Pointer<'a> for &'b T {
                 type Inner = T;
                 unsafe fn decouple_lifetime(&self) -> &'a Self::Inner {
-                    $core::mem::transmute(*self)
+                    core::mem::transmute(*self)
                 }
 
-                #[allow(clippy::transmute_ptr_to_ref)]
-                unsafe fn assignable(self) -> &'a mut Self::Inner {
-                    $core::mem::transmute(self as *const T)
+                unsafe fn assignable(self) -> *mut Self::Inner {
+                    core::mem::transmute(self as *const T)
                 }
             }
 
-            impl<'a, 'b, T> Pointer<'a> for &'b mut T {
+            impl<'a, 'b, T: ?Sized> Pointer<'a> for &'b mut T {
                 type Inner = T;
 
                 #[allow(clippy::transmute_ptr_to_ref)]
                 unsafe fn decouple_lifetime(&self) -> &'a Self::Inner {
-                    $core::mem::transmute::<_, &&'a T>(self)
+                    core::mem::transmute::<_, &&'a T>(self)
                 }
 
-                unsafe fn assignable(self) -> &'a mut Self::Inner {
-                    $core::mem::transmute(self)
-                }
-            }
-
-            impl<'a, T> Pointer<'a> for *const T {
-                type Inner = T;
-                unsafe fn decouple_lifetime(&self) -> &'a Self::Inner {
-                    &**self as &'a T
-                }
-
-                #[allow(clippy::transmute_ptr_to_ref)]
-                unsafe fn assignable(self) -> &'a mut Self::Inner {
-                    $core::mem::transmute(self)
+                unsafe fn assignable(self) -> *mut Self::Inner {
+                    self as *mut T
                 }
             }
 
-            impl<'a, T> Pointer<'a> for *mut T {
+            impl<'a, T: ?Sized> Pointer<'a> for *const T {
                 type Inner = T;
                 unsafe fn decouple_lifetime(&self) -> &'a Self::Inner {
                     &**self as &'a T
                 }
 
-                #[allow(clippy::transmute_ptr_to_ref)]
-                unsafe fn assignable(self) -> &'a mut Self::Inner {
-                    $core::mem::transmute(self)
+                unsafe fn assignable(self) -> *mut Self::Inner {
+                    core::mem::transmute(self)
+                }
+            }
+
+            impl<'a, T: ?Sized> Pointer<'a> for *mut T {
+                type Inner = T;
+                unsafe fn decouple_lifetime(&self) -> &'a Self::Inner {
+                    &**self as &'a T
+                }
+
+                unsafe fn assignable(self) -> *mut Self::Inner {
+                    self
                 }
             }
 
@@ -390,6 +389,48 @@ macro_rules! kani_intrinsics {
             #[doc(hidden)]
             pub fn apply_closure<T, U: Fn(&T) -> bool>(f: U, x: &T) -> bool {
                 f(x)
+            }
+
+            /// Recieves a reference to a pointer-like object and assigns kani::any_modifies to that object.
+            /// Only for use within function contracts and will not be replaced if the recursive or function stub
+            /// replace contracts are not used.
+            #[rustc_diagnostic_item = "KaniWriteAny"]
+            #[inline(never)]
+            #[doc(hidden)]
+            pub unsafe fn write_any<T: ?Sized>(_pointer: *mut T) {
+                // This function should not be reacheable.
+                // Users must include `#[kani::recursion]` in any function contracts for recursive functions;
+                // otherwise, this might not be properly instantiate. We mark this as unreachable to make
+                // sure Kani doesn't report any false positives.
+                unreachable!()
+            }
+
+            /// Fill in a slice with kani::any.
+            /// Intended as a post compilation replacement for write_any
+            #[rustc_diagnostic_item = "KaniWriteAnySlice"]
+            #[inline(always)]
+            pub unsafe fn write_any_slice<T: Arbitrary>(slice: *mut [T]) {
+                (*slice).fill_with(T::any)
+            }
+
+            /// Fill in a pointer with kani::any.
+            /// Intended as a post compilation replacement for write_any
+            #[rustc_diagnostic_item = "KaniWriteAnySlim"]
+            #[inline(always)]
+            pub unsafe fn write_any_slim<T: Arbitrary>(pointer: *mut T) {
+                ptr::write(pointer, T::any())
+            }
+
+            /// Fill in a str with kani::any.
+            /// Intended as a post compilation replacement for write_any.
+            /// Not yet implemented
+            #[rustc_diagnostic_item = "KaniWriteAnyStr"]
+            #[inline(always)]
+            pub unsafe fn write_any_str(_s: *mut str) {
+                //TODO: strings introduce new UB
+                //(*s).as_bytes_mut().fill_with(u8::any)
+                //TODO: String validation
+                unimplemented!("Kani does not support creating arbitrary `str`")
             }
         }
     };

--- a/tests/script-based-pre/verify_std_cmd/verify_core.rs
+++ b/tests/script-based-pre/verify_std_cmd/verify_core.rs
@@ -1,0 +1,75 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+/// Dummy code that gets injected into `core` for basic tests for `verify-std` subcommand.
+#[cfg(kani)]
+kani_core::kani_lib!(core);
+
+#[cfg(kani)]
+#[unstable(feature = "kani", issue = "none")]
+pub mod verify {
+    use crate::kani;
+    use core::num::NonZeroU8;
+
+    #[kani::proof]
+    pub fn harness() {
+        kani::assert(true, "yay");
+    }
+
+    #[kani::proof_for_contract(fake_function)]
+    fn dummy_proof() {
+        fake_function(true);
+    }
+
+    /// Add a `rustc_diagnostic_item` to ensure this works.
+    /// See <https://github.com/model-checking/kani/issues/3251> for more details.
+    #[kani::requires(x == true)]
+    #[rustc_diagnostic_item = "fake_function"]
+    fn fake_function(x: bool) -> bool {
+        x
+    }
+
+    #[kani::proof_for_contract(dummy_read)]
+    fn check_dummy_read() {
+        let val: char = kani::any();
+        assert_eq!(unsafe { dummy_read(&val) }, val);
+    }
+
+    /// Ensure we can verify constant functions.
+    #[kani::requires(kani::mem::can_dereference(ptr))]
+    #[rustc_diagnostic_item = "dummy_read"]
+    const unsafe fn dummy_read<T: Copy>(ptr: *const T) -> T {
+        *ptr
+    }
+
+    #[kani::proof_for_contract(swap_tuple)]
+    fn check_swap_tuple() {
+        let initial: (char, NonZeroU8) = kani::any();
+        let _swapped = swap_tuple(initial);
+    }
+
+    #[kani::ensures(| result | result.0 == second && result.1 == first)]
+    fn swap_tuple((first, second): (char, NonZeroU8)) -> (NonZeroU8, char) {
+        (second, first)
+    }
+
+    #[kani::proof_for_contract(add_one)]
+    fn check_add_one() {
+        let mut initial: [u32; 4] = kani::any();
+        unsafe { add_one(&mut initial) };
+    }
+
+    /// Function with a more elaborated contract that uses `old` and `modifies`.
+    #[kani::modifies(inout)]
+    #[kani::requires(kani::mem::can_dereference(inout)
+    && unsafe { inout.as_ref_unchecked().iter().all(| i | * i < u32::MAX) })]
+    #[kani::requires(kani::mem::can_write(inout))]
+    #[kani::ensures(| result | {
+    let (orig, i) = old({
+    let i = kani::any_where(| i: & usize | * i < unsafe { inout.len() });
+    (unsafe { inout.as_ref_unchecked()[i] }, i)});
+    unsafe { inout.as_ref_unchecked()[i] > orig }
+    })]
+    unsafe fn add_one(inout: *mut [u32]) {
+        inout.as_mut_unchecked().iter_mut().for_each(|e| *e += 1)
+    }
+}

--- a/tests/script-based-pre/verify_std_cmd/verify_std.expected
+++ b/tests/script-based-pre/verify_std_cmd/verify_std.expected
@@ -9,7 +9,13 @@ VERIFICATION:- SUCCESSFUL
 Checking harness verify::check_dummy_read...
 VERIFICATION:- SUCCESSFUL
 
+Checking harness verify::check_add_one...
+VERIFICATION:- SUCCESSFUL
+
+Checking harness verify::check_swap_tuple...
+VERIFICATION:- SUCCESSFUL
+
 Checking harness num::verify::check_non_zero...
 VERIFICATION:- SUCCESSFUL
 
-Complete - 4 successfully verified harnesses, 0 failures, 4 total.
+Complete - 6 successfully verified harnesses, 0 failures, 6 total.

--- a/tests/script-based-pre/verify_std_cmd/verify_std.sh
+++ b/tests/script-based-pre/verify_std_cmd/verify_std.sh
@@ -21,47 +21,7 @@ STD_PATH="${SYSROOT}/lib/rustlib/src/rust/library"
 cp -r "${STD_PATH}" "${TMP_DIR}"
 
 # Insert a small harness in one of the standard library modules.
-CORE_CODE='
-#[cfg(kani)]
-kani_core::kani_lib!(core);
-
-#[cfg(kani)]
-#[unstable(feature = "kani", issue = "none")]
-pub mod verify {
-    use crate::kani;
-
-    #[kani::proof]
-    pub fn harness() {
-        kani::assert(true, "yay");
-    }
-
-    #[kani::proof_for_contract(fake_function)]
-    fn dummy_proof() {
-        fake_function(true);
-    }
-
-    /// Add a `rustc_diagnostic_item` to ensure this works.
-    /// See <https://github.com/model-checking/kani/issues/3251> for more details.
-    #[kani::requires(x == true)]
-    #[rustc_diagnostic_item = "fake_function"]
-    fn fake_function(x: bool) -> bool {
-        x
-    }
-
-    #[kani::proof_for_contract(dummy_read)]
-    fn check_dummy_read() {
-        let val: char = kani::any();
-        assert_eq!(unsafe { dummy_read(&val) }, val);
-    }
-
-    /// Ensure we can verify constant functions.
-    #[kani::requires(kani::mem::can_dereference(ptr))]
-    #[rustc_diagnostic_item = "dummy_read"]
-    const unsafe fn dummy_read<T: Copy>(ptr: *const T) -> T {
-        *ptr
-    }
-}
-'
+CORE_CODE=$(cat verify_core.rs)
 
 STD_CODE='
 #[cfg(kani)]


### PR DESCRIPTION
  - Add Arbitrary for array
  - Add Arbitrary for tuples
  - Add missing changes from modifies slices (#3295)

Note that for adding `any_array` I had to cleanup the unnecessary usage of constant parameters from `kani::any_raw`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
