### PR TITLE
fix: Allow multiple `stub_verified`s on a single harness

### DIFF
--- a/tests/expected/function-contract/simple_replace_multiple_pass.expected
+++ b/tests/expected/function-contract/simple_replace_multiple_pass.expected
@@ -1,0 +1,13 @@
+.assertion\
+- Status: SUCCESS\
+- Description: "divisor != 0"
+
+.assertion\
+- Status: SUCCESS\
+- Description: "a >= b"
+
+main.assertion\
+- Status: SUCCESS\
+- Description: ""contract guarantees smallness""
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/simple_replace_multiple_pass.rs
+++ b/tests/expected/function-contract/simple_replace_multiple_pass.rs
@@ -1,0 +1,22 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Zfunction-contracts
+
+#[kani::requires(divisor != 0)]
+#[kani::ensures(|result : &u32| *result <= dividend)]
+fn div(dividend: u32, divisor: u32) -> u32 {
+    dividend / divisor
+}
+
+#[kani::requires(a >= b)]
+#[kani::ensures(|result : &u32| *result <= a)]
+fn sub(a: u32, b: u32) -> u32 {
+    a - b
+}
+
+#[kani::proof]
+#[kani::stub_verified(div)]
+#[kani::stub_verified(sub)]
+fn main() {
+    assert!(div(sub(9, 1), 1) != 10, "contract guarantees smallness");
+}


### PR DESCRIPTION
It seems that we can actually use multple `stub_verified`s on a single harness internally, but the checking logic prevents such usages.
This PR removes such restrection.

Resolves #3804

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
