### PR TITLE
Install the right toolchain for HEAD and BASE checks in `verify-std-check.yml`

### DIFF
--- a/.github/workflows/verify-std-check.yml
+++ b/.github/workflows/verify-std-check.yml
@@ -62,12 +62,24 @@ jobs:
             -Z mem-predicates -Z loop-contracts --enable-unstable --cbmc-args --object-bits 12
 
       # If the head failed, check if it's a new failure.
-      - name: Checkout base
+      - name: Checkout BASE
         working-directory: kani
         if: steps.check-head.outcome != 'success' && github.event_name == 'pull_request'
         run: |
           BASE_REF=${{ github.event.pull_request.base.sha }}
           git checkout ${BASE_REF}
+
+      - name: Setup Kani Dependencies BASE
+        uses: ./kani/.github/actions/setup
+        if: steps.check-head.outcome != 'success' && github.event_name == 'pull_request'
+        with:
+          os: ${{ matrix.os }}
+          kani_dir: kani
+
+      - name: Build Kani BASE
+        working-directory: kani
+        if: steps.check-head.outcome != 'success' && github.event_name == 'pull_request'
+        run: |
           cargo build-dev
 
       - name: Run verification with BASE


### PR DESCRIPTION
The versions of the toolchain and deps can differ between BASE and HEAD versions and we build twice, so we ensure
the right versions are installed.
