### PR TITLE
Pin C standard to C17

### DIFF
--- a/kani-driver/src/call_goto_cc.rs
+++ b/kani-driver/src/call_goto_cc.rs
@@ -25,6 +25,7 @@ impl KaniSession {
 
         // TODO get goto-cc path from self
         let mut cmd = Command::new("goto-cc");
+        cmd.arg("-std=gnu17");
         cmd.args(args);
 
         self.run_suppress(cmd)?;
@@ -40,6 +41,7 @@ impl KaniSession {
         function: &str,
     ) -> Result<()> {
         let mut cmd = Command::new("goto-cc");
+        cmd.arg("-std=gnu17");
         cmd.arg(input).args(["--function", function, "-o"]).arg(output);
 
         self.run_suppress(cmd)?;


### PR DESCRIPTION
GCC 15 (which was released a week ago) changed the default language version from C17 to C23:

https://gcc.gnu.org/gcc-15/changes.html#c

With C23, some of the code in https://github.com/model-checking/kani/blob/main/library/kani/kani_lib.c doesn't compile (see #4052). To allow Kani to run in environments with the newer GCC version, this PR pins the language version to C17.

Resolves #4052 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
