### PR TITLE
Autoharness: `--list` option

### DIFF
--- a/kani-compiler/src/kani_middle/codegen_units.rs
+++ b/kani-compiler/src/kani_middle/codegen_units.rs
@@ -92,8 +92,7 @@ impl CodegenUnits {
                     args,
                     *kani_fns.get(&KaniModel::Any.into()).unwrap(),
                 );
-                let chosen_fn_names =
-                    chosen.iter().map(|func| func.name().clone()).collect::<Vec<_>>();
+                let chosen_fn_names = chosen.iter().map(|func| func.name()).collect::<Vec<_>>();
                 AUTOHARNESS_MD
                     .set(AutoHarnessMetadata { chosen: chosen_fn_names, skipped })
                     .expect("Initializing the autoharness metdata failed");

--- a/kani-compiler/src/kani_middle/codegen_units.rs
+++ b/kani-compiler/src/kani_middle/codegen_units.rs
@@ -36,7 +36,7 @@ use std::sync::OnceLock;
 use tracing::debug;
 
 /// An identifier for the harness function.
-type Harness = Instance;
+pub type Harness = Instance;
 
 /// A set of stubs.
 pub type Stubs = HashMap<FnDef, FnDef>;
@@ -166,7 +166,7 @@ impl CodegenUnits {
             proof_harnesses,
             unsupported_features: vec![],
             test_harnesses,
-            contracted_functions: gen_contracts_metadata(tcx),
+            contracted_functions: gen_contracts_metadata(tcx, &self.harness_info),
             autoharness_md: AUTOHARNESS_MD.get().cloned(),
         }
     }

--- a/kani-driver/src/args/list_args.rs
+++ b/kani-driver/src/args/list_args.rs
@@ -64,6 +64,13 @@ impl ValidateArgs for CargoListArgs {
             ));
         }
 
+        if self.format == Format::Pretty && self.common_args.quiet {
+            return Err(Error::raw(
+                ErrorKind::ArgumentConflict,
+                "The `--quiet` flag is not compatible with the `pretty` format, since `pretty` prints to the terminal. Either specify a different format or don't pass `--quiet`.",
+            ));
+        }
+
         Ok(())
     }
 }
@@ -75,6 +82,13 @@ impl ValidateArgs for StandaloneListArgs {
             return Err(Error::raw(
                 ErrorKind::MissingRequiredArgument,
                 "The `list` subcommand is unstable and requires -Z list",
+            ));
+        }
+
+        if self.format == Format::Pretty && self.common_args.quiet {
+            return Err(Error::raw(
+                ErrorKind::ArgumentConflict,
+                "The `--quiet` flag is not compatible with the `pretty` format, since `pretty` prints to the terminal. Either specify a different format or don't pass `--quiet`.",
             ));
         }
 

--- a/kani-driver/src/list/collect_metadata.rs
+++ b/kani-driver/src/list/collect_metadata.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use kani_metadata::{ContractedFunction, HarnessKind, KaniMetadata};
 
 /// Process the KaniMetadata output from kani-compiler and output the list subcommand results
