### PR TITLE
Add an option to skip codegen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,8 @@ exclude = [
   "tests/script-based-pre/build-cache-dirty/target/new_dep",
   "tests/script-based-pre/verify_std_cmd/tmp_dir/target/kani_verify_std",
   "tests/script-based-pre/kani_lib_dep",
+  "tests/script-based-pre/no_codegen",
+  "tests/script-based-pre/no_codegen_error",
 ]
 
 [workspace.lints.clippy]

--- a/kani-driver/src/args/mod.rs
+++ b/kani-driver/src/args/mod.rs
@@ -242,6 +242,11 @@ pub struct VerificationArgs {
     #[arg(long, hide_short_help = true)]
     pub only_codegen: bool,
 
+    /// Run Kani without codegen. Useful for checking compilation errors (similar to `cargo check`).
+    /// This feature is unstable and requires `-Z unstable-options` to be used
+    #[arg(long, hide_short_help = true)]
+    pub no_codegen: bool,
+
     /// Specify the value used for loop unwinding in CBMC
     #[arg(long)]
     pub default_unwind: Option<u32>,
@@ -657,6 +662,12 @@ impl ValidateArgs for VerificationArgs {
         self.common_args.check_unstable(
             !self.cbmc_args.is_empty(),
             "--cbmc-args",
+            UnstableFeature::UnstableOptions,
+        )?;
+
+        self.common_args.check_unstable(
+            self.no_codegen,
+            "--no-codegen",
             UnstableFeature::UnstableOptions,
         )?;
 

--- a/kani-driver/src/args/mod.rs
+++ b/kani-driver/src/args/mod.rs
@@ -242,7 +242,7 @@ pub struct VerificationArgs {
     #[arg(long, hide_short_help = true)]
     pub only_codegen: bool,
 
-    /// Run Kani without codegen. Useful for checking compilation errors (similar to `cargo check`).
+    /// Run Kani without codegen. Useful for quick feedback on whether the code would compile successfully (similar to `cargo check`).
     /// This feature is unstable and requires `-Z unstable-options` to be used
     #[arg(long, hide_short_help = true)]
     pub no_codegen: bool,

--- a/kani-driver/src/call_single_file.rs
+++ b/kani-driver/src/call_single_file.rs
@@ -182,6 +182,11 @@ impl KaniSession {
             .map(OsString::from),
         );
 
+        if self.args.no_codegen {
+            flags.push("-Z".into());
+            flags.push("no-codegen".into());
+        }
+
         if let Some(seed_opt) = self.args.randomize_layout {
             flags.push("-Z".into());
             flags.push("randomize-layout".into());

--- a/kani-driver/src/project.rs
+++ b/kani-driver/src/project.rs
@@ -6,7 +6,7 @@
 
 use crate::metadata::from_json;
 use crate::session::KaniSession;
-use crate::util::crate_name;
+use crate::util::{crate_name, info_operation};
 use anyhow::{Context, Result};
 use kani_metadata::{
     ArtifactType, ArtifactType::*, HarnessMetadata, KaniMetadata, artifact::convert_type,
@@ -177,6 +177,13 @@ impl Artifact {
 /// be collected from the project.
 pub fn cargo_project(session: &mut KaniSession, keep_going: bool) -> Result<Project> {
     let outputs = session.cargo_build(keep_going)?;
+    if session.args.no_codegen {
+        info_operation(
+            "info",
+            "Skipping codegen. Rerun without `--no-codegen` to perform codegen.",
+        );
+        return Ok(Project::default());
+    }
     let outdir = outputs.outdir.canonicalize()?;
     // For the MIR Linker we know there is only one metadata per crate. Use that in our favor.
     let metadata =

--- a/kani-driver/src/project.rs
+++ b/kani-driver/src/project.rs
@@ -180,7 +180,7 @@ pub fn cargo_project(session: &mut KaniSession, keep_going: bool) -> Result<Proj
     if session.args.no_codegen {
         info_operation(
             "info",
-            "Skipping codegen. Rerun without `--no-codegen` to perform codegen.",
+            "Compilation succeeded up until codegen. Skipping codegen because of `--no-codegen` option. Rerun without `--no-codegen` to perform codegen.",
         );
         return Ok(Project::default());
     }

--- a/kani-driver/src/project.rs
+++ b/kani-driver/src/project.rs
@@ -179,7 +179,7 @@ pub fn cargo_project(session: &mut KaniSession, keep_going: bool) -> Result<Proj
     let outputs = session.cargo_build(keep_going)?;
     if session.args.no_codegen {
         info_operation(
-            "info",
+            "info:",
             "Compilation succeeded up until codegen. Skipping codegen because of `--no-codegen` option. Rerun without `--no-codegen` to perform codegen.",
         );
         return Ok(Project::default());

--- a/tests/script-based-pre/no_codegen/Cargo.toml
+++ b/tests/script-based-pre/no_codegen/Cargo.toml
@@ -1,0 +1,9 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+[package]
+name = "no_codegen"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/tests/script-based-pre/no_codegen/config.yml
+++ b/tests/script-based-pre/no_codegen/config.yml
@@ -1,0 +1,5 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: run.sh
+expected: expected
+exit_code: 0

--- a/tests/script-based-pre/no_codegen/expected
+++ b/tests/script-based-pre/no_codegen/expected
@@ -1,1 +1,1 @@
-info Skipping codegen. Rerun without `--no-codegen` to perform codegen.
+info: Compilation succeeded up until codegen. Skipping codegen because of `--no-codegen` option. Rerun without `--no-codegen` to perform codegen.

--- a/tests/script-based-pre/no_codegen/expected
+++ b/tests/script-based-pre/no_codegen/expected
@@ -1,0 +1,1 @@
+info Skipping codegen. Rerun without `--no-codegen` to perform codegen.

--- a/tests/script-based-pre/no_codegen/run.sh
+++ b/tests/script-based-pre/no_codegen/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+rm -rf target
+
+# Test the behavior of the `--no-codegen` option
+cargo kani --no-codegen -Zunstable-options
+
+# Ensure no goto binaries (*.out) are generated
+[[ -z $(find target -name "*.out") ]] || {
+    echo "ERROR: Found goto binaries (*.out) in target directory"
+    exit 1
+}

--- a/tests/script-based-pre/no_codegen/src/main.rs
+++ b/tests/script-based-pre/no_codegen/src/main.rs
@@ -1,0 +1,14 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test checks the behavior of Kani's `--no-codegen` option
+
+#[kani::proof]
+fn main() {
+    let x: u8 = kani::any();
+    if x < 100 {
+        assert!(x < 101);
+    } else {
+        assert!(x > 99);
+    }
+}

--- a/tests/script-based-pre/no_codegen_error/Cargo.toml
+++ b/tests/script-based-pre/no_codegen_error/Cargo.toml
@@ -1,0 +1,9 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+[package]
+name = "no_codegen_error"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/tests/script-based-pre/no_codegen_error/config.yml
+++ b/tests/script-based-pre/no_codegen_error/config.yml
@@ -1,0 +1,5 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: run.sh
+expected: expected
+exit_code: 1

--- a/tests/script-based-pre/no_codegen_error/expected
+++ b/tests/script-based-pre/no_codegen_error/expected
@@ -1,0 +1,1 @@
+could not compile `no_codegen_error`

--- a/tests/script-based-pre/no_codegen_error/run.sh
+++ b/tests/script-based-pre/no_codegen_error/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+rm -rf target
+
+# Test the behavior of the `--no-codegen` option
+cargo kani --no-codegen -Zunstable-options

--- a/tests/script-based-pre/no_codegen_error/src/main.rs
+++ b/tests/script-based-pre/no_codegen_error/src/main.rs
@@ -1,0 +1,13 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test checks the behavior of Kani's `--no-codegen` option when the crate
+//! has compilation errors
+
+#[kani::proof]
+fn main() {
+    let x: i32 = 5;
+    // Error: different types
+    let y: u32 = x;
+    assert_eq!(y, 5);
+}


### PR DESCRIPTION
This PR adds a new unstable option, `--no-codegen`, that can be used for running Kani, just to check if the code compiles, i.e. similar to running `cargo check`. This is useful as a lightweight check for compilation errors including code under `#[cfg(kani)]`.

This is implemented through passing rustc's `-Zno-codegen` option, which is what `cargo check` passes to `rustc`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
