### PR TITLE
Upgrade toolchain to 2024-09-15

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -1255,7 +1255,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     TyKind::RigidTy(RigidTy::Uint(UintTy::U32))
                 )
             {
-                self.simd_size_and_type(farg_types[2]).0.try_into().unwrap()
+                self.simd_size_and_type(farg_types[2]).0
             } else {
                 let err_msg = format!(
                     "simd_shuffle index must be a SIMD vector of `u32`, got `{}`",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-09-12"
+channel = "nightly-2024-09-15"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/expected/intrinsics/simd-shuffle-indexes-out/main.rs
+++ b/tests/expected/intrinsics/simd-shuffle-indexes-out/main.rs
@@ -11,11 +11,14 @@ use std::intrinsics::simd::simd_shuffle;
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x2([i64; 2]);
 
+#[repr(simd)]
+struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
+
 #[kani::proof]
 fn main() {
     let y = i64x2([0, 1]);
     let z = i64x2([1, 2]);
     // Only [0, 3] are valid indexes, 4 is out of bounds
-    const I: [u32; 2] = [1, 4];
+    const I: SimdShuffleIdx<2> = SimdShuffleIdx([1, 4]);
     let _: i64x2 = unsafe { simd_shuffle(y, z, I) };
 }

--- a/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-size/main.rs
+++ b/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-size/main.rs
@@ -16,11 +16,14 @@ pub struct i64x2([i64; 2]);
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x4([i64; 4]);
 
+#[repr(simd)]
+struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
+
 #[kani::proof]
 fn main() {
     let y = i64x2([0, 1]);
     let z = i64x2([1, 2]);
-    const I: [u32; 4] = [1, 2, 1, 2];
+    const I: SimdShuffleIdx<4> = SimdShuffleIdx([1, 2, 1, 2]);
     let x: i64x2 = unsafe { simd_shuffle(y, z, I) };
     // ^^^^ The code above fails to type-check in Rust with the error:
     // ```

--- a/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-type/main.rs
+++ b/tests/expected/intrinsics/simd-shuffle-result-type-is-diff-type/main.rs
@@ -16,11 +16,14 @@ pub struct i64x2([i64; 2]);
 #[derive(Clone, Copy, PartialEq)]
 pub struct f64x2([f64; 2]);
 
+#[repr(simd)]
+struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
+
 #[kani::proof]
 fn main() {
     let y = i64x2([0, 1]);
     let z = i64x2([1, 2]);
-    const I: [u32; 2] = [1, 2];
+    const I: SimdShuffleIdx<2> = SimdShuffleIdx([1, 2]);
     let x: f64x2 = unsafe { simd_shuffle(y, z, I) };
     // ^^^^ The code above fails to type-check in Rust with the error:
     // ```

--- a/tests/kani/Intrinsics/SIMD/Shuffle/main.rs
+++ b/tests/kani/Intrinsics/SIMD/Shuffle/main.rs
@@ -16,12 +16,15 @@ pub struct i64x2([i64; 2]);
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x4([i64; 4]);
 
+#[repr(simd)]
+struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
+
 #[kani::proof]
 fn main() {
     {
         let y = i64x2([0, 1]);
         let z = i64x2([1, 2]);
-        const I: [u32; 2] = [1, 2];
+        const I: SimdShuffleIdx<2> = SimdShuffleIdx([1, 2]);
         let x: i64x2 = unsafe { simd_shuffle(y, z, I) };
         assert!(x.0[0] == 1);
         assert!(x.0[1] == 1);
@@ -29,7 +32,7 @@ fn main() {
     {
         let y = i64x2([0, 1]);
         let z = i64x2([1, 2]);
-        const I: [u32; 2] = [1, 2];
+        const I: SimdShuffleIdx<2> = SimdShuffleIdx([1, 2]);
         let x: i64x2 = unsafe { simd_shuffle(y, z, I) };
         assert!(x.0[0] == 1);
         assert!(x.0[1] == 1);
@@ -37,7 +40,7 @@ fn main() {
     {
         let a = i64x4([1, 2, 3, 4]);
         let b = i64x4([5, 6, 7, 8]);
-        const I: [u32; 4] = [1, 3, 5, 7];
+        const I: SimdShuffleIdx<4> = SimdShuffleIdx([1, 3, 5, 7]);
         let c: i64x4 = unsafe { simd_shuffle(a, b, I) };
         assert!(c == i64x4([2, 4, 6, 8]));
     }
@@ -48,7 +51,7 @@ fn check_shuffle() {
     {
         let y = i64x2([0, 1]);
         let z = i64x2([1, 2]);
-        const I: [u32; 4] = [1, 2, 0, 3];
+        const I: SimdShuffleIdx<4> = SimdShuffleIdx([1, 2, 0, 3]);
         let _x: i64x4 = unsafe { simd_shuffle(y, z, I) };
     }
 }


### PR DESCRIPTION
Relevant upstream PR:

https://github.com/rust-lang/rust/commit/60ee1b7ac6 simd_shuffle: require index argument to be a vector

Resolves https://github.com/model-checking/kani/issues/3530

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
