### PR TITLE
Avoid spurious action failures in forks

### DIFF
--- a/.github/workflows/cbmc-update.yml
+++ b/.github/workflows/cbmc-update.yml
@@ -75,7 +75,7 @@ jobs:
             Upgrade CBMC to its latest release.
 
       - name: Create Issue
-        if: ${{ env.next_step == 'create_issue' }}
+        if: ${{ env.next_step == 'create_issue' && github.repository_owner == 'model-checking' }}
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ github.token }}

--- a/.github/workflows/toolchain-upgrade.yml
+++ b/.github/workflows/toolchain-upgrade.yml
@@ -68,7 +68,7 @@ jobs:
             })
 
       - name: Create Issue
-        if: ${{ env.next_step == 'create_issue' }}
+        if: ${{ env.next_step == 'create_issue' && github.repository_owner == 'model-checking' }}
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ github.token }}


### PR DESCRIPTION
Forks are not generally configured to take issues, making the create-issue step (spuriously) fail with "Issues are disabled for this repo". To avoid repeat notifications about those spurious failures, do not attempt the run the create-issue step outside the main repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
