### PR TITLE
Reduce memory consumption of cell_stub.rs test

### DIFF
--- a/tests/expected/function-contract/interior-mutability/api/cell_stub.rs
+++ b/tests/expected/function-contract/interior-mutability/api/cell_stub.rs
@@ -1,6 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// kani-flags: -Zfunction-contracts
+// kani-flags: -Zfunction-contracts --solver minisat
 
 /// The objective of this test is to show that the contracts for double can be replaced as a stub within the contracts for quadruple.
 /// This shows that we can generate `kani::any()` for Cell.


### PR DESCRIPTION
With MiniSat the test takes 45 seconds instead of 30 seconds, but only consumes 5.5 GB of memory instead of 9 GB. This will hopefully fix CI failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
