### PR TITLE
Fix transmute codegen when sizes are different

### DIFF
--- a/tests/expected/intrinsics/transmute_diff_size.expected
+++ b/tests/expected/intrinsics/transmute_diff_size.expected
@@ -1,0 +1,2 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+error: aborting due to 3 previous errors

--- a/tests/expected/intrinsics/transmute_diff_size.rs
+++ b/tests/expected/intrinsics/transmute_diff_size.rs
@@ -1,0 +1,33 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Checks that compilation fails when trying to transmute with different src and target sizes.
+
+#![feature(core_intrinsics)]
+use std::intrinsics::transmute;
+
+/// This should fail due to UB detection.
+#[kani::proof]
+pub fn transmute_diff_size() {
+    let a: u32 = kani::any();
+    if kani::any() {
+        let smaller: u16 = unsafe { transmute(a) };
+        std::hint::black_box(smaller);
+    } else {
+        let bigger: (u64, isize) = unsafe { transmute(a) };
+        std::hint::black_box(bigger);
+    }
+}
+
+/// Generic transmute wrapper.
+pub unsafe fn generic_transmute<S, D>(src: S) -> D {
+    transmute(src)
+}
+
+/// This should also fail due to UB detection.
+#[kani::proof]
+pub fn transmute_wrapper_diff_size() {
+    let a: (u32, char) = kani::any();
+    let b: u128 = unsafe { generic_transmute(a) };
+    std::hint::black_box(b);
+}

--- a/tests/expected/intrinsics/transmute_unchecked_size.expected
+++ b/tests/expected/intrinsics/transmute_unchecked_size.expected
@@ -1,0 +1,24 @@
+Checking harness transmute_wrapper_diff_size...
+Status: UNREACHABLE\
+Description: ""Unreachable expected""
+
+Failed Checks: Cannot transmute between types of different sizes. Transmuting from `8` to `16` bytes
+
+VERIFICATION:- FAILED
+
+Checking harness transmute_diff_size...
+
+Status: UNREACHABLE\
+Description: ""This should never be reached""
+
+Status: UNREACHABLE\
+Description: ""Neither this one""
+
+Failed Checks: Cannot transmute between types of different sizes. Transmuting from `4` to `2` bytes
+Failed Checks: Cannot transmute between types of different sizes. Transmuting from `4` to `16` bytes
+
+VERIFICATION:- FAILED
+
+Verification failed for - transmute_wrapper_diff_size
+Verification failed for - transmute_diff_size
+0 successfully verified harnesses, 2 failures, 2 total

--- a/tests/expected/intrinsics/transmute_unchecked_size.rs
+++ b/tests/expected/intrinsics/transmute_unchecked_size.rs
@@ -1,0 +1,44 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Checks that Kani correctly identify UB when invoking `transmute_unchecked` with different sizes.
+//! See <https://github.com/model-checking/kani/issues/3839> for more details.
+
+#![feature(core_intrinsics)]
+use std::intrinsics::transmute_unchecked;
+
+/// Reachability doesn't seem to work for unreachable statements.
+macro_rules! unreachable {
+    ($msg:literal) => {
+        assert!(false, $msg)
+    };
+}
+
+/// This should fail due to UB detection.
+#[kani::proof]
+pub fn transmute_diff_size() {
+    let a: u32 = kani::any();
+    if kani::any() {
+        let smaller: u16 = unsafe { transmute_unchecked(a) };
+        std::hint::black_box(smaller);
+        unreachable!("This should never be reached");
+    } else {
+        let bigger: (u64, isize) = unsafe { transmute_unchecked(a) };
+        std::hint::black_box(bigger);
+        unreachable!("Neither this one");
+    }
+}
+
+/// Generic transmute wrapper.
+pub unsafe fn generic_transmute<S, D>(src: S) -> D {
+    transmute_unchecked(src)
+}
+
+/// This should also fail due to UB detection.
+#[kani::proof]
+pub fn transmute_wrapper_diff_size() {
+    let a: (u32, char) = kani::any();
+    let b: u128 = unsafe { generic_transmute(a) };
+    std::hint::black_box(b);
+    unreachable!("Unreachable expected");
+}

--- a/tests/expected/intrinsics/transmute_unchecked_size.rs
+++ b/tests/expected/intrinsics/transmute_unchecked_size.rs
@@ -7,7 +7,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::transmute_unchecked;
 
-/// Reachability doesn't seem to work for unreachable statements.
+/// Kani reachability checks are not currently applied to `unreachable` statements.
 macro_rules! unreachable {
     ($msg:literal) => {
         assert!(false, $msg)


### PR DESCRIPTION
Instead of crashing, add a safety check that ensures the transmute is not reachable.

Resolves #3839 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
