### PR TITLE
Toolchain auto-update: fix comment posting

### DIFF
--- a/.github/workflows/toolchain-upgrade.yml
+++ b/.github/workflows/toolchain-upgrade.yml
@@ -50,22 +50,21 @@ jobs:
 
       - name: Add debugging hints
         if: ${{ steps.create_pr.outputs.pull-request-number }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({
               issue_number: ${{ steps.create_pr.outputs.pull-request-number }},
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: >
-                This is an automatically generated pull request. If any of the CI checks fail,
+              body: `This is an automatically generated pull request. If any of the CI checks fail,
                 manual intervention is required. In such a case, review the changes at
                 https://github.com/rust-lang/rust from
                 https://github.com/rust-lang/rust/commit/${{ env.current_toolchain_hash }} up to
                 https://github.com/rust-lang/rust/commit/${{ env.next_toolchain_hash }}. The log
                 for this commit range is:
 
-                ${{ env.git_log }}
+                ${{ env.git_log }}`
             })
 
       - name: Create Issue


### PR DESCRIPTION
actions/github-script uses Javascript, so we need to use Javascript rather than YAML syntax in the body of the script. Also, update to version 7 to avoid deprecation warnings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
