### PR TITLE
Upgrade toolchain to 2024-09-07

### DIFF
--- a/kani-compiler/src/kani_middle/resolve.rs
+++ b/kani-compiler/src/kani_middle/resolve.rs
@@ -586,7 +586,8 @@ where
         debug!(?name, ?ty, "resolve_in_primitive");
         let internal_ty = rustc_internal::internal(tcx, ty);
         let simple_ty =
-            fast_reject::simplify_type(tcx, internal_ty, TreatParams::AsCandidateKey).unwrap();
+            fast_reject::simplify_type(tcx, internal_ty, TreatParams::InstantiateWithInfer)
+                .unwrap();
         let impls = tcx.incoherent_impls(simple_ty).unwrap();
         // Find the primitive impl.
         let item = impls

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-09-06"
+channel = "nightly-2024-09-07"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Relevant upstream PR:

https://github.com/rust-lang/rust/pull/128776: The `TreatParams` enum variants were renamed.

Resolves #3503 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
