### PR TITLE
Remove symtab2gb from bundle

### DIFF
--- a/src/os_hacks.rs
+++ b/src/os_hacks.rs
@@ -81,7 +81,7 @@ fn setup_nixos_patchelf(kani_dir: &Path) -> Result<()> {
     for filename in &["kani-compiler", "kani-driver"] {
         patch_interp(&bin.join(filename))?;
     }
-    for filename in &["cbmc", "goto-analyzer", "goto-cc", "goto-instrument", "kissat", "symtab2gb"]
+    for filename in &["cbmc", "goto-analyzer", "goto-cc", "goto-instrument", "kissat"]
     {
         let file = bin.join(filename);
         patch_interp(&file)?;

--- a/src/os_hacks.rs
+++ b/src/os_hacks.rs
@@ -81,8 +81,7 @@ fn setup_nixos_patchelf(kani_dir: &Path) -> Result<()> {
     for filename in &["kani-compiler", "kani-driver"] {
         patch_interp(&bin.join(filename))?;
     }
-    for filename in &["cbmc", "goto-analyzer", "goto-cc", "goto-instrument", "kissat"]
-    {
+    for filename in &["cbmc", "goto-analyzer", "goto-cc", "goto-instrument", "kissat"] {
         let file = bin.join(filename);
         patch_interp(&file)?;
         patch_rpath(&file)?;

--- a/tools/build-kani/src/main.rs
+++ b/tools/build-kani/src/main.rs
@@ -138,7 +138,6 @@ fn bundle_cbmc(dir: &Path) -> Result<()> {
     cp(&which::which("cbmc")?, &bin)?;
     cp(&which::which("goto-instrument")?, &bin)?;
     cp(&which::which("goto-cc")?, &bin)?;
-    cp(&which::which("symtab2gb")?, &bin)?;
     cp(&which::which("goto-analyzer")?, &bin)?;
 
     Ok(())


### PR DESCRIPTION
CBMC's `symtab2gb` binary is no longer used since Kani now generates a goto binary directly. Removing it from the Kani bundle.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
