### PR TITLE
Remove symtab json support

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -31,27 +31,6 @@ jobs:
       - name: Execute Kani regression
         run: ./scripts/kani-regression.sh
 
-  write-json-symtab-regression:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout Kani
-        uses: actions/checkout@v4
-
-      - name: Setup Kani Dependencies
-        uses: ./.github/actions/setup
-        with:
-          os: ubuntu-20.04
-
-      - name: Build Kani
-        run: cargo build-dev -- --features write_json_symtab
-
-      - name: Run tests
-        run: |
-          cargo run -p compiletest --quiet -- --suite kani --mode kani --quiet --no-fail-fast
-          cargo run -p compiletest --quiet -- --suite expected --mode expected --quiet --no-fail-fast
-          cargo run -p compiletest --quiet -- --suite cargo-kani --mode cargo-kani --quiet --no-fail-fast
-
-
   benchcomp-tests:
     runs-on: ubuntu-20.04
     steps:

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -34,7 +34,6 @@ tracing-tree = "0.4.0"
 default = ['cprover', 'llbc']
 llbc = ['charon']
 cprover = ['cbmc', 'num', 'serde']
-write_json_symtab = []
 
 [package.metadata.rust-analyzer]
 # This package uses rustc crates.

--- a/kani-compiler/src/args.rs
+++ b/kani-compiler/src/args.rs
@@ -51,11 +51,6 @@ pub struct Arguments {
     /// Option used for suppressing global ASM error.
     #[clap(long)]
     pub ignore_global_asm: bool,
-    #[clap(long)]
-    /// Option used to write JSON symbol tables instead of GOTO binaries.
-    ///
-    /// When set, instructs the compiler to produce the symbol table for CBMC in JSON format and use symtab2gb.
-    pub write_json_symtab: bool,
     /// Option name used to select which reachability analysis to perform.
     #[clap(long = "reachability", default_value = "none")]
     pub reachability_analysis: ReachabilityType,

--- a/kani-driver/src/args/mod.rs
+++ b/kani-driver/src/args/mod.rs
@@ -573,6 +573,10 @@ impl ValidateArgs for VerificationArgs {
             );
         }
 
+        if self.write_json_symtab {
+            print_obsolete(&self.common_args, "--write-json-symtab");
+        }
+
         if self.visualize {
             if !self.common_args.enable_unstable {
                 return Err(Error::raw(

--- a/kani-driver/src/call_single_file.rs
+++ b/kani-driver/src/call_single_file.rs
@@ -129,11 +129,6 @@ impl KaniSession {
             flags.push("--ignore-global-asm".into());
         }
 
-        // Users activate it via the command line switch
-        if self.args.write_json_symtab {
-            flags.push("--write-json-symtab".into());
-        }
-
         if self.args.is_stubbing_enabled() {
             flags.push("--enable-stubbing".into());
         }


### PR DESCRIPTION
I believe the plan was to keep this in case of a regression for about a year. The time has long gone, so I think it's time to get rid of it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
