### PR TITLE
Upgrade toolchain to nightly-2025-01-22

### DIFF
--- a/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
+++ b/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
@@ -575,7 +575,7 @@ impl<'tcx> PointsToAnalysis<'_, 'tcx> {
                 // The same story from BinOp applies here, too. Need to track those things.
                 self.successors_for_operand(state, operand)
             }
-            Rvalue::NullaryOp(..) | Rvalue::Discriminant(..) => {
+            Rvalue::NullaryOp(..) | Rvalue::Discriminant(..) | Rvalue::Len(_) => {
                 // All of those should yield a constant.
                 HashSet::new()
             }

--- a/kani-compiler/src/main.rs
+++ b/kani-compiler/src/main.rs
@@ -16,7 +16,6 @@
 #![feature(f128)]
 #![feature(f16)]
 #![feature(non_exhaustive_omitted_patterns_lint)]
-#![feature(float_next_up_down)]
 #![feature(try_blocks)]
 extern crate rustc_abi;
 extern crate rustc_ast;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-01-16"
+channel = "nightly-2025-01-17"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-01-17"
+channel = "nightly-2025-01-19"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-01-20"
+channel = "nightly-2025-01-22"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-01-19"
+channel = "nightly-2025-01-20"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/expected/function-contract/valid_ptr.expected
+++ b/tests/expected/function-contract/valid_ptr.expected
@@ -1,5 +1,8 @@
 Checking harness pre_condition::harness_invalid_ptr...
-VERIFICATION:- SUCCESSFUL (encountered one or more panics as expected)
+Failed Checks: assertion failed: unsafe { read_ptr(ptr) } == -20
+Failed Checks: Kani does not support reasoning about pointer to unallocated memory
+Failed Checks: dereference failure: pointer outside object bounds
+VERIFICATION:- FAILED
 
 Checking harness pre_condition::harness_stack_ptr...
 VERIFICATION:- SUCCESSFUL
@@ -7,4 +10,4 @@ VERIFICATION:- SUCCESSFUL
 Checking harness pre_condition::harness_head_ptr...
 VERIFICATION:- SUCCESSFUL
 
-Complete - 3 successfully verified harnesses, 0 failures, 3 total
+Complete - 2 successfully verified harnesses, 1 failures, 3 total

--- a/tests/expected/function-contract/valid_ptr.rs
+++ b/tests/expected/function-contract/valid_ptr.rs
@@ -28,7 +28,6 @@ mod pre_condition {
     }
 
     #[kani::proof_for_contract(read_ptr)]
-    #[kani::should_panic]
     fn harness_invalid_ptr() {
         let ptr = std::ptr::NonNull::<i32>::dangling().as_ptr();
         assert_eq!(unsafe { read_ptr(ptr) }, -20);


### PR DESCRIPTION
Changes required due to
- rust-lang/rust#135344: Less unsafe in `dangling`/`without_provenance`
- rust-lang/rust#135661: Stabilize `float_next_up_down`
- rust-lang/rust#135709: Temporarily bring back `Rvalue::Len`

Resolves: #3840

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
