### PR TITLE
Upgrade toolchain to 2024-11-01

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -721,7 +721,7 @@ impl GotocCtx<'_> {
 
         // For all intrinsics we first check `is_uninhabited` to give a more
         // precise error message
-        if layout.abi.is_uninhabited() {
+        if layout.backend_repr.is_uninhabited() {
             return self.codegen_fatal_error(
                 PropertyClass::SafetyCheck,
                 &format!(

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -18,8 +18,8 @@ use rustc_middle::ty::{List, TypeFoldable};
 use rustc_smir::rustc_internal;
 use rustc_span::def_id::DefId;
 use rustc_target::abi::{
-    Abi::Vector, FieldIdx, FieldsShape, Float, Integer, LayoutData, Primitive, Size, TagEncoding,
-    TyAndLayout, VariantIdx, Variants,
+    BackendRepr::Vector, FieldIdx, FieldsShape, Float, Integer, LayoutData, Primitive, Size,
+    TagEncoding, TyAndLayout, VariantIdx, Variants,
 };
 use stable_mir::abi::{ArgAbi, FnAbi, PassMode};
 use stable_mir::mir::Body;
@@ -1451,7 +1451,7 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     fn codegen_vector(&mut self, ty: Ty<'tcx>) -> Type {
-        let layout = &self.layout_of(ty).layout.abi();
+        let layout = &self.layout_of(ty).layout.backend_repr();
         debug! {"handling simd with layout {:?}", layout};
 
         let (element, size) = match layout {

--- a/kani-driver/src/cbmc_output_parser.rs
+++ b/kani-driver/src/cbmc_output_parser.rs
@@ -480,9 +480,9 @@ impl Parser {
 
     /// Read the process output and return when an item is found in the output
     /// or the EOF is reached
-    async fn read_output<'a, 'b>(
+    async fn read_output(
         &mut self,
-        buffer: &'a mut BufReader<&'b mut ChildStdout>,
+        buffer: &mut BufReader<&mut ChildStdout>,
     ) -> Option<ParserItem> {
         loop {
             let mut input = String::new();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2024-10-31"
+channel = "nightly-2024-11-01"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Changes required due to https://github.com/rust-lang/rust/pull/132246 (Rename `rustc_abi::Abi` to `BackendRepr`).

Resolves: #3669

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
