### PR TITLE
Bump Kani version to 0.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Fix crash if a function pointer is created but never used by @celinval in https://github.com/model-checking/kani/pull/3862
 * Fix transmute codegen when sizes are different by @celinval in https://github.com/model-checking/kani/pull/3861
 * Stub linker to avoid missing symbols errors by @celinval in https://github.com/model-checking/kani/pull/3858
-* Toolchain upgrade to nightly-2025-01-28 by @feliperodri in https://github.com/model-checking/kani/pull/3855
+* Toolchain upgrade to nightly-2025-01-28 by @feliperodri @tautschnig
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.58.0...kani-0.59.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## Breaking Changes
 * Deprecate `--enable-unstable` and `--restrict-vtable` by @celinval in https://github.com/model-checking/kani/pull/3859
+* Do not report arithmetic overflow for floating point operations that produce +/-Inf by @rajath-mk in https://github.com/model-checking/kani/pull/3873
 
 ## What's Changed
 * Fix validity checks for `char` by @celinval in https://github.com/model-checking/kani/pull/3853
 * Support verifying contracts/stubs for generic types with multiple inherent implementations by @carolynzech in https://github.com/model-checking/kani/pull/3829
 * Allow multiple stub_verified annotations, but check for duplicate targets by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3808
-* Do not report arithmetic overflow for floating point operations that produce +/-Inf by @rajath-mk in https://github.com/model-checking/kani/pull/3873
 * Fix crash if a function pointer is created but never used by @celinval in https://github.com/model-checking/kani/pull/3862
 * Fix transmute codegen when sizes are different by @celinval in https://github.com/model-checking/kani/pull/3861
 * Stub linker to avoid missing symbols errors by @celinval in https://github.com/model-checking/kani/pull/3858

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## Breaking Changes
+* Deprecate `--enable-unstable` and `--restrict-vtable` by @celinval in https://github.com/model-checking/kani/pull/3859
+
+## What's Changed
+* Fix validity checks for `char` by @celinval in https://github.com/model-checking/kani/pull/3853
+* Support verifying contracts/stubs for generic types with multiple inherent implementations by @carolynzech in https://github.com/model-checking/kani/pull/3829
+* Allow multiple stub_verified annotations, but check for duplicate targets by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3808
+* Do not report arithmetic overflow for floating point operations that produce +/-Inf by @rajath-mk in https://github.com/model-checking/kani/pull/3873
+* Fix crash if a function pointer is created but never used by @celinval in https://github.com/model-checking/kani/pull/3862
+* Fix transmute codegen when sizes are different by @celinval in https://github.com/model-checking/kani/pull/3861
+* Stub linker to avoid missing symbols errors by @celinval in https://github.com/model-checking/kani/pull/3858
+* Toolchain upgrade to nightly-2025-01-28 by @feliperodri in https://github.com/model-checking/kani/pull/3855
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.58.0...kani-0.59.0
+
 ## [0.58.0]
 
 ### Major/Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -809,7 +809,7 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "kani"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "kani_core",
  "kani_macros",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "kani-compiler"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "charon",
  "clap",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "home",
