### PR TITLE
Upgrade toolchain to 2024-09-09

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-09-08"
+channel = "nightly-2024-09-09"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/kani/Coroutines/rustc-coroutine-tests/niche-in-generator-size.rs
+++ b/tests/kani/Coroutines/rustc-coroutine-tests/niche-in-generator-size.rs
@@ -26,7 +26,7 @@ fn main() {
         take(x);
     };
 
-    // FIXME(https://github.com/rust-lang/rust/issues/63818#issuecomment-2264915918): 
+    // FIXME(https://github.com/rust-lang/rust/issues/63818#issuecomment-2264915918):
     // niches in coroutines are disabled. Should be `assert_eq`.
     assert_ne!(size_of_val(&gen1), size_of_val(&Some(gen1)));
 }

--- a/tests/kani/Coroutines/rustc-coroutine-tests/niche-in-generator-size.rs
+++ b/tests/kani/Coroutines/rustc-coroutine-tests/niche-in-generator-size.rs
@@ -26,6 +26,7 @@ fn main() {
         take(x);
     };
 
-    // FIXME: size of coroutines does not work reliably (https://github.com/model-checking/kani/issues/1395)
-    assert_eq!(size_of_val(&gen1), size_of_val(&Some(gen1)));
+    // FIXME(https://github.com/rust-lang/rust/issues/63818#issuecomment-2264915918): 
+    // niches in coroutines are disabled. Should be `assert_eq`.
+    assert_ne!(size_of_val(&gen1), size_of_val(&Some(gen1)));
 }


### PR DESCRIPTION
Relevant upstream PR:

https://github.com/rust-lang/rust/pull/129313:  Supress niches in coroutines to avoid aliasing violations #129313 

Resolves https://github.com/model-checking/kani/issues/3512

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.