### PR TITLE
Fix iss3495

### DIFF
--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0"
-proc-macro-error2 = "2.0.0"
+proc-macro-error2 = { version = "2.0.0", features = ["nightly"] }
 quote = "1.0.20"
 syn = { version = "2.0.18", features = ["full", "visit-mut", "visit", "extra-traits"] }
 

--- a/tests/ui/derive-arbitrary/union/expected
+++ b/tests/ui/derive-arbitrary/union/expected
@@ -3,7 +3,10 @@ error: Cannot derive `Arbitrary` for `Wrapper` union
 |\
 | #[derive(kani::Arbitrary)]\
 |          ^^^^^^^^^^^^^^^\
-|
+|\
 note: `#[derive(Arbitrary)]` cannot be used for unions such as `Wrapper`
 
+|\
+| union Wrapper {\
+|       ^^^^^^^\
 = note: this error originates in the derive macro `kani::Arbitrary`


### PR DESCRIPTION
As suggested in https://github.com/GnomedDev/proc-macro-error-2/issues/1#issuecomment-2333926796, turning on the `nightly` feature for `proc-macro-error2` to restore the previous error message for `derive(Arbitrary)`.

Resolves #3495 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
