### PR TITLE
Update charon submodule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,12 +106,6 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
@@ -155,7 +159,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
 ]
 
 [[package]]
@@ -176,7 +180,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "which 7.0.1",
+ "which",
 ]
 
 [[package]]
@@ -240,28 +244,27 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.45"
+version = "0.1.58"
 dependencies = [
+ "annotate-snippets",
+ "anstream",
  "anyhow",
  "assert_cmd",
  "clap",
  "colored",
- "convert_case 0.6.0",
- "derive-visitor",
+ "convert_case",
+ "derive_generic_visitor",
  "env_logger",
  "hashlink",
  "index_vec",
  "indoc",
- "itertools 0.13.0",
+ "itertools",
  "lazy_static",
  "log",
  "macros",
  "nom",
  "nom-supreme",
  "petgraph",
- "pretty",
- "regex",
- "rustc_apfloat",
  "rustc_version",
  "serde",
  "serde-map-to-array",
@@ -273,7 +276,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-tree 0.4.0 (git+https://github.com/Nadrieril/tracing-tree)",
- "which 6.0.3",
+ "which",
 ]
 
 [[package]]
@@ -307,7 +310,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn",
 ]
 
 [[package]]
@@ -382,12 +385,6 @@ dependencies = [
  "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -482,6 +479,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,25 +523,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-visitor"
-version = "0.4.0"
+name = "derive_generic_visitor"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47165df83b9707cbada3216607a5d66125b6a66906de0bc1216c0669767ca9e"
+checksum = "e0729a8f5d509da0c280502837a56a9d05c16866ae5b608ef34bd687e9f21af8"
 dependencies = [
- "derive-visitor-macros",
+ "derive_generic_visitor_macros",
 ]
 
 [[package]]
-name = "derive-visitor-macros"
-version = "0.4.0"
+name = "derive_generic_visitor_macros"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427b39a85fecafea16b1a5f3f50437151022e35eb4fe038107f08adbf7f8def6"
+checksum = "3c2b7f15bf93ca0d978ecb96792c71a43c629a1e18b2a5de7a35a5d218e6c85e"
 dependencies = [
- "convert_case 0.4.0",
- "itertools 0.10.5",
+ "convert_case",
+ "darling",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -592,6 +625,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -692,6 +731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indent_write"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,15 +775,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -774,7 +810,7 @@ dependencies = [
  "clap",
  "cprover_bindings",
  "home",
- "itertools 0.13.0",
+ "itertools",
  "kani_metadata",
  "lazy_static",
  "num",
@@ -785,7 +821,7 @@ dependencies = [
  "shell-words",
  "strum",
  "strum_macros",
- "syn 2.0.93",
+ "syn",
  "tracing",
  "tracing-subscriber",
  "tracing-tree 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -834,7 +870,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "which 7.0.1",
+ "which",
 ]
 
 [[package]]
@@ -860,7 +896,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn",
 ]
 
 [[package]]
@@ -924,7 +960,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn",
 ]
 
 [[package]]
@@ -1223,17 +1259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
-dependencies = [
- "arrayvec 0.5.2",
- "typed-arena",
- "unicode-width 0.1.14",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,7 +1277,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn",
 ]
 
 [[package]]
@@ -1392,16 +1417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustc_apfloat"
-version = "0.2.2+llvm-462a31f5a5ab"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121e2195ff969977a4e2b5c9965ea867fce7e4cb5aee5b09dee698a7932d574f"
-dependencies = [
- "bitflags",
- "smallvec",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,7 +1512,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn",
 ]
 
 [[package]]
@@ -1648,18 +1663,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.93",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]
@@ -1724,7 +1728,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn",
 ]
 
 [[package]]
@@ -1735,7 +1739,7 @@ checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn",
 ]
 
 [[package]]
@@ -1858,7 +1862,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn",
 ]
 
 [[package]]
@@ -1968,12 +1972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,18 +2043,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "which"
-version = "6.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
-dependencies = [
- "either",
- "home",
- "rustix",
- "winsafe",
-]
 
 [[package]]
 name = "which"
