### PR TITLE
Bump Kani version to 0.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.58.0]
+
+### Major/Breaking Changes
+* Improve `--jobs` UI by @carolynzech in https://github.com/model-checking/kani/pull/3790
+* Generate contracts of dependencies as assertions by @carolynzech in https://github.com/model-checking/kani/pull/3802
+* Add UB checks for ptr_offset_from* intrinsics by @celinval in https://github.com/model-checking/kani/pull/3757
+
+### What's Changed
+* Package Docker release step: ensure compiler is installed by @tautschnig in https://github.com/model-checking/kani/pull/3789
+* fix: clippy by @ShoyuVanilla in https://github.com/model-checking/kani/pull/3806
+* Fix hanging command in `std-analysis.sh` by @carolynzech in https://github.com/model-checking/kani/pull/3818
+* Include manifest-path when checking if packages are in the workspace by @qinheping in https://github.com/model-checking/kani/pull/3819
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.57.0...kani-0.58.0
+
 ## [0.57.0]
 
 ### Major Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Add UB checks for ptr_offset_from* intrinsics by @celinval in https://github.com/model-checking/kani/pull/3757
 
 ### What's Changed
-* Package Docker release step: ensure compiler is installed by @tautschnig in https://github.com/model-checking/kani/pull/3789
 * Include manifest-path when checking if packages are in the workspace by @qinheping in https://github.com/model-checking/kani/pull/3819
 * Update kissat to v4.0.1 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3791
 * Rust toolchain upgraded to 2025-01-07 by @remi-delmas-3000 @zhassan-aws

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ### What's Changed
 * Package Docker release step: ensure compiler is installed by @tautschnig in https://github.com/model-checking/kani/pull/3789
-* Fix hanging command in `std-analysis.sh` by @carolynzech in https://github.com/model-checking/kani/pull/3818
 * Include manifest-path when checking if packages are in the workspace by @qinheping in https://github.com/model-checking/kani/pull/3819
 * Update kissat to v4.0.1 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3791
 * Rust toolchain upgraded to 2025-01-07 by @remi-delmas-3000 @zhassan-aws

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ### What's Changed
 * Package Docker release step: ensure compiler is installed by @tautschnig in https://github.com/model-checking/kani/pull/3789
-* fix: clippy by @ShoyuVanilla in https://github.com/model-checking/kani/pull/3806
 * Fix hanging command in `std-analysis.sh` by @carolynzech in https://github.com/model-checking/kani/pull/3818
 * Include manifest-path when checking if packages are in the workspace by @qinheping in https://github.com/model-checking/kani/pull/3819
+* Update kissat to v4.0.1 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3791
+* Rust toolchain upgraded to 2025-01-07 by @remi-delmas-3000 @zhassan-aws
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.57.0...kani-0.58.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -796,7 +796,7 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "kani"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "kani_core",
  "kani_macros",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "kani-compiler"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "charon",
  "clap",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "home",
@@ -884,14 +884,14 @@ dependencies = [
 
 [[package]]
 name = "kani_core"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani_macros"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "std"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_core/Cargo.toml
+++ b/library/kani_core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_core"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## What's Changed
* Package Docker release step: ensure compiler is installed by @tautschnig in https://github.com/model-checking/kani/pull/3789
* Improve `--jobs` UI by @carolynzech in https://github.com/model-checking/kani/pull/3790
* Update kissat to v4.0.1 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3791
* Automatic cargo update to 2024-12-23 by @github-actions in https://github.com/model-checking/kani/pull/3792
* Bump tests/perf/s2n-quic from `0b3f892` to `a54686e` by @dependabot in https://github.com/model-checking/kani/pull/3793
* Upgrade toolchain to nightly-2024-12-18 by @zhassan-aws in https://github.com/model-checking/kani/pull/3794
* Automatic cargo update to 2024-12-30 by @github-actions in https://github.com/model-checking/kani/pull/3800
* fix: clippy by @ShoyuVanilla in https://github.com/model-checking/kani/pull/3806
* Update dependencies (02.01.2025). by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3809
* Update charon submodule by @zhassan-aws in https://github.com/model-checking/kani/pull/3801
* Upgrade toolchain to 2024-12-19 by @zhassan-aws in https://github.com/model-checking/kani/pull/3810
* Automatic cargo update to 2025-01-06 by @github-actions in https://github.com/model-checking/kani/pull/3812
* Bump tests/perf/s2n-quic from `a54686e` to `ac52a48` by @dependabot in https://github.com/model-checking/kani/pull/3813
* Generate contracts of dependencies as assertions by @carolynzech in https://github.com/model-checking/kani/pull/3802
* Fix hanging command in `std-analysis.sh` by @carolynzech in https://github.com/model-checking/kani/pull/3818
* Add UB checks for ptr_offset_from* intrinsics by @celinval in https://github.com/model-checking/kani/pull/3757
* Toolchain update 06-01-2025 by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3814
* Automatic toolchain upgrade to nightly-2025-01-07 by @github-actions in https://github.com/model-checking/kani/pull/3820
* Include manifest-path when checking if packages are in the workspace by @qinheping in https://github.com/model-checking/kani/pull/3819

## New Contributors
* @ShoyuVanilla made their first contribution in https://github.com/model-checking/kani/pull/3806

**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.57.0...kani-0.58.0