### PR TITLE
Bump Kani version to 0.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## [0.61.0]
 
-### Major Changes
-* Enable Kani to work with a stable toolchain by @zhassan-aws in https://github.com/model-checking/kani/pull/3964
-
 ### What's Changed
 * Make `is_inbounds` public by @rajath-mk in https://github.com/model-checking/kani/pull/3958
 * Finish adding support for `f16` and `f128` by @carolynzech in https://github.com/model-checking/kani/pull/3943
@@ -17,7 +14,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Add support for struct field access in loop contracts by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3970
 * Autoharness: Don't panic on `_` argument by @carolynzech in https://github.com/model-checking/kani/pull/3942
 * Autoharness: improve metdata printed to terminal and enable standard library application by @carolynzech in https://github.com/model-checking/kani/pull/3948, https://github.com/model-checking/kani/pull/3952, https://github.com/model-checking/kani/pull/3971
-* Automatic toolchain upgrade to nightly-2025-04-02 by @github-actions in https://github.com/model-checking/kani/pull/3983
+* Upgrade toolchain to nightly-2025-04-02 by @qinheping, @tautschnig, @zhassan-aws, @carolynzech in https://github.com/model-checking/kani/pull/3983
 * Update CBMC dependency to 6.5.0 by @tautschnig in https://github.com/model-checking/kani/pull/3936
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.60.0...kani-0.61.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Add support for struct field access in loop contracts by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3970
 * Autoharness: Don't panic on `_` argument by @carolynzech in https://github.com/model-checking/kani/pull/3942
 * Autoharness: improve metdata printed to terminal and enable standard library application by @carolynzech in https://github.com/model-checking/kani/pull/3948, https://github.com/model-checking/kani/pull/3952, https://github.com/model-checking/kani/pull/3971
-* Upgrade toolchain to nightly-2025-04-02 by @qinheping, @tautschnig, @zhassan-aws, @carolynzech in https://github.com/model-checking/kani/pull/3983
+* Upgrade toolchain to nightly-2025-04-03 by @qinheping, @tautschnig, @zhassan-aws, @carolynzech in https://github.com/model-checking/kani/pull/3988
 * Update CBMC dependency to 6.5.0 by @tautschnig in https://github.com/model-checking/kani/pull/3936
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.60.0...kani-0.61.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.61.0]
+
+### Major Changes
+* Enable Kani to work with a stable toolchain by @zhassan-aws in https://github.com/model-checking/kani/pull/3964
+
+### What's Changed
+* Make `is_inbounds` public by @rajath-mk in https://github.com/model-checking/kani/pull/3958
+* Finish adding support for `f16` and `f128` by @carolynzech in https://github.com/model-checking/kani/pull/3943
+* Support user overrides of Rust built-ins by @tautschnig in https://github.com/model-checking/kani/pull/3945
+* Add support for anonymous nested statics by @carolynzech in https://github.com/model-checking/kani/pull/3953
+* Add support for struct field access in loop contracts by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3970
+* Autoharness: Don't panic on `_` argument by @carolynzech in https://github.com/model-checking/kani/pull/3942
+* Autoharness: improve metdata printed to terminal and enable standard library application by @carolynzech in https://github.com/model-checking/kani/pull/3948, https://github.com/model-checking/kani/pull/3952, https://github.com/model-checking/kani/pull/3971
+* Automatic toolchain upgrade to nightly-2025-04-02 by @github-actions in https://github.com/model-checking/kani/pull/3983
+* Update CBMC dependency to 6.5.0 by @tautschnig in https://github.com/model-checking/kani/pull/3936
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.60.0...kani-0.61.0
+
 ## [0.60.0]
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -824,7 +824,7 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "kani"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "kani_core",
  "kani_macros",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "kani-compiler"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "charon",
  "clap",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "anyhow",
  "home",
