### PR TITLE
Bump Kani version to 0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.57.0]
+
+### Major Changes
+* `kani-cov`: A coverage tool for Kani by @adpaco-aws in https://github.com/model-checking/kani/pull/3121 https://github.com/model-checking/kani/pull/3641
+
+### Breaking Changes
+* [Breaking change] Make `kani::check` private by @celinval in https://github.com/model-checking/kani/pull/3614
+
+### What's Changed
+* Remove the overflow checks for wrapping_offset by @zhassan-aws in https://github.com/model-checking/kani/pull/3589
+* Support fully-qualified --package arguments by @celinval in https://github.com/model-checking/kani/pull/3593
+* Loop Contracts Annotation for While-Loop by @qinheping in https://github.com/model-checking/kani/pull/3151
+* Implement proper function pointer handling for validity checks by @celinval in https://github.com/model-checking/kani/pull/3606
+* [aeneas] Preserve variable names by @zhassan-aws in https://github.com/model-checking/kani/pull/3560
+* Emit an error when proof_for_contract function is not found by @zhassan-aws in https://github.com/model-checking/kani/pull/3609
+* Add `free(0)` to codegen of loop contracts by @qinheping in https://github.com/model-checking/kani/pull/3637
+* [Lean] Rename user-facing options from Aeneas to Lean by @zhassan-aws in https://github.com/model-checking/kani/pull/3630
+* Fix ICE due to mishandling of Aggregate rvalue for raw pointers to trait objects by @carolynzech in https://github.com/model-checking/kani/pull/3636
+* Call `goto-instrument` with `DFCC` only once by @qinheping in https://github.com/model-checking/kani/pull/3642
+* Fix loop contracts transformation when loops in branching by @qinheping in https://github.com/model-checking/kani/pull/3640
+* Reduce the number of object bits for refcell test by @zhassan-aws in https://github.com/model-checking/kani/pull/3656
+* Move any_slice_from_array to kani_core by @qinheping in https://github.com/model-checking/kani/pull/3646
+* Add a timeout option by @zhassan-aws in https://github.com/model-checking/kani/pull/3649
+* Implement `Arbitrary` for `Range*` by @c410-f3r in https://github.com/model-checking/kani/pull/3666
+* Automatic toolchain upgrade to nightly-2024-11-03 by @github-actions in https://github.com/model-checking/kani/pull/3674
+* codegen: Ask the layout if it is uninhabited, not its impl detail by @workingjubilee in https://github.com/model-checking/kani/pull/3675
+* Harness output individual files by @Alexander-Aghili in https://github.com/model-checking/kani/pull/3360
+* Update Charon submodule to 2024-11-04 by @zhassan-aws in https://github.com/model-checking/kani/pull/3686
+* Add support for float_to_int_unchecked by @zhassan-aws in https://github.com/model-checking/kani/pull/3660
+
+## New Contributors
+* @c410-f3r made their first contribution in https://github.com/model-checking/kani/pull/3666
+* @workingjubilee made their first contribution in https://github.com/model-checking/kani/pull/3675
+* @Alexander-Aghili made their first contribution in https://github.com/model-checking/kani/pull/3360
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.56.0...kani-0.57.0
+
 ## [0.56.0]
 
 ### Major/Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -769,7 +769,7 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "kani"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "kani_core",
  "kani_macros",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "kani-compiler"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "charon",
  "clap",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "home",
