### PR TITLE
Package Docker release step: ensure compiler is installed

### DIFF
--- a/scripts/ci/Dockerfile.bundle-release-20-04
+++ b/scripts/ci/Dockerfile.bundle-release-20-04
@@ -17,7 +17,7 @@ COPY ./target/package/kani-verifier-*[^e] ./kani-verifier
 # directory. Rustup is purged for space.
 
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y curl build-essential && \
     curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none && \
     (cd kani-verifier/; cargo) && \
     rustup default $(rustup toolchain list | awk '{ print $1 }') && \

--- a/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04
+++ b/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04
@@ -7,7 +7,7 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y curl build-essential && \
     curl -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04-alt
+++ b/scripts/ci/Dockerfile.bundle-test-ubuntu-20-04-alt
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true \
     KANI_HOME="/tmp"
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y curl build-essential && \
     curl -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/scripts/ci/Dockerfile.bundle-test-ubuntu-22-04
+++ b/scripts/ci/Dockerfile.bundle-test-ubuntu-22-04
@@ -7,7 +7,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y curl build-essential && \
     curl -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/scripts/ci/Dockerfile.bundle-test-ubuntu-24-04
+++ b/scripts/ci/Dockerfile.bundle-test-ubuntu-24-04
@@ -7,7 +7,7 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y curl build-essential && \
     curl -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 


### PR DESCRIPTION
The "Package Docker" job failed with "error: linker `cc` not found", see https://github.com/model-checking/kani/actions/runs/12371001460/job/34526835431.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
