### PR TITLE
Remove dead Option layer from run_piped

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -88,8 +88,8 @@ impl KaniSession {
             cmd.arg("--json-ui");
 
             // Spawn the CBMC process and process its output below
-            let cbmc_process_opt = self.run_piped(cmd)?;
-            let cbmc_process = cbmc_process_opt.ok_or(anyhow::Error::msg("Failed to run cbmc"))?;
+            let cbmc_process =
+                self.run_piped(cmd).map_err(|_| anyhow::Error::msg("Failed to run cbmc"))?;
             let output = process_cbmc_output(cbmc_process, |i| {
                 kani_cbmc_output_filter(
                     i,

--- a/kani-driver/src/session.rs
+++ b/kani-driver/src/session.rs
@@ -124,7 +124,7 @@ impl KaniSession {
     }
 
     /// Call [run_piped] with the verbosity configured by the user.
-    pub fn run_piped(&self, cmd: Command) -> Result<Option<Child>> {
+    pub fn run_piped(&self, cmd: Command) -> Result<Child> {
         run_piped(&self.args.common_args, cmd)
     }
 
@@ -227,7 +227,7 @@ pub fn run_redirect(
 ///
 /// NOTE: Unlike other `run_` functions, this function does not attempt to indicate
 /// the process exit code, you need to remember to check this yourself.
-pub fn run_piped(verbosity: &impl Verbosity, mut cmd: Command) -> Result<Option<Child>> {
+pub fn run_piped(verbosity: &impl Verbosity, mut cmd: Command) -> Result<Child> {
     if verbosity.verbose() {
         println!("[Kani] Running: `{}`", render_command(&cmd).to_string_lossy());
     }
@@ -237,7 +237,7 @@ pub fn run_piped(verbosity: &impl Verbosity, mut cmd: Command) -> Result<Option<
         .spawn()
         .context(format!("Failed to invoke {}", cmd.get_program().to_string_lossy()))?;
 
-    Ok(Some(process))
+    Ok(process)
 }
 
 /// Execute the provided function and measure the clock time it took for its execution.


### PR DESCRIPTION
This is a clean-up PR: I noticed that the `run_piped` function has an `Option` layer that is unnecessary:
- If the process launching fails, it returns an error.
- If it succeeds, it returns `Ok(Some(process))`

Thus, the `Option` layer is always `Some`. The main change is updating the function signature from:
```rust
pub fn run_piped(verbosity: &impl Verbosity, mut cmd: Command) -> Result<Option<Child>>
```
to:
```rust
pub fn run_piped(verbosity: &impl Verbosity, mut cmd: Command) -> Result<Child>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
