### PR TITLE
Fix hanging command in `std-analysis.sh`

### DIFF
--- a/scripts/std-analysis.sh
+++ b/scripts/std-analysis.sh
@@ -104,10 +104,8 @@ for f in $results/*overall.csv; do
     fname=$(basename $f)
     crate=${fname%_scan_overall.csv}
     echo -n "$crate," >> $summary
-    temp_file=$(mktemp)
-    tr -d '[:alpha:]_,;' < "$f" > $temp_file
-    tr -s '\n' ',' < $temp_file >> "$summary"
-    rm $temp_file
+    tr -d '[:alpha:]_,;' < $f | tr -s '\n' ',' \
+        >> $summary
     echo "" >> $summary
 done
 

--- a/scripts/std-analysis.sh
+++ b/scripts/std-analysis.sh
@@ -104,8 +104,10 @@ for f in $results/*overall.csv; do
     fname=$(basename $f)
     crate=${fname%_scan_overall.csv}
     echo -n "$crate," >> $summary
-    tr -d [:alpha:]_,; < $f | tr -s '\n' ',' \
-        >> $summary
+    temp_file=$(mktemp)
+    tr -d '[:alpha:]_,;' < "$f" > $temp_file
+    tr -s '\n' ',' < $temp_file >> "$summary"
+    rm $temp_file
     echo "" >> $summary
 done
 


### PR DESCRIPTION
This command hangs on my machine (ARM64 Mac). Adding quotes around the `tr -d [:alpha:]_, ... ` part fixes the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
