### PR TITLE
Remove Ubuntu 20.04 CI usage

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   perf-benchcomp:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Save push event HEAD and HEAD~ to environment variables
         if: ${{ github.event_name == 'push' }}
@@ -46,13 +46,13 @@ jobs:
       - name: Set up Kani Dependencies (old variant)
         uses: ./old/.github/actions/setup
         with:
-          os: ubuntu-20.04
+          os: ubuntu-24.04
           kani_dir: old
 
       - name: Set up Kani Dependencies (new variant)
         uses: ./new/.github/actions/setup
         with:
-          os: ubuntu-20.04
+          os: ubuntu-24.04
           kani_dir: new
 
       - name: Copy benchmarks from new to old

--- a/.github/workflows/cbmc-latest.yml
+++ b/.github/workflows/cbmc-latest.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, ubuntu-20.04, ubuntu-22.04]
+        os: [macos-13, ubuntu-22.04, ubuntu-24.04]
     steps:
       - name: Checkout Kani under "kani"
         uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
         run: ./scripts/kani-regression.sh
 
   perf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Kani under "kani"
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Kani Dependencies
         uses: ./kani/.github/actions/setup
         with:
-          os: ubuntu-20.04
+          os: ubuntu-24.04
           kani_dir: 'kani'
 
       - name: Build Kani using release mode

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -31,7 +31,7 @@ jobs:
           ./scripts/run-autopep8.sh
 
   clippy-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Kani
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
-          os: ubuntu-20.04
+          os: ubuntu-24.04
 
       - name: 'Install jq for parsing.'
         run: |

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-14]
+        os: [macos-13, ubuntu-22.04, ubuntu-24.04, macos-14]
     steps:
       - name: Checkout Kani
         uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
         run: ./scripts/kani-regression.sh
 
   benchcomp-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Kani
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
-          os: ubuntu-20.04
+          os: ubuntu-24.04
 
       - name: Build Kani using release mode
         run: cargo build-dev -- --release
@@ -55,7 +55,7 @@ jobs:
         run: pushd tools/benchcomp && PATH=$(realpath ../../scripts):$PATH test/run
 
   perf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Kani
         uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
-          os: ubuntu-20.04
+          os: ubuntu-24.04
 
       - name: Execute Kani performance tests
         run: ./scripts/kani-perf.sh
@@ -71,7 +71,7 @@ jobs:
           RUST_TEST_THREADS: 1
 
   documentation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
 
   build_bundle_linux:
     name: BuildBundle-Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.bundle.outputs.version }}
       bundle: ${{ steps.bundle.outputs.bundle }}
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
-          os: ubuntu-20.04
+          os: ubuntu-22.04
 
       - name: Build bundle
         id: bundle
@@ -97,14 +97,11 @@ jobs:
     needs: [build_bundle_macos, build_bundle_linux]
     strategy:
       matrix:
-        os: [macos-13, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [macos-13, ubuntu-22.04, ubuntu-24.04]
         include:
         - os: macos-13
           rust_target: x86_64-apple-darwin
           prev_job: ${{ needs.build_bundle_macos.outputs }}
-        - os: ubuntu-20.04
-          rust_target: x86_64-unknown-linux-gnu
-          prev_job: ${{ needs.build_bundle_linux.outputs }}
         - os: ubuntu-22.04
           rust_target: x86_64-unknown-linux-gnu
           prev_job: ${{ needs.build_bundle_linux.outputs }}
@@ -200,7 +197,7 @@ jobs:
     needs: [build_bundle_macos, build_bundle_linux]
     strategy:
       matrix:
-        os: [macos-13, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [macos-13, ubuntu-22.04, ubuntu-24.04]
         include:
           # Stores the output of the previous job conditional to the OS
           - prev_job: ${{ needs.build_bundle_linux.outputs }}
@@ -244,7 +241,7 @@ jobs:
   kani_release:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/kani-') }}
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [build_bundle_macos, build_bundle_macos_aarch64, build_bundle_linux, test_bundle]
     outputs:
       version: ${{ steps.versioning.outputs.version }}
@@ -301,12 +298,12 @@ jobs:
   package_docker:
     name: Package Docker
     needs: kani_release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       packages: write
     env:
-      os: ubuntu-20.04
+      os: ubuntu-24.04
       target: x86_64-unknown-linux-gnu
     steps:
       - name: Checkout code
@@ -315,7 +312,7 @@ jobs:
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
-          os: ubuntu-20.04
+          os: ubuntu-24.04
 
       - name: 'Build release bundle'
         run: |
@@ -339,7 +336,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: scripts/ci/Dockerfile.bundle-release-20-04
+          file: scripts/ci/Dockerfile.bundle-release-24-04
           push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tags: |

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, ubuntu-20.04, ubuntu-22.04]
+        os: [macos-13, ubuntu-22.04, ubuntu-24.04]
     steps:
       - name: Checkout Kani
         uses: actions/checkout@v4


### PR DESCRIPTION
This is deprecated per
https://github.com/actions/runner-images/issues/11101 and will be fully removed on 2025-04-01.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
