### PR TITLE
Update toolchain to 2024-08-05

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -139,17 +139,6 @@ impl<'tcx> GotocCtx<'tcx> {
         sym
     }
 
-    // Generate a Symbol Expression representing a function variable from the MIR
-    pub fn gen_function_local_variable(
-        &mut self,
-        c: u64,
-        fname: &str,
-        t: Type,
-        loc: Location,
-    ) -> Symbol {
-        self.gen_stack_variable(c, fname, "var", t, loc)
-    }
-
     /// Given a counter `c` a function name `fname, and a prefix `prefix`, generates a new function local variable
     /// It is an error to reuse an existing `c`, `fname` `prefix` tuple.
     fn gen_stack_variable(

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/names.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/names.rs
@@ -45,10 +45,6 @@ impl<'tcx> GotocCtx<'tcx> {
         (name, base_name)
     }
 
-    pub fn initializer_fn_name(var_name: &str) -> String {
-        format!("{var_name}_init")
-    }
-
     /// The name for a tuple field
     pub fn tuple_fld_name(n: usize) -> String {
         format!("{n}")

--- a/kani-compiler/src/kani_middle/transform/body.rs
+++ b/kani-compiler/src/kani_middle/transform/body.rs
@@ -322,31 +322,6 @@ impl MutableBody {
         };
     }
 
-    /// Insert basic block before or after the source instruction and update `source` accordingly. If
-    /// `InsertPosition` is `InsertPosition::Before`, `source` will point to the same instruction as
-    /// before. If `InsertPosition` is `InsertPosition::After`, `source` will point to the
-    /// terminator of the newly inserted basic block.
-    pub fn insert_bb(
-        &mut self,
-        mut bb: BasicBlock,
-        source: &mut SourceInstruction,
-        position: InsertPosition,
-    ) {
-        // Splitting adds 1 block, so the added block index is len + 1;
-        let split_bb_idx = self.blocks().len();
-        let inserted_bb_idx = self.blocks().len() + 1;
-        // Update the terminator of the basic block to point at the remaining part of the split
-        // basic block.
-        let target = get_mut_target_ref(&mut bb.terminator);
-        *target = split_bb_idx;
-        let new_term = Terminator {
-            kind: TerminatorKind::Goto { target: inserted_bb_idx },
-            span: source.span(&self.blocks),
-        };
-        self.split_bb(source, position, new_term);
-        self.blocks.push(bb);
-    }
-
     pub fn insert_terminator(
         &mut self,
         source: &mut SourceInstruction,

--- a/kani-compiler/src/kani_middle/transform/body.rs
+++ b/kani-compiler/src/kani_middle/transform/body.rs
@@ -54,6 +54,11 @@ impl MutableBody {
         &self.locals
     }
 
+    #[allow(dead_code)]
+    pub fn arg_count(&self) -> usize {
+        self.arg_count
+    }
+
     /// Create a mutable body from the original MIR body.
     pub fn from(body: Body) -> Self {
         MutableBody {
@@ -326,6 +331,7 @@ impl MutableBody {
     /// `InsertPosition` is `InsertPosition::Before`, `source` will point to the same instruction as
     /// before. If `InsertPosition` is `InsertPosition::After`, `source` will point to the
     /// terminator of the newly inserted basic block.
+    #[allow(dead_code)]
     pub fn insert_bb(
         &mut self,
         mut bb: BasicBlock,

--- a/kani-compiler/src/kani_middle/transform/body.rs
+++ b/kani-compiler/src/kani_middle/transform/body.rs
@@ -17,9 +17,13 @@ pub struct MutableBody {
 
     /// Declarations of locals within the function.
     ///
-    /// The first local is the return value pointer, followed by locals for the function arguments,
-    /// followed by any user-declared variables and temporaries.
+    /// The first local is the return value pointer, followed by `arg_count`
+    /// locals for the function arguments, followed by any user-declared
+    /// variables and temporaries.
     locals: Vec<LocalDecl>,
+
+    /// The number of arguments this function takes.
+    arg_count: usize,
 
     /// Debug information pertaining to user variables, including captures.
     var_debug_info: Vec<VarDebugInfo>,
@@ -54,6 +58,7 @@ impl MutableBody {
     pub fn from(body: Body) -> Self {
         MutableBody {
             locals: body.locals().to_vec(),
+            arg_count: body.arg_locals().len(),
             spread_arg: body.spread_arg(),
             blocks: body.blocks,
             var_debug_info: body.var_debug_info,
@@ -63,7 +68,14 @@ impl MutableBody {
 
     /// Create the new body consuming this mutable body.
     pub fn into(self) -> Body {
-        Body::new(self.blocks, self.locals, self.var_debug_info, self.spread_arg, self.span)
+        Body::new(
+            self.blocks,
+            self.locals,
+            self.arg_count,
+            self.var_debug_info,
+            self.spread_arg,
+            self.span,
+        )
     }
 
     /// Add a new local to the body with the given attributes.

--- a/kani-compiler/src/kani_middle/transform/body.rs
+++ b/kani-compiler/src/kani_middle/transform/body.rs
@@ -322,6 +322,31 @@ impl MutableBody {
         };
     }
 
+    /// Insert basic block before or after the source instruction and update `source` accordingly. If
+    /// `InsertPosition` is `InsertPosition::Before`, `source` will point to the same instruction as
+    /// before. If `InsertPosition` is `InsertPosition::After`, `source` will point to the
+    /// terminator of the newly inserted basic block.
+    pub fn insert_bb(
+        &mut self,
+        mut bb: BasicBlock,
+        source: &mut SourceInstruction,
+        position: InsertPosition,
+    ) {
+        // Splitting adds 1 block, so the added block index is len + 1;
+        let split_bb_idx = self.blocks().len();
+        let inserted_bb_idx = self.blocks().len() + 1;
+        // Update the terminator of the basic block to point at the remaining part of the split
+        // basic block.
+        let target = get_mut_target_ref(&mut bb.terminator);
+        *target = split_bb_idx;
+        let new_term = Terminator {
+            kind: TerminatorKind::Goto { target: inserted_bb_idx },
+            span: source.span(&self.blocks),
+        };
+        self.split_bb(source, position, new_term);
+        self.blocks.push(bb);
+    }
+
     pub fn insert_terminator(
         &mut self,
         source: &mut SourceInstruction,

--- a/kani-compiler/src/kani_middle/transform/body.rs
+++ b/kani-compiler/src/kani_middle/transform/body.rs
@@ -17,13 +17,9 @@ pub struct MutableBody {
 
     /// Declarations of locals within the function.
     ///
-    /// The first local is the return value pointer, followed by `arg_count`
-    /// locals for the function arguments, followed by any user-declared
-    /// variables and temporaries.
+    /// The first local is the return value pointer, followed by locals for the function arguments,
+    /// followed by any user-declared variables and temporaries.
     locals: Vec<LocalDecl>,
-
-    /// The number of arguments this function takes.
-    arg_count: usize,
 
     /// Debug information pertaining to user variables, including captures.
     var_debug_info: Vec<VarDebugInfo>,
@@ -54,15 +50,10 @@ impl MutableBody {
         &self.locals
     }
 
-    pub fn arg_count(&self) -> usize {
-        self.arg_count
-    }
-
     /// Create a mutable body from the original MIR body.
     pub fn from(body: Body) -> Self {
         MutableBody {
             locals: body.locals().to_vec(),
-            arg_count: body.arg_locals().len(),
             spread_arg: body.spread_arg(),
             blocks: body.blocks,
             var_debug_info: body.var_debug_info,
@@ -72,14 +63,7 @@ impl MutableBody {
 
     /// Create the new body consuming this mutable body.
     pub fn into(self) -> Body {
-        Body::new(
-            self.blocks,
-            self.locals,
-            self.arg_count,
-            self.var_debug_info,
-            self.spread_arg,
-            self.span,
-        )
+        Body::new(self.blocks, self.locals, self.var_debug_info, self.spread_arg, self.span)
     }
 
     /// Add a new local to the body with the given attributes.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-08-03"
+channel = "nightly-2024-08-05"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
* Remove `gen_function_local_variable` and `initializer_fn_name`, the last uses of both of which were removed in #3305.
* Mark `arg_count`, which was introduced in #3363, as `allow(dead_code)` as it will soon be used.
* Mark `insert_bb`, which was introduced in #3382, as `allow(dead_code)` as it will soon be used.

The toolchain upgrade to 2024-08-04 includes several bugfixes to dead-code analysis in rustc, explaining why we the recent PRs as listed above weren't flagged before for introducing dead code.

Resolves: #3411

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
