### PR TITLE
Build and include `kani-cov` in the bundle

### DIFF
--- a/tools/build-kani/src/main.rs
+++ b/tools/build-kani/src/main.rs
@@ -10,7 +10,9 @@
 mod parser;
 mod sysroot;
 
-use crate::sysroot::{build_bin, build_lib, kani_no_core_lib, kani_playback_lib, kani_sysroot_lib};
+use crate::sysroot::{
+    build_bin, build_lib, build_tools, kani_no_core_lib, kani_playback_lib, kani_sysroot_lib,
+};
 use anyhow::{Result, bail};
 use clap::Parser;
 use std::{ffi::OsString, path::Path, process::Command};
@@ -72,6 +74,8 @@ fn prebundle(dir: &Path) -> Result<()> {
         bail!("Couldn't find the 'cbmc' binary to include in the release bundle.");
     }
 
+    build_tools(&["--release"])?;
+
     // Before we begin, ensure Kani is built successfully in release mode.
     // And that libraries have been built too.
     build_lib(&build_bin(&["--release"])?)
@@ -86,6 +90,7 @@ fn bundle_kani(dir: &Path) -> Result<()> {
     let release = Path::new("./target/release");
     cp(&release.join("kani-driver"), &bin)?;
     cp(&release.join("kani-compiler"), &bin)?;
+    cp(&release.join("kani-cov"), &bin)?;
 
     // 2. Kani scripts
     let scripts = dir.join("scripts");

--- a/tools/build-kani/src/sysroot.rs
+++ b/tools/build-kani/src/sysroot.rs
@@ -279,17 +279,16 @@ pub fn build_bin<T: AsRef<OsStr>>(extra_args: &[T]) -> Result<PathBuf> {
     Ok(out_dir)
 }
 
-/// Build tool binaries with the extra arguments provided and return the path to
-/// the binaries folder. At present, the only tool we build for the bundle is
-/// `kani-cov`, but this could include other tools in the future.
-pub fn build_tools<T: AsRef<OsStr>>(extra_args: &[T]) -> Result<PathBuf> {
-    let out_dir = kani_sysroot_bin();
-    let args = ["-p", "kani-cov", "--target-dir", out_dir.to_str().unwrap()];
+/// Build tool binaries with the extra arguments provided.
+/// At present, the only tool we build for the bundle is `kani-cov`, but this
+/// could include other tools in the future.
+pub fn build_tools<T: AsRef<OsStr>>(extra_args: &[T]) -> Result<()> {
+    let args = ["-p", "kani-cov"];
     Command::new("cargo")
         .arg("build")
         .args(extra_args)
         .args(args)
         .run()
         .or(Err(format_err!("Failed to build tool binaries.")))?;
-    Ok(out_dir)
+    Ok(())
 }

--- a/tools/build-kani/src/sysroot.rs
+++ b/tools/build-kani/src/sysroot.rs
@@ -278,3 +278,18 @@ pub fn build_bin<T: AsRef<OsStr>>(extra_args: &[T]) -> Result<PathBuf> {
         .or(Err(format_err!("Failed to build binaries.")))?;
     Ok(out_dir)
 }
+
+/// Build tool binaries with the extra arguments provided and return the path to
+/// the binaries folder. At present, the only tool we build for the bundle is
+/// `kani-cov`, but this could include other tools in the future.
+pub fn build_tools<T: AsRef<OsStr>>(extra_args: &[T]) -> Result<PathBuf> {
+    let out_dir = kani_sysroot_bin();
+    let args = ["-p", "kani-cov", "--target-dir", out_dir.to_str().unwrap()];
+    Command::new("cargo")
+        .arg("build")
+        .args(extra_args)
+        .args(args)
+        .run()
+        .or(Err(format_err!("Failed to build tool binaries.")))?;
+    Ok(out_dir)
+}


### PR DESCRIPTION
This PR adds another step to the `cargo bundle` command so that `kani-cov` is built in release mode and then included in the bundle. This will allow users to call `kani-cov` once Kani has been setup.

I have manually tested it works by running:

```
cargo bundle
tar -xzf kani-0.56.0-x86_64-unknown-linux-gnu.tar.gz
ls kani-0.56.0/bin/
```

This showed `kani-cov` along with other binaries like `cbmc` and `kissat`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
