### PR TITLE
Deprecate `--enable-unstable` and `--restrict-vtable`

### DIFF
--- a/kani-compiler/src/kani_middle/mod.rs
+++ b/kani-compiler/src/kani_middle/mod.rs
@@ -44,7 +44,7 @@ pub fn check_crate_items(tcx: TyCtxt, ignore_asm: bool) {
             if !ignore_asm {
                 let error_msg = format!(
                     "Crate {krate} contains global ASM, which is not supported by Kani. Rerun with \
-                    `--enable-unstable --ignore-global-asm` to suppress this error \
+                    `-Z unstable-options --ignore-global-asm` to suppress this error \
                     (**Verification results may be impacted**).",
                 );
                 tcx.dcx().err(error_msg);

--- a/kani-driver/src/args/common.rs
+++ b/kani-driver/src/args/common.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Define arguments that should be common to all subcommands in Kani.
-use crate::args::ValidateArgs;
+use crate::args::{ValidateArgs, print_deprecated};
 use clap::{error::Error, error::ErrorKind};
 pub use kani_metadata::{EnabledUnstableFeatures, UnstableFeature};
 
@@ -38,6 +38,30 @@ impl ValidateArgs for CommonArgs {
                 ErrorKind::ValueValidation,
                 "The `--dry-run` option is obsolete. Use --verbose instead.",
             ));
+        }
+        Ok(())
+    }
+}
+
+impl CommonArgs {
+    pub fn check_unstable(
+        &self,
+        enabled: bool,
+        argument: &str,
+        required: UnstableFeature,
+    ) -> Result<(), Error> {
+        if enabled && !self.unstable_features.contains(required) {
+            let z_feature = format!("-Z {required}");
+            if self.enable_unstable {
+                print_deprecated(self, "--enable-unstable", &z_feature);
+            } else {
+                return Err(Error::raw(
+                    ErrorKind::MissingRequiredArgument,
+                    format!(
+                        "The `{argument}` argument is unstable and requires `{z_feature}` to be used.",
+                    ),
+                ));
+            }
         }
         Ok(())
     }

--- a/kani-driver/src/assess/mod.rs
+++ b/kani-driver/src/assess/mod.rs
@@ -49,7 +49,7 @@ fn assess_project(mut session: KaniSession) -> Result<AssessMetadata> {
     session.codegen_tests = true;
     if session.args.jobs.is_none() {
         // assess will default to fully parallel instead of single-threaded.
-        // can be overridden with e.g. `cargo kani --enable-unstable -j 8 assess`
+        // can be overridden with e.g. `cargo kani -Z unstable-options -j 8 assess`
         session.args.jobs = Some(None); // -j, num_cpu
     }
 

--- a/kani-driver/src/assess/scan.rs
+++ b/kani-driver/src/assess/scan.rs
@@ -179,7 +179,8 @@ fn invoke_assess(
     // TODO: -p likewise, probably fixed with a "CargoArgs" refactoring
     // Additionally, this should be `--manifest-path` but `cargo kani` doesn't support that yet.
     cmd.arg("-p").arg(package);
-    cmd.arg("--enable-unstable"); // This has to be after `-p` due to an argument parsing bug in kani-driver
+    // This has to be after `-p` due to an argument parsing bug in kani-driver
+    cmd.arg("-Zunstable-options");
     cmd.args(["assess", "--emit-metadata"])
         .arg(outfile)
         .current_dir(dir)

--- a/kani-driver/src/cbmc_property_renderer.rs
+++ b/kani-driver/src/cbmc_property_renderer.rs
@@ -456,7 +456,7 @@ fn postprocess_error_message(message: ParserItem) -> ParserItem {
     {
         ParserItem::Message {
             message_text: message_text
-                .replace("--object-bits ", "--enable-unstable --cbmc-args --object-bits "),
+                .replace("--object-bits ", "-Z unstable-options --cbmc-args --object-bits "),
             message_type: String::from("ERROR"),
         }
     } else {

--- a/kani_metadata/src/unstable.rs
+++ b/kani_metadata/src/unstable.rs
@@ -102,6 +102,8 @@ pub enum UnstableFeature {
     List,
     /// Kani APIs related to floating-point operations (e.g. `float_to_int_in_range`)
     FloatLib,
+    /// Enable vtable restriction.
+    RestrictVtable,
 }
 
 impl UnstableFeature {

--- a/scripts/assess-scan-regression.sh
+++ b/scripts/assess-scan-regression.sh
@@ -10,7 +10,7 @@ KANI_DIR=$SCRIPT_DIR/..
 echo "Running assess scan test:"
 
 cd $KANI_DIR/tests/assess-scan-test-scaffold
-cargo kani --enable-unstable assess scan
+cargo kani -Z unstable-options assess scan
 
 # Clean up
 (cd foo && cargo clean)

--- a/scripts/exps/assess-scan-on-repos.sh
+++ b/scripts/exps/assess-scan-on-repos.sh
@@ -61,7 +61,7 @@ popd
 
 echo "Starting assess scan..."
 
-time cargo kani --only-codegen --enable-unstable assess scan \
+time cargo kani --only-codegen -Z unstable-options assess scan \
   --filter-packages-file $NAME_FILE \
   --emit-metadata ./scan-results.json
 

--- a/tests/cargo-kani/asm/global_error/doesnt_call_crate_with_global_asm.expected
+++ b/tests/cargo-kani/asm/global_error/doesnt_call_crate_with_global_asm.expected
@@ -1,1 +1,1 @@
-error: Crate crate_with_global_asm contains global ASM, which is not supported by Kani. Rerun with `--enable-unstable --ignore-global-asm` to suppress this error (**Verification results may be impacted**).
+error: Crate crate_with_global_asm contains global ASM, which is not supported by Kani. Rerun with `-Z unstable-options --ignore-global-asm` to suppress this error (**Verification results may be impacted**).

--- a/tests/cargo-kani/assess-artifacts/Cargo.toml
+++ b/tests/cargo-kani/assess-artifacts/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 # See src/lib.rs for a comment on this tests's purpose
 
 [package.metadata.kani]
-flags = { assess=true, enable-unstable=true }
+flags = { assess = true }
+unstable = { unstable-options = true }

--- a/tests/cargo-kani/assess-workspace-artifacts/Cargo.toml
+++ b/tests/cargo-kani/assess-workspace-artifacts/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2021"
 # See src/lib.rs for a comment on this tests's purpose
 
 [package.metadata.kani]
-flags = { assess=true, enable-unstable=true, workspace=true }
+flags = { assess = true, workspace = true }
+unstable = { unstable-options = true }
 
 [workspace]
 members = ["subpackage"]

--- a/tests/cargo-kani/simple-config-toml/Cargo.toml
+++ b/tests/cargo-kani/simple-config-toml/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2018"
 
 [workspace]
 
-[kani.flags]
-enable-unstable = true
-gen-c = true
+[package.metadata.kani]
+flags = { gen-c = true }
+unstable = { unstable-options = true }

--- a/tests/cargo-kani/simple-kissat/Cargo.toml
+++ b/tests/cargo-kani/simple-kissat/Cargo.toml
@@ -11,5 +11,7 @@ description = "Tests that Kani can be invoked with Kissat"
 [dependencies]
 
 [kani.flags]
-enable-unstable = true
 cbmc-args = ["--external-sat-solver", "kissat" ]
+
+[package.metadata.kani]
+unstable = { unstable-options = true }

--- a/tests/cargo-ui/assess-error/Cargo.toml
+++ b/tests/cargo-ui/assess-error/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [package.metadata.kani]
-flags = { assess=true, enable-unstable=true }
+flags = { assess = true }
+unstable = { unstable-options = true }

--- a/tests/expected/function-contract/history/stub.rs
+++ b/tests/expected/function-contract/history/stub.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // This test consumes > 9 GB of memory with 16 object bits. Reducing the number
 // of object bits to 8 to avoid running out of memory.
-// kani-flags: -Zfunction-contracts --enable-unstable --cbmc-args --object-bits 8
+// kani-flags: -Zfunction-contracts -Z unstable-options --cbmc-args --object-bits 8
 
 #[kani::ensures(|result| old(*ptr + *ptr) == *ptr)]
 #[kani::requires(*ptr < 100)]

--- a/tests/expected/function-contract/interior-mutability/whole-struct/refcell.rs
+++ b/tests/expected/function-contract/interior-mutability/whole-struct/refcell.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Temporarily reduce the number of object bits till
 // https://github.com/model-checking/kani/issues/3611 is fixed
-// kani-flags: -Zfunction-contracts --enable-unstable --cbmc-args --object-bits 12
+// kani-flags: -Zfunction-contracts -Z unstable-options --cbmc-args --object-bits 12
 
 /// The objective of this test is to check the modification of a RefCell used as interior mutability in an immutable struct
 use std::cell::RefCell;

--- a/tests/expected/loop-contract/multiple_loops.rs
+++ b/tests/expected/loop-contract/multiple_loops.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: -Z loop-contracts --enable-unstable --cbmc-args --object-bits 8
+// kani-flags: -Z loop-contracts -Z unstable-options --cbmc-args --object-bits 8
 
 //! Check if loop contracts is correctly applied.
 

--- a/tests/expected/loop-contract/small_slice_eq.rs
+++ b/tests/expected/loop-contract/small_slice_eq.rs
@@ -6,7 +6,7 @@
 // Modifications Copyright Kani Contributors
 // See GitHub history for details.
 
-// kani-flags: -Z loop-contracts -Z mem-predicates --enable-unstable --cbmc-args --object-bits 8
+// kani-flags: -Z loop-contracts -Z mem-predicates -Z unstable-options --cbmc-args --object-bits 8
 
 //! Check if loop contracts are correctly applied.
 

--- a/tests/expected/object-bits/insufficient/expected
+++ b/tests/expected/object-bits/insufficient/expected
@@ -1,1 +1,1 @@
-too many addressed objects: maximum number of objects is set to 2^n=32 (with n=5); use the `--enable-unstable --cbmc-args --object-bits n` option to increase the maximum number
+too many addressed objects: maximum number of objects is set to 2^n=32 (with n=5); use the `-Z unstable-options --cbmc-args --object-bits n` option to increase the maximum number

--- a/tests/expected/object-bits/insufficient/main.rs
+++ b/tests/expected/object-bits/insufficient/main.rs
@@ -1,6 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// kani-flags: --default-unwind 30 --enable-unstable --cbmc-args --object-bits 5
+// kani-flags: --default-unwind 30 -Z unstable-options --cbmc-args --object-bits 5
 //! Checks for error message with an --object-bits value that is too small
 //! Use linked list to ensure that each member represents a new object.
 

--- a/tests/expected/unwind-flags-conflict/main.rs
+++ b/tests/expected/unwind-flags-conflict/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --default-unwind 2 --enable-unstable --cbmc-args --unwindset 2
+// kani-flags: --default-unwind 2 -Z unstable-options --cbmc-args --unwindset 2
 
 #[kani::proof]
 fn main() {}

--- a/tests/firecracker/virtio-balloon-compact/ignore-main.rs
+++ b/tests/firecracker/virtio-balloon-compact/ignore-main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
-// Try with: kani ignore-main.rs --default-unwind 3 --enable-unstable --cbmc-args --object-bits 11
+// Try with: kani ignore-main.rs --default-unwind 3-Z unstable-options --cbmc-args --object-bits 11
 // With kissat as the solver (--external-sat-solver /path/to/kissat) this takes ~5mins
 
 pub const MAX_PAGE_COMPACT_BUFFER: usize = 2048;

--- a/tests/kani/DynTrait/any_cast_int.rs
+++ b/tests/kani/DynTrait/any_cast_int.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --no-restrict-vtable
+// kani-flags: --no-restrict-vtable -Z restrict-vtable
 // Tracking issue for the need for this flag:
 // https://github.com/model-checking/kani/issues/802
 

--- a/tests/kani/DynTrait/vtable_restrictions.rs
+++ b/tests/kani/DynTrait/vtable_restrictions.rs
@@ -5,7 +5,7 @@
 
 // FIXME until the corresponding CBMC path lands:
 
-// kani-flags: --enable-unstable --restrict-vtable
+// kani-flags: -Z restrict-vtable
 
 struct Sheep {}
 struct Cow {}

--- a/tests/kani/Overflow/pointer_overflow_fail.rs
+++ b/tests/kani/Overflow/pointer_overflow_fail.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
-// kani-flags: --enable-unstable --extra-pointer-checks
+// kani-flags:-Z unstable-options --extra-pointer-checks
 // kani-verify-fail
 
 #[kani::proof]

--- a/tests/ui/concrete-playback/array/main.rs
+++ b/tests/ui/concrete-playback/array/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 #[kani::unwind(10)]

--- a/tests/ui/concrete-playback/bool/main.rs
+++ b/tests/ui/concrete-playback/bool/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/cover/main.rs
+++ b/tests/ui/concrete-playback/cover/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/custom/main.rs
+++ b/tests/ui/concrete-playback/custom/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 struct MyStruct {
     field1: u8,

--- a/tests/ui/concrete-playback/f32/main.rs
+++ b/tests/ui/concrete-playback/f32/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 /// Note: Don't include NaN because there are multiple possible NaN values.
 #[kani::proof]

--- a/tests/ui/concrete-playback/f64/main.rs
+++ b/tests/ui/concrete-playback/f64/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 /// Note: Don't include NaN because there are multiple possible NaN values.
 #[kani::proof]

--- a/tests/ui/concrete-playback/i128/main.rs
+++ b/tests/ui/concrete-playback/i128/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/i16/main.rs
+++ b/tests/ui/concrete-playback/i16/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/i32/main.rs
+++ b/tests/ui/concrete-playback/i32/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/i64/main.rs
+++ b/tests/ui/concrete-playback/i64/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/i8/main.rs
+++ b/tests/ui/concrete-playback/i8/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/isize/main.rs
+++ b/tests/ui/concrete-playback/isize/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/mult-harnesses/main.rs
+++ b/tests/ui/concrete-playback/mult-harnesses/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 //! Multiple harnesses with the same name but under different modules.
 

--- a/tests/ui/concrete-playback/non_zero/main.rs
+++ b/tests/ui/concrete-playback/non_zero/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 use std::num::NonZeroU8;
 

--- a/tests/ui/concrete-playback/option/main.rs
+++ b/tests/ui/concrete-playback/option/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/result/main.rs
+++ b/tests/ui/concrete-playback/result/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/slice-formula/main.rs
+++ b/tests/ui/concrete-playback/slice-formula/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 //! We explicitly don't check what concrete values are returned for `_u8_1` and `_u8_3` as they could be anything.
 //! In practice, though, they will likely be 0.

--- a/tests/ui/concrete-playback/u128/main.rs
+++ b/tests/ui/concrete-playback/u128/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/u16/main.rs
+++ b/tests/ui/concrete-playback/u16/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/u32/main.rs
+++ b/tests/ui/concrete-playback/u32/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/u64/main.rs
+++ b/tests/ui/concrete-playback/u64/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/u8/main.rs
+++ b/tests/ui/concrete-playback/u8/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/concrete-playback/unsupported/loop.rs
+++ b/tests/ui/concrete-playback/unsupported/loop.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 #[kani::unwind(2)]

--- a/tests/ui/concrete-playback/usize/main.rs
+++ b/tests/ui/concrete-playback/usize/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --concrete-playback=print
+// kani-flags: -Zconcrete-playback --concrete-playback=print
 
 #[kani::proof]
 pub fn harness() {

--- a/tests/ui/invalid-cbmc-function-arg/main.rs
+++ b/tests/ui/invalid-cbmc-function-arg/main.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
-// kani-flags: --enable-unstable
+// kani-flags: -Z unstable-options
 // cbmc-flags: --function main
 
 //! This testcase is to ensure that user cannot pass --function as cbmc-flags

--- a/tests/ui/loop-contracts-synthesis/main_signed/main_signed.rs
+++ b/tests/ui/loop-contracts-synthesis/main_signed/main_signed.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --synthesize-loop-contracts
+// kani-flags: -Z unstable-options --synthesize-loop-contracts
 
 // Check if goto-synthesizer is correctly called, and synthesizes the required
 // loop invariants.

--- a/tests/ui/loop-contracts-synthesis/main_unsigned/main_unsigned.rs
+++ b/tests/ui/loop-contracts-synthesis/main_unsigned/main_unsigned.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// kani-flags: --enable-unstable --synthesize-loop-contracts --cbmc-args --object-bits 4
+// kani-flags: -Z unstable-options --synthesize-loop-contracts --cbmc-args --object-bits 4
 
 // Check if goto-synthesizer is correctly called, and synthesizes the required
 // loop invariants.

--- a/tools/compiletest/src/runtest.rs
+++ b/tools/compiletest/src/runtest.rs
@@ -308,7 +308,7 @@ impl TestCx<'_> {
         kani.arg(&self.testpaths.file).args(&self.props.kani_flags);
 
         if !self.props.cbmc_flags.is_empty() {
-            kani.arg("--enable-unstable").arg("--cbmc-args").args(&self.props.cbmc_flags);
+            kani.arg("-Zunstable-options").arg("--cbmc-args").args(&self.props.cbmc_flags);
         }
 
         self.compose_and_run(kani)


### PR DESCRIPTION
For unstable options, require `-Z unstable-options` instead. `--restrict-vtable` is deprecated in favor of `-Z restrict-vtable`

Towards #2279
Towards #3068 

## Call-out

- We should consider adding a `-Z dev-options` or something similar to distinguish between unstable features and developer only features, i.e., features not meant to be ever stabilized.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
