### PR TITLE
Cleanup a few internal compiler deps

### DIFF
--- a/kani-compiler/src/kani_middle/abi.rs
+++ b/kani-compiler/src/kani_middle/abi.rs
@@ -24,6 +24,11 @@ impl LayoutOf {
         self.layout.is_sized()
     }
 
+    /// Return whether this is a zero-sized type
+    pub fn is_zst(&self) -> bool {
+        self.is_sized() && self.layout.size.bytes() == 0
+    }
+
     /// Return whether the type is unsized and its tail is a foreign item.
     ///
     /// This will also return `true` if the type is foreign.

--- a/kani-compiler/src/kani_middle/attributes.rs
+++ b/kani-compiler/src/kani_middle/attributes.rs
@@ -622,8 +622,9 @@ impl<'tcx> KaniAttributes<'tcx> {
                 ),
             );
         } else {
-            let instance = Instance::mono(tcx, self.item);
-            if !super::fn_abi(tcx, instance).args.is_empty() {
+            let instance = rustc_internal::stable(Instance::mono(tcx, self.item));
+            let fn_abi = instance.fn_abi().unwrap();
+            if !fn_abi.args.is_empty() {
                 tcx.dcx().span_err(span, "functions used as harnesses cannot have any arguments");
             }
         }


### PR DESCRIPTION
Some of this code was broken by the toolchain update. Instead of changing it, replace it by StableMIR APIs.

Related to #3731 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
