### PR TITLE
Add support for struct field accessing in loop contracts

### DIFF
--- a/kani-compiler/src/kani_middle/transform/loop_contracts.rs
+++ b/kani-compiler/src/kani_middle/transform/loop_contracts.rs
@@ -16,8 +16,8 @@ use rustc_middle::ty::TyCtxt;
 use rustc_span::Symbol;
 use stable_mir::mir::mono::Instance;
 use stable_mir::mir::{
-    AggregateKind, BasicBlock, BasicBlockIdx, Body, ConstOperand, Operand, Rvalue,
-    Statement, StatementKind, Terminator, TerminatorKind, VarDebugInfoContents,
+    AggregateKind, BasicBlock, BasicBlockIdx, Body, ConstOperand, Operand, Rvalue, Statement,
+    StatementKind, Terminator, TerminatorKind, VarDebugInfoContents,
 };
 use stable_mir::ty::{FnDef, MirConst, RigidTy, UintTy};
 use std::collections::{HashMap, HashSet, VecDeque};

--- a/kani-compiler/src/kani_middle/transform/loop_contracts.rs
+++ b/kani-compiler/src/kani_middle/transform/loop_contracts.rs
@@ -16,7 +16,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_span::Symbol;
 use stable_mir::mir::mono::Instance;
 use stable_mir::mir::{
-    AggregateKind, BasicBlock, BasicBlockIdx, Body, ConstOperand, Operand, Place, Rvalue,
+    AggregateKind, BasicBlock, BasicBlockIdx, Body, ConstOperand, Operand, Rvalue,
     Statement, StatementKind, Terminator, TerminatorKind, VarDebugInfoContents,
 };
 use stable_mir::ty::{FnDef, MirConst, RigidTy, UintTy};
@@ -299,7 +299,7 @@ impl LoopContractPass {
                 // All user variables are support
                 supported_vars.extend(new_body.var_debug_info().iter().filter_map(|info| {
                     match &info.value {
-                        VarDebugInfoContents::Place(debug_place) => Some(debug_place.local.clone()),
+                        VarDebugInfoContents::Place(debug_place) => Some(debug_place.local),
                         _ => None,
                     }
                 }));
@@ -309,11 +309,10 @@ impl LoopContractPass {
                 // if it assigns to other places, we cache if the assigned places are supported.
                 for stmt in &new_body.blocks()[bb_idx].statements {
                     if let StatementKind::Assign(place, rvalue) = &stmt.kind {
-                        println!("stmt : {:?}", rvalue);
                         match rvalue {
                             Rvalue::Ref(_,_,rplace) => {
                                 if supported_vars.contains(&rplace.local) {
-                                    supported_vars.push(place.local.clone());
+                                    supported_vars.push(place.local);
                                 } }
                             Rvalue::Aggregate(AggregateKind::Closure(..), closure_args) => {
                                 if closure_args.iter().any(|arg| !matches!(arg, Operand::Copy(arg_place) | Operand::Move(arg_place) if supported_vars.contains(&arg_place.local))) {
@@ -325,7 +324,7 @@ impl LoopContractPass {
                             }
                             _ => {
                                 if self.is_supported_argument_of_closure(rvalue, new_body) {
-                                    supported_vars.push(place.local.clone());
+                                    supported_vars.push(place.local);
                                 }
                             }
                         }

--- a/tests/expected/loop-contract/struct_projection.expected
+++ b/tests/expected/loop-contract/struct_projection.expected
@@ -1,0 +1,14 @@
+struct_projection.loop_invariant_step.1\
+	 - Status: SUCCESS\
+	 - Description: "Check invariant after step for loop struct_projection.0"
+
+struct_projection.loop_invariant_step.2\
+	 - Status: SUCCESS\
+	 - Description: "Check invariant after step for loop struct_projection.0"
+
+struct_projection.assertion.3\
+	 - Status: SUCCESS\
+	 - Description: "assertion failed: s.b == 2"
+
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/loop-contract/struct_projection.rs
+++ b/tests/expected/loop-contract/struct_projection.rs
@@ -1,0 +1,26 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags: -Z loop-contracts
+
+//! add support for struct field projection for loop-contract
+
+#![feature(stmt_expr_attributes)]
+#![feature(proc_macro_hygiene)]
+
+struct mystruct {
+    a: i32,
+    b: i32,
+}
+
+#[kani::proof]
+fn struct_projection() {
+    let mut s = mystruct { a: 0, b: 2 };
+    let mut i = 0;
+    #[kani::loop_invariant((i<=10) && (s.a == i) && (s.b == 2))]
+    while i < 10 {
+        s.a += 1;
+        i += 1;
+    }
+    assert!(s.b == 2)
+}


### PR DESCRIPTION
This PR adds support for struct field accessing in loop contracts.
Previously, using struct field accessing in loop contracts may result in a panic:

```
internal error: entered unreachable code: The loop invariant support only reference of user variables. The provided invariants contain unsupported dereference. Please report github.com/model-checking/kani/issues/new?template=bug_report.md
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Resolves #3700

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
