### PR TITLE
Apply loop contracts only if there exists some usage

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -263,6 +263,7 @@ impl CodegenBackend for GotocCodegenBackend {
                 ReachabilityType::Harnesses => {
                     let mut units = CodegenUnits::new(&queries, tcx);
                     let mut modifies_instances = vec![];
+                    let mut loop_contracts_instances = vec![];
                     // Cross-crate collecting of all items that are reachable from the crate harnesses.
                     for unit in units.iter() {
                         // We reset the body cache for now because each codegen unit has different
@@ -280,6 +281,9 @@ impl CodegenBackend for GotocCodegenBackend {
                                 contract_metadata,
                                 transformer,
                             );
+                            if gcx.has_loop_contracts {
+                                loop_contracts_instances.push(*harness);
+                            }
                             results.extend(gcx, items, None);
                             if let Some(assigns_contract) = contract_info {
                                 modifies_instances.push((*harness, assigns_contract));
@@ -287,6 +291,7 @@ impl CodegenBackend for GotocCodegenBackend {
                         }
                     }
                     units.store_modifies(&modifies_instances);
+                    units.store_loop_contracts(&loop_contracts_instances);
                     units.write_metadata(&queries, tcx);
                 }
                 ReachabilityType::Tests => {

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -74,6 +74,8 @@ pub struct GotocCtx<'tcx> {
     pub concurrent_constructs: UnsupportedConstructs,
     /// The body transformation agent.
     pub transformer: BodyTransformation,
+    /// If there exist some usage of loop contracts int context.
+    pub has_loop_contracts: bool,
 }
 
 /// Constructor
@@ -103,6 +105,7 @@ impl<'tcx> GotocCtx<'tcx> {
             unsupported_constructs: FxHashMap::default(),
             concurrent_constructs: FxHashMap::default(),
             transformer,
+            has_loop_contracts: false
         }
     }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -105,7 +105,7 @@ impl<'tcx> GotocCtx<'tcx> {
             unsupported_constructs: FxHashMap::default(),
             concurrent_constructs: FxHashMap::default(),
             transformer,
-            has_loop_contracts: false
+            has_loop_contracts: false,
         }
     }
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -576,25 +576,43 @@ impl GotocHook for LoopInvariantRegister {
 
         gcx.has_loop_contracts = true;
 
-        // Add `free(0)` to make sure the body of `free` won't be dropped to
-        // satisfy the requirement of DFCC.
-        Stmt::block(
-            vec![
-                BuiltinFn::Free
-                    .call(vec![Expr::pointer_constant(0, Type::void_pointer())], loc)
-                    .as_stmt(loc),
-                unwrap_or_return_codegen_unimplemented_stmt!(
-                    gcx,
-                    gcx.codegen_place_stable(assign_to, loc)
-                )
-                .goto_expr
-                .assign(Expr::c_true(), loc),
-                Stmt::goto(bb_label(target.unwrap()), loc).with_loop_contracts(
-                    func_exp.call(fargs).cast_to(Type::CInteger(CIntType::Bool)),
-                ),
-            ],
-            loc,
-        )
+        if gcx.queries.args().unstable_features.contains(&"loop-contracts".to_string()) {
+            // When loop-contracts is enabled, codegen
+            // free(0)
+            // goto target --- with loop contracts annotated.
+
+            // Add `free(0)` to make sure the body of `free` won't be dropped to
+            // satisfy the requirement of DFCC.
+            Stmt::block(
+                vec![
+                    BuiltinFn::Free
+                        .call(vec![Expr::pointer_constant(0, Type::void_pointer())], loc)
+                        .as_stmt(loc),
+                    Stmt::goto(bb_label(target.unwrap()), loc).with_loop_contracts(
+                        func_exp.call(fargs).cast_to(Type::CInteger(CIntType::Bool)),
+                    ),
+                ],
+                loc,
+            )
+        } else {
+            // When loop-contracts is not enabled, codegen
+            // assign_to = true
+            // goto target
+            Stmt::block(
+                vec![
+                    unwrap_or_return_codegen_unimplemented_stmt!(
+                        gcx,
+                        gcx.codegen_place_stable(assign_to, loc)
+                    )
+                    .goto_expr
+                    .assign(Expr::c_true(), loc),
+                    Stmt::goto(bb_label(target.unwrap()), loc).with_loop_contracts(
+                        func_exp.call(fargs).cast_to(Type::CInteger(CIntType::Bool)),
+                    ),
+                ],
+                loc,
+            )
+        }
     }
 }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -567,7 +567,7 @@ impl GotocHook for LoopInvariantRegister {
         gcx: &mut GotocCtx,
         instance: Instance,
         fargs: Vec<Expr>,
-        _assign_to: &Place,
+        assign_to: &Place,
         target: Option<BasicBlockIdx>,
         span: Span,
     ) -> Stmt {
@@ -583,6 +583,12 @@ impl GotocHook for LoopInvariantRegister {
                 BuiltinFn::Free
                     .call(vec![Expr::pointer_constant(0, Type::void_pointer())], loc)
                     .as_stmt(loc),
+                unwrap_or_return_codegen_unimplemented_stmt!(
+                    gcx,
+                    gcx.codegen_place_stable(assign_to, loc)
+                )
+                .goto_expr
+                .assign(Expr::c_true(), loc),
                 Stmt::goto(bb_label(target.unwrap()), loc).with_loop_contracts(
                     func_exp.call(fargs).cast_to(Type::CInteger(CIntType::Bool)),
                 ),

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -573,6 +573,9 @@ impl GotocHook for LoopInvariantRegister {
     ) -> Stmt {
         let loc = gcx.codegen_span_stable(span);
         let func_exp = gcx.codegen_func_expr(instance, loc);
+
+        gcx.has_loop_contracts = true;
+
         // Add `free(0)` to make sure the body of `free` won't be dropped to
         // satisfy the requirement of DFCC.
         Stmt::block(

--- a/kani-compiler/src/kani_middle/codegen_units.rs
+++ b/kani-compiler/src/kani_middle/codegen_units.rs
@@ -91,6 +91,13 @@ impl CodegenUnits {
         }
     }
 
+    /// We flag that the harness contains usage of loop contracts.
+    pub fn store_loop_contracts(&mut self, harnesses: &[Harness]) {
+        for harness in harnesses {
+            self.harness_info.get_mut(harness).unwrap().has_loop_contracts = true;
+        }
+    }
+
     /// Write compilation metadata into a file.
     pub fn write_metadata(&self, queries: &QueryDb, tcx: TyCtxt) {
         let metadata = self.generate_metadata(tcx);

--- a/kani-compiler/src/kani_middle/metadata.rs
+++ b/kani-compiler/src/kani_middle/metadata.rs
@@ -38,6 +38,7 @@ pub fn gen_proof_metadata(tcx: TyCtxt, instance: Instance, base_name: &Path) -> 
         // TODO: This no longer needs to be an Option.
         goto_file: Some(model_file),
         contract: Default::default(),
+        has_loop_contracts: false,
     }
 }
 
@@ -108,5 +109,6 @@ pub fn gen_test_metadata(
         // TODO: This no longer needs to be an Option.
         goto_file: Some(model_file),
         contract: Default::default(),
+        has_loop_contracts: false,
     }
 }

--- a/kani-driver/src/call_goto_instrument.rs
+++ b/kani-driver/src/call_goto_instrument.rs
@@ -37,7 +37,13 @@ impl KaniSession {
             self.goto_sanity_check(output)?;
         }
 
-        self.instrument_contracts(harness, output)?;
+        let is_loop_contracts_enabled = self
+            .args
+            .common_args
+            .unstable_features
+            .contains(kani_metadata::UnstableFeature::LoopContracts)
+            && harness.has_loop_contracts;
+        self.instrument_contracts(harness, is_loop_contracts_enabled, output)?;
 
         if self.args.checks.undefined_function_on() {
             self.add_library(output)?;
@@ -164,16 +170,21 @@ impl KaniSession {
     }
 
     /// Apply annotated function contracts and loop contracts with goto-instrument.
-    pub fn instrument_contracts(&self, harness: &HarnessMetadata, file: &Path) -> Result<()> {
+    pub fn instrument_contracts(
+        &self,
+        harness: &HarnessMetadata,
+        is_loop_contracts_enabled: bool,
+        file: &Path,
+    ) -> Result<()> {
         // Do nothing if neither loop contracts nor function contracts is enabled.
-        if !harness.has_loop_contracts && harness.contract.is_none() {
+        if !is_loop_contracts_enabled && harness.contract.is_none() {
             return Ok(());
         }
 
         let mut args: Vec<OsString> =
             vec!["--dfcc".into(), (&harness.mangled_name).into(), "--no-malloc-may-fail".into()];
 
-        if harness.has_loop_contracts {
+        if is_loop_contracts_enabled {
             args.append(&mut vec![
                 "--apply-loop-contracts".into(),
                 "--loop-contracts-no-unwind".into(),

--- a/kani-driver/src/call_goto_instrument.rs
+++ b/kani-driver/src/call_goto_instrument.rs
@@ -37,12 +37,7 @@ impl KaniSession {
             self.goto_sanity_check(output)?;
         }
 
-        let is_loop_contracts_enabled = self
-            .args
-            .common_args
-            .unstable_features
-            .contains(kani_metadata::UnstableFeature::LoopContracts);
-        self.instrument_contracts(harness, is_loop_contracts_enabled, output)?;
+        self.instrument_contracts(harness, output)?;
 
         if self.args.checks.undefined_function_on() {
             self.add_library(output)?;
@@ -172,18 +167,17 @@ impl KaniSession {
     pub fn instrument_contracts(
         &self,
         harness: &HarnessMetadata,
-        is_loop_contracts_enabled: bool,
         file: &Path,
     ) -> Result<()> {
         // Do nothing if neither loop contracts nor function contracts is enabled.
-        if !is_loop_contracts_enabled && harness.contract.is_none() {
+        if !harness.has_loop_contracts && harness.contract.is_none() {
             return Ok(());
         }
 
         let mut args: Vec<OsString> =
             vec!["--dfcc".into(), (&harness.mangled_name).into(), "--no-malloc-may-fail".into()];
 
-        if is_loop_contracts_enabled {
+        if harness.has_loop_contracts {
             args.append(&mut vec![
                 "--apply-loop-contracts".into(),
                 "--loop-contracts-no-unwind".into(),

--- a/kani-driver/src/call_goto_instrument.rs
+++ b/kani-driver/src/call_goto_instrument.rs
@@ -164,11 +164,7 @@ impl KaniSession {
     }
 
     /// Apply annotated function contracts and loop contracts with goto-instrument.
-    pub fn instrument_contracts(
-        &self,
-        harness: &HarnessMetadata,
-        file: &Path,
-    ) -> Result<()> {
+    pub fn instrument_contracts(&self, harness: &HarnessMetadata, file: &Path) -> Result<()> {
         // Do nothing if neither loop contracts nor function contracts is enabled.
         if !harness.has_loop_contracts && harness.contract.is_none() {
             return Ok(());

--- a/kani-driver/src/metadata.rs
+++ b/kani-driver/src/metadata.rs
@@ -223,6 +223,7 @@ pub mod tests {
             attributes,
             goto_file: model_file,
             contract: Default::default(),
+            has_loop_contracts: false,
         }
     }
 

--- a/kani_metadata/src/harness.rs
+++ b/kani_metadata/src/harness.rs
@@ -36,6 +36,8 @@ pub struct HarnessMetadata {
     pub attributes: HarnessAttributes,
     /// A CBMC-level assigns contract that should be enforced when running this harness.
     pub contract: Option<AssignsContract>,
+    /// If the harness contains some usage of loop contracts.
+    pub has_loop_contracts: bool,
 }
 
 /// The attributes added by the user to control how a harness is executed.

--- a/tests/expected/loop-contract/multiple_loops.expected
+++ b/tests/expected/loop-contract/multiple_loops.expected
@@ -1,1 +1,2 @@
 VERIFICATION:- SUCCESSFUL
+Complete - 2 successfully verified harnesses, 0 failures, 2 total.

--- a/tests/expected/loop-contract/multiple_loops.rs
+++ b/tests/expected/loop-contract/multiple_loops.rs
@@ -44,6 +44,14 @@ fn simple_while_loops() {
     assert!(x == 2);
 }
 
+/// Check that `loop-contracts` works correctly for harness
+/// without loop contracts.
+#[kani::proof]
+fn no_loop_harness(){
+    let x = 2;
+    assert!(x == 2);
+}
+
 #[kani::proof]
 fn multiple_loops_harness() {
     multiple_loops();

--- a/tests/expected/loop-contract/multiple_loops.rs
+++ b/tests/expected/loop-contract/multiple_loops.rs
@@ -47,7 +47,7 @@ fn simple_while_loops() {
 /// Check that `loop-contracts` works correctly for harness
 /// without loop contracts.
 #[kani::proof]
-fn no_loop_harness(){
+fn no_loop_harness() {
     let x = 2;
     assert!(x == 2);
 }

--- a/tests/expected/loop-contract/simple_while_loop_not_enabled.expected
+++ b/tests/expected/loop-contract/simple_while_loop_not_enabled.expected
@@ -1,0 +1,2 @@
+Unwinding loop
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/loop-contract/simple_while_loop_not_enabled.rs
+++ b/tests/expected/loop-contract/simple_while_loop_not_enabled.rs
@@ -1,0 +1,21 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags:
+
+//! Check if the harness can be proved when loop contracts is not enabled.
+
+#![feature(stmt_expr_attributes)]
+#![feature(proc_macro_hygiene)]
+
+#[kani::proof]
+fn simple_while_loop_harness() {
+    let mut x: u8 = 10;
+
+    #[kani::loop_invariant(x >= 2)]
+    while x > 2 {
+        x = x - 1;
+    }
+
+    assert!(x == 2);
+}


### PR DESCRIPTION
In this PR, we detect the usage of loop contracts, and apply loop contracts with goto-instrument only if there exists some usage of loop contracts in the codegen unit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