@@ -906,14 +906,14 @@ dependencies = [
 
 [[package]]
 name = "kani_core"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani_macros"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "std"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_core/Cargo.toml
+++ b/library/kani_core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_core"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bump Kani version to 0.61.0.

Github-generated release notes:

## What's Changed
* Fix CHANGELOG of 0.60.0 by @qinheping in https://github.com/model-checking/kani/pull/3925
* Bump tests/perf/s2n-quic from `d88faa4` to `8670e83` by @dependabot in https://github.com/model-checking/kani/pull/3928
* Update toolchain to 2025-03-04 by @qinheping in https://github.com/model-checking/kani/pull/3927
* Install the right toolchain for HEAD and BASE checks in `verify-std-check.yml` by @remi-delmas-3000 in https://github.com/model-checking/kani/pull/3920
* Automatic cargo update to 2025-03-10 by @github-actions in https://github.com/model-checking/kani/pull/3926
* Automatic toolchain upgrade to nightly-2025-03-05 by @github-actions in https://github.com/model-checking/kani/pull/3929
* Upgrade toolchain to nightly-2025-03-07 by @tautschnig in https://github.com/model-checking/kani/pull/3931
* Upgrade toolchain to nightly-2025-03-12 by @tautschnig in https://github.com/model-checking/kani/pull/3933
* Automatic toolchain upgrade to nightly-2025-03-13 by @github-actions in https://github.com/model-checking/kani/pull/3934
* Update CBMC dependency to 6.5.0 by @tautschnig in https://github.com/model-checking/kani/pull/3936
* Automatic toolchain upgrade to nightly-2025-03-14 by @github-actions in https://github.com/model-checking/kani/pull/3937
* Automatic toolchain upgrade to nightly-2025-03-15 by @github-actions in https://github.com/model-checking/kani/pull/3938
* Automatic toolchain upgrade to nightly-2025-03-16 by @github-actions in https://github.com/model-checking/kani/pull/3939
* Automatic toolchain upgrade to nightly-2025-03-17 by @github-actions in https://github.com/model-checking/kani/pull/3940
* Automatic cargo update to 2025-03-17 by @github-actions in https://github.com/model-checking/kani/pull/3941
* Autoharness: Don't panic on `_` argument and add `_autoharness` suffix to GOTO files by @carolynzech in https://github.com/model-checking/kani/pull/3942
* Implement `f16` and `f128` cases in `codegen_float_type` by @carolynzech in https://github.com/model-checking/kani/pull/3943
* Support function implementations of known built-ins by @tautschnig in https://github.com/model-checking/kani/pull/3945
* Autoharness: metadata improvements and enable standard library application by @carolynzech in https://github.com/model-checking/kani/pull/3948
* Autoharness: `--list` option by @carolynzech in https://github.com/model-checking/kani/pull/3952
* Add support for anonymous nested statics by @carolynzech in https://github.com/model-checking/kani/pull/3953
* Automatic cargo update to 2025-03-24 by @github-actions in https://github.com/model-checking/kani/pull/3954
* Bump tests/perf/s2n-quic from `8670e83` to `324cf31` by @dependabot in https://github.com/model-checking/kani/pull/3955
* Document behavior of checked_size_of_raw and is_inbounds by @rajath-mk in https://github.com/model-checking/kani/pull/3956
* Upgrade toolchain to 2025-03-18 by @zhassan-aws in https://github.com/model-checking/kani/pull/3959
* Remove unstable-features from code formatting script by @zhassan-aws in https://github.com/model-checking/kani/pull/3962
* Remove CI job to update features/verify-rust-std by @tautschnig in https://github.com/model-checking/kani/pull/3963
* Make is_inbounds public by @rajath-mk in https://github.com/model-checking/kani/pull/3958
* Enable Kani to work with a stable toolchain by @zhassan-aws in https://github.com/model-checking/kani/pull/3964
* Automatic cargo update to 2025-03-31 by @github-actions in https://github.com/model-checking/kani/pull/3966
* Add support for struct field accessing in loop contracts by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3970
* Bump tests/perf/s2n-quic from `324cf31` to `d0aff82` by @dependabot in https://github.com/model-checking/kani/pull/3968
* Clarify `is_inbounds` docs by @carolynzech in https://github.com/model-checking/kani/pull/3974
* Upgrade toolchain to 2025-04-01 by @carolynzech in https://github.com/model-checking/kani/pull/3973
* Remove remaining `--enable-unstable` mentions by @carolynzech in https://github.com/model-checking/kani/pull/3978
* Clean up unused dependencies by @zhassan-aws in https://github.com/model-checking/kani/pull/3981
* Automatic toolchain upgrade to nightly-2025-04-02 by @github-actions in https://github.com/model-checking/kani/pull/3983
* Update dependencies per `cargo-outdated` by @carolynzech in https://github.com/model-checking/kani/pull/3982
* Fix `autoharness` termination test & print metadata in alphabetical order by @carolynzech in https://github.com/model-checking/kani/pull/3971
* Fix cargo invocations to only use `pkg_args` where appropriate by @carolynzech in https://github.com/model-checking/kani/pull/3984


**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.60.0...kani-0.61.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
