### PR TITLE
Add support for anonymous nested statics

### DIFF
--- a/kani-compiler/src/kani_middle/mod.rs
+++ b/kani-compiler/src/kani_middle/mod.rs
@@ -9,10 +9,10 @@ use crate::kani_queries::QueryDb;
 use rustc_hir::{def::DefKind, def_id::DefId as InternalDefId, def_id::LOCAL_CRATE};
 use rustc_middle::ty::TyCtxt;
 use rustc_smir::rustc_internal;
-use stable_mir::CrateDef;
 use stable_mir::mir::mono::MonoItem;
 use stable_mir::ty::{FnDef, RigidTy, Span as SpanStable, Ty, TyKind};
 use stable_mir::visitor::{Visitable, Visitor as TyVisitor};
+use stable_mir::{CrateDef, DefId};
 use std::ops::ControlFlow;
 
 use self::attributes::KaniAttributes;
@@ -143,6 +143,15 @@ impl SourceLocation {
         let end_line = loc.end_line;
         let end_col = loc.end_col;
         SourceLocation { filename, start_line, start_col, end_line, end_col }
+    }
+}
+
+/// Return whether `def_id` refers to a nested static allocation.
+pub fn is_anon_static(tcx: TyCtxt, def_id: DefId) -> bool {
+    let int_def_id = rustc_internal::internal(tcx, def_id);
+    match tcx.def_kind(int_def_id) {
+        rustc_hir::def::DefKind::Static { nested, .. } => nested,
+        _ => false,
     }
 }
 

