### PR TITLE
Toolchain update: avoid Javascript interpreting git log

### DIFF
--- a/.github/workflows/toolchain-upgrade.yml
+++ b/.github/workflows/toolchain-upgrade.yml
@@ -64,7 +64,7 @@ jobs:
                 https://github.com/rust-lang/rust/commit/${{ env.next_toolchain_hash }}. The log
                 for this commit range is:
 
-                ${{ env.git_log }}`
+                ` + process.env.git_log
             })
 
       - name: Create Issue


### PR DESCRIPTION
git log entries may themselves use backticks, which prematurely ended the string (and then caused Javascript syntax errors). Avoid this problem by using the environment variable rather than having Javascript see the string contents (of that environment variable).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
