### PR TITLE
Contracts/Stubs for multiple inherent impls: fix checking the generic args path for equality

### DIFF
--- a/kani-compiler/src/kani_middle/resolve.rs
+++ b/kani-compiler/src/kani_middle/resolve.rs
@@ -715,6 +715,17 @@ fn is_item_name_with_generic_args(
     name: &str,
 ) -> bool {
     let item_path = tcx.def_path_str(item);
-    let all_but_base_type = item_path.find("::").map_or("", |idx| &item_path[idx..]);
-    all_but_base_type == format!("{generic_args}::{name}")
+    let parts: Vec<&str> = item_path.split("::").collect();
+
+    if parts.len() < 2 {
+        return false;
+    }
+
+    let actual_last_two =
+        format!("{}{}{}{}", "::", parts[parts.len() - 2], "::", parts[parts.len() - 1]);
+
+    let last_two = format!("{}{}{}", generic_args, "::", name);
+
+    // The last two components of the item_path should be the same as ::{generic_args}::{name}
+    last_two == actual_last_two
 }


### PR DESCRIPTION
#3829 fixed an issue where we couldn't verify contracts or stubs for types with multiple inherent impls. However, the logic to  check for path equality incorrectly assumed that there would only be one element in the path before the generic argument, when in fact the path can be arbitrarily long if there are modules involved. Change the logic to just look at the last two elements, since we can expect those will be the generic argument and the method name.

Before this PR, the new test would fail with this error:

```
error: Failed to resolve checking function NegativeNumber::<i32>::unchecked_mul because the generic arguments ::<i32> are invalid. The available implementations are: 
       num::negative::NegativeNumber::<i32>::unchecked_mul
       num::negative::NegativeNumber::<i16>::unchecked_mul
  --> /Users/cmzech/kani/tests/kani/FunctionContracts/multiple_inherent_impls.rs:57:5
   |
57 |     #[kani::proof_for_contract(NegativeNumber::<i32>::unchecked_mul)]
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `kani::proof_for_contract` (in Nightly builds, run with -Z macro-backtrace for more info)
```

because we'd try to compare `::negative::NegativeNumber::<i32>::unchecked_mul` to `::<i32>::unchecked_mul` and find they weren't equal.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