--- a/kani-compiler/src/kani_middle/reachability.rs
+++ b/kani-compiler/src/kani_middle/reachability.rs
@@ -219,20 +219,30 @@ impl<'tcx, 'a> MonoItemsCollector<'tcx, 'a> {
         let _guard = debug_span!("visit_static", ?def).entered();
         let mut next_items = vec![];
 
-        // Collect drop function.
-        let static_ty = def.ty();
-        let instance = Instance::resolve_drop_in_place(static_ty);
-        next_items
-            .push(CollectedItem { item: instance.into(), reason: CollectionReason::StaticDrop });
+        // Collect drop function, unless it's an anonymous static.
+        let int_def_id = rustc_internal::internal(self.tcx, def.def_id());
+        let anonymous = match self.tcx.def_kind(int_def_id) {
+            rustc_hir::def::DefKind::Static { nested, .. } => nested,
+            _ => false,
+        };
+        if !anonymous {
+            let static_ty = def.ty();
+            let instance = Instance::resolve_drop_in_place(static_ty);
+            next_items.push(CollectedItem {
+                item: instance.into(),
+                reason: CollectionReason::StaticDrop,
+            });
 
-        // Collect initialization.
-        let alloc = def.eval_initializer().unwrap();
-        for (_, prov) in alloc.provenance.ptrs {
-            next_items.extend(
-                collect_alloc_items(prov.0)
-                    .into_iter()
-                    .map(|item| CollectedItem { item, reason: CollectionReason::Static }),
-            );
+            // Collect initialization.
+            let alloc = def.eval_initializer().unwrap();
+            debug!(?alloc, "visit_static: initializer");
+            for (_, prov) in alloc.provenance.ptrs {
+                next_items.extend(
+                    collect_alloc_items(self.tcx, prov.0)
+                        .into_iter()
+                        .map(|item| CollectedItem { item, reason: CollectionReason::Static }),
+                );
+            }
         }
 
         next_items
@@ -331,7 +341,7 @@ impl MonoItemsFnCollector<'_, '_> {
         debug!(?alloc, "collect_allocation");
         for (_, id) in &alloc.provenance.ptrs {
             self.collected.extend(
-                collect_alloc_items(id.0)
+                collect_alloc_items(self.tcx, id.0)
                     .into_iter()
                     .map(|item| CollectedItem { item, reason: CollectionReason::Static }),
             )
@@ -520,27 +530,43 @@ fn should_codegen_locally(instance: &Instance) -> bool {
     !instance.is_foreign_item()
 }
 
-fn collect_alloc_items(alloc_id: AllocId) -> Vec<MonoItem> {
+fn collect_alloc_items(tcx: TyCtxt, alloc_id: AllocId) -> Vec<MonoItem> {
     trace!(?alloc_id, "collect_alloc_items");
     let mut items = vec![];
     match GlobalAlloc::from(alloc_id) {
         GlobalAlloc::Static(def) => {
-            // This differ from rustc's collector since rustc does not include static from
-            // upstream crates.
-            let instance = Instance::try_from(CrateItem::from(def)).unwrap();
-            should_codegen_locally(&instance).then(|| items.push(MonoItem::from(def)));
+            let int_def_id = rustc_internal::internal(tcx, def.def_id());
+            let anonymous = match tcx.def_kind(int_def_id) {
+                rustc_hir::def::DefKind::Static { nested, .. } => nested,
+                _ => false,
+            };
+            if anonymous {
+                let alloc = def.eval_initializer().unwrap();
+                items.extend(
+                    alloc
+                        .provenance
+                        .ptrs
+                        .iter()
+                        .flat_map(|(_, prov)| collect_alloc_items(tcx, prov.0)),
+                );
+            } else {
+                // This differ from rustc's collector since rustc does not include static from
+                // upstream crates.
+                let instance = Instance::try_from(CrateItem::from(def)).unwrap();
+                should_codegen_locally(&instance).then(|| items.push(MonoItem::from(def)));
+            }
         }
         GlobalAlloc::Function(instance) => {
             should_codegen_locally(&instance).then(|| items.push(MonoItem::from(instance)));
         }
         GlobalAlloc::Memory(alloc) => {
             items.extend(
-                alloc.provenance.ptrs.iter().flat_map(|(_, prov)| collect_alloc_items(prov.0)),
+                alloc.provenance.ptrs.iter().flat_map(|(_, prov)| collect_alloc_items(tcx, prov.0)),
             );
         }
         vtable_alloc @ GlobalAlloc::VTable(..) => {
             let vtable_id = vtable_alloc.vtable_allocation().unwrap();
-            items = collect_alloc_items(vtable_id);
+            items = collect_alloc_items(tcx, vtable_id);
         }
     };
     items

--- a/tests/kani/Static/anon_static.rs
+++ b/tests/kani/Static/anon_static.rs
@@ -1,0 +1,56 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Test that Kani can codegen statics that contain pointers to nested statics.
+// See https://github.com/model-checking/kani/issues/3904
+
+mod example_1 {
+    // FOO contains a pointer to the anonymous nested static alloc2.
+    // alloc1 (static: FOO, size: 8, align: 8) {
+    //     ╾───────alloc2────────╼                         │ ╾──────╼
+    // }
+
+    // alloc2 (static: FOO::{constant#0}, size: 4, align: 4) {
+    //     2a 00 00 00                                     │ *...
+    // }
+    static mut FOO: &mut u32 = &mut 42;
+
+    #[kani::proof]
+    fn main() {
+        unsafe {
+            *FOO = 43;
+        }
+    }
+}
+
+mod example_2 {
+    // FOO and BAR both point to the anonymous nested static alloc2.
+    // Test taken from https://github.com/rust-lang/rust/issues/71212#issuecomment-738666248
+    // alloc3 (static: BAR, size: 16, align: 8) {
+    //     ╾───────alloc2────────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+    // }
+
+    // alloc2 (static: FOO::{constant#0}, size: 4, align: 4) {
+    //     2a 00 00 00                                     │ *...
+    // }
+
+    // alloc1 (static: FOO, size: 16, align: 8) {
+    //     ╾───────alloc2────────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+    // }
+    pub mod a {
+        #[no_mangle]
+        pub static mut FOO: &mut [i32] = &mut [42];
+    }
+
+    pub mod b {
+        #[no_mangle]
+        pub static mut BAR: &mut [i32] = unsafe { &mut *crate::example_2::a::FOO };
+    }
+
+    #[kani::proof]
+    fn main() {
+        unsafe {
+            assert_eq!(a::FOO.as_ptr(), b::BAR.as_ptr());
+        }
+    }
+}

--- a/tests/kani/Static/pointer_to_const_alloc.rs
+++ b/tests/kani/Static/pointer_to_const_alloc.rs
@@ -1,9 +1,10 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// Test that Kani can codegen statics that contain pointers to constant allocations.
+// Test that Kani can codegen statics that contain pointers to constant (i.e., immutable) allocations.
 // Test taken from https://github.com/rust-lang/rust/issues/79738#issuecomment-1946578159
 
+// The MIR is:
 // alloc4 (static: BAR, size: 16, align: 8) {
 //     ╾─────alloc3<imm>─────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
 // }

--- a/tests/kani/Static/pointer_to_const_alloc.rs
+++ b/tests/kani/Static/pointer_to_const_alloc.rs
@@ -1,0 +1,24 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Test that Kani can codegen statics that contain pointers to constant allocations.
+// Test taken from https://github.com/rust-lang/rust/issues/79738#issuecomment-1946578159
+
+// alloc4 (static: BAR, size: 16, align: 8) {
+//     ╾─────alloc3<imm>─────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+// }
+
+// alloc3 (size: 4, align: 4) {
+//     2a 00 00 00                                     │ *...
+// }
+
+// alloc1 (static: FOO, size: 16, align: 8) {
+//     ╾─────alloc3<imm>─────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+// }
+pub static FOO: &[i32] = &[42];
+pub static BAR: &[i32] = &*FOO;
+
+#[kani::proof]
+fn main() {
+    assert_eq!(FOO.as_ptr(), BAR.as_ptr());
+}


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/121644 added support for anonymous nested allocations to statics. This PR adds support for such statics to Kani.

The idea is to treat an anonymous `GlobalAlloc::Static` the same as we would treat a `GlobalAlloc::Memory`, since an anonymous static is a nested memory allocation. To frame this change in terms of the tests:

`pointer_to_const_alloc.rs` contains a test for the `GlobalAlloc::Memory` case, which we could already handle prior to this PR. The MIR looks like:
```
alloc3 (size: 4, align: 4) {
    2a 00 00 00                                     │ *...
}

alloc1 (static: FOO, size: 16, align: 8) {
    ╾─────alloc3<imm>─────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
}
```

meaning that `FOO` contains a pointer to the *immutable* allocation alloc3 (note the `alloc3<imm>`, imm standing for "immutable"). 

`anon_static.rs` tests the code introduced in this PR. The MIR from `example_1` looks almost identical:
```
alloc2 (static: FOO::{constant#0}, size: 4, align: 4) {
    2a 00 00 00                                     │ *...
}

alloc1 (static: FOO, size: 16, align: 8) {
    ╾───────alloc2────────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
}
```
Note, however, that `alloc2` is mutable, and is thus an anonymous nested static rather than a constant allocation.
But we can just call `codegen_const_allocation` anyway, since it ends up checking if the allocation is indeed constant before declaring the global variable in the symbol table:
https://github.com/model-checking/kani/blob/319040b8cd2cb72ec0603653fad7a8d934857d57/kani-compiler/src/codegen_cprover_gotoc/codegen/operand.rs#L556

Resolves #3904

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
