### PR TITLE
`cover_or_fail!` macro

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -386,8 +386,13 @@ fn verification_outcome_from_properties(
 
 /// Determines the `FailedProperties` variant that corresponds to an array of properties
 fn determine_failed_properties(properties: &[Property]) -> FailedProperties {
-    let failed_properties: Vec<&Property> =
-        properties.iter().filter(|prop| prop.status == CheckStatus::Failure).collect();
+    let failed_properties: Vec<&Property> = properties
+        .iter()
+        .filter(|prop| {
+            prop.status == CheckStatus::Failure
+                || (prop.is_cover_or_fail_property() && prop.status != CheckStatus::Satisfied)
+        })
+        .collect();
     // Return `FAILURE` if there isn't at least one failed property
     if failed_properties.is_empty() {
         FailedProperties::None

--- a/kani-driver/src/cbmc_output_parser.rs
+++ b/kani-driver/src/cbmc_output_parser.rs
@@ -96,6 +96,7 @@ pub struct PropertyId {
 
 impl Property {
     const COVER_PROPERTY_CLASS: &'static str = "cover";
+    const COVER_OR_FAIL_PROPERTY_CLASS: &'static str = "cover_or_fail";
     const COVERAGE_PROPERTY_CLASS: &'static str = "code_coverage";
 
     pub fn property_class(&self) -> String {
@@ -110,6 +111,12 @@ impl Property {
     /// Returns true if this is a cover property
     pub fn is_cover_property(&self) -> bool {
         self.property_id.class == Self::COVER_PROPERTY_CLASS
+            || self.property_id.class == Self::COVER_OR_FAIL_PROPERTY_CLASS
+    }
+
+    /// Returns true if this is a cover or fail property
+    pub fn is_cover_or_fail_property(&self) -> bool {
+        self.property_id.class == Self::COVER_OR_FAIL_PROPERTY_CLASS
     }
 
     pub fn property_name(&self) -> String {

--- a/kani-driver/src/cbmc_property_renderer.rs
+++ b/kani-driver/src/cbmc_property_renderer.rs
@@ -247,8 +247,9 @@ fn format_item_terse(_item: &ParserItem) -> Option<String> {
 ///
 /// This function reports the results of normal checks (e.g. assertions and
 /// arithmetic overflow checks) and cover properties (specified using the
-/// `kani::cover` macro) separately. Cover properties currently do not impact
-/// the overall verification success or failure.
+/// `kani::cover` or `kani::cover_or_fail` macros) separately.
+/// The results of `kani::cover` do not affect overall verification success or failure,
+/// while any unreachable or unsatisfiable `kani::cover_or_fail`s will trigger verification failure.
 ///
 /// TODO: We could `write!` to `result_str` instead
 /// <https://github.com/model-checking/kani/issues/1480>

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -73,6 +73,19 @@ macro_rules! cover {
     };
 }
 
+#[macro_export]
+macro_rules! cover_or_fail {
+    () => {
+        kani::cover_or_fail(true, "cover location");
+    };
+    ($cond:expr $(,)?) => {
+        kani::cover_or_fail($cond, concat!("cover condition: ", stringify!($cond)));
+    };
+    ($cond:expr, $msg:literal) => {
+        kani::cover_or_fail($cond, $msg);
+    };
+}
+
 /// `implies!(premise => conclusion)` means that if the `premise` is true, so
 /// must be the `conclusion`.
 ///

--- a/library/kani_core/src/lib.rs
+++ b/library/kani_core/src/lib.rs
@@ -176,6 +176,16 @@ macro_rules! kani_intrinsics {
         #[rustc_diagnostic_item = "KaniCover"]
         pub const fn cover(_cond: bool, _msg: &'static str) {}
 
+        /// Creates a cover property with the specified condition and message.
+        /// Provides the same functionality as `kani::cover` with the additional constraint that
+        /// unreachability or unsatisfiability causes verification failure.
+        /// See `kani::cover` for examples.
+        /// This function is called by the [`cover_or_fail!`] macro. The macro is more
+        /// convenient to use.
+        #[inline(never)]
+        #[rustc_diagnostic_item = "KaniCoverOrFail"]
+        pub const fn cover_or_fail(_cond: bool, _msg: &'static str) {}
+
         /// This creates an symbolic *valid* value of type `T`. You can assign the return value of this
         /// function to a variable that you want to make symbolic.
         ///

--- a/tests/expected/cover-or-fail/cover-fail/expected
+++ b/tests/expected/cover-or-fail/cover-fail/expected
@@ -1,0 +1,7 @@
+Status: UNSATISFIABLE\
+Description: "cover condition: x != 0"\
+in function cover_overconstrained
+
+ ** 0 of 1 cover properties satisfied
+
+VERIFICATION:- FAILED

--- a/tests/expected/cover-or-fail/cover-fail/main.rs
+++ b/tests/expected/cover-or-fail/cover-fail/main.rs
@@ -1,0 +1,31 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Check that overconstraining could lead to unsatisfiable cover statements
+
+enum Sign {
+    Positive,
+    Negative,
+    Zero,
+}
+
+fn get_sign(x: i32) -> Sign {
+    if x > 0 {
+        Sign::Positive
+    } else if x < 0 {
+        Sign::Negative
+    } else {
+        Sign::Zero
+    }
+}
+
+#[kani::proof]
+fn cover_overconstrained() {
+    let x: i32 = kani::any();
+    let sign = get_sign(x);
+
+    match sign {
+        Sign::Zero => kani::cover_or_fail!(x != 0),
+        _ => {}
+    }
+}

--- a/tests/expected/cover-or-fail/cover-message/expected
+++ b/tests/expected/cover-or-fail/cover-message/expected
@@ -1,0 +1,15 @@
+Status: SATISFIED\
+Description: "foo may return Err"\
+main.rs:17:20 in function cover_match
+
+Status: SATISFIED\
+Description: "y may be greater than 20"\
+main.rs:15:28 in function cover_match
+
+Status: UNSATISFIABLE\
+Description: "y may be greater than 10"\
+main.rs:16:18 in function cover_match
+
+ ** 2 of 3 cover properties satisfied
+
+VERIFICATION:- FAILED

--- a/tests/expected/cover-or-fail/cover-message/main.rs
+++ b/tests/expected/cover-or-fail/cover-message/main.rs
@@ -1,0 +1,19 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Check that the message used in the kani::cover_or_fail macro appears in the results
+
+fn foo(x: i32) -> Result<i32, &'static str> {
+    if x < 100 { Ok(x / 2) } else { Err("x is too big") }
+}
+
+#[kani::proof]
+#[kani::unwind(21)]
+fn cover_match() {
+    let x = kani::any();
+    match foo(x) {
+        Ok(y) if x > 20 => kani::cover_or_fail!(y > 20, "y may be greater than 20"), // satisfiable
+        Ok(y) => kani::cover_or_fail!(y > 10, "y may be greater than 10"), // unsatisfiable
+        Err(_s) => kani::cover_or_fail!(true, "foo may return Err"),       // satisfiable
+    }
+}

--- a/tests/expected/cover-or-fail/cover-pass/expected
+++ b/tests/expected/cover-or-fail/cover-pass/expected
@@ -1,0 +1,11 @@
+Status: SATISFIED\
+Description: "cover condition: sorted == arr"\
+main.rs:12:5 in function cover_sorted
+
+Status: SATISFIED\
+Description: "cover condition: sorted != arr"\
+main.rs:13:5 in function cover_sorted
+
+ ** 2 of 2 cover properties satisfied
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/cover-or-fail/cover-pass/main.rs
+++ b/tests/expected/cover-or-fail/cover-pass/main.rs
@@ -1,0 +1,14 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Check that a sorted array may be the same or different than the original
+
+#[kani::proof]
+#[kani::unwind(21)]
+fn cover_sorted() {
+    let arr: [i32; 5] = kani::any();
+    let mut sorted = arr.clone();
+    sorted.sort();
+    kani::cover_or_fail!(sorted == arr);
+    kani::cover_or_fail!(sorted != arr);
+}

--- a/tests/expected/cover-or-fail/cover-undetermined/expected
+++ b/tests/expected/cover-or-fail/cover-undetermined/expected
@@ -1,0 +1,11 @@
+Status: UNDETERMINED\
+Description: "cover condition: sum == 10"\
+main.rs:15:5 in function cover_undetermined
+
+ ** 0 of 1 cover properties satisfied (1 undetermined)
+
+Failed Checks: unwinding assertion loop 0
+
+VERIFICATION:- FAILED
+[Kani] info: Verification output shows one or more unwinding failures.
+[Kani] tip: Consider increasing the unwinding value or disabling `--unwinding-assertions`.

--- a/tests/expected/cover-or-fail/cover-undetermined/main.rs
+++ b/tests/expected/cover-or-fail/cover-undetermined/main.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Check that a failed unwinding assertion would lead to reporting a cover
+/// property as UNDETERMINED if it's not satisfiable with the given unwind bound
+
+#[kani::proof]
+#[kani::unwind(10)]
+fn cover_undetermined() {
+    let x = [1; 10];
+    let mut sum = 0;
+    for i in x {
+        sum += i;
+    }
+    kani::cover_or_fail!(sum == 10);
+}

--- a/tests/expected/cover-or-fail/cover-unreachable-outside-harness-fail/expected
+++ b/tests/expected/cover-or-fail/cover-unreachable-outside-harness-fail/expected
@@ -2,6 +2,8 @@ Status: UNREACHABLE\
 Description: "cover location"\
 in function my_function
 
- ** 0 of 1 cover properties satisfied (1 unreachable)
+Status: UNREACHABLE\
+Description: "cover location"\
+in function test
 
 VERIFICATION:- FAILED

--- a/tests/expected/cover-or-fail/cover-unreachable-outside-harness-fail/expected
+++ b/tests/expected/cover-or-fail/cover-unreachable-outside-harness-fail/expected
@@ -1,0 +1,7 @@
+Status: UNREACHABLE\
+Description: "cover location"\
+in function my_function
+
+ ** 0 of 1 cover properties satisfied (1 unreachable)
+
+VERIFICATION:- FAILED

--- a/tests/expected/cover-or-fail/cover-unreachable-outside-harness-fail/main.rs
+++ b/tests/expected/cover-or-fail/cover-unreachable-outside-harness-fail/main.rs
@@ -15,3 +15,17 @@ fn proof() {
     // but the kani::cover_or_fail!() call *may or may not be* reachable, verification fails
     my_function(false);
 }
+
+// Simplified version of the .filter(|_| false).for_each(|_| {} pattern 
+// in https://github.com/model-checking/kani/issues/2792
+fn test() {
+    let my_vec: Vec<u8> = vec![1, 2, 3];
+    my_vec.into_iter().filter(|_| false).for_each(|_| {
+        kani::cover_or_fail!();
+    });
+}
+
+#[kani::proof]
+fn bolero_use_case() {
+    test();
+}

--- a/tests/expected/cover-or-fail/cover-unreachable-outside-harness-fail/main.rs
+++ b/tests/expected/cover-or-fail/cover-unreachable-outside-harness-fail/main.rs
@@ -16,7 +16,7 @@ fn proof() {
     my_function(false);
 }
 
-// Simplified version of the .filter(|_| false).for_each(|_| {} pattern 
+// .filter(|_| false).for_each(|_| {} pattern
 // in https://github.com/model-checking/kani/issues/2792
 fn test() {
     let my_vec: Vec<u8> = vec![1, 2, 3];

--- a/tests/expected/cover-or-fail/cover-unreachable-outside-harness-fail/main.rs
+++ b/tests/expected/cover-or-fail/cover-unreachable-outside-harness-fail/main.rs
@@ -1,0 +1,17 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Example of cover_or_fail being used outside a proof harness with an unreachability failure
+
+fn my_function(x: bool) {
+    if x {
+        kani::cover_or_fail!();
+    }
+}
+
+#[kani::proof]
+fn proof() {
+    // Since my_function() *is* reachable from the proof harness (i.e., CBMC's entry point),
+    // but the kani::cover_or_fail!() call *may or may not be* reachable, verification fails
+    my_function(false);
+}

--- a/tests/expected/cover-or-fail/cover-unreachable-outside-harness-pass/expected
+++ b/tests/expected/cover-or-fail/cover-unreachable-outside-harness-pass/expected
@@ -1,0 +1,9 @@
+Status: SUCCESS\
+Description: "assertion failed: true"\
+in function proof_a
+
+Status: SUCCESS\
+Description: "assertion failed: true"\
+in function proof_b
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/cover-or-fail/cover-unreachable-outside-harness-pass/main.rs
+++ b/tests/expected/cover-or-fail/cover-unreachable-outside-harness-pass/main.rs
@@ -1,0 +1,31 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Examples of cover_or_fail being used outside proof harnesses
+// Both of these calls are unreachable from the proof harness,
+// yet verification succeeds
+
+fn my_function() {
+    kani::cover_or_fail!();
+}
+
+#[kani::proof]
+fn proof_a() {
+    // Since my_function() isn't reachable from the proof harness (i.e., CBMC's entry point),
+    // the verification succeeds
+    assert!(true);
+}
+
+fn my_function_b() {
+    if false {
+        kani::cover_or_fail!();
+    }
+}
+
+#[kani::proof]
+fn proof_b() {
+    // The kani::cover_or_fail call in my_function_b() gets optimized out because it will never be called,
+    // so we don't execute the coverage check and verification succeeds
+    my_function_b();
+    assert!(true);
+}

--- a/tests/expected/cover-or-fail/cover-unreachable/expected
+++ b/tests/expected/cover-or-fail/cover-unreachable/expected
@@ -1,0 +1,16 @@
+Status: UNREACHABLE\
+Description: "cover condition: x == 2"\
+in function cover_unreachable
+
+Status: UNREACHABLE\
+Description: "Unreachable with a message"\
+in function cover_unreachable
+
+Status: SATISFIED\
+Description: "cover condition: x == 5"\
+in function cover_unreachable
+
+
+ ** 1 of 3 cover properties satisfied (2 unreachable)
+
+VERIFICATION:- FAILED

--- a/tests/expected/cover-or-fail/cover-unreachable/main.rs
+++ b/tests/expected/cover-or-fail/cover-unreachable/main.rs
@@ -1,0 +1,20 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Check that Kani reports an unreachable cover property as such
+
+#[kani::proof]
+fn cover_unreachable() {
+    let x: i32 = kani::any();
+    if x > 10 {
+        if x < 5 {
+            kani::cover_or_fail!(x == 2); // unreachable
+        }
+    } else {
+        if x > 20 {
+            kani::cover_or_fail!(x == 30, "Unreachable with a message"); // unreachable
+        } else {
+            kani::cover_or_fail!(x == 5); // satisfiable
+        }
+    }
+}

--- a/tests/expected/cover/cover-message/main.rs
+++ b/tests/expected/cover/cover-message/main.rs
@@ -13,7 +13,7 @@ fn cover_match() {
     let x = kani::any();
     match foo(x) {
         Ok(y) if x > 20 => kani::cover!(y > 20, "y may be greater than 20"), // satisfiable
-        Ok(y) => kani::cover!(y > 10, "y may be greater than 10"),           // unsatisfiable
-        Err(_s) => kani::cover!(true, "foo may return Err"),                 // satisfiable
+        Ok(y) => kani::cover!(y > 10, "y may be greater than 10"),  // unsatisfiable
+        Err(_s) => kani::cover!(true, "foo may return Err"),        // satisfiable
     }
 }

--- a/tests/expected/cover/cover-message/main.rs
+++ b/tests/expected/cover/cover-message/main.rs
@@ -13,7 +13,7 @@ fn cover_match() {
     let x = kani::any();
     match foo(x) {
         Ok(y) if x > 20 => kani::cover!(y > 20, "y may be greater than 20"), // satisfiable
-        Ok(y) => kani::cover!(y > 10, "y may be greater than 10"),  // unsatisfiable
-        Err(_s) => kani::cover!(true, "foo may return Err"),        // satisfiable
+        Ok(y) => kani::cover!(y > 10, "y may be greater than 10"),           // unsatisfiable
+        Err(_s) => kani::cover!(true, "foo may return Err"),                 // satisfiable
     }
 }


### PR DESCRIPTION
This PR adds a `cover_or_fail!` macro to Kani. This macro has the same functionality as the existing `cover!` macro, except it causes verification to fail when the outcome is unsatisfiable or unreachable.

Currently, a caller can invoke this macro from anywhere in their code (not just harnesses), which is also true for `cover`. However, we only analyze reachability starting from a given proof harness (the entry point), so if the `cover_or_fail` call is contained inside a function that the harness does not call, the verification will succeed even though the call actually is not covered. I'm concerned that this behavior will produce confusing results for users. Specifically, see the test cases inside `cover-unreachable-outside-harness-pass` (which pass verification) and `cover-unreachable-outside-harness-fail` (which fail verification). See also the discussion of this issue [here](https://github.com/model-checking/kani/pull/1906#issuecomment-1318036336). Is this the behavior that we want?

Our options are:

1. Leave the implementation like this, with clear documentation of the reachability behavior. The benefit of this design is that users can more easily use `cover_or_fail` throughout their code for debugging.
2. Add a pass which scans the entire crate for calls to `cover_or_fail` and makes sure that CBMC marked them all as reachable. This allows using `cover_or_fail` throughout the codebase and avoids any confusing reachability behavior, but may be slow.
3. Restrict calls to `cover_or_fail` to proof harnesses only. This approach solves the reachability issue, since CBMC will see every call to `cover_or_fail`, but does restrict users--the author of the issue that prompted this PR, for example, wanted to use it outside of a proof harness.

I'm leaning toward #1 or #3, but curious to hear others' thoughts.

Resolves #2792

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
