### PR TITLE
codegen: Ask the layout if it is uninhabited, not its impl detail

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -721,7 +721,7 @@ impl GotocCtx<'_> {
 
         // For all intrinsics we first check `is_uninhabited` to give a more
         // precise error message
-        if layout.backend_repr.is_uninhabited() {
+        if layout.is_uninhabited() {
             return self.codegen_fatal_error(
                 PropertyClass::SafetyCheck,
                 &format!(


### PR DESCRIPTION
Directly question the layout if it is uninhabited. This makes Kani more resilient to changes in the upstream rustc toolchain, as the convenience function which exposes this is precisely to allow compilers to not fixate as much on the innermost details of rustc's codegen process.

Found while reviewing https://github.com/model-checking/kani/pull/3671