### PR TITLE
Update toolchain to 2025-03-04

### DIFF
--- a/cprover_bindings/src/irep/goto_binary_serde.rs
+++ b/cprover_bindings/src/irep/goto_binary_serde.rs
@@ -84,7 +84,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::hash::Hash;
 use std::io::{self, BufReader};
-use std::io::{BufWriter, Bytes, Error, ErrorKind, Read, Write};
+use std::io::{BufWriter, Bytes, Error, Read, Write};
 use std::path::Path;
 
 /// Writes a symbol table to a file in goto binary format in version 6.
@@ -585,7 +585,7 @@ where
     /// afterwards.
     fn new(reader: R) -> Self {
         GotoBinaryDeserializer {
-            bytes: BufReader::new(reader).bytes(),
+            bytes: reader.bytes(),
             numbering: IrepNumbering::new(),
             string_count: Vec::new(),
             string_map: Vec::new(),

--- a/cprover_bindings/src/irep/goto_binary_serde.rs
+++ b/cprover_bindings/src/irep/goto_binary_serde.rs
@@ -557,7 +557,7 @@ where
     R: Read,
 {
     /// Stream of bytes from which GOTO objects are read.
-    bytes: Bytes<R>,
+    bytes: Bytes<BufReader<R>>,
 
     /// Numbering for ireps
     numbering: IrepNumbering,
@@ -584,8 +584,9 @@ where
     /// Constructor. The reader is moved into this object and cannot be used
     /// afterwards.
     fn new(reader: R) -> Self {
+        let buffered_reader = BufReader::new(reader);
         GotoBinaryDeserializer {
-            bytes: reader.bytes(),
+            bytes: buffered_reader.bytes(),
             numbering: IrepNumbering::new(),
             string_count: Vec::new(),
             string_map: Vec::new(),

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -5,7 +5,7 @@ use cbmc::goto_program::{DatatypeComponent, Expr, Location, Parameter, Symbol, S
 use cbmc::utils::aggr_tag;
 use cbmc::{InternString, InternedString};
 use rustc_abi::{
-    BackendRepr::Vector, FieldIdx, FieldsShape, Float, Integer, LayoutData, Primitive, Size,
+    BackendRepr::SimdVector, FieldIdx, FieldsShape, Float, Integer, LayoutData, Primitive, Size,
     TagEncoding, TyAndLayout, VariantIdx, Variants,
 };
 use rustc_ast::ast::Mutability;
@@ -1473,7 +1473,7 @@ impl<'tcx> GotocCtx<'tcx> {
         debug! {"handling simd with layout {:?}", layout};
 
         let (element, size) = match layout {
-            Vector { element, count } => (element, count),
+            SimdVector { element, count } => (element, count),
             _ => unreachable!(),
         };
 

--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -420,7 +420,7 @@ impl CodegenBackend for GotocCodegenBackend {
         let requested_crate_types = &codegen_results.crate_info.crate_types.clone();
         let local_crate_name = codegen_results.crate_info.local_crate_name;
         // Create the rlib if one was requested.
-        if requested_crate_types.iter().any(|crate_type| *crate_type == CrateType::Rlib) {
+        if requested_crate_types.contains(&CrateType::Rlib) {
             link_binary(sess, &ArArchiveBuilderBuilder, codegen_results, outputs);
         }
 

--- a/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
+++ b/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
@@ -468,7 +468,7 @@ impl MirVisitor for CheckUninitVisitor {
                         && !ptx.is_mutating()
                     {
                         let contains_deref_projection =
-                            { place.projection.iter().any(|elem| *elem == ProjectionElem::Deref) };
+                            { place.projection.contains(&ProjectionElem::Deref) };
                         if contains_deref_projection {
                             // We do not currently support having a deref projection in the same
                             // place as union field access.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-03-03"
+channel = "nightly-2025-03-04"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-03-02"
+channel = "nightly-2025-03-03"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Resolves: #3924
Related commits:
https://github.com/rust-lang/rust/commit/aac65f562b rename BackendRepr::Vector → SimdVector

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
