### PR TITLE
Update charon submodule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,6 @@ dependencies = [
  "clap",
  "colored",
  "convert_case 0.6.0",
- "derivative",
  "derive-visitor",
  "env_logger",
  "hashlink",
@@ -495,17 +494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]


### PR DESCRIPTION
Update `charon` submodule to latest commit. This should enable #3712.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
