### PR TITLE
Update deny action

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -4,7 +4,7 @@
 # 1. Checks licenses for allowed license.
 # 2. Checks Rust-Sec registry for security advisories.
 
-name: Cargo Audit
+name: Cargo Deny
 on:
   pull_request:
   merge_group:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           arguments: --all-features --workspace
           command-arguments: -s

--- a/deny.toml
+++ b/deny.toml
@@ -7,10 +7,7 @@
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
 yanked = "deny"
-notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
@@ -21,19 +18,14 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-default = "deny"
-unlicensed = "deny"
-copyleft = "deny"
 allow = [
     "MIT",
     "Apache-2.0",
 ]
-allow-osi-fsf-free = "neither"
 confidence-threshold = 0.8
 
 # All these exceptions should probably appear in: tools/build-kani/license-notes.txt
 exceptions = [
-    { name = "Inflector", allow=["BSD-2-Clause"] },
     { name = "unicode-ident", allow=["Unicode-DFS-2016"] },
 ]
 


### PR DESCRIPTION
The current `cargo deny` configuration in `deny.toml` uses several keys that have been deprecated. This PR removes the deprecated keys, and updates the deny action to use v2 (as well as renames it from `audit.yml` to `deny.yml`).

The only semantic difference is that `cargo deny` will now reject crates that are maintained or have a notice on them, whereas previously, our configuration set both to "warn". As mentioned in the docs though, one can add an "ignore" if needed to bypass those advisories:

https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html#the-version-field-optional

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
