### PR TITLE
Fix the package docker job in the release workflow

### DIFF
--- a/scripts/ci/Dockerfile.bundle-release-24-04
+++ b/scripts/ci/Dockerfile.bundle-release-24-04
@@ -1,9 +1,9 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-# Docker image for Kani GitHub Package release ubuntu-20-04.
+# Docker image for Kani GitHub Package release ubuntu-24-04.
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true \
     PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
https://github.com/model-checking/kani/pull/3918 included this change to the release workflow:
```diff
diff --git a/.github/workflows/release.yml b/.github/workflows/release.yml
index df2710ee3e0..244c8063f0c 100644
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
       - name: 'Build release bundle'
         run: |
@@ -339,7 +336,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: scripts/ci/Dockerfile.bundle-release-20-04
+          file: scripts/ci/Dockerfile.bundle-release-24-04
           push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tags: |
```
but the referenced file (`scripts/ci/Dockerfile.bundle-release-20-04`) was not renamed. This caused the package docker job to fail in the last release: https://github.com/model-checking/kani/actions/runs/14296758126/job/40065081063 with:
```
ERROR: failed to solve: failed to read dockerfile: open Dockerfile.bundle-release-24-04: no such file or directory
```

This PR renames the file and updates it to use Ubuntu 24.04.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
