### PR TITLE
Fix missing function declaration issue

### DIFF
--- a/tests/kani/CodegenMisc/missing_mut_fn.rs
+++ b/tests/kani/CodegenMisc/missing_mut_fn.rs
@@ -1,0 +1,27 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Ensure Kani can codegen code with a pointer to a function that is never used
+//! See <https://github.com/model-checking/kani/issues/3799> for more details.
+fn foo<F: Fn()>(_func: &mut F) {}
+fn foo_dyn(_func: &mut dyn Fn()) {}
+
+#[kani::proof]
+fn check_foo() {
+    fn f() {}
+
+    foo(&mut f);
+}
+
+#[kani::proof]
+fn check_foo_dyn() {
+    fn f() {}
+
+    foo_dyn(&mut f);
+}
+
+#[kani::proof]
+fn check_foo_unused() {
+    fn f() {}
+
+    let ptr = &mut f;
+}


### PR DESCRIPTION
In cases where a function pointer is created, but its value is never used, Kani crashes due to missing function declaration.

For now, collect any instance that has its address taken even if its never used.

Fixes #3799

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
