### PR TITLE
Fix verify-std-check outcome check

### DIFF
--- a/.github/workflows/verify-std-check.yml
+++ b/.github/workflows/verify-std-check.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: kani
+          fetch-depth: 0
 
       - name: Setup Kani Dependencies
         uses: ./kani/.github/actions/setup
@@ -79,7 +80,7 @@ jobs:
             -Z mem-predicates -Z ptr-to-ref-cast-checks
 
       - name: Compare PR results
-        if: steps.check-head.outcome != 'success' && steps.check-head.output != github.check-base.output
+        if: steps.check-head.outcome != 'success' && steps.check-head.outcome != github.check-base.outcome
         run: |
           echo "New failure introduced by this change"
           exit 1

--- a/.github/workflows/verify-std-check.yml
+++ b/.github/workflows/verify-std-check.yml
@@ -80,8 +80,10 @@ jobs:
             -Z mem-predicates -Z ptr-to-ref-cast-checks
 
       - name: Compare PR results
-        if: steps.check-head.outcome != 'success' && steps.check-head.outcome != github.check-base.outcome
+        if: steps.check-head.outcome != 'success' && steps.check-head.outcome != steps.check-base.outcome
         run: |
           echo "New failure introduced by this change"
+          echo "HEAD: ${{ steps.check-head.outcome }}"
+          echo "BASE: ${{ steps.check-base.outcome }}"
           exit 1
 


### PR DESCRIPTION
It looks like I used `output` instead of `outcome` variable.

I noticed that [this PR](https://github.com/model-checking/kani/pull/3392) should've failed the workflow but it didn't because of this mistake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
