### PR TITLE
Remove unstable-features from code formatting script

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,13 +6,3 @@ edition = "2021"
 style_edition = "2024"
 use_small_heuristics = "Max"
 merge_derives = false
-
-ignore = [
-    "**/build/",
-    "**/target/",
-
-    # Do not format submodules
-    # For some reason, this is not working without the directory wildcard.
-    "**/firecracker",
-    "**/tests/perf/s2n-quic/",
-]

--- a/scripts/kani-fmt.sh
+++ b/scripts/kani-fmt.sh
@@ -19,19 +19,25 @@ error=0
 cargo fmt "$@" || error=1
 
 # Check test source files.
-# Note that this will respect the ignore section of rustfmt.toml. If you need to
-# skip any file / directory, add it there.
 TESTS=("tests" "docs/src/tutorial")
+# Add ignore patterns for code we don't want to format.
+IGNORE=("*/perf/s2n-quic/*")
+
+# Arguments for the find command for excluding the IGNORE paths
+IGNORE_ARGS=()
+for ignore in "${IGNORE[@]}"; do
+    IGNORE_ARGS+=(-not -path "$ignore")
+done
 
 for suite in "${TESTS[@]}"; do
     # Find uses breakline to split between files. This ensures that we can
     # handle files with space in their path.
     set -f; IFS=$'\n'
-    files=($(find "${suite}" -name "*.rs"))
+    files=($(find "${suite}" -name "*.rs" ${IGNORE_ARGS[@]}))
     set +f; unset IFS
     # Note: We set the configuration file here because some submodules have
     # their own configuration file.
-    rustfmt --unstable-features "$@" --config-path rustfmt.toml "${files[@]}" || error=1
+    rustfmt --config-path rustfmt.toml "${files[@]}" || error=1
 done
 
 exit $error


### PR DESCRIPTION
The code formatting script [scripts/kani-fmt.sh](https://github.com/model-checking/kani/blob/main/scripts/kani-fmt.sh) currently uses `--unstable-features` to enable the usage of the `--ignore` pattern in [rustfmt.toml](https://github.com/model-checking/kani/blob/main/rustfmt.toml). Since we're already using a find command to find all the files to format, it is easy to instead add the patterns to exclude to the find command rather than relying on an unstable feature.

Resolves #ISSUE-NUMBER

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
