### PR TITLE
Remove `DefKind::Ctor` from filtering crate items

### DIFF
--- a/kani-compiler/src/kani_middle/reachability.rs
+++ b/kani-compiler/src/kani_middle/reachability.rs
@@ -84,16 +84,13 @@ where
         .iter()
         .filter_map(|item| {
             // Only collect monomorphic items.
-            // TODO: Remove the def_kind check once https://github.com/rust-lang/rust/pull/119135 has been released.
-            let def_id = rustc_internal::internal(tcx, item.def_id());
-            (matches!(tcx.def_kind(def_id), rustc_hir::def::DefKind::Ctor(..))
-                || matches!(item.kind(), ItemKind::Fn))
-            .then(|| {
-                Instance::try_from(*item)
-                    .ok()
-                    .and_then(|instance| predicate(tcx, instance).then_some(instance))
-            })
-            .flatten()
+            matches!(item.kind(), ItemKind::Fn)
+                .then(|| {
+                    Instance::try_from(*item)
+                        .ok()
+                        .and_then(|instance| predicate(tcx, instance).then_some(instance))
+                })
+                .flatten()
         })
         .collect::<Vec<_>>()
 }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/119135 is merged, so we shouldn't need this anymore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
