### PR TITLE
Scanner: log crate-level visibility of functions

### DIFF
--- a/tests/script-based-pre/tool-scanner/scanner-test.expected
+++ b/tests/script-based-pre/tool-scanner/scanner-test.expected
@@ -1,6 +1,6 @@
 5 test_scan_fn_loops.csv
 19 test_scan_functions.csv
 5 test_scan_input_tys.csv
-16 test_scan_overall.csv
+18 test_scan_overall.csv
 3 test_scan_recursion.csv
 5 test_scan_unsafe_ops.csv

--- a/tools/scanner/src/analysis.rs
+++ b/tools/scanner/src/analysis.rs
@@ -243,8 +243,9 @@ impl OverallStats {
                 if !kind.is_fn() {
                     return None;
                 };
-                let is_public = tcx.visibility(item.def_id()).is_public()
-                    || tcx.visibility(item.def_id()).is_visible_locally();
+                let int_def_id = rustc_internal::internal(*tcx, item.def_id());
+                let is_public = tcx.visibility(int_def_id).is_public()
+                    || tcx.visibility(int_def_id).is_visible_locally();
                 self.fn_stats.get_mut(&item).unwrap().is_public = Some(is_public);
                 Some((item, is_public))
             })

--- a/tools/scanner/src/analysis.rs
+++ b/tools/scanner/src/analysis.rs
@@ -7,6 +7,8 @@ use crate::info;
 use csv::WriterBuilder;
 use graph_cycles::Cycles;
 use petgraph::graph::Graph;
+use rustc_middle::ty::TyCtxt;
+use rustc_smir::rustc_internal;
 use serde::{Serialize, Serializer, ser::SerializeStruct};
 use stable_mir::mir::mono::Instance;
 use stable_mir::mir::visit::{Location, PlaceContext, PlaceRef};
@@ -35,6 +37,7 @@ struct FnStats {
     has_unsafe_ops: Option<bool>,
     has_unsupported_input: Option<bool>,
     has_loop_or_iterator: Option<bool>,
+    is_public: Option<bool>,
 }
 
 impl FnStats {
@@ -45,6 +48,7 @@ impl FnStats {
             has_unsafe_ops: None,
             has_unsupported_input: None,
             has_loop_or_iterator: None,
+            is_public: None,
         }
     }
 }
@@ -227,6 +231,30 @@ impl OverallStats {
                 })
                 .collect::<Vec<_>>(),
         );
+    }
+
+    /// Iterate over all functions defined in this crate and log public vs private
+    pub fn public_fns(&mut self, tcx: &TyCtxt) {
+        let effective_visibilities = tcx.effective_visibilities(());
+        let all_items = stable_mir::all_local_items();
+        let (public_fns, private_fns) = all_items
+            .into_iter()
+            .filter_map(|item| {
+                let kind = item.ty().kind();
+                if !kind.is_fn() {
+                    return None;
+                };
+                let int_def_id = rustc_internal::internal(*tcx, item.def_id());
+                let is_public =
+                    effective_visibilities.is_directly_public(int_def_id.expect_local());
+                self.fn_stats.get_mut(&item).unwrap().is_public = Some(is_public);
+                Some((item, is_public))
+            })
+            .partition::<Vec<(CrateItem, bool)>, _>(|(_, is_public)| *is_public);
+        self.counters.extend_from_slice(&[
+            ("public_fns", public_fns.len()),
+            ("private_fns", private_fns.len()),
+        ]);
     }
 }
 

--- a/tools/scanner/src/analysis.rs
+++ b/tools/scanner/src/analysis.rs
@@ -235,7 +235,6 @@ impl OverallStats {
 
     /// Iterate over all functions defined in this crate and log public vs private
     pub fn public_fns(&mut self, tcx: &TyCtxt) {
-        let effective_visibilities = tcx.effective_visibilities(());
         let all_items = stable_mir::all_local_items();
         let (public_fns, private_fns) = all_items
             .into_iter()
@@ -244,9 +243,8 @@ impl OverallStats {
                 if !kind.is_fn() {
                     return None;
                 };
-                let int_def_id = rustc_internal::internal(*tcx, item.def_id());
-                let is_public =
-                    effective_visibilities.is_directly_public(int_def_id.expect_local());
+                let is_public = tcx.visibility(item.def_id()).is_public()
+                    || tcx.visibility(item.def_id()).is_visible_locally();
                 self.fn_stats.get_mut(&item).unwrap().is_public = Some(is_public);
                 Some((item, is_public))
             })

--- a/tools/scanner/src/lib.rs
+++ b/tools/scanner/src/lib.rs
@@ -65,6 +65,8 @@ pub enum Analysis {
     FnLoops,
     /// Collect information about recursion via direct calls.
     Recursion,
+    /// Collect information about function visibility.
+    PublicFns,
 }
 
 fn info(msg: String) {
@@ -96,6 +98,7 @@ fn analyze_crate(tcx: TyCtxt, analyses: &[Analysis]) -> ControlFlow<()> {
             Analysis::UnsafeOps => crate_stats.unsafe_operations(out_path),
             Analysis::FnLoops => crate_stats.loops(out_path),
             Analysis::Recursion => crate_stats.recursion(out_path),
+            Analysis::PublicFns => crate_stats.public_fns(&tcx),
         }
     }
     crate_stats.store_csv(base_path, &file_stem);


### PR DESCRIPTION
This will help determine whether a failed property appears in a public or private function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
