### PR TITLE
Add an option to generate contracts as assertions

### DIFF
--- a/kani-compiler/src/kani_middle/attributes.rs
+++ b/kani-compiler/src/kani_middle/attributes.rs
@@ -44,8 +44,8 @@ enum KaniAttributeKind {
     /// contract, e.g. the contract check is substituted for the target function
     /// before the the verification runs.
     ProofForContract,
-    /// Internal attribute of the contracts implementation that identifies the
-    /// code implementing the function with the contract clauses as assertions.
+    /// Internal attribute of the contracts implementation. Identifies the
+    /// code implementing the function with its contract clauses asserted.
     AssertedWith,
     /// Attribute on a function with a contract that identifies the code
     /// implementing the check for this contract.

--- a/kani-compiler/src/kani_middle/transform/contracts.rs
+++ b/kani-compiler/src/kani_middle/transform/contracts.rs
@@ -446,7 +446,9 @@ impl FunctionWithContractPass {
     }
 
     /// Return which contract mode to use for this function if any.
-    /// TODO document precedence
+    /// Note that the Check and Replace modes take precedence over the Assert mode.
+    /// This precedence ensures that a given `target` of a proof_for_contract(target) or stub_verified(target)
+    /// use their Check or Replace closures, respectively, rather than the Assert closure.
     fn contract_mode(&self, tcx: TyCtxt, fn_def: FnDef) -> Option<ContractMode> {
         let kani_attributes = KaniAttributes::for_def_id(tcx, fn_def.def_id());
         kani_attributes.has_contract().then(|| {

--- a/kani_metadata/src/unstable.rs
+++ b/kani_metadata/src/unstable.rs
@@ -85,6 +85,8 @@ pub enum UnstableFeature {
     FunctionContracts,
     /// Enable loop contracts [RFC 12](https://model-checking.github.io/kani/rfc/rfcs/0012-loop-contracts.html)
     LoopContracts,
+    /// Enable function contracts to be interpreted as assertions. (Requires function-contracts option).
+    ContractsAsAssertions,
     /// Memory predicate APIs.
     MemPredicates,
     /// Automatically check that no invalid value is produced which is considered UB in Rust.

--- a/kani_metadata/src/unstable.rs
+++ b/kani_metadata/src/unstable.rs
@@ -85,7 +85,7 @@ pub enum UnstableFeature {
     FunctionContracts,
     /// Enable loop contracts [RFC 12](https://model-checking.github.io/kani/rfc/rfcs/0012-loop-contracts.html)
     LoopContracts,
-    /// Enable function contracts to be interpreted as assertions. (Requires function-contracts option).
+    /// Interpret function contracts as assertions. (Requires function-contracts option).
     ContractsAsAssertions,
     /// Memory predicate APIs.
     MemPredicates,

--- a/library/kani_core/src/lib.rs
+++ b/library/kani_core/src/lib.rs
@@ -496,6 +496,9 @@ macro_rules! kani_intrinsics {
             /// Stub the body with its contract.
             pub const REPLACE: Mode = 3;
 
+            /// Insert the contract into the body of the function as assertion(s).
+            pub const ASSERT: Mode = 4;
+
             /// Creates a non-fatal property with the specified condition and message.
             ///
             /// This check will not impact the program control flow even when it fails.

--- a/library/kani_macros/src/sysroot/contracts/assert.rs
+++ b/library/kani_macros/src/sysroot/contracts/assert.rs
@@ -1,0 +1,90 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Logic used for generating the code that generates contract preconditions and postconditions as assertions.
+
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
+use quote::quote;
+use std::mem;
+use syn::{Stmt, parse_quote};
+
+use super::{
+    ContractConditionsData, ContractConditionsHandler, ContractMode, INTERNAL_RESULT_IDENT,
+    helpers::*,
+    shared::{build_ensures, split_for_remembers},
+};
+
+impl<'a> ContractConditionsHandler<'a> {
+    /// Generate a token stream that represents the assert closure.
+    ///
+    /// See [`Self::make_assert_body`] for the most interesting parts of this
+    /// function.
+    pub fn assert_closure(&self) -> TokenStream2 {
+        let assert_ident = Ident::new(&self.assert_name, Span::call_site());
+        let sig = &self.annotated_fn.sig;
+        let output = &sig.output;
+        let body_stmts = self.initial_assert_stmts();
+        let body = self.make_assert_body(body_stmts);
+
+        quote!(
+            #[kanitool::is_contract_generated(assert)]
+            #[allow(dead_code, unused_variables, unused_mut)]
+            let mut #assert_ident = || #output #body;
+        )
+    }
+
+    /// Expand the assert closure body.
+    pub fn expand_assert(&self, closure: &mut Stmt) {
+        let body = closure_body(closure);
+        *body = syn::parse2(self.make_assert_body(mem::take(&mut body.block.stmts))).unwrap();
+    }
+
+    /// Initialize the list of statements for the assert closure body.
+    fn initial_assert_stmts(&self) -> Vec<syn::Stmt> {
+        let return_type = return_type_to_type(&self.annotated_fn.sig.output);
+        let stmts = &self.annotated_fn.block.stmts;
+        let result = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
+        parse_quote! {
+            let #result : #return_type = {#(#stmts)*};
+            #result
+        }
+    }
+
+    /// Create the body of an assert closure.
+    ///
+    /// Wraps the conditions from this attribute around `self.body`.
+    fn make_assert_body(&self, mut body_stmts: Vec<Stmt>) -> TokenStream2 {
+        let Self { attr_copy, .. } = self;
+        match &self.condition_type {
+            ContractConditionsData::Requires { attr } => {
+                quote!({
+                    kani::assert(#attr, stringify!(#attr_copy));
+                    #(#body_stmts)*
+                })
+            }
+            ContractConditionsData::Ensures { attr } => {
+                let (remembers, ensures_clause) = build_ensures(attr);
+
+                let exec_postconditions = quote!(
+                    kani::assert(#ensures_clause, stringify!(#attr_copy));
+                );
+
+                let return_expr = body_stmts.pop();
+
+                let (asserts, rest_of_body) =
+                    split_for_remembers(&body_stmts[..], ContractMode::Assert);
+
+                quote!({
+                    #(#asserts)*
+                    #remembers
+                    #(#rest_of_body)*
+                    #exec_postconditions
+                    #return_expr
+                })
+            }
+            ContractConditionsData::Modifies { .. } => {
+                quote!({#(#body_stmts)*})
+            }
+        }
+    }
+}

--- a/library/kani_macros/src/sysroot/contracts/check.rs
+++ b/library/kani_macros/src/sysroot/contracts/check.rs
@@ -9,7 +9,7 @@ use std::mem;
 use syn::{Block, Expr, FnArg, Local, LocalInit, Pat, PatIdent, ReturnType, Stmt, parse_quote};
 
 use super::{
-    ClosureType, ContractConditionsData, ContractConditionsHandler, INTERNAL_RESULT_IDENT,
+    ContractMode, ContractConditionsData, ContractConditionsHandler, INTERNAL_RESULT_IDENT,
     helpers::*, shared::build_ensures,
 };
 
@@ -40,7 +40,7 @@ impl<'a> ContractConditionsHandler<'a> {
                 let return_expr = body_stmts.pop();
 
                 let (assumes, rest_of_body) =
-                    split_for_remembers(&body_stmts[..], ClosureType::Check);
+                    split_for_remembers(&body_stmts[..], ContractMode::SimpleCheck);
 
                 quote!({
                     #(#assumes)*

--- a/library/kani_macros/src/sysroot/contracts/check.rs
+++ b/library/kani_macros/src/sysroot/contracts/check.rs
@@ -9,8 +9,9 @@ use std::mem;
 use syn::{Block, Expr, FnArg, Local, LocalInit, Pat, PatIdent, ReturnType, Stmt, parse_quote};
 
 use super::{
-    ContractMode, ContractConditionsData, ContractConditionsHandler, INTERNAL_RESULT_IDENT,
-    helpers::*, shared::{build_ensures, split_for_remembers}
+    ContractConditionsData, ContractConditionsHandler, ContractMode, INTERNAL_RESULT_IDENT,
+    helpers::*,
+    shared::{build_ensures, split_for_remembers},
 };
 
 const WRAPPER_ARG: &str = "_wrapper_arg";

--- a/library/kani_macros/src/sysroot/contracts/check.rs
+++ b/library/kani_macros/src/sysroot/contracts/check.rs
@@ -10,7 +10,7 @@ use syn::{Block, Expr, FnArg, Local, LocalInit, Pat, PatIdent, ReturnType, Stmt,
 
 use super::{
     ContractMode, ContractConditionsData, ContractConditionsHandler, INTERNAL_RESULT_IDENT,
-    helpers::*, shared::build_ensures,
+    helpers::*, shared::{build_ensures, split_for_remembers}
 };
 
 const WRAPPER_ARG: &str = "_wrapper_arg";

--- a/library/kani_macros/src/sysroot/contracts/helpers.rs
+++ b/library/kani_macros/src/sysroot/contracts/helpers.rs
@@ -7,10 +7,7 @@
 use proc_macro2::{Ident, Span};
 use std::borrow::Cow;
 use syn::spanned::Spanned;
-use syn::{
-    Attribute, Expr, ExprBlock, Local, LocalInit, PatIdent, Stmt,
-    parse_quote,
-};
+use syn::{Attribute, Expr, ExprBlock, Local, LocalInit, PatIdent, Stmt, parse_quote};
 
 /// If an explicit return type was provided it is returned, otherwise `()`.
 pub fn return_type_to_type(return_type: &syn::ReturnType) -> Cow<syn::Type> {

--- a/library/kani_macros/src/sysroot/contracts/helpers.rs
+++ b/library/kani_macros/src/sysroot/contracts/helpers.rs
@@ -4,7 +4,7 @@
 //! Functions that operate third party data structures with no logic that is
 //! specific to Kani and contracts.
 
-use crate::attr_impl::contracts::ClosureType;
+use crate::attr_impl::contracts::ContractMode;
 use proc_macro2::{Ident, Span};
 use std::borrow::Cow;
 use syn::spanned::Spanned;
@@ -174,7 +174,7 @@ pub fn chunks_by<'a, T, C: Default + Extend<T>>(
 }
 
 /// Splits `stmts` into (preconditions, rest).
-/// For example, ClosureType::Check assumes preconditions, so given this sequence of statements:
+/// For example, ContractMode::SimpleCheck assumes preconditions, so given this sequence of statements:
 /// ```ignore
 /// kani::assume(.. precondition_1);
 /// kani::assume(.. precondition_2);
@@ -183,7 +183,7 @@ pub fn chunks_by<'a, T, C: Default + Extend<T>>(
 /// ```
 /// This function would return the two kani::assume statements in the former slice
 /// and the remaining statements in the latter.
-/// The flow for ClosureType::Replace is the same, except preconditions are asserted rather than assumed.
+/// The flow for ContractMode::Replace is the same, except preconditions are asserted rather than assumed.
 ///
 /// The caller can use the returned tuple to insert remembers statements after `preconditions` and before `rest`.
 /// Inserting the remembers statements after `preconditions` ensures that they are bound by the preconditions.
@@ -197,12 +197,12 @@ pub fn chunks_by<'a, T, C: Default + Extend<T>>(
 ///
 /// Inserting the remembers statements before `rest` ensures that they are declared before the original function executes,
 /// so that they will store historical, pre-computation values as intended.
-pub fn split_for_remembers(stmts: &[Stmt], closure_type: ClosureType) -> (&[Stmt], &[Stmt]) {
+pub fn split_for_remembers(stmts: &[Stmt], closure_type: ContractMode) -> (&[Stmt], &[Stmt]) {
     let mut pos = 0;
 
     let check_str = match closure_type {
-        ClosureType::Check => "assume",
-        ClosureType::Replace => "assert",
+        ContractMode::SimpleCheck => "assume",
+        ContractMode::Replace => "assert",
     };
 
     for stmt in stmts {

--- a/library/kani_macros/src/sysroot/contracts/helpers.rs
+++ b/library/kani_macros/src/sysroot/contracts/helpers.rs
@@ -4,12 +4,11 @@
 //! Functions that operate third party data structures with no logic that is
 //! specific to Kani and contracts.
 
-use crate::attr_impl::contracts::ContractMode;
 use proc_macro2::{Ident, Span};
 use std::borrow::Cow;
 use syn::spanned::Spanned;
 use syn::{
-    Attribute, Expr, ExprBlock, ExprCall, ExprPath, Local, LocalInit, PatIdent, Path, Stmt,
+    Attribute, Expr, ExprBlock, Local, LocalInit, PatIdent, Stmt,
     parse_quote,
 };
 
@@ -171,53 +170,6 @@ pub fn chunks_by<'a, T, C: Default + Extend<T>>(
         }
         (!empty).then_some(new)
     })
-}
-
-/// Splits `stmts` into (preconditions, rest).
-/// For example, ContractMode::SimpleCheck assumes preconditions, so given this sequence of statements:
-/// ```ignore
-/// kani::assume(.. precondition_1);
-/// kani::assume(.. precondition_2);
-/// let _wrapper_arg = (ptr as * const _,);
-/// ...
-/// ```
-/// This function would return the two kani::assume statements in the former slice
-/// and the remaining statements in the latter.
-/// The flow for ContractMode::Replace is the same, except preconditions are asserted rather than assumed.
-///
-/// The caller can use the returned tuple to insert remembers statements after `preconditions` and before `rest`.
-/// Inserting the remembers statements after `preconditions` ensures that they are bound by the preconditions.
-/// To understand why this is important, take the following example:
-/// ```ignore
-/// #[kani::requires(x < u32::MAX)]
-/// #[kani::ensures(|result| old(x + 1) == *result)]
-/// fn add_one(x: u32) -> u32 {...}
-/// ```
-/// If the `old(x + 1)` statement didn't respect the precondition's upper bound on `x`, Kani would encounter an integer overflow.
-///
-/// Inserting the remembers statements before `rest` ensures that they are declared before the original function executes,
-/// so that they will store historical, pre-computation values as intended.
-pub fn split_for_remembers(stmts: &[Stmt], closure_type: ContractMode) -> (&[Stmt], &[Stmt]) {
-    let mut pos = 0;
-
-    let check_str = match closure_type {
-        ContractMode::SimpleCheck => "assume",
-        ContractMode::Replace => "assert",
-    };
-
-    for stmt in stmts {
-        if let Stmt::Expr(Expr::Call(ExprCall { func, .. }), _) = stmt {
-            if let Expr::Path(ExprPath { path: Path { segments, .. }, .. }) = func.as_ref() {
-                let first_two_idents =
-                    segments.iter().take(2).map(|sgmt| sgmt.ident.to_string()).collect::<Vec<_>>();
-
-                if first_two_idents == vec!["kani", check_str] {
-                    pos += 1;
-                }
-            }
-        }
-    }
-    stmts.split_at(pos)
 }
 
 macro_rules! assert_spanned_err {

--- a/library/kani_macros/src/sysroot/contracts/initialize.rs
+++ b/library/kani_macros/src/sysroot/contracts/initialize.rs
@@ -71,6 +71,7 @@ impl<'a> ContractConditionsHandler<'a> {
 
         let fn_name = &annotated_fn.sig.ident;
         let generate_name = |purpose| format!("__kani_{purpose}_{fn_name}");
+        let assert_name = generate_name("assert");
         let check_name = generate_name("check");
         let replace_name = generate_name("replace");
         let recursion_name = generate_name("recursion_check");
@@ -84,6 +85,7 @@ impl<'a> ContractConditionsHandler<'a> {
             check_name,
             replace_name,
             recursion_name,
+            assert_name,
             modify_name: modifies_name,
         })
     }

--- a/library/kani_macros/src/sysroot/contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/contracts/mod.rs
@@ -128,11 +128,11 @@
 //!  }
 //!  
 //!  #[kani::requires(x > 0)]
-//!  fn bar(x: i32) {...}
+//!  fn bar(x: i32) { }
 //! ```
 //! If we call foo(0), we would satisfy the check closure, since we satisfy foo's precondition.
-//! However, we would violate bar()'s precondition that x > 0.
-//! By using bar's assert closure instead of its original body, we can assert that callers of bar() respect its contract
+//! However, we would violate bar's precondition that x > 0.
+//! By using bar's assert closure instead of its original body, we can assert that callers of bar respect its contract
 //! and catch this issue.
 //!
 //! We register this closure as `#[kanitool::asserted_with = "__kani_assert_..."]`

--- a/library/kani_macros/src/sysroot/contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/contracts/mod.rs
@@ -132,6 +132,7 @@
 //! #[kanitool::checked_with = "__kani_check_div"]
 //! #[kanitool::replaced_with = "__kani_replace_div"]
 //! #[kanitool::modifies_wrapper = "__kani_modifies_div"]
+//! #[kanitool::asserted_with = "__kani_assert_div"]
 //! fn div(dividend: u32, divisor: u32) -> u32 {
 //!     #[inline(never)]
 //!     #[kanitool::fn_marker = "kani_register_contract"]
@@ -226,6 +227,22 @@
 //!             ;
 //!             kani_register_contract(__kani_check_div)
 //!         }
+//!         kani::internal::ASSERT => {
+//!             #[kanitool::is_contract_generated(assert)]
+//!             #[allow(dead_code, unused_variables, unused_mut)]
+//!             let mut __kani_assert_div =
+//!                 || -> u32
+//!                     {
+//!                         kani::assert(divisor != 0, "divisor != 0");
+//!                         let result_kani_internal: u32 = { dividend / divisor };
+//!                         kani::assert(kani::internal::apply_closure(|result: &u32|
+//!                                     *result <= dividend, &result_kani_internal),
+//!                             "|result : &u32| *result <= dividend");
+//!                         result_kani_internal
+//!                     };
+//!             ;
+//!             kani_register_contract(__kani_assert_div)
+//!         }
 //!         _ => { dividend / divisor }
 //!     }
 //! }
@@ -265,6 +282,7 @@
 //! #[kanitool::checked_with = "__kani_check_modify"]
 //! #[kanitool::replaced_with = "__kani_replace_modify"]
 //! #[kanitool::modifies_wrapper = "__kani_modifies_modify"]
+//! #[kanitool::asserted_with = "__kani_assert_modify"]
 //! fn modify(ptr: &mut u32) {
 //!     #[inline(never)]
 //!     #[kanitool::fn_marker = "kani_register_contract"]
@@ -387,6 +405,27 @@
 //!             ;
 //!             kani_register_contract(__kani_check_modify)
 //!         }
+//!         kani::internal::ASSERT => {
+//!             #[kanitool::is_contract_generated(assert)]
+//!             #[allow(dead_code, unused_variables, unused_mut)]
+//!             let mut __kani_assert_modify =
+//!                 ||
+//!                     {
+//!                         kani::assert(*ptr < 100, "*ptr < 100");
+//!                         let remember_kani_internal_92cc419d8aca576c = *ptr + 1;
+//!                         let remember_kani_internal_92cc419d8aca576c = *ptr + 1;
+//!                         let result_kani_internal: () = { *ptr += 1; };
+//!                         kani::assert(kani::internal::apply_closure(|result|
+//!                                     (remember_kani_internal_92cc419d8aca576c) == *ptr,
+//!                                 &result_kani_internal), "|result| old(*ptr + 1) == *ptr");
+//!                         kani::assert(kani::internal::apply_closure(|result|
+//!                                     (remember_kani_internal_92cc419d8aca576c) == *ptr,
+//!                                 &result_kani_internal), "|result| old(*ptr + 1) == *ptr");
+//!                         result_kani_internal
+//!                     };
+//!             ;
+//!             kani_register_contract(__kani_assert_modify)
+//!         }
 //!         _ => { *ptr += 1; }
 //!     }
 //! }
@@ -397,6 +436,7 @@ use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::quote;
 use syn::{Expr, ExprClosure, ItemFn, parse_macro_input, parse_quote};
 
+mod assert;
 mod bootstrap;
 mod check;
 #[macro_use]
@@ -483,6 +523,8 @@ struct ContractConditionsHandler<'a> {
     replace_name: String,
     /// The name of the recursion closure.
     recursion_name: String,
+    /// The name of the assertion closure.
+    assert_name: String,
     /// The name of the modifies closure.
     modify_name: String,
 }

--- a/library/kani_macros/src/sysroot/contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/contracts/mod.rs
@@ -514,11 +514,15 @@ enum ContractConditionsData {
     },
 }
 
-/// Which function are we currently generating?
-#[derive(Copy, Clone, Eq, PartialEq)]
-enum ClosureType {
-    Check,
-    Replace,
+/// Enumeration that stores the contract mode values.
+///
+/// Keep the discriminant values in sync with [kani::internal::mode].
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum ContractMode {
+    Original = 0,
+    RecursiveCheck = 1,
+    SimpleCheck = 2,
+    Replace = 3,
 }
 
 impl<'a> ContractConditionsHandler<'a> {

--- a/library/kani_macros/src/sysroot/contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/contracts/mod.rs
@@ -514,15 +514,13 @@ enum ContractConditionsData {
     },
 }
 
-/// Enumeration that stores the contract mode values.
-///
-/// Keep the discriminant values in sync with [kani::internal::mode].
+/// Enumeration that stores (some of) the contract mode values.
+/// We elide the Original and RecursiveCheck variants because we don't need them for any work in this module.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum ContractMode {
-    Original = 0,
-    RecursiveCheck = 1,
-    SimpleCheck = 2,
-    Replace = 3,
+    SimpleCheck,
+    Replace,
+    Assert,
 }
 
 impl<'a> ContractConditionsHandler<'a> {

--- a/library/kani_macros/src/sysroot/contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/contracts/mod.rs
@@ -116,6 +116,27 @@
 //!
 //! We register this closure as `#[kanitool::recursion_check = "__kani_recursion_..."]`.
 //!
+//! ## Assert closure
+//! Kani has an option to interpret contracts as assertions.
+//! To support that option, we generate a closure that asserts preconditions and postconditions.
+//! This option is especially useful for verifying that a function does not violate the contracts of its dependencies.
+//! For example:
+//! ```ignore
+//!  #[kani::requires(x >= 0)]
+//!  fn foo(x: i32) {
+//!    bar(x);
+//!  }
+//!  
+//!  #[kani::requires(x > 0)]
+//!  fn bar(x: i32) {...}
+//! ```
+//! If we call foo(0), we would satisfy the check closure, since we satisfy foo's precondition.
+//! However, we would violate bar()'s precondition that x > 0.
+//! By using bar's assert closure instead of its original body, we can assert that callers of bar() respect its contract
+//! and catch this issue.
+//!
+//! We register this closure as `#[kanitool::asserted_with = "__kani_assert_..."]`
+//!
 //! # Complete example
 //!
 //! ```
@@ -557,7 +578,7 @@ enum ContractConditionsData {
 }
 
 /// Enumeration that stores (some of) the contract mode values.
-/// We elide the Original and RecursiveCheck variants because we don't need them for any work in this module.
+/// We elide the Original and RecursiveCheck variants because we don't need them for any work in this crate.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum ContractMode {
     SimpleCheck,

--- a/library/kani_macros/src/sysroot/contracts/replace.rs
+++ b/library/kani_macros/src/sysroot/contracts/replace.rs
@@ -9,7 +9,7 @@ use std::mem;
 use syn::{Block, Stmt};
 
 use super::{
-    ContractMode, ContractConditionsData, ContractConditionsHandler, INTERNAL_RESULT_IDENT,
+    ContractConditionsData, ContractConditionsHandler, ContractMode, INTERNAL_RESULT_IDENT,
     helpers::*,
     shared::{build_ensures, split_for_remembers, try_as_result_assign},
 };

--- a/library/kani_macros/src/sysroot/contracts/replace.rs
+++ b/library/kani_macros/src/sysroot/contracts/replace.rs
@@ -11,7 +11,7 @@ use syn::{Block, Stmt};
 use super::{
     ContractMode, ContractConditionsData, ContractConditionsHandler, INTERNAL_RESULT_IDENT,
     helpers::*,
-    shared::{build_ensures, try_as_result_assign},
+    shared::{build_ensures, split_for_remembers, try_as_result_assign},
 };
 
 impl<'a> ContractConditionsHandler<'a> {

--- a/library/kani_macros/src/sysroot/contracts/replace.rs
+++ b/library/kani_macros/src/sysroot/contracts/replace.rs
@@ -9,7 +9,7 @@ use std::mem;
 use syn::{Block, Stmt};
 
 use super::{
-    ClosureType, ContractConditionsData, ContractConditionsHandler, INTERNAL_RESULT_IDENT,
+    ContractMode, ContractConditionsData, ContractConditionsHandler, INTERNAL_RESULT_IDENT,
     helpers::*,
     shared::{build_ensures, try_as_result_assign},
 };
@@ -96,7 +96,7 @@ impl<'a> ContractConditionsHandler<'a> {
                 let (remembers, ensures_clause) = build_ensures(attr);
                 let result = Ident::new(INTERNAL_RESULT_IDENT, Span::call_site());
 
-                let (asserts, rest_of_before) = split_for_remembers(before, ClosureType::Replace);
+                let (asserts, rest_of_before) = split_for_remembers(before, ContractMode::Replace);
 
                 quote!({
                     #(#asserts)*

--- a/library/kani_macros/src/sysroot/contracts/shared.rs
+++ b/library/kani_macros/src/sysroot/contracts/shared.rs
@@ -12,7 +12,9 @@ use std::collections::HashMap;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
 use std::hash::{DefaultHasher, Hash, Hasher};
-use syn::{Expr, ExprCall, ExprClosure, ExprPath, Path, Stmt, spanned::Spanned, visit_mut::VisitMut};
+use syn::{
+    Expr, ExprCall, ExprClosure, ExprPath, Path, Stmt, spanned::Spanned, visit_mut::VisitMut,
+};
 
 use super::{ContractMode, INTERNAL_RESULT_IDENT};
 

--- a/library/kani_macros/src/sysroot/contracts/shared.rs
+++ b/library/kani_macros/src/sysroot/contracts/shared.rs
@@ -12,9 +12,56 @@ use std::collections::HashMap;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
 use std::hash::{DefaultHasher, Hash, Hasher};
-use syn::{Expr, ExprCall, ExprClosure, ExprPath, Path, spanned::Spanned, visit_mut::VisitMut};
+use syn::{Expr, ExprCall, ExprClosure, ExprPath, Path, Stmt, spanned::Spanned, visit_mut::VisitMut};
 
-use super::INTERNAL_RESULT_IDENT;
+use super::{ContractMode, INTERNAL_RESULT_IDENT};
+
+/// Splits `stmts` into (preconditions, rest).
+/// For example, ContractMode::SimpleCheck assumes preconditions, so given this sequence of statements:
+/// ```ignore
+/// kani::assume(.. precondition_1);
+/// kani::assume(.. precondition_2);
+/// let _wrapper_arg = (ptr as * const _,);
+/// ...
+/// ```
+/// This function would return the two kani::assume statements in the former slice
+/// and the remaining statements in the latter.
+/// The flow for ContractMode::Replace is the same, except preconditions are asserted rather than assumed.
+///
+/// The caller can use the returned tuple to insert remembers statements after `preconditions` and before `rest`.
+/// Inserting the remembers statements after `preconditions` ensures that they are bound by the preconditions.
+/// To understand why this is important, take the following example:
+/// ```ignore
+/// #[kani::requires(x < u32::MAX)]
+/// #[kani::ensures(|result| old(x + 1) == *result)]
+/// fn add_one(x: u32) -> u32 {...}
+/// ```
+/// If the `old(x + 1)` statement didn't respect the precondition's upper bound on `x`, Kani would encounter an integer overflow.
+///
+/// Inserting the remembers statements before `rest` ensures that they are declared before the original function executes,
+/// so that they will store historical, pre-computation values as intended.
+pub fn split_for_remembers(stmts: &[Stmt], contract_mode: ContractMode) -> (&[Stmt], &[Stmt]) {
+    let mut pos = 0;
+
+    let check_str = match contract_mode {
+        ContractMode::SimpleCheck => "assume",
+        ContractMode::Replace | ContractMode::Assert => "assert",
+    };
+
+    for stmt in stmts {
+        if let Stmt::Expr(Expr::Call(ExprCall { func, .. }), _) = stmt {
+            if let Expr::Path(ExprPath { path: Path { segments, .. }, .. }) = func.as_ref() {
+                let first_two_idents =
+                    segments.iter().take(2).map(|sgmt| sgmt.ident.to_string()).collect::<Vec<_>>();
+
+                if first_two_idents == vec!["kani", check_str] {
+                    pos += 1;
+                }
+            }
+        }
+    }
+    stmts.split_at(pos)
+}
 
 /// Used as the "single source of truth" for [`try_as_result_assign`] and [`try_as_result_assign_mut`]
 /// since we can't abstract over mutability. Input is the object to match on and the name of the

--- a/tests/expected/function-contract/as-assertions/assert-postconditions.expected
+++ b/tests/expected/function-contract/as-assertions/assert-postconditions.expected
@@ -1,0 +1,9 @@
+assertion\
+	 - Status: FAILURE\
+	 - Description: "|result| old(*add_two_ptr + 1) == *add_two_ptr"
+
+assertion\
+	 - Status: SUCCESS\
+	 - Description: "|result| old(*add_one_ptr + 1) == *add_one_ptr"
+
+VERIFICATION:- FAILED

--- a/tests/expected/function-contract/as-assertions/assert-postconditions.rs
+++ b/tests/expected/function-contract/as-assertions/assert-postconditions.rs
@@ -1,0 +1,32 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Zfunction-contracts -Zcontracts-as-assertions
+
+// Test -Zcontracts-as-assertions for postconditions.
+
+#[kani::requires(*add_three_ptr < 100)]
+#[kani::modifies(add_three_ptr)]
+fn add_three(add_three_ptr: &mut u32) {
+    *add_three_ptr += 1;
+    add_two(add_three_ptr);
+}
+
+#[kani::ensures(|result| old(*add_two_ptr + 1) == *add_two_ptr)] // incorrect -- should be old(*add_two_ptr + 1)
+fn add_two(add_two_ptr: &mut u32) {
+    *add_two_ptr += 1;
+    add_one(add_two_ptr)
+}
+
+#[kani::requires(*add_one_ptr < 102)]
+#[kani::modifies(add_one_ptr)]
+#[kani::ensures(|result| old(*add_one_ptr + 1) == *add_one_ptr)] // correct -- assertion should always succeed
+fn add_one(add_one_ptr: &mut u32) {
+    *add_one_ptr += 1;
+}
+
+// -Zcontracts-as-assertions introduces this failure; without it, add_two's and add_one's contracts are ignored.
+#[kani::proof_for_contract(add_three)]
+fn prove_add_three() {
+    let mut i = kani::any();
+    add_three(&mut i);
+}

--- a/tests/expected/function-contract/as-assertions/assert-preconditions.expected
+++ b/tests/expected/function-contract/as-assertions/assert-preconditions.expected
@@ -1,0 +1,21 @@
+assertion\
+	 - Status: SUCCESS\
+	 - Description: "*ptr < 100"\
+
+assertion\
+	 - Status: FAILURE\
+	 - Description: "*ptr == 1"
+
+assertion\
+	 - Status: FAILURE\
+	 - Description: "*ptr < 100"
+
+assertion\
+	 - Status: FAILURE\
+	 - Description: "*ptr == 1"
+
+Summary:
+Verification failed for - should_fail::prove_add_three_contract
+Verification failed for - should_fail::prove_add_one
+Verification failed for - should_fail::prove_add_three
+Complete - 1 successfully verified harnesses, 3 failures, 4 total.

--- a/tests/expected/function-contract/as-assertions/assert-preconditions.rs
+++ b/tests/expected/function-contract/as-assertions/assert-preconditions.rs
@@ -1,0 +1,64 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Zfunction-contracts -Zcontracts-as-assertions
+
+// Test -Zcontracts-as-assertions for preconditions.
+
+#[kani::requires(*ptr < 100)]
+#[kani::ensures(|result| old(*ptr + 3) == *ptr)]
+#[kani::modifies(ptr)]
+fn add_three(ptr: &mut u32) {
+    *ptr += 1;
+    add_two(ptr);
+}
+
+#[kani::requires(*ptr < 101)]
+#[kani::ensures(|result| old(*ptr + 2) == *ptr)]
+fn add_two(ptr: &mut u32) {
+    *ptr += 1;
+    add_one(ptr);
+}
+
+#[kani::requires(*ptr == 1)]
+#[kani::modifies(ptr)]
+fn add_one(ptr: &mut u32) {
+    *ptr += 1;
+}
+
+mod should_fail {
+    use crate::*;
+
+    // add_three and add_one's preconditions are asserted, causing failure.
+    #[kani::proof]
+    fn prove_add_three() {
+        let mut i = kani::any();
+        add_three(&mut i);
+    }
+
+    // add_three's precondition is asserted, causing failure.
+    #[kani::proof_for_contract(add_one)]
+    fn prove_add_one() {
+        let mut i = kani::any();
+        add_three(&mut i);
+    }
+
+    // Since add_three is the target of the proof_for_contract, its precondition gets assumed.
+    // However, add_one's precondition is still asserted, causing failure.
+    #[kani::proof_for_contract(add_three)]
+    fn prove_add_three_contract() {
+        let mut i = kani::any();
+        add_three(&mut i);
+    }
+}
+
+mod should_pass {
+    use crate::*;
+    // Same as should_fail::prove_add_one, with the added assumption of add_three's precondition.
+    // Note that add_one's precondition gets assumed since it's the target of the proof_for_contract.
+    #[kani::proof_for_contract(add_one)]
+    fn prove_add_one() {
+        let mut i = kani::any();
+        kani::assume(i < 100);
+        add_three(&mut i);
+    }
+}

--- a/tests/expected/function-contract/as-assertions/precedence.expected
+++ b/tests/expected/function-contract/as-assertions/precedence.expected
@@ -1,0 +1,13 @@
+assertion\
+	 - Status: UNREACHABLE\
+	 - Description: "*add_one_ptr == 1"
+
+assertion\
+	 - Status: UNREACHABLE\
+	 - Description: "|result| old(*add_one_ptr + 1) == *add_one_ptr"
+
+assertion\
+	 - Status: UNREACHABLE\
+	 - Description: "|result| old(*add_one_ptr + 1) == *add_one_ptr"
+
+Complete - 2 successfully verified harnesses, 0 failures, 2 total.

--- a/tests/expected/function-contract/as-assertions/precedence.rs
+++ b/tests/expected/function-contract/as-assertions/precedence.rs
@@ -1,0 +1,48 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Zfunction-contracts -Zcontracts-as-assertions
+
+// If a function is the target of a proof_for_contract or stub_verified, we should defer to the contract handling for those modes.
+// i.e., test that -Zcontracts-as-assertions does not override the contract handling for proof_for_contract and stub_verified.
+
+#[kani::modifies(add_three_ptr)]
+#[kani::requires(*add_three_ptr < 100)]
+fn add_three(add_three_ptr: &mut u32) {
+    *add_three_ptr += 1;
+    add_two(add_three_ptr);
+}
+
+#[kani::requires(*add_two_ptr < 101)]
+#[kani::ensures(|result| old(*add_two_ptr + 2) == *add_two_ptr)]
+fn add_two(add_two_ptr: &mut u32) {
+    *add_two_ptr += 1;
+    add_one(add_two_ptr);
+}
+
+#[kani::modifies(add_one_ptr)]
+#[kani::requires(*add_one_ptr == 1)]
+#[kani::ensures(|result| old(*add_one_ptr + 1) == *add_one_ptr)]
+fn add_one(add_one_ptr: &mut u32) {
+    *add_one_ptr += 1;
+}
+
+// Test that proof_for_contract takes precedence over the assert mode, i.e.
+// that the target of the proof for contract still has its preconditions assumed.
+#[kani::proof_for_contract(add_one)]
+fn proof_for_contract_takes_precedence() {
+    let mut i = kani::any();
+    // if add_one's precondition was asserted, verification would fail,
+    // but since it's assumed, we get a vacuously successful proof instead.
+    kani::assume(i == 2);
+    add_one(&mut i);
+}
+
+// Test that stub_verified takes precedence over the assert mode.
+// Verification should succeed because we stub add_two by its contract,
+// meaning we never reach add_one's contract.
+#[kani::proof_for_contract(add_three)]
+#[kani::stub_verified(add_two)]
+fn stub_verified_takes_precedence() {
+    let mut i = kani::any();
+    add_three(&mut i);
+}


### PR DESCRIPTION
Add an unstable option `-Zcontracts-as-assertions` that generates contract clauses as assertions. This works by adding a new contract mode that outputs the original body of the function with its contract clauses asserted. During the `FunctionWithContractPass`, if this option was passed, we use this closure instead of the original body of the function.

I'm omitting a description of why this is useful from the PR description--there's one in the module documentation, and I want that to be a self-contained explanation (i.e., if something is unclear, I want to fix it there).

Resolves #3326

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
