### PR TITLE
Support fully-qualified --package arguments

### DIFF
--- a/kani-driver/src/args/cargo.rs
+++ b/kani-driver/src/args/cargo.rs
@@ -33,7 +33,7 @@ pub struct CargoCommonArgs {
     #[arg(long)]
     pub workspace: bool,
 
-    /// Run Kani on the specified packages.
+    /// Run Kani on the specified packages  (see `cargo help pkgid` for accepted format)
     #[arg(long, short, conflicts_with("workspace"), num_args(1..))]
     pub package: Vec<String>,
 

--- a/kani-driver/src/args/cargo.rs
+++ b/kani-driver/src/args/cargo.rs
@@ -33,7 +33,7 @@ pub struct CargoCommonArgs {
     #[arg(long)]
     pub workspace: bool,
 
-    /// Run Kani on the specified packages  (see `cargo help pkgid` for accepted format)
+    /// Run Kani on the specified packages (see `cargo help pkgid` for the accepted format)
     #[arg(long, short, conflicts_with("workspace"), num_args(1..))]
     pub package: Vec<String>,
 

--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -368,7 +368,7 @@ impl KaniSession {
 
     /// Extract the packages that should be verified.
     ///
-    /// The result is build following these rules:
+    /// The result is built following these rules:
     /// - If `--package <pkg>` is given, return the list of packages selected.
     /// - If `--exclude <pkg>` is given, return the list of packages not excluded.
     /// - If `--workspace` is given, return the list of workspace members.
@@ -401,7 +401,7 @@ impl KaniSession {
                     .filter_map(|pkg| pkg_ids.get(&pkg.id).copied())
                     .collect();
                 bail!(
-                    "The following packages specified do not belong to this workspace: `{}`",
+                    "The following specified packages were not found in this workspace: `{}`",
                     outer.join("`,")
                 );
             }

--- a/tests/cargo-ui/ws-package-exclude-unknown/expected
+++ b/tests/cargo-ui/ws-package-exclude-unknown/expected
@@ -1,1 +1,2 @@
-error: couldn't find package `unknown_package`
+error: package ID specification `unknown_package` did not match any packages
+error: Failed to retrieve information for `unknown_package`

--- a/tests/cargo-ui/ws-package-select-unknown/expected
+++ b/tests/cargo-ui/ws-package-select-unknown/expected
@@ -1,1 +1,2 @@
-error: couldn't find package `unknown_package`
+error: package ID specification `unknown_package` did not match any packages
+error: Failed to retrieve information for `unknown_package`

--- a/tests/script-based-pre/ambiguous_crate/Cargo.toml
+++ b/tests/script-based-pre/ambiguous_crate/Cargo.toml
@@ -1,0 +1,11 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+[package]
+name = "zerocopy"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+zerocopy = "=0.8.4"
+
+[workspace]

--- a/tests/script-based-pre/ambiguous_crate/ambiguous.sh
+++ b/tests/script-based-pre/ambiguous_crate/ambiguous.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Test how Kani handle ambiguous crate names.
+
+rm -rf target
+set -e
+cargo kani --output-format terse && echo "No package is needed"
+cargo kani -p zerocopy@0.0.1 --output-format terse && echo "But passing the correct package works"
+
+# These next commands should fail so disable failures
+set +e
+cargo kani -p zerocopy || echo "Found expected ambiguous crate error"
+cargo kani -p zerocopy@0.8.4 || echo "Found expected out of workspace error"
+
+rm -rf target

--- a/tests/script-based-pre/ambiguous_crate/config.yml
+++ b/tests/script-based-pre/ambiguous_crate/config.yml
@@ -1,0 +1,4 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: ambiguous.sh
+expected: expected

--- a/tests/script-based-pre/ambiguous_crate/expected
+++ b/tests/script-based-pre/ambiguous_crate/expected
@@ -11,5 +11,5 @@ Please re-run this command with one of the following specifications:
 error: Failed to retrieve information for `zerocopy`
 Found expected ambiguous crate error
 
-error: The following packages specified do not belong to this workspace: `zerocopy@0.8.4`
+error: The following specified packages were not found in this workspace: `zerocopy@0.8.4`
 Found expected out of workspace error

--- a/tests/script-based-pre/ambiguous_crate/expected
+++ b/tests/script-based-pre/ambiguous_crate/expected
@@ -1,0 +1,15 @@
+Complete - 1 successfully verified harnesses, 0 failures, 1 total\
+No package is needed
+
+Complete - 1 successfully verified harnesses, 0 failures, 1 total\
+But passing the correct package works
+
+error: There are multiple `zerocopy` packages in your project, and the specification `zerocopy` is ambiguous.
+Please re-run this command with one of the following specifications:
+  zerocopy@0.0.1
+  zerocopy@0.8.4
+error: Failed to retrieve information for `zerocopy`
+Found expected ambiguous crate error
+
+error: The following packages specified do not belong to this workspace: `zerocopy@0.8.4`
+Found expected out of workspace error

--- a/tests/script-based-pre/ambiguous_crate/src/lib.rs
+++ b/tests/script-based-pre/ambiguous_crate/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+//! Test that cargo kani works when there are ambiguous packages.
+//! See <https://github.com/model-checking/kani/issues/3563>
+
+use zerocopy::FromZeros;
+
+#[kani::proof]
+fn check_zero_copy() {
+    let opt = Option::<&char>::new_zeroed();
+    assert_eq!(opt, None);
+}


### PR DESCRIPTION
We were previously matching the name of the package, which would limit users if the name is ambiguous.

Instead, use `cargo pkgid` to validate the `--package` argument and to retrieve the package id.

Resolves #3563 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
