### PR TITLE
Bump Kani version to 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.55.0]
+
+### What's Changed
+* Update CBMC build instructions for Amazon Linux 2 by @tautschnig in https://github.com/model-checking/kani/pull/3431
+* Implement memory initialization state copy functionality by @artemagvanian in https://github.com/model-checking/kani/pull/3350
+* Make points-to analysis handle all intrinsics explicitly by @artemagvanian in https://github.com/model-checking/kani/pull/3452
+* Add loop scanner to tool-scanner by @qinheping in https://github.com/model-checking/kani/pull/3443
+* Avoid corner-cases by grouping instrumentation into basic blocks and using backward iteration by @artemagvanian in https://github.com/model-checking/kani/pull/3438
+* Fix ICE due to mishandling of Aggregate rvalue for raw pointers to `str` by @celinval in https://github.com/model-checking/kani/pull/3448
+* Basic support for memory initialization checks for unions by @artemagvanian in https://github.com/model-checking/kani/pull/3444
+* RFC: Source-based code coverage by @adpaco-aws in https://github.com/model-checking/kani/pull/3143
+* Adopt Rust's source-based code coverage instrumentation by @adpaco-aws in https://github.com/model-checking/kani/pull/3119
+* Extra tests and bug fixes to the delayed UB instrumentation by @artemagvanian in https://github.com/model-checking/kani/pull/3419
+* Partially integrate uninit memory checks into `verify_std` by @artemagvanian in https://github.com/model-checking/kani/pull/3470
+* RFC for List Subcommand by @carolynzech in https://github.com/model-checking/kani/pull/3463
+* Rust toolchain upgraded to `nightly-2024-09-03` by @jaisnan @carolynzech 
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.54.0...kani-0.55.0
+
 ## [0.54.0]
 
 ### Major Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "build-kani"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -459,7 +459,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "kani"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "kani_core",
  "kani_macros",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "kani-compiler"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "home",
@@ -529,14 +529,14 @@ dependencies = [
 
 [[package]]
 name = "kani_core"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani_macros"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1098,7 +1098,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "std"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_core/Cargo.toml
+++ b/library/kani_core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_core"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
These are the auto-generated release notes:

## What's Changed
* Update CBMC build instructions for Amazon Linux 2 by @tautschnig in https://github.com/model-checking/kani/pull/3431
* Handle intrinsics systematically by @artemagvanian in https://github.com/model-checking/kani/pull/3422
* Bump tests/perf/s2n-quic from `445f73b` to `ab9723a` by @dependabot in https://github.com/model-checking/kani/pull/3434
* Automatic cargo update to 2024-08-12 by @github-actions in https://github.com/model-checking/kani/pull/3433
* Actually apply CBMC patch by @tautschnig in https://github.com/model-checking/kani/pull/3436
* Update features/verify-rust-std branch by @feliperodri in https://github.com/model-checking/kani/pull/3435
* Add test related to issue 3432 by @celinval in https://github.com/model-checking/kani/pull/3439
* Implement memory initialization state copy functionality  by @artemagvanian in https://github.com/model-checking/kani/pull/3350
* Bump tests/perf/s2n-quic from `ab9723a` to `80b93a7` by @dependabot in https://github.com/model-checking/kani/pull/3453
* Make points-to analysis handle all intrinsics explicitly by @artemagvanian in https://github.com/model-checking/kani/pull/3452
* Automatic cargo update to 2024-08-19 by @github-actions in https://github.com/model-checking/kani/pull/3450
* Add loop scanner to tool-scanner by @qinheping in https://github.com/model-checking/kani/pull/3443
* Avoid corner-cases by grouping instrumentation into basic blocks and using backward iteration by @artemagvanian in https://github.com/model-checking/kani/pull/3438
* Re-enabled hierarchical logs in the compiler by @celinval in https://github.com/model-checking/kani/pull/3449
* Fix ICE due to mishandling of Aggregate rvalue for raw pointers to `str` by @celinval in https://github.com/model-checking/kani/pull/3448
* Automatic cargo update to 2024-08-26 by @github-actions in https://github.com/model-checking/kani/pull/3459
* Bump tests/perf/s2n-quic from `80b93a7` to `8f7c04b` by @dependabot in https://github.com/model-checking/kani/pull/3460
* Update deny action by @zhassan-aws in https://github.com/model-checking/kani/pull/3461
* Basic support for memory initialization checks for unions by @artemagvanian in https://github.com/model-checking/kani/pull/3444
* Adjust test patterns so as not to check for trivial properties by @tautschnig in https://github.com/model-checking/kani/pull/3464
* Clarify comment in RFC Template by @carolynzech in https://github.com/model-checking/kani/pull/3462
* RFC: Source-based code coverage by @adpaco-aws in https://github.com/model-checking/kani/pull/3143
* Adopt Rust's source-based code coverage instrumentation by @adpaco-aws in https://github.com/model-checking/kani/pull/3119
* Upgrade toolchain to 08/28 by @jaisnan in https://github.com/model-checking/kani/pull/3454
* Extra tests and bug fixes to the delayed UB instrumentation by @artemagvanian in https://github.com/model-checking/kani/pull/3419
* Upgrade Toolchain to 8/29 by @carolynzech in https://github.com/model-checking/kani/pull/3468
* Automatic toolchain upgrade to nightly-2024-08-30 by @github-actions in https://github.com/model-checking/kani/pull/3469
* Extend name resolution to support qualified paths (Partial Fix) by @celinval in https://github.com/model-checking/kani/pull/3457
* Partially integrate uninit memory checks into `verify_std` by @artemagvanian in https://github.com/model-checking/kani/pull/3470
* Update Toolchain to 9/1 by @carolynzech in https://github.com/model-checking/kani/pull/3478
* Automatic cargo update to 2024-09-02 by @github-actions in https://github.com/model-checking/kani/pull/3480
* Bump tests/perf/s2n-quic from `8f7c04b` to `1ff3a9c` by @dependabot in https://github.com/model-checking/kani/pull/3481
* Automatic toolchain upgrade to nightly-2024-09-02 by @github-actions in https://github.com/model-checking/kani/pull/3479
* Automatic toolchain upgrade to nightly-2024-09-03 by @github-actions in https://github.com/model-checking/kani/pull/3482
* RFC for List Subcommand by @carolynzech in https://github.com/model-checking/kani/pull/3463
* Add tests for fixed issues. by @carolynzech in https://github.com/model-checking/kani/pull/3484


**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.54.0...kani-0.55.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
