### PR TITLE
Remove assigns clause for ZST pointers

### DIFF
--- a/tests/expected/function-contract/modifies/zst_pass.expected
+++ b/tests/expected/function-contract/modifies/zst_pass.expected
@@ -1,6 +1,5 @@
 .assertion\
 - Status: SUCCESS\
 - Description: "ptr NULL or writable up to size"\
-in function __CPROVER_contracts_car_set_insert
 
 VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/modifies/zst_pass.expected
+++ b/tests/expected/function-contract/modifies/zst_pass.expected
@@ -1,0 +1,6 @@
+.assertion\
+- Status: SUCCESS\
+- Description: "ptr NULL or writable up to size"\
+in function __CPROVER_contracts_car_set_insert
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/modifies/zst_pass.rs
+++ b/tests/expected/function-contract/modifies/zst_pass.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // kani-flags: -Zfunction-contracts
 
-// #[kani::requires(assert_valid_ptr(dst) && has_valid_value(dst))]
-#[kani::requires(true)]
 #[kani::modifies(dst)]
 pub unsafe fn replace<T>(dst: *mut T, src: T) -> T {
     std::ptr::replace(dst, src)

--- a/tests/expected/function-contract/modifies/zst_pass.rs
+++ b/tests/expected/function-contract/modifies/zst_pass.rs
@@ -1,0 +1,24 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Zfunction-contracts
+
+// #[kani::requires(assert_valid_ptr(dst) && has_valid_value(dst))]
+#[kani::requires(true)]
+#[kani::modifies(dst)]
+pub unsafe fn replace<T>(dst: *mut T, src: T) -> T {
+    std::ptr::replace(dst, src)
+}
+
+#[kani::proof_for_contract(replace)]
+pub fn check_replace_unit() {
+    check_replace_impl::<()>();
+}
+
+fn check_replace_impl<T: kani::Arbitrary + Eq + Clone>() {
+    let mut dst = T::any();
+    let orig = dst.clone();
+    let src = T::any();
+    let ret = unsafe { replace(&mut dst, src.clone()) };
+    assert_eq!(ret, orig);
+    assert_eq!(dst, src);
+}

--- a/tests/std-checks/core/mem.expected
+++ b/tests/std-checks/core/mem.expected
@@ -1,7 +1,3 @@
 Checking harness mem::verify::check_swap_unit...
 
-Failed Checks: ptr NULL or writable up to size
-
-Summary:
-Verification failed for - mem::verify::check_swap_unit
-Complete - 6 successfully verified harnesses, 1 failures, 7 total.
+Complete - 7 successfully verified harnesses, 0 failures, 7 total.

--- a/tests/std-checks/core/ptr.expected
+++ b/tests/std-checks/core/ptr.expected
@@ -1,4 +1,3 @@
 Summary:
-Verification failed for - ptr::verify::check_replace_unit
 Verification failed for - ptr::verify::check_as_ref_dangling
-Complete - 4 successfully verified harnesses, 2 failures, 6 total.
+Complete - 5 successfully verified harnesses, 1 failures, 6 total.

--- a/tests/std-checks/core/src/mem.rs
+++ b/tests/std-checks/core/src/mem.rs
@@ -48,8 +48,6 @@ mod verify {
         contracts::swap(&mut x, &mut y)
     }
 
-    /// FIX-ME: Modifies clause fail with pointer to ZST.
-    /// <https://github.com/model-checking/kani/issues/3181>
     #[kani::proof_for_contract(contracts::swap)]
     pub fn check_swap_unit() {
         let mut x: () = kani::any();

--- a/tests/std-checks/core/src/ptr.rs
+++ b/tests/std-checks/core/src/ptr.rs
@@ -89,8 +89,6 @@ mod verify {
         let _rf = unsafe { contracts::as_ref(&non_null) };
     }
 
-    /// FIX-ME: Modifies clause fail with pointer to ZST.
-    /// <https://github.com/model-checking/kani/issues/3181>
     #[kani::proof_for_contract(contracts::replace)]
     pub fn check_replace_unit() {
         check_replace_impl::<()>();


### PR DESCRIPTION
This PR filters out ZST pointee types when generating CMBC assigns clauses for contracts. This prevents CMBC from complaining that the pointer doesn't point to a valid allocation.

Resolves #3181

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
