### PR TITLE
Enable "Auto label" for merge-queue actions

### DIFF
--- a/.github/workflows/extra_jobs.yml
+++ b/.github/workflows/extra_jobs.yml
@@ -18,7 +18,9 @@
 # See <https://github.com/actions/labeler/issues/121> for more details.
 
 name: Kani Extra
-on: pull_request_target
+on:
+  pull_request_target:
+  merge_group:
 
 jobs:
   # Keep this job minimal since it requires extra permission


### PR DESCRIPTION
This will Fix merge-queue CI actions as this is a required CI action, but wasn't being run for jobs entering the queue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
