### PR TITLE
Upgrade toolchain to nightly-2025-03-12

### DIFF
--- a/kani-compiler/src/codegen_aeneas_llbc/mir_to_ullbc/mod.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/mir_to_ullbc/mod.rs
@@ -813,7 +813,7 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
             let disambiguator = CharonDisambiguator::new(data.disambiguator as usize);
             use rustc_hir::definitions::DefPathData;
             match &data.data {
-                DefPathData::TypeNs(symbol) => {
+                DefPathData::TypeNs(Some(symbol)) => {
                     error_assert!(self, span, data.disambiguator == 0); // Sanity check
                     name.push(CharonPathElem::Ident(symbol.to_string(), disambiguator));
                 }
@@ -956,7 +956,7 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
             let disambiguator = CharonDisambiguator::new(data.disambiguator as usize);
             use rustc_hir::definitions::DefPathData;
             match &data.data {
-                DefPathData::TypeNs(symbol) => {
+                DefPathData::TypeNs(Some(symbol)) => {
                     error_assert!(self, span, data.disambiguator == 0); // Sanity check
                     name.push(CharonPathElem::Ident(symbol.to_string(), disambiguator));
                 }
@@ -1063,7 +1063,7 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
             let disambiguator = CharonDisambiguator::new(data.disambiguator as usize);
             use rustc_hir::definitions::DefPathData;
             match &data.data {
-                DefPathData::TypeNs(symbol) => {
+                DefPathData::TypeNs(Some(symbol)) => {
                     error_assert!(self, span, data.disambiguator == 0); // Sanity check
                     name.push(CharonPathElem::Ident(symbol.to_string(), disambiguator));
                 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-03-07"
+channel = "nightly-2025-03-12"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Changes required due to
- rust-lang/rust#137977: Reduce `kw::Empty` usage, part 1

Resolves: #3932

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
