### PR TITLE
Toolchain upgrade to nightly-2025-01-28

### DIFF
--- a/kani-compiler/src/kani_compiler.rs
+++ b/kani-compiler/src/kani_compiler.rs
@@ -3,7 +3,7 @@
 
 //! This module defines all compiler extensions that form the Kani compiler.
 //!
-//! The [KaniCompiler] can be used across multiple rustc driver runs ([RunCompiler::run()]),
+//! The [KaniCompiler] can be used across multiple rustc driver runs ([`rustc_driver::run_compiler`]),
 //! which is used to implement stubs.
 //!
 //! In the first run, [KaniCompiler::config] will implement the compiler configuration and it will
@@ -25,7 +25,7 @@ use crate::kani_queries::QueryDb;
 use crate::session::init_session;
 use clap::Parser;
 use rustc_codegen_ssa::traits::CodegenBackend;
-use rustc_driver::{Callbacks, Compilation, RunCompiler};
+use rustc_driver::{Callbacks, Compilation, run_compiler};
 use rustc_interface::Config;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::config::ErrorOutputType;
@@ -34,7 +34,7 @@ use std::sync::{Arc, Mutex};
 use tracing::debug;
 
 /// Run the Kani flavour of the compiler.
-/// This may require multiple runs of the rustc driver ([RunCompiler::run]).
+/// This may require multiple runs of the rustc driver ([`rustc_driver::run_compiler`]).
 pub fn run(args: Vec<String>) {
     let mut kani_compiler = KaniCompiler::new();
     kani_compiler.run(args);
@@ -96,10 +96,7 @@ impl KaniCompiler {
     /// actually invoke the rust compiler multiple times.
     pub fn run(&mut self, args: Vec<String>) {
         debug!(?args, "run_compilation_session");
-        let queries = self.queries.clone();
-        let mut compiler = RunCompiler::new(&args, self);
-        compiler.set_make_codegen_backend(Some(Box::new(move |_cfg| backend(queries))));
-        compiler.run();
+        run_compiler(&args, self);
     }
 }
 
@@ -108,6 +105,10 @@ impl Callbacks for KaniCompiler {
     /// Configure the [KaniCompiler] `self` object during the [CompilationStage::Init].
     fn config(&mut self, config: &mut Config) {
         let mut args = vec!["kani-compiler".to_string()];
+        config.make_codegen_backend = Some(Box::new({
+            let queries = self.queries.clone();
+            move |_cfg| backend(queries)
+        }));
         args.extend(config.opts.cg.llvm_args.iter().cloned());
         let args = Arguments::parse_from(args);
         init_session(&args, matches!(config.opts.error_format, ErrorOutputType::Json { .. }));

--- a/kani-compiler/src/main.rs
+++ b/kani-compiler/src/main.rs
@@ -50,7 +50,7 @@ mod kani_middle;
 mod kani_queries;
 mod session;
 
-use rustc_driver::{RunCompiler, TimePassesCallbacks};
+use rustc_driver::{TimePassesCallbacks, run_compiler};
 use std::env;
 
 /// Main function. Configure arguments and run the compiler.
@@ -63,8 +63,7 @@ fn main() {
         kani_compiler::run(rustc_args);
     } else {
         let mut callbacks = TimePassesCallbacks::default();
-        let compiler = RunCompiler::new(&rustc_args, &mut callbacks);
-        compiler.run();
+        run_compiler(&rustc_args, &mut callbacks);
     }
 }
 

--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -57,7 +57,7 @@ static JSON_PANIC_HOOK: LazyLock<Box<dyn Fn(&panic::PanicHookInfo<'_>) + Sync + 
             let mut emitter = JsonEmitter::new(
                 Box::new(io::BufWriter::new(io::stderr())),
                 #[allow(clippy::arc_with_non_send_sync)]
-                Lrc::new(SourceMap::new(FilePathMapping::empty())),
+                Some(Lrc::new(SourceMap::new(FilePathMapping::empty()))),
                 fallback_bundle,
                 false,
                 HumanReadableErrorType::Default,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-01-27"
+channel = "nightly-2025-01-28"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-01-26"
+channel = "nightly-2025-01-27"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-01-24"
+channel = "nightly-2025-01-26"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Resolves https://github.com/model-checking/kani/issues/3854.

This upgrade requires changes to remove `RunCompiler` due to the following changes:

- https://github.com/rust-lang/rust/commit/a77776cc1d Remove RunCompiler


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
