### PR TITLE
Use Kani's Cargo when calling `cargo metadata`

### DIFF
--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -4,7 +4,9 @@
 use crate::args::VerificationArgs;
 use crate::call_single_file::{LibConfig, to_rustc_arg};
 use crate::project::Artifact;
-use crate::session::{KaniSession, lib_folder, lib_no_core_folder, setup_cargo_command};
+use crate::session::{
+    KaniSession, bundled_cargo_path, lib_folder, lib_no_core_folder, setup_cargo_command,
+};
 use crate::util;
 use anyhow::{Context, Result, bail};
 use cargo_metadata::diagnostic::{Diagnostic, DiagnosticLevel};
@@ -241,6 +243,9 @@ crate-type = ["lib"]
 
     pub fn cargo_metadata(&self, build_target: &str) -> Result<Metadata> {
         let mut cmd = MetadataCommand::new();
+        if let Some(cargo_path) = bundled_cargo_path()? {
+            cmd.cargo_path(cargo_path);
+        }
 
         // restrict metadata command to host platform. References:
         // https://github.com/rust-lang/rust-analyzer/issues/6908

--- a/kani-driver/src/session.rs
+++ b/kani-driver/src/session.rs
@@ -442,3 +442,11 @@ pub fn setup_cargo_command() -> Result<Command> {
 
     Ok(cmd)
 }
+
+pub fn bundled_cargo_path() -> Result<Option<PathBuf>> {
+    if let InstallType::Release(kani_dir) = InstallType::new()? {
+        Ok(Some(kani_dir.join("toolchain").join("bin").join("cargo")))
+    } else {
+        Ok(None)
+    }
+}


### PR DESCRIPTION
When Kani is installed normally, use the Cargo binary from the linked Rust toolchain when calling `cargo metadata`.
If a `rust-toolchain.toml` is present, or the toolchain has been manually overridden with `cargo +1.xx kani` an older version of `cargo metadata` can be used, which causes incompatible package IDs to be passed.

Resolves #3967

Tested by installing and verifying that `cargo +1.76 kani` no longer produces an error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
