### PR TITLE
Add a regression test for `no_std` feature

### DIFF
--- a/tests/cargo-kani/no-std/Cargo.toml
+++ b/tests/cargo-kani/no-std/Cargo.toml
@@ -1,0 +1,9 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+[package]
+name = "no-std"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/tests/cargo-kani/no-std/expected
+++ b/tests/cargo-kani/no-std/expected
@@ -1,0 +1,1 @@
+Complete - 2 successfully verified harnesses, 0 failures, 2 total.

--- a/tests/cargo-kani/no-std/src/lib.rs
+++ b/tests/cargo-kani/no-std/src/lib.rs
@@ -1,0 +1,25 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Ensure that "extern crate kani" is sufficient to run Kani when no_std is enabled.
+
+#![no_std]
+extern crate kani;
+
+fn add(x: u8, y: u8) -> u8 {
+    x + y
+}
+
+#[kani::proof]
+fn prove_add() {
+    let x = kani::any_where(|n| *n < u8::MAX / 2);
+    let y = kani::any_where(|n| *n < u8::MAX / 2);
+    add(x, y);
+}
+
+use kani::cover;
+
+#[kani::proof]
+fn verify_point() {
+    cover!(true)
+}


### PR DESCRIPTION
Add a regression test to ensure that we can run Kani in crates with the `no_std` feature enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
