### PR TITLE
Update toolchain to 10/25

### DIFF
--- a/kani-compiler/src/kani_middle/transform/stubs.rs
+++ b/kani-compiler/src/kani_middle/transform/stubs.rs
@@ -3,7 +3,7 @@
 //! This module contains code related to the MIR-to-MIR pass that performs the
 //! stubbing of functions and methods.
 use crate::kani_middle::codegen_units::Stubs;
-use crate::kani_middle::stubbing::{contract_host_param, validate_stub_const};
+use crate::kani_middle::stubbing::validate_stub_const;
 use crate::kani_middle::transform::body::{MutMirVisitor, MutableBody};
 use crate::kani_middle::transform::{TransformPass, TransformationType};
 use crate::kani_queries::QueryDb;
@@ -46,12 +46,8 @@ impl TransformPass for FnStubPass {
     fn transform(&mut self, tcx: TyCtxt, body: Body, instance: Instance) -> (bool, Body) {
         trace!(function=?instance.name(), "transform");
         let ty = instance.ty();
-        if let TyKind::RigidTy(RigidTy::FnDef(fn_def, mut args)) = ty.kind() {
+        if let TyKind::RigidTy(RigidTy::FnDef(fn_def, args)) = ty.kind() {
             if let Some(replace) = self.stubs.get(&fn_def) {
-                if let Some(idx) = contract_host_param(tcx, fn_def, *replace) {
-                    debug!(?idx, "FnStubPass::transform remove_host_param");
-                    args.0.remove(idx);
-                }
                 let new_instance = Instance::resolve(*replace, &args).unwrap();
                 debug!(from=?instance.name(), to=?new_instance.name(), "FnStubPass::transform");
                 if let Some(body) = FnStubValidator::validate(tcx, (fn_def, *replace), new_instance)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-10-24"
+channel = "nightly-2024-10-25"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Culprit PR: https://github.com/rust-lang/rust/pull/131985

The automatic PR failed because the culprit PR removed the `host_param_index` field that we used in the `contract_host_param` function. We needed the `contract_host_param` function in the first place because previously, Rust would add a `<const HOST: bool>` parameter to a function's `GenericArgs` to handle trait constness (c.f. #3258). The culprit PR [removed that argument](https://github.com/rust-lang/rust/pull/131985/files#diff-0a61b538a3cec072c76fecae4635af6a12ec3256860029ac70549c2aa53ab394L1527), so our logic to find and remove this parameter during stubbing is no longer necessary.

Resolves #3645

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
