### PR TITLE
Downgrade once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "os_info"


### PR DESCRIPTION
Version 1.20.0 of the `once_cell` crate was yanked:

https://crates.io/crates/once_cell/1.20.0

which is causing cargo deny in our CI to fail, e.g.:
https://github.com/model-checking/kani/actions/runs/10888030526/job/30211573712?pr=3516

Downgrading the version to 1.19.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
