### PR TITLE
Make expected test more lenient

### DIFF
--- a/tests/cargo-ui/verbose-cmds/expected
+++ b/tests/cargo-ui/verbose-cmds/expected
@@ -1,5 +1,5 @@
 CARGO_ENCODED_RUSTFLAGS=
-cargo +
+cargo
 Running: `goto-cc
 Running: `goto-instrument
 Checking harness dummy_harness...


### PR DESCRIPTION
During some experimentation with the stable branch, it seems that in some cases, the command that gets executed is `cargo kani`, i.e. without an explicit `+<toolchain>` or `+<stable-version>` argument. Make the expected test more lenient to avoid failures for those cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
