### PR TITLE
Include manifest-path when checking if packages are in the workspace

### DIFF
--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -371,6 +371,10 @@ crate-type = ["lib"]
             .map(|pkg| {
                 let mut cmd = setup_cargo_command()?;
                 cmd.arg("pkgid");
+                if let Some(path) = &self.args.cargo.manifest_path {
+                    cmd.arg("--manifest-path");
+                    cmd.arg(path);
+                }
                 cmd.arg(pkg);
                 // For some reason clippy cannot see that we are invoking wait() in the next line.
                 #[allow(clippy::zombie_processes)]

--- a/tests/script-based-pre/cargo_manifest_test/add/Cargo.toml
+++ b/tests/script-based-pre/cargo_manifest_test/add/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "add"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/tests/script-based-pre/cargo_manifest_test/add/Cargo.toml
+++ b/tests/script-based-pre/cargo_manifest_test/add/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
 [package]
 name = "add"
 version = "0.1.0"

--- a/tests/script-based-pre/cargo_manifest_test/add/src/main.rs
+++ b/tests/script-based-pre/cargo_manifest_test/add/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #[kani::proof]
 fn main() {
     1 + 1;

--- a/tests/script-based-pre/cargo_manifest_test/add/src/main.rs
+++ b/tests/script-based-pre/cargo_manifest_test/add/src/main.rs
@@ -1,0 +1,4 @@
+#[kani::proof]
+fn main() {
+    1 + 1;
+}

--- a/tests/script-based-pre/cargo_manifest_test/config.yml
+++ b/tests/script-based-pre/cargo_manifest_test/config.yml
@@ -1,0 +1,4 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: manifest_test.sh
+expected: manifest_test.expected

--- a/tests/script-based-pre/cargo_manifest_test/manifest_test.expected
+++ b/tests/script-based-pre/cargo_manifest_test/manifest_test.expected
@@ -1,0 +1,1 @@
+Complete - 1 successfully verified harnesses, 0 failures, 1 total.

--- a/tests/script-based-pre/cargo_manifest_test/manifest_test.sh
+++ b/tests/script-based-pre/cargo_manifest_test/manifest_test.sh
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 # Test if Kani can correctly check if package in the workspace when
-# manifest-path presents.
+# manifest-path present.
 
 cargo kani --manifest-path=add/Cargo.toml --package add --debug

--- a/tests/script-based-pre/cargo_manifest_test/manifest_test.sh
+++ b/tests/script-based-pre/cargo_manifest_test/manifest_test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# Test if Kani can correctly check if package in the workspace when
+# manifest-path presents.
+
+cargo kani --manifest-path=add/Cargo.toml --package add --debug


### PR DESCRIPTION
With this PR, we include `--manifest-path` in `to_package_ids` function as part of the command.

Resolves #3816

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
