### PR TITLE
Update coverage flag in docs

### DIFF
--- a/docs/src/reference/experimental/coverage.md
+++ b/docs/src/reference/experimental/coverage.md
@@ -14,7 +14,7 @@ Fortunately, Kani is able to report a coverage metric for each proof harness.
 In the `first-steps-v2` directory, try running:
 
 ```
-cargo kani --coverage -Z line-coverage --harness verify_success
+cargo kani --coverage -Z source-coverage --harness verify_success
 ```
 
 which verifies the harness, then prints coverage information for each line.

--- a/docs/src/tutorial-real-code.md
+++ b/docs/src/tutorial-real-code.md
@@ -74,7 +74,7 @@ A first proof will likely start in the following form:
 Running Kani on this simple starting point will help figure out:
 
 1. What unexpected constraints might be needed on your inputs (using `kani::assume`) to avoid "expected" failures.
-2. Whether you're over-constrained. Check the coverage report using `--coverage -Z line-coverage`. Ideally you'd see 100% coverage, and if not, it's usually because you've assumed too much (thus over-constraining the inputs).
+2. Whether you're over-constrained. Check the coverage report using `--coverage -Z source-coverage`. Ideally you'd see 100% coverage, and if not, it's usually because you've assumed too much (thus over-constraining the inputs).
 3. Whether Kani will support all the Rust features involved.
 4. Whether you've started with a tractable problem.
 (Remember to try setting `#[kani::unwind(1)]` to force early termination and work up from there.)


### PR DESCRIPTION
TL; DR: `/s/line-coverage/source-coverage`

Starting Kani 0.55.0, the unstable flag required for enabling `--coverage` was changed from `-Zline-coverage` to `-Zsource-coverage`. Updating the documentation to reflect this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
