### PR TITLE
Re-enabled hierarchical logs in the compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,7 @@ dependencies = [
  "strum_macros",
  "tracing",
  "tracing-subscriber",
+ "tracing-tree",
 ]
 
 [[package]]
@@ -597,6 +598,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1233,7 +1243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "parking_lot",
  "regex",
@@ -1246,6 +1256,18 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-tree"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f459ca79f1b0d5f71c54ddfde6debfc59c8b6eeb46808ae492077f739dc7b49c"
+dependencies = [
+ "nu-ansi-term 0.50.1",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -24,6 +24,7 @@ strum_macros = "0.26"
 shell-words = "1.0.0"
 tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-subscriber = {version = "0.3.8", features = ["env-filter", "json", "fmt"]}
+tracing-tree = "0.4.0"
 
 # Future proofing: enable backend dependencies using feature.
 [features]

--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -19,6 +19,7 @@ use std::io::IsTerminal;
 use std::panic;
 use std::sync::LazyLock;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
+use tracing_tree::HierarchicalLayer;
 
 /// Environment variable used to control this session log tracing.
 const LOG_ENV_VAR: &str = "KANI_LOG";
@@ -114,10 +115,13 @@ fn hier_logs(args: &Arguments, filter: EnvFilter) {
     let use_colors = std::io::stdout().is_terminal() || args.color_output;
     let subscriber = Registry::default().with(filter);
     let subscriber = subscriber.with(
-        tracing_subscriber::fmt::layer()
+        HierarchicalLayer::default()
             .with_writer(std::io::stderr)
+            .with_indent_lines(true)
             .with_ansi(use_colors)
-            .with_target(true),
+            .with_targets(true)
+            .with_verbose_exit(true)
+            .with_indent_amount(4),
     );
     tracing::subscriber::set_global_default(subscriber).unwrap();
 }


### PR DESCRIPTION
We reverted the hierarchical logs a while ago (#2581) due to an outdated dependency that has since been fixed.

I think this makes the logs much more readable, by indenting the logs given the scope. More than one scope makes the lines way too long, which I think it's harder to read.

This is how the logs look without this change:

```
2024-08-17T02:42:21.874979Z DEBUG CodegenFunction{name="kani::assert"}: kani_compiler::codegen_cprover_gotoc::utils::debug: handling kani::assert
2024-08-17T02:42:21.875008Z DEBUG CodegenFunction{name="kani::assert"}: kani_compiler::codegen_cprover_gotoc::utils::debug: variables:
2024-08-17T02:42:21.875026Z DEBUG CodegenFunction{name="kani::assert"}: kani_compiler::codegen_cprover_gotoc::utils::debug: let _0: Ty { id: 4, kind: RigidTy(Tuple([])) }

```

This is how it looks after this change:

```
┐kani_compiler::codegen_cprover_gotoc::codegen::function::CodegenFunction name="kani::assert"
├─── DEBUG kani_compiler::codegen_cprover_gotoc::utils::debug handling kani::assert
├─── DEBUG kani_compiler::codegen_cprover_gotoc::utils::debug variables:
├─── DEBUG kani_compiler::codegen_cprover_gotoc::utils::debug let _0: Ty { id: 4, kind: RigidTy(Tuple([])) }
├─── DEBUG kani_compiler::codegen_cprover_gotoc::utils::debug let _1: Ty { id: 6, kind: RigidTy(Bool) }

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