-fn process_metadata(metadata: Vec<KaniMetadata>) -> ListMetadata {
+pub fn process_metadata(metadata: Vec<KaniMetadata>) -> ListMetadata {
     // We use ordered maps and sets so that the output is in lexicographic order (and consistent across invocations).
 
     // Map each file to a vector of its harnesses.

--- a/kani-driver/src/list/mod.rs
+++ b/kani-driver/src/list/mod.rs
@@ -6,9 +6,9 @@ use kani_metadata::ContractedFunction;
 use std::collections::{BTreeMap, BTreeSet};
 
 pub mod collect_metadata;
-mod output;
+pub mod output;
 
-struct ListMetadata {
+pub struct ListMetadata {
     // Files mapped to their #[kani::proof] harnesses
     standard_harnesses: BTreeMap<String, BTreeSet<String>>,
     // Total number of #[kani::proof] harnesses

--- a/tests/script-based-pre/cargo_autoharness_list/Cargo.toml
+++ b/tests/script-based-pre/cargo_autoharness_list/Cargo.toml
@@ -1,0 +1,10 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+[package]
+name = "cargo_autoharness_list"
+version = "0.1.0"
+edition = "2024"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }

--- a/tests/script-based-pre/cargo_autoharness_list/config.yml
+++ b/tests/script-based-pre/cargo_autoharness_list/config.yml
@@ -1,0 +1,4 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: list.sh
+expected: list.expected

--- a/tests/script-based-pre/cargo_autoharness_list/list.expected
+++ b/tests/script-based-pre/cargo_autoharness_list/list.expected
@@ -1,0 +1,26 @@
+Kani generated automatic harnesses for 3 function(s):
++---------------------------+
+| Chosen Function           |
++===========================+
+| f_u8                      |
+|---------------------------|
+| has_recursion_gcd         |
+|---------------------------|
+| verify::has_recursion_gcd |
++---------------------------+
+
+Skipped Functions: None. Kani generated automatic harnesses for all functions in the available crate(s).
+
+Contracts:
++-------+---------------------------+-----------------------------------------------------------------------------+
+|       | Function                  | Contract Harnesses (#[kani::proof_for_contract])                            |
++=================================================================================================================+
+|       | has_recursion_gcd         | my_harness, my_harness_2, kani::internal::automatic_harness                 |
+|-------+---------------------------+-----------------------------------------------------------------------------|
+|       | verify::has_recursion_gcd | verify::my_harness, verify::my_harness_2, kani::internal::automatic_harness |
+|-------+---------------------------+-----------------------------------------------------------------------------|
+| Total | 2                         | 6                                                                           |
++-------+---------------------------+-----------------------------------------------------------------------------+
+
+Standard Harnesses (#[kani::proof]):
+1. f_u8

--- a/tests/script-based-pre/cargo_autoharness_list/list.sh
+++ b/tests/script-based-pre/cargo_autoharness_list/list.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+cargo kani autoharness -Z autoharness --list -Z list -Z function-contracts

--- a/tests/script-based-pre/cargo_autoharness_list/src/lib.rs
+++ b/tests/script-based-pre/cargo_autoharness_list/src/lib.rs
@@ -1,0 +1,65 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Test that `kani autoharness --list` finds all of the manual and automatic harnesses
+// and correctly matches them to their target function.
+// Note that the proof_for_contract attributes use different, but equivalent, paths to their target functions;
+// this tests that we can group the harnesses under the same target function even when the attribute value strings differ.
+
+fn f_u8(x: u8) -> u8 {
+    x
+}
+
+#[kani::requires(x != 0 && y != 0)]
+#[kani::ensures(|result : &u8| *result != 0 && x % *result == 0 && y % *result == 0)]
+#[kani::recursion]
+fn has_recursion_gcd(x: u8, y: u8) -> u8 {
+    let mut max = x;
+    let mut min = y;
+    if min > max {
+        let val = max;
+        max = min;
+        min = val;
+    }
+
+    let res = max % min;
+    if res == 0 { min } else { has_recursion_gcd(min, res) }
+}
+
+#[kani::proof_for_contract(crate::has_recursion_gcd)]
+fn my_harness() {
+    has_recursion_gcd(kani::any(), kani::any());
+}
+
+#[kani::proof_for_contract(has_recursion_gcd)]
+fn my_harness_2() {
+    has_recursion_gcd(kani::any(), kani::any());
+}
+
+mod verify {
+    #[kani::requires(x != 0 && y != 0)]
+    #[kani::ensures(|result : &u8| *result != 0 && x % *result == 0 && y % *result == 0)]
+    #[kani::recursion]
+    fn has_recursion_gcd(x: u8, y: u8) -> u8 {
+        let mut max = x;
+        let mut min = y;
+        if min > max {
+            let val = max;
+            max = min;
+            min = val;
+        }
+
+        let res = max % min;
+        if res == 0 { min } else { has_recursion_gcd(min, res) }
+    }
+
+    #[kani::proof_for_contract(crate::verify::has_recursion_gcd)]
+    fn my_harness() {
+        has_recursion_gcd(kani::any(), kani::any());
+    }
+
+    #[kani::proof_for_contract(has_recursion_gcd)]
+    fn my_harness_2() {
+        has_recursion_gcd(kani::any(), kani::any());
+    }
+}


### PR DESCRIPTION
Add `--list` option to the autoharness subcommand, which invokes the driver logic from the list subcommand to list automatic and manual harness metadata together.

Towards #3832

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
