### PR TITLE
Running `verify-std` no longer changes Cargo files

### DIFF
--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -51,7 +51,7 @@ impl KaniSession {
     /// crate manually. =( See <https://github.com/rust-lang/cargo/issues/8365>.
     ///
     /// Without setting up a new workspace, cargo init will modify the workspace where this is
-    /// running.
+    /// running. See <https://github.com/model-checking/kani/issues/3574> for details.
     pub fn cargo_init_lib(&self, path: &Path) -> Result<()> {
         let toml_path = path.join("Cargo.toml");
         if toml_path.exists() {

--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -46,10 +46,39 @@ pub struct CargoOutputs {
 
 impl KaniSession {
     /// Create a new cargo library in the given path.
+    ///
+    /// Since we cannot create a new workspace with `cargo init --lib`, we create the dummy
+    /// crate manually. =( See <https://github.com/rust-lang/cargo/issues/8365>.
+    ///
+    /// Without setting up a new workspace, cargo init will modify the workspace where this is
+    /// running.
     pub fn cargo_init_lib(&self, path: &Path) -> Result<()> {
-        let mut cmd = setup_cargo_command()?;
-        cmd.args(["init", "--lib", path.to_string_lossy().as_ref()]);
-        self.run_terminal(cmd)
+        let toml_path = path.join("Cargo.toml");
+        if toml_path.exists() {
+            bail!("Cargo.toml already exists in {}", path.display());
+        }
+
+        // Create folder for library
+        fs::create_dir_all(path.join("src"))?;
+
+        // Create dummy crate and write dummy body
+        let lib_path = path.join("src/lib.rs");
+        fs::write(&lib_path, "pub fn dummy() {}")?;
+
+        // Create Cargo.toml
+        fs::write(
+            &toml_path,
+            r#"[package]
+name = "dummy"
+version = "0.1.0"
+
+[lib]
+crate-type = ["lib"]
+
+[workspace]
+"#,
+        )?;
+        Ok(())
     }
 
     pub fn cargo_build_std(&self, std_path: &Path, krate_path: &Path) -> Result<Vec<Artifact>> {

--- a/tests/script-based-pre/verify_std_cmd/verify_std.expected
+++ b/tests/script-based-pre/verify_std_cmd/verify_std.expected
@@ -1,3 +1,7 @@
+[TEST] Only codegen inside library folder
+No kani crate inside Cargo.toml as expected
+
+
 [TEST] Run kani verify-std
 
 Checking harness verify::dummy_proof...


### PR DESCRIPTION
In order to create a dummy crate we were using `cargo init` command. However, this command will interact with any existing workspace.

Instead, explicitly create a dummy `Cargo.toml` and `src/lib.rs`.

Resolves #3574

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