@@ -2216,5 +2202,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,18 +524,18 @@ dependencies = [
 
 [[package]]
 name = "derive_generic_visitor"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0729a8f5d509da0c280502837a56a9d05c16866ae5b608ef34bd687e9f21af8"
+checksum = "b3e1c241e4f464b614bd7650f1a7c4c0e20e5ef21564d6b916b4c51fd76f7688"
 dependencies = [
  "derive_generic_visitor_macros",
 ]
 
 [[package]]
 name = "derive_generic_visitor_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2b7f15bf93ca0d978ecb96792c71a43c629a1e18b2a5de7a35a5d218e6c85e"
+checksum = "885f5274163b5b1720591c0c24b34350a0b05e4774351f9fb3d13c192d8c995b"
 dependencies = [
  "convert_case",
  "darling",

--- a/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
@@ -35,7 +35,7 @@ use rustc_session::Session;
 use rustc_session::config::{CrateType, OutputFilenames, OutputType};
 use rustc_session::output::out_filename;
 use rustc_smir::rustc_internal;
-use stable_mir::mir::mono::{Instance, InstanceKind, MonoItem};
+use stable_mir::mir::mono::{Instance, MonoItem};
 use stable_mir::{CrateDef, DefId};
 use std::any::Any;
 use std::fs::File;
@@ -111,16 +111,14 @@ impl LlbcCodegenBackend {
         for item in &items {
             match item {
                 MonoItem::Fn(instance) => {
-                    if let InstanceKind::Item = instance.kind {
-                        let mut fcx = Context::new(
-                            tcx,
-                            *instance,
-                            &mut ccx.translated,
-                            &mut id_map,
-                            &mut ccx.errors,
-                        );
-                        let _ = fcx.translate();
-                    }
+                    let mut fcx = Context::new(
+                        tcx,
+                        *instance,
+                        &mut ccx.translated,
+                        &mut id_map,
+                        &mut ccx.errors,
+                    );
+                    let _ = fcx.translate();
                 }
                 MonoItem::Static(_def) => todo!(),
                 MonoItem::GlobalAsm(_) => {} // We have already warned above

--- a/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
@@ -38,7 +38,6 @@ use rustc_smir::rustc_internal;
 use stable_mir::mir::mono::{Instance, MonoItem};
 use stable_mir::{CrateDef, DefId};
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -394,16 +393,6 @@ fn create_charon_transformation_context(tcx: TyCtxt) -> TransformCtx {
     };
     let crate_name = tcx.crate_name(LOCAL_CRATE).as_str().into();
     let translated = TranslatedCrate { crate_name, ..TranslatedCrate::default() };
-    let errors = ErrorCtx {
-        continue_on_failure: true,
-        error_on_warnings: false,
-        dcx: &(),
-        external_decls_with_errors: HashSet::new(),
-        ignored_failed_decls: HashSet::new(),
-        external_dep_sources: HashMap::new(),
-        def_id: None,
-        def_id_is_local: true,
-        error_count: 0,
-    };
+    let errors = ErrorCtx::new(true, false);
     TransformCtx { options, translated, errors }
 }

--- a/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
@@ -35,7 +35,7 @@ use rustc_session::Session;
 use rustc_session::config::{CrateType, OutputFilenames, OutputType};
 use rustc_session::output::out_filename;
 use rustc_smir::rustc_internal;
-use stable_mir::mir::mono::{Instance, MonoItem};
+use stable_mir::mir::mono::{Instance, InstanceKind, MonoItem};
 use stable_mir::{CrateDef, DefId};
 use std::any::Any;
 use std::fs::File;
@@ -111,14 +111,16 @@ impl LlbcCodegenBackend {
         for item in &items {
             match item {
                 MonoItem::Fn(instance) => {
-                    let mut fcx = Context::new(
-                        tcx,
-                        *instance,
-                        &mut ccx.translated,
-                        &mut id_map,
-                        &mut ccx.errors,
-                    );
-                    let _ = fcx.translate();
+                    if let InstanceKind::Item = instance.kind {
+                        let mut fcx = Context::new(
+                            tcx,
+                            *instance,
+                            &mut ccx.translated,
+                            &mut id_map,
+                            &mut ccx.errors,
+                        );
+                        let _ = fcx.translate();
+                    }
                 }
                 MonoItem::Static(_def) => todo!(),
                 MonoItem::GlobalAsm(_) => {} // We have already warned above


### PR DESCRIPTION
Update Charon submodule to https://github.com/AeneasVerif/charon/commit/adc0a855aa1428d68e4270edef0d52131cef06ab

Relevant Charon PRs:
https://github.com/AeneasVerif/charon/pull/457: This required updating the code that creates places to also pass in the type.
https://github.com/AeneasVerif/charon/pull/464: This replaced the file-to-id hash table by a vector, thus requiring that we add one in Kani's translation context.
https://github.com/AeneasVerif/charon/pull/474: The translation context is no longer parameterized by a lifetime
https://github.com/AeneasVerif/charon/pull/491: This required changing the type of indices

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