@@ -856,14 +856,14 @@ dependencies = [
 
 [[package]]
 name = "kani_core"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani_macros"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "std"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_core/Cargo.toml
+++ b/library/kani_core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_core"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
# Description of changes:
- Bumps version of Kani crates to 0.57.0.
- Adds release notes to CHANGELOG.md

Please check the changes included in `CHANGELOG.md`, and let me know if you think any other changes should be included. For reference, the initial auto-generated release notes were:

```
## What's Changed
* Remove the overflow checks for wrapping_offset by @zhassan-aws in https://github.com/model-checking/kani/pull/3589
* `kani-cov`: A coverage tool for Kani by @adpaco-aws in https://github.com/model-checking/kani/pull/3121
* Automatic toolchain upgrade to nightly-2024-10-04 by @github-actions in https://github.com/model-checking/kani/pull/3570
* Automatic toolchain upgrade to nightly-2024-10-05 by @github-actions in https://github.com/model-checking/kani/pull/3591
* Automatic toolchain upgrade to nightly-2024-10-06 by @github-actions in https://github.com/model-checking/kani/pull/3592
* Exclude Charon from workspace by @zhassan-aws in https://github.com/model-checking/kani/pull/3580
* Support fully-qualified --package arguments by @celinval in https://github.com/model-checking/kani/pull/3593
* Automatic toolchain upgrade to nightly-2024-10-07 by @github-actions in https://github.com/model-checking/kani/pull/3595
* Automatic toolchain upgrade to nightly-2024-10-08 by @github-actions in https://github.com/model-checking/kani/pull/3597
* Automatic cargo update to 2024-10-14 by @github-actions in https://github.com/model-checking/kani/pull/3598
* Bump tests/perf/s2n-quic from `17171ec` to `7752afb` by @dependabot in https://github.com/model-checking/kani/pull/3601
* Automatic toolchain upgrade to nightly-2024-10-09 by @github-actions in https://github.com/model-checking/kani/pull/3600
* Automatic toolchain upgrade to nightly-2024-10-10 by @github-actions in https://github.com/model-checking/kani/pull/3602
* Automatic toolchain upgrade to nightly-2024-10-11 by @github-actions in https://github.com/model-checking/kani/pull/3603
* Loop Contracts Annotation for While-Loop by @qinheping in https://github.com/model-checking/kani/pull/3151
* Automatic toolchain upgrade to nightly-2024-10-12 by @github-actions in https://github.com/model-checking/kani/pull/3604
* Update toolchain to 2024-10-15 by @zhassan-aws in https://github.com/model-checking/kani/pull/3605
* Automatic toolchain upgrade to nightly-2024-10-16 by @github-actions in https://github.com/model-checking/kani/pull/3607
* Implement proper function pointer handling for validity checks by @celinval in https://github.com/model-checking/kani/pull/3606
* Update toolchain to 2024-10-17 by @zhassan-aws in https://github.com/model-checking/kani/pull/3610
* Add fn that checks pointers point to same allocation by @celinval in https://github.com/model-checking/kani/pull/3583
* Automatic toolchain upgrade to nightly-2024-10-18 by @github-actions in https://github.com/model-checking/kani/pull/3613
* [aeneas] Preserve variable names by @zhassan-aws in https://github.com/model-checking/kani/pull/3560
* [Breaking change] Make `kani::check` private by @celinval in https://github.com/model-checking/kani/pull/3614
* Emit an error when proof_for_contract function is not found by @zhassan-aws in https://github.com/model-checking/kani/pull/3609
* Automatic toolchain upgrade to nightly-2024-10-19 by @github-actions in https://github.com/model-checking/kani/pull/3617
* Automatic toolchain upgrade to nightly-2024-10-20 by @github-actions in https://github.com/model-checking/kani/pull/3619
* Update test small_slice_eq by @qinheping in https://github.com/model-checking/kani/pull/3618
* Automatic toolchain upgrade to nightly-2024-10-21 by @github-actions in https://github.com/model-checking/kani/pull/3621
* Automatic cargo update to 2024-10-21 by @github-actions in https://github.com/model-checking/kani/pull/3622
* Bump tests/perf/s2n-quic from `7752afb` to `cd0314b` by @dependabot in https://github.com/model-checking/kani/pull/3625
* Update coverage flag in docs by @zhassan-aws in https://github.com/model-checking/kani/pull/3626
* Automatic toolchain upgrade to nightly-2024-10-22 by @github-actions in https://github.com/model-checking/kani/pull/3628
* Automatic toolchain upgrade to nightly-2024-10-23 by @github-actions in https://github.com/model-checking/kani/pull/3635
* Remove dead Option layer from run_piped by @zhassan-aws in https://github.com/model-checking/kani/pull/3634
* Add `free(0)` to codegen of loop contracts by @qinheping in https://github.com/model-checking/kani/pull/3637
* [Lean] Rename user-facing options from Aeneas to Lean by @zhassan-aws in https://github.com/model-checking/kani/pull/3630
* Fix ICE due to mishandling of Aggregate rvalue for raw pointers to trait objects by @carolynzech in https://github.com/model-checking/kani/pull/3636
* Automatic toolchain upgrade to nightly-2024-10-24 by @github-actions in https://github.com/model-checking/kani/pull/3639
* Add regular & fixme tests for function contracts by @celinval in https://github.com/model-checking/kani/pull/3371
* Call `goto-instrument` with `DFCC` only once by @qinheping in https://github.com/model-checking/kani/pull/3642
* Build and include `kani-cov` in the bundle by @adpaco-aws in https://github.com/model-checking/kani/pull/3641
* Fix loop contracts transformation when loops in branching by @qinheping in https://github.com/model-checking/kani/pull/3640
* Update toolchain to 10/25 by @carolynzech in https://github.com/model-checking/kani/pull/3648
* Automatic toolchain upgrade to nightly-2024-10-26 by @github-actions in https://github.com/model-checking/kani/pull/3651
* Automatic toolchain upgrade to nightly-2024-10-27 by @github-actions in https://github.com/model-checking/kani/pull/3652
* Bump tests/perf/s2n-quic from `cd0314b` to `ed9db08` by @dependabot in https://github.com/model-checking/kani/pull/3655
* Automatic cargo update to 2024-10-28 by @github-actions in https://github.com/model-checking/kani/pull/3654
* Automatic toolchain upgrade to nightly-2024-10-28 by @github-actions in https://github.com/model-checking/kani/pull/3653
* Reduce the number of object bits for refcell test by @zhassan-aws in https://github.com/model-checking/kani/pull/3656
* Move any_slice_from_array to kani_core by @qinheping in https://github.com/model-checking/kani/pull/3646
* Upgrade toolchain to 2024-10-29 by @zhassan-aws in https://github.com/model-checking/kani/pull/3658
* Add a timeout option by @zhassan-aws in https://github.com/model-checking/kani/pull/3649
* Upgrade toolchain to 2024-10-30 by @tautschnig in https://github.com/model-checking/kani/pull/3661
* Upgrade Rust toolchain to 2024-10-31 by @zhassan-aws in https://github.com/model-checking/kani/pull/3668
* Upgrade toolchain to 2024-11-01 by @tautschnig in https://github.com/model-checking/kani/pull/3671
* Automatic toolchain upgrade to nightly-2024-11-02 by @github-actions in https://github.com/model-checking/kani/pull/3673
* Implement `Arbitrary` for `Range*` by @c410-f3r in https://github.com/model-checking/kani/pull/3666
* Automatic toolchain upgrade to nightly-2024-11-03 by @github-actions in https://github.com/model-checking/kani/pull/3674
* codegen: Ask the layout if it is uninhabited, not its impl detail by @workingjubilee in https://github.com/model-checking/kani/pull/3675
* Automatic cargo update to 2024-11-04 by @github-actions in https://github.com/model-checking/kani/pull/3677
* Bump tests/perf/s2n-quic from `192de7d` to `65d55a4` by @dependabot in https://github.com/model-checking/kani/pull/3678
* Update dependencies following Audit workflow failure. by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3680
* Harness output individual files by @Alexander-Aghili in https://github.com/model-checking/kani/pull/3360
* Update Charon submodule to 2024-11-04 by @zhassan-aws in https://github.com/model-checking/kani/pull/3686
* Add support for float_to_int_unchecked by @zhassan-aws in https://github.com/model-checking/kani/pull/3660

## New Contributors
* @c410-f3r made their first contribution in https://github.com/model-checking/kani/pull/3666
* @workingjubilee made their first contribution in https://github.com/model-checking/kani/pull/3675
* @Alexander-Aghili made their first contribution in https://github.com/model-checking/kani/pull/3360

**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.56.0...kani-0.57.0
```

# Call-outs:

These open issues may be considered blocking for this release (no decision yet):
- https://github.com/model-checking/kani/issues/3616
- https://github.com/model-checking/kani/issues/3627
- https://github.com/model-checking/kani/issues/3670

# Testing:

- How is this change tested? Existing regression.
- Is this a refactor change? N/A