### PR TITLE
Make is_inbounds public

### DIFF
--- a/library/kani_core/src/mem.rs
+++ b/library/kani_core/src/mem.rs
@@ -166,7 +166,12 @@ macro_rules! kani_mem {
         /// Checks that `ptr` points to an allocation that can hold data of size calculated from `T`.
         ///
         /// This will panic if `ptr` points to an invalid `non_null`
-        fn is_inbounds<T: ?Sized>(ptr: *const T) -> bool {
+        #[crate::kani::unstable_feature(
+            feature = "mem-predicates",
+            issue = 3946,
+            reason = "experimental memory predicate API"
+        )]
+        pub fn is_inbounds<T: ?Sized>(ptr: *const T) -> bool {
             // If size overflows, then pointer cannot be inbounds.
             let Some(sz) = checked_size_of_raw(ptr) else { return false };
             if sz == 0 {

--- a/tests/expected/MemPredicates/ptr_size_validity.expected
+++ b/tests/expected/MemPredicates/ptr_size_validity.expected
@@ -1,0 +1,1 @@
+Complete - 2 successfully verified harnesses, 0 failures, 2 total.

--- a/tests/expected/MemPredicates/ptr_size_validity.expected
+++ b/tests/expected/MemPredicates/ptr_size_validity.expected
@@ -1,1 +1,1 @@
-Complete - 1 successfully verified harnesses, 0 failures, 1 total.
+Complete - 2 successfully verified harnesses, 0 failures, 2 total.

--- a/tests/expected/MemPredicates/ptr_size_validity.expected
+++ b/tests/expected/MemPredicates/ptr_size_validity.expected
@@ -1,1 +1,1 @@
-Complete - 2 successfully verified harnesses, 0 failures, 2 total.
+Complete - 1 successfully verified harnesses, 0 failures, 1 total.

--- a/tests/expected/MemPredicates/ptr_size_validity.rs
+++ b/tests/expected/MemPredicates/ptr_size_validity.rs
@@ -9,16 +9,6 @@ mod size {
     use super::*;
 
     #[kani::proof]
-    fn verify_checked_size_of_raw_exceeds_isize_max() {
-        let len_exceeding_isize_max = (isize::MAX as usize) + 1;
-        let data_ptr: *const [u8] = core::ptr::from_raw_parts(core::ptr::null::<u8>(), len_exceeding_isize_max);
-
-        let size = kani::mem::checked_size_of_raw(data_ptr);
-
-        assert!(size.is_none());
-    }
-
-    #[kani::proof]
     fn verify_is_inbounds() {
         let val = 42u8;
         let ptr = &val as *const u8;

--- a/tests/expected/MemPredicates/ptr_size_validity.rs
+++ b/tests/expected/MemPredicates/ptr_size_validity.rs
@@ -5,7 +5,7 @@
 
 extern crate kani;
 
-mod size {    
+mod size {
     use super::*;
 
     #[kani::proof]

--- a/tests/expected/MemPredicates/ptr_size_validity.rs
+++ b/tests/expected/MemPredicates/ptr_size_validity.rs
@@ -1,0 +1,30 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z mem-predicates
+#![feature(ptr_metadata)]
+
+extern crate kani;
+
+mod size {    
+    use super::*;
+
+    #[kani::proof]
+    fn verify_checked_size_of_raw_exceeds_isize_max() {
+        let len_exceeding_isize_max = (isize::MAX as usize) + 1;
+        let data_ptr: *const [u8] = core::ptr::from_raw_parts(core::ptr::null::<u8>(), len_exceeding_isize_max);
+
+        let size = kani::mem::checked_size_of_raw(data_ptr);
+
+        assert!(size.is_none());
+    }
+
+    #[kani::proof]
+    fn verify_is_inbounds() {
+        let val = 42u8;
+        let ptr = &val as *const u8;
+        assert!(kani::mem::is_inbounds(ptr));
+
+        let null_ptr: *const u8 = core::ptr::null();
+        assert!(!kani::mem::is_inbounds(null_ptr));
+    }
+}


### PR DESCRIPTION
Resolves #3946 

This PR makes `kani::mem::is_inbounds` publicly accessible, allowing direct validation of pointer sizes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