@@ -897,14 +897,14 @@ dependencies = [
 
 [[package]]
 name = "kani_core"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani_macros"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "std"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_core/Cargo.toml
+++ b/library/kani_core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_core"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Github generated release notes:

## What's Changed
* Automatic toolchain upgrade to nightly-2025-01-08 by @github-actions in https://github.com/model-checking/kani/pull/3821
* Automatic cargo update to 2025-01-13 by @github-actions in https://github.com/model-checking/kani/pull/3824
* Automatic toolchain upgrade to nightly-2025-01-09 by @github-actions in https://github.com/model-checking/kani/pull/3825
* Bump ncipollo/release-action from 1.14.0 to 1.15.0 by @dependabot in https://github.com/model-checking/kani/pull/3826
* Bump tests/perf/s2n-quic from `ac52a48` to `adc7ba9` by @dependabot in https://github.com/model-checking/kani/pull/3827
* Automatic toolchain upgrade to nightly-2025-01-10 by @github-actions in https://github.com/model-checking/kani/pull/3828
* Automatic toolchain upgrade to nightly-2025-01-11 by @github-actions in https://github.com/model-checking/kani/pull/3830
* Verify contracts/stubs for generic types with multiple inherent implementations by @carolynzech in https://github.com/model-checking/kani/pull/3829
* Update Charon submodule  by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3823
* Automatic toolchain upgrade to nightly-2025-01-12 by @github-actions in https://github.com/model-checking/kani/pull/3831
* Automatic toolchain upgrade to nightly-2025-01-13 by @github-actions in https://github.com/model-checking/kani/pull/3833
* Upgrade toolchain to 2025-01-15 by @tautschnig in https://github.com/model-checking/kani/pull/3835
* Automatic toolchain upgrade to nightly-2025-01-16 by @github-actions in https://github.com/model-checking/kani/pull/3836
* Add a regression test for `no_std` feature by @carolynzech in https://github.com/model-checking/kani/pull/3837
* Use fully-qualified name for size_of by @zhassan-aws in https://github.com/model-checking/kani/pull/3838
* Automatic cargo update to 2025-01-20 by @github-actions in https://github.com/model-checking/kani/pull/3842
* Bump tests/perf/s2n-quic from `adc7ba9` to `f0649f9` by @dependabot in https://github.com/model-checking/kani/pull/3844
* Upgrade toolchain to nightly-2025-01-22 by @tautschnig in https://github.com/model-checking/kani/pull/3843
* Remove `DefKind::Ctor` from filtering crate items by @carolynzech in https://github.com/model-checking/kani/pull/3845
* Enable valid_ptr post_condition harnesses by @tautschnig in https://github.com/model-checking/kani/pull/3847
* Update build command in docs to use release mode by @zhassan-aws in https://github.com/model-checking/kani/pull/3846
* Automatic toolchain upgrade to nightly-2025-01-23 by @github-actions in https://github.com/model-checking/kani/pull/3848
* Automatic toolchain upgrade to nightly-2025-01-24 by @github-actions in https://github.com/model-checking/kani/pull/3850
* Remove the openssl-devel package from dependencies by @zhassan-aws in https://github.com/model-checking/kani/pull/3852
* Fix validity checks for `char` by @celinval in https://github.com/model-checking/kani/pull/3853
* Bump tests/perf/s2n-quic from `f0649f9` to `4500593` by @dependabot in https://github.com/model-checking/kani/pull/3857
* Automatic cargo update to 2025-01-27 by @github-actions in https://github.com/model-checking/kani/pull/3856
* Deprecate `--enable-unstable` and `--restrict-vtable` by @celinval in https://github.com/model-checking/kani/pull/3859
* Stub linker to avoid missing symbols errors by @celinval in https://github.com/model-checking/kani/pull/3858
* Toolchain upgrade to nightly-2025-01-28 by @feliperodri in https://github.com/model-checking/kani/pull/3855
* Allow multiple  annotations, but check for duplicate targets. by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3808
* Move documentation of kani_core modules to right places by @qinheping in https://github.com/model-checking/kani/pull/3851
* Fix missing function declaration issue by @celinval in https://github.com/model-checking/kani/pull/3862
* Fix transmute codegen when sizes are different by @celinval in https://github.com/model-checking/kani/pull/3861
* Remove symtab2gb from bundle by @zhassan-aws in https://github.com/model-checking/kani/pull/3865
* Update the rustc hack for CLion / RustRover by @celinval in https://github.com/model-checking/kani/pull/3868
* Bump tests/perf/s2n-quic from `4500593` to `82dd0b5` by @dependabot in https://github.com/model-checking/kani/pull/3872
* Automatic cargo update to 2025-02-03 by @github-actions in https://github.com/model-checking/kani/pull/3869
* Add reference for loop contracts by @qinheping in https://github.com/model-checking/kani/pull/3849
* remove flag float-overflow-check by @rajath-mk in https://github.com/model-checking/kani/pull/3873

## New Contributors
* @rajath-mk made their first contribution in https://github.com/model-checking/kani/pull/3873

**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.58.0...kani-0.59.0



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
