### PR TITLE
Add `free(0)` to codegen of loop contracts

### DIFF
--- a/tests/expected/loop-contract/count_zero.rs
+++ b/tests/expected/loop-contract/count_zero.rs
@@ -27,9 +27,5 @@ const fn count_zero(slice: &[u8]) -> usize {
 
 #[kani::proof]
 pub fn check_counter() {
-    // Needed to avoid having `free` be removed as unused function. This is
-    // because DFCC contract enforcement assumes that a definition for `free`
-    // exists.
-    let _ = Box::new(10);
     assert_eq!(count_zero(&[1, 2, 3]), 0)
 }

--- a/tests/expected/loop-contract/memchar_naive.rs
+++ b/tests/expected/loop-contract/memchar_naive.rs
@@ -13,10 +13,6 @@
 
 #[kani::proof]
 fn memchar_naive_harness() {
-    // Needed to avoid having `free` be removed as unused function. This is
-    // because DFCC contract enforcement assumes that a definition for `free`
-    // exists.
-    let _ = Box::new(10);
     let text = [1, 2, 3, 4, 5];
     let x = 5;
     let mut i = 0;

--- a/tests/expected/loop-contract/multiple_loops.rs
+++ b/tests/expected/loop-contract/multiple_loops.rs
@@ -44,10 +44,6 @@ fn simple_while_loops() {
 
 #[kani::proof]
 fn multiple_loops_harness() {
-    // Needed to avoid having `free` be removed as unused function. This is
-    // because DFCC contract enforcement assumes that a definition for `free`
-    // exists.
-    let _ = Box::new(10);
     multiple_loops();
     simple_while_loops();
 }

--- a/tests/expected/loop-contract/simple_while_loop.rs
+++ b/tests/expected/loop-contract/simple_while_loop.rs
@@ -9,12 +9,7 @@
 #![feature(proc_macro_hygiene)]
 
 #[kani::proof]
-#[kani::solver(kissat)]
 fn simple_while_loop_harness() {
-    // Needed to avoid having `free` be removed as unused function. This is
-    // because DFCC contract enforcement assumes that a definition for `free`
-    // exists.
-    let _ = Box::new(10);
     let mut x: u8 = kani::any_where(|i| *i >= 2);
 
     #[kani::loop_invariant(x >= 2)]

--- a/tests/expected/loop-contract/small_slice_eq.rs
+++ b/tests/expected/loop-contract/small_slice_eq.rs
@@ -39,10 +39,6 @@ unsafe fn small_slice_eq(x: &[u8], y: &[u8]) -> bool {
 
 #[kani::proof]
 fn small_slice_eq_harness() {
-    // Needed to avoid having `free` be removed as unused function. This is
-    // because DFCC contract enforcement assumes that a definition for `free`
-    // exists.
-    let _ = Box::new(10);
     let mut a = [1; 2000];
     let mut b = [1; 2000];
     unsafe {


### PR DESCRIPTION
Add `free(0)` to the codegen result of loop contracts to avoid dropping the body of `free`, which is required by DFCC. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
