### PR TITLE
Update build command in docs to use release mode

### DIFF
--- a/docs/src/build-from-source.md
+++ b/docs/src/build-from-source.md
@@ -50,11 +50,16 @@ source $HOME/.cargo/env
 
 ## Build and test Kani
 
-Build the Kani package:
+Build the Kani package using:
 
+```
+cargo build-dev -- --release
+```
+to compile with optimizations turned on or using:
 ```
 cargo build-dev
 ```
+to compile in debug/development mode.
 
 Then, optionally, run the regression tests:
 


### PR DESCRIPTION
The [Building from source](https://model-checking.github.io/kani/build-from-source.html) page lists `cargo build-dev` as the command to build Kani. However, this command builds Kani in debug/development mode where optimizations are turned off, and thus may be much slower than the optimized binaries. This PR updates the docs to list the command to build in release mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
