### PR TITLE
scanner: Fix loop stats in overall function stats summary

### DIFF
--- a/tools/scanner/src/analysis.rs
+++ b/tools/scanner/src/analysis.rs
@@ -44,7 +44,6 @@ impl FnStats {
             is_unsafe: None,
             has_unsafe_ops: None,
             has_unsupported_input: None,
-            // TODO: Implement this.
             has_loop: None,
         }
     }
@@ -191,7 +190,10 @@ impl OverallStats {
                 if !kind.is_fn() {
                     return None;
                 };
-                Some(FnLoops::new(item.name()).collect(&item.body()))
+                let fn_props = FnLoops::new(item.name()).collect(&item.body());
+                self.fn_stats.get_mut(&item).unwrap().has_loop =
+                    Some(fn_props.has_iterators() || fn_props.has_loops());
+                Some(fn_props)
             })
             .partition::<Vec<_>, _>(|props| props.has_iterators() || props.has_loops());
 

--- a/tools/scanner/src/analysis.rs
+++ b/tools/scanner/src/analysis.rs
@@ -34,7 +34,7 @@ struct FnStats {
     is_unsafe: Option<bool>,
     has_unsafe_ops: Option<bool>,
     has_unsupported_input: Option<bool>,
-    has_loop: Option<bool>,
+    has_loop_or_iterator: Option<bool>,
 }
 
 impl FnStats {
@@ -44,7 +44,7 @@ impl FnStats {
             is_unsafe: None,
             has_unsafe_ops: None,
             has_unsupported_input: None,
-            has_loop: None,
+            has_loop_or_iterator: None,
         }
     }
 }
@@ -191,7 +191,7 @@ impl OverallStats {
                     return None;
                 };
                 let fn_props = FnLoops::new(item.name()).collect(&item.body());
-                self.fn_stats.get_mut(&item).unwrap().has_loop =
+                self.fn_stats.get_mut(&item).unwrap().has_loop_or_iterator =
                     Some(fn_props.has_iterators() || fn_props.has_loops());
                 Some(fn_props)
             })


### PR DESCRIPTION
We already have loop statistics ever since d2141e4c5f59683, they were just not merged into the overall per-function summary (which had an unset `has_loop` column).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
