### PR TITLE
Remove the openssl-devel package from dependencies

### DIFF
--- a/scripts/setup/al2/install_deps.sh
+++ b/scripts/setup/al2/install_deps.sh
@@ -13,7 +13,6 @@ DEPS=(
   cmake3
   gcc10-c++
   git
-  openssl-devel
   wget
 )
 


### PR DESCRIPTION
I confirmed the `openssl-devel` package is not needed to build Kani using fresh AL2 instances (both `aarch64` and `x86_64`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
