### PR TITLE
Upgrade toolchain to 2025-01-15

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-01-13"
+channel = "nightly-2025-01-15"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Upgrade Rust toolchain to 2025-01-15 without source changes. We just had to skip over 2025-01-14 as no toolchain was released that day.

Resolves: #3834

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
