### PR TITLE
Improve `--jobs` UI

### DIFF
--- a/kani-driver/src/args/mod.rs
+++ b/kani-driver/src/args/mod.rs
@@ -257,8 +257,11 @@ pub struct VerificationArgs {
     // consumes everything
     pub cbmc_args: Vec<OsString>,
 
-    /// Number of parallel jobs, defaults to 1
-    #[arg(short, long, hide = true, requires("enable_unstable"))]
+    /// Number of threads to spawn to verify harnesses in parallel.
+    /// Omit the flag entirely to run sequentially (i.e. one thread).
+    /// Pass -j to run with the thread pool's default number of threads.
+    /// Pass -j <N> to specify N threads.
+    #[arg(short, long, hide_short_help = true, requires("enable_unstable"))]
     pub jobs: Option<Option<usize>>,
 
     /// Enable extra pointer checks such as invalid pointers in relation operations and pointer

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -116,9 +116,9 @@ impl KaniSession {
 
             let output = result.render(&self.args.output_format, harness.attributes.should_panic);
             if rayon::current_num_threads() > 1 {
-                println!("Thread {thread_index}: {}", output);
+                println!("Thread {thread_index}: {output}");
             } else {
-                println!("{}", output);
+                println!("{output}");
             }
         }
     }


### PR DESCRIPTION
Improve the documentation for the `--jobs` option, change it to use `hide_short_help` like other unstable options, and print the current thread number so that users can match the harness to its output.

Example:
```rust

#[kani::modifies(x)]
#[kani::ensures(|_| x.iter().map(|v| *v == 0).fold(true,|a,b|a&b))]
fn zero(x: &mut [u8]) {
    x.fill(0)
}

#[kani::proof_for_contract(zero)]
fn harness() {
    let mut x = [kani::any(), kani::any(), kani::any()];
    zero(&mut x);
}

#[kani::proof]
fn harness_2() {
    assert!(true);
}

#[kani::proof]
fn harness_3() {
    assert!(false);
}
```

```
cargo kani -j --enable-unstable --output-format=terse -Z function-contracts
Kani Rust Verifier 0.57.0 (cargo plugin)
warning: Found the following unsupported constructs:
             - caller_location (1)
             - foreign function (1)
         
         Verification will fail if one or more of these constructs is reachable.
         See https://model-checking.github.io/kani/rust-feature-support.html for more details.

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
Thread 4: Checking harness harness_2...
Thread 2: Checking harness harness_3...
Thread 4: 
VERIFICATION RESULT:
 ** 0 of 1 failed

VERIFICATION:- SUCCESSFUL
Verification Time: 0.0137195s

Thread 2: 
VERIFICATION RESULT:
 ** 1 of 1 failed
Failed Checks: assertion failed: false
 File: "src/lib.rs", line 26, in harness_3

VERIFICATION:- FAILED
Verification Time: 0.012914542s

Thread 0: Checking harness harness...
Thread 0: 
VERIFICATION RESULT:
 ** 0 of 217 failed

VERIFICATION:- SUCCESSFUL
Verification Time: 18.47224s

Summary:
Verification failed for - harness_3
Complete - 2 successfully verified harnesses, 1 failures, 3 total.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
