### PR TITLE
set kani default value to 1

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -544,7 +544,8 @@ pub fn resolve_unwind_value(
 ) -> Option<u32> {
     // Check for which flag is being passed and prioritize extracting unwind from the
     // respective flag/annotation.
-    args.unwind.or(harness_metadata.attributes.unwind_value).or(args.default_unwind)
+    // If no unwind value is specified, default to 1 to prevent memory consumption issues
+    args.unwind.or(harness_metadata.attributes.unwind_value).or(args.default_unwind).or(Some(1))
 }
 
 #[cfg(test)]
@@ -575,7 +576,7 @@ mod tests {
         }
 
         // test against no unwind annotation
-        assert_eq!(resolve(&args_empty, &harness_none), None);
+        assert_eq!(resolve(&args_empty, &harness_none), Some(1));
         assert_eq!(resolve(&args_only_default, &harness_none), Some(2));
         assert_eq!(resolve(&args_only_harness, &harness_none), Some(1));
         assert_eq!(resolve(&args_both, &harness_none), Some(1));


### PR DESCRIPTION
Towards #3769 

If no default unwind value is given, we default it to 1 to prevent the harness from running forever. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
