### PR TITLE
Add loop scanner to tool-scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -350,6 +351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +381,17 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "graph-cycles"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6ad932c6dd3cfaf16b66754a42f87bbeefd591530c4b6a8334270a7df3e853"
+dependencies = [
+ "ahash",
+ "petgraph",
+ "thiserror",
+]
 
 [[package]]
 name = "hashbrown"
@@ -724,6 +742,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +956,8 @@ name = "scanner"
 version = "0.0.0"
 dependencies = [
  "csv",
+ "graph-cycles",
+ "petgraph",
  "serde",
  "strum",
  "strum_macros",

--- a/tests/script-based-pre/tool-scanner/scanner-test.expected
+++ b/tests/script-based-pre/tool-scanner/scanner-test.expected
@@ -1,6 +1,6 @@
-2 test_scan_fn_loops.csv
-16 test_scan_functions.csv
+5 test_scan_fn_loops.csv
+19 test_scan_functions.csv
 5 test_scan_input_tys.csv
-14 test_scan_overall.csv
+16 test_scan_overall.csv
 3 test_scan_recursion.csv
 5 test_scan_unsafe_ops.csv

--- a/tests/script-based-pre/tool-scanner/test.rs
+++ b/tests/script-based-pre/tool-scanner/test.rs
@@ -36,6 +36,33 @@ pub fn with_iterator(input: &[usize]) -> usize {
         .unwrap_or_else(|| input.iter().fold(0, |acc, i| acc + 1))
 }
 
+pub fn with_for_loop(input: &[usize]) -> usize {
+    let mut res = 0;
+    for n in input {
+        res += 1;
+    }
+    res
+}
+
+pub fn with_while_loop(input: &[usize]) -> usize {
+    let mut res = 0;
+    while res < input.len() {
+        res += 1;
+    }
+    return res;
+}
+
+pub fn with_loop_loop(input: &[usize]) -> usize {
+    let mut res = 0;
+    loop {
+        if res == input.len() {
+            break;
+        }
+        res += 1;
+    }
+    res
+}
+
 static mut COUNTER: Option<usize> = Some(0);
 static OK: bool = true;
 

--- a/tests/script-based-pre/tool-scanner/test.rs
+++ b/tests/script-based-pre/tool-scanner/test.rs
@@ -33,12 +33,12 @@ pub fn with_iterator(input: &[usize]) -> usize {
         .iter()
         .copied()
         .find(|e| *e == 0)
-        .unwrap_or_else(|| input.iter().fold(0, |acc, i| acc + 1))
+        .unwrap_or_else(|| input.iter().fold(0, |acc, _| acc + 1))
 }
 
 pub fn with_for_loop(input: &[usize]) -> usize {
     let mut res = 0;
-    for n in input {
+    for _ in input {
         res += 1;
     }
     res

--- a/tools/scanner/Cargo.toml
+++ b/tools/scanner/Cargo.toml
@@ -15,6 +15,8 @@ csv = "1.3"
 serde = {version = "1", features = ["derive"]}
 strum = "0.26"
 strum_macros = "0.26"
+petgraph = "0.6.5"
+graph-cycles = "0.1.0"
 
 [package.metadata.rust-analyzer]
 # This crate uses rustc crates.

--- a/tools/scanner/src/analysis.rs
+++ b/tools/scanner/src/analysis.rs
@@ -573,9 +573,9 @@ impl<'a> MirVisitor for IteratorVisitor<'a> {
                     self.props.loops += 1;
                 }
             }
-            TerminatorKind::InlineAsm { destination, .. } => {
-                if let Some(target) = destination {
-                    self.props.loops += self.visited_blocks.contains(target) as usize;
+            TerminatorKind::InlineAsm { destination: Some(target), .. } => {
+                if self.visited_blocks.contains(target) {
+                    self.props.loops += 1;
                 }
             }
             // No targets in other terminators.

--- a/tools/scanner/src/analysis.rs
+++ b/tools/scanner/src/analysis.rs
@@ -504,82 +504,56 @@ impl<'a> MirVisitor for IteratorVisitor<'a> {
     }
 
     fn visit_terminator(&mut self, term: &Terminator, location: Location) {
-        match &term.kind {
-            TerminatorKind::Goto { target } => {
-                // A goto is identified as a loop latch if its target has been visited.
-                if self.visited_blocks.contains(target) {
-                    self.props.loops += 1;
-                }
-            }
-            TerminatorKind::SwitchInt { targets, .. } => {
-                let successors = targets.all_targets();
-                // Check if any of the targets of SwitchInt has been visited.
-                if self.visited_blocks.contains(&successors[0])
-                    || self.visited_blocks.contains(&successors[1])
-                {
-                    self.props.loops += 1;
-                }
-            }
-            TerminatorKind::Drop { target, .. } => {
-                if self.visited_blocks.contains(target) {
-                    self.props.loops += 1;
-                }
-            }
-            TerminatorKind::Call { func, .. } => {
-                let kind = func.ty(self.body.locals()).unwrap().kind();
-                // Check if the target is a visited block.
+        // Check if any successor has been visited---the terminator is a loop latch.
+        let successors = term.kind.successors();
+        let mut contain_loop = false;
+        for target in successors {
+            contain_loop |= self.visited_blocks.contains(&target);
+        }
+        self.props.loops += contain_loop as usize;
 
-                // Check if the call is an iterator function that contains loops.
-                if let TyKind::RigidTy(RigidTy::FnDef(def, _)) = kind {
-                    let fullname = def.name();
-                    let names = fullname.split("::").collect::<Vec<_>>();
-                    if let [.., s_last, last] = names.as_slice() {
-                        if *s_last == "Iterator"
-                            && [
-                                "for_each",
-                                "collect",
-                                "advance_by",
-                                "all",
-                                "any",
-                                "partition",
-                                "partition_in_place",
-                                "fold",
-                                "try_fold",
-                                "spec_fold",
-                                "spec_try_fold",
-                                "try_for_each",
-                                "for_each",
-                                "try_reduce",
-                                "reduce",
-                                "find",
-                                "find_map",
-                                "try_find",
-                                "position",
-                                "rposition",
-                                "nth",
-                                "count",
-                                "last",
-                                "find",
-                            ]
-                            .contains(last)
-                        {
-                            self.props.iterators += 1;
-                        }
+        if let TerminatorKind::Call { func, .. } = &term.kind {
+            let kind = func.ty(self.body.locals()).unwrap().kind();
+            // Check if the target is a visited block.
+
+            // Check if the call is an iterator function that contains loops.
+            if let TyKind::RigidTy(RigidTy::FnDef(def, _)) = kind {
+                let fullname = def.name();
+                let names = fullname.split("::").collect::<Vec<_>>();
+                if let [.., s_last, last] = names.as_slice() {
+                    if *s_last == "Iterator"
+                        && [
+                            "for_each",
+                            "collect",
+                            "advance_by",
+                            "all",
+                            "any",
+                            "partition",
+                            "partition_in_place",
+                            "fold",
+                            "try_fold",
+                            "spec_fold",
+                            "spec_try_fold",
+                            "try_for_each",
+                            "for_each",
+                            "try_reduce",
+                            "reduce",
+                            "find",
+                            "find_map",
+                            "try_find",
+                            "position",
+                            "rposition",
+                            "nth",
+                            "count",
+                            "last",
+                            "find",
+                        ]
+                        .contains(last)
+                    {
+                        self.props.iterators += 1;
                     }
                 }
             }
-            TerminatorKind::Assert { target, .. } => {
-                if self.visited_blocks.contains(target) {
-                    self.props.loops += 1;
-                }
-            }
-            TerminatorKind::InlineAsm { destination: Some(target), .. } => {
-                if self.visited_blocks.contains(target) {
-                    self.props.loops += 1;
-                }
-            }
-            // No targets in other terminators.
-            _ => {}
         }
 
         self.super_terminator(term, location)


### PR DESCRIPTION
This extend #3120 with loop scanner that counts the number of loops in each function and the number of functions that contain loops.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
