### PR TITLE
Bump Kani version 0.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## [0.62.0]
 
-## What's Changed
+### What's Changed
 * Disable llbc feature by default by @zhassan-aws in https://github.com/model-checking/kani/pull/3980
 * Add an option to skip codegen by @zhassan-aws in https://github.com/model-checking/kani/pull/4002
 * Add support for loop-contract historic values by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3951

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,12 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## What's Changed
 * Disable llbc feature by default by @zhassan-aws in https://github.com/model-checking/kani/pull/3980
-* Automatic toolchain upgrade to nightly-2025-04-04 by @github-actions in https://github.com/model-checking/kani/pull/3991
-* Automatic cargo update to 2025-04-07 by @github-actions in https://github.com/model-checking/kani/pull/3992
 * Fix release schedule in docs by @carolynzech in https://github.com/model-checking/kani/pull/3994
-* Automatic toolchain upgrade to nightly-2025-04-05 by @github-actions in https://github.com/model-checking/kani/pull/3996
 * Bump tests/perf/s2n-quic from `d0aff82` to `9f7e0a9` by @dependabot in https://github.com/model-checking/kani/pull/3995
-* Automatic toolchain upgrade to nightly-2025-04-06 by @github-actions in https://github.com/model-checking/kani/pull/4004
 * Fix the package docker job in the release workflow by @zhassan-aws in https://github.com/model-checking/kani/pull/4003
 * Avoid spurious action failures in forks by @tautschnig in https://github.com/model-checking/kani/pull/4005
 * Add an option to skip codegen by @zhassan-aws in https://github.com/model-checking/kani/pull/4002
-* Automatic toolchain upgrade to nightly-2025-04-07 by @github-actions in https://github.com/model-checking/kani/pull/4006
 * Add support for loop-contract historic values by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3951
-* Automatic cargo update to 2025-04-14 by @github-actions in https://github.com/model-checking/kani/pull/4013
 * Clarify Rust intrinsic assumption error message by @carolynzech in https://github.com/model-checking/kani/pull/4015
 * Bump tests/perf/s2n-quic from `9f7e0a9` to `0413d9a` by @dependabot in https://github.com/model-checking/kani/pull/4014
 * Autoharness: enable function-contracts and loop-contracts features by default by @carolynzech in https://github.com/model-checking/kani/pull/4016
@@ -30,27 +24,18 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * List Subcommand: include crate name by @carolynzech in https://github.com/model-checking/kani/pull/4024
 * Autoharness: Update Filtering Options by @carolynzech in https://github.com/model-checking/kani/pull/4025
 * CI Formatting Fixes by @carolynzech in https://github.com/model-checking/kani/pull/4028
-* Update toolchain to 2025-04-14 by @zhassan-aws in https://github.com/model-checking/kani/pull/4018
-* Upgrade toolchain to 2025-04-18 by @zhassan-aws in https://github.com/model-checking/kani/pull/4031
-* Automatic toolchain upgrade to nightly-2025-04-19 by @github-actions in https://github.com/model-checking/kani/pull/4033
-* Automatic toolchain upgrade to nightly-2025-04-20 by @github-actions in https://github.com/model-checking/kani/pull/4034
-* Automatic cargo update to 2025-04-21 by @github-actions in https://github.com/model-checking/kani/pull/4036
 * Bump tests/perf/s2n-quic from `0413d9a` to `f42521d` by @dependabot in https://github.com/model-checking/kani/pull/4038
-* Automatic toolchain upgrade to nightly-2025-04-21 by @github-actions in https://github.com/model-checking/kani/pull/4035
-* Automatic toolchain upgrade to nightly-2025-04-22 by @github-actions in https://github.com/model-checking/kani/pull/4039
 * Introduce BoundedArbitrary trait and macro for bounded proofs by @sgpthomas in https://github.com/model-checking/kani/pull/4000
 * Support `trait_upcasting` by @clubby789 in https://github.com/model-checking/kani/pull/4001
-* Automatic toolchain upgrade to nightly-2025-04-23 by @github-actions in https://github.com/model-checking/kani/pull/4040
 * Analyze unsafe code reachability by @carolynzech in https://github.com/model-checking/kani/pull/4037
-* Automatic toolchain upgrade to nightly-2025-04-24 by @github-actions in https://github.com/model-checking/kani/pull/4042
 * Scanner: log crate-level visibility of functions by @tautschnig in https://github.com/model-checking/kani/pull/4041
 * Autoharness: exit code 1 upon harness failure by @carolynzech in https://github.com/model-checking/kani/pull/4043
-* Automatic cargo update to 2025-04-28 by @github-actions in https://github.com/model-checking/kani/pull/4047
 * Bump tests/perf/s2n-quic from `f42521d` to `29e5e15` by @dependabot in https://github.com/model-checking/kani/pull/4048
 * Overflow operators can also be used with vectors by @tautschnig in https://github.com/model-checking/kani/pull/4049
 * Update CBMC dependency to 6.6.0 by @qinheping in https://github.com/model-checking/kani/pull/4050
-* Automatic cargo update to 2025-05-05 by @github-actions in https://github.com/model-checking/kani/pull/4053
 * Bump tests/perf/s2n-quic from `29e5e15` to `6aa9975` by @dependabot in https://github.com/model-checking/kani/pull/4054
+* Automatic cargo update to 2025-05-05 by @github-actions in https://github.com/model-checking/kani/pull/4053
+* Automatic toolchain upgrade to nightly-2025-04-24 by @zhassan-aws in https://github.com/model-checking/kani/pull/4042
 
 ## New Contributors
 * @sgpthomas made their first contribution in https://github.com/model-checking/kani/pull/4000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,9 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## What's Changed
 * Disable llbc feature by default by @zhassan-aws in https://github.com/model-checking/kani/pull/3980
-* Fix release schedule in docs by @carolynzech in https://github.com/model-checking/kani/pull/3994
-* Bump tests/perf/s2n-quic from `d0aff82` to `9f7e0a9` by @dependabot in https://github.com/model-checking/kani/pull/3995
-* Fix the package docker job in the release workflow by @zhassan-aws in https://github.com/model-checking/kani/pull/4003
-* Avoid spurious action failures in forks by @tautschnig in https://github.com/model-checking/kani/pull/4005
 * Add an option to skip codegen by @zhassan-aws in https://github.com/model-checking/kani/pull/4002
 * Add support for loop-contract historic values by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3951
 * Clarify Rust intrinsic assumption error message by @carolynzech in https://github.com/model-checking/kani/pull/4015
-* Bump tests/perf/s2n-quic from `9f7e0a9` to `0413d9a` by @dependabot in https://github.com/model-checking/kani/pull/4014
 * Autoharness: enable function-contracts and loop-contracts features by default by @carolynzech in https://github.com/model-checking/kani/pull/4016
 * Autoharness: Harness Generation Improvements by @carolynzech in https://github.com/model-checking/kani/pull/4017
 * Add support for Loop-loops by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4011
@@ -23,17 +18,14 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Fix the bug of while loop invariant contains no local variables by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4022
 * List Subcommand: include crate name by @carolynzech in https://github.com/model-checking/kani/pull/4024
 * Autoharness: Update Filtering Options by @carolynzech in https://github.com/model-checking/kani/pull/4025
-* CI Formatting Fixes by @carolynzech in https://github.com/model-checking/kani/pull/4028
-* Bump tests/perf/s2n-quic from `0413d9a` to `f42521d` by @dependabot in https://github.com/model-checking/kani/pull/4038
 * Introduce BoundedArbitrary trait and macro for bounded proofs by @sgpthomas in https://github.com/model-checking/kani/pull/4000
 * Support `trait_upcasting` by @clubby789 in https://github.com/model-checking/kani/pull/4001
 * Analyze unsafe code reachability by @carolynzech in https://github.com/model-checking/kani/pull/4037
 * Scanner: log crate-level visibility of functions by @tautschnig in https://github.com/model-checking/kani/pull/4041
 * Autoharness: exit code 1 upon harness failure by @carolynzech in https://github.com/model-checking/kani/pull/4043
-* Bump tests/perf/s2n-quic from `f42521d` to `29e5e15` by @dependabot in https://github.com/model-checking/kani/pull/4048
 * Overflow operators can also be used with vectors by @tautschnig in https://github.com/model-checking/kani/pull/4049
+* Remove bool typedef by @zhassan-aws in https://github.com/model-checking/kani/pull/4058
 * Update CBMC dependency to 6.6.0 by @qinheping in https://github.com/model-checking/kani/pull/4050
-* Bump tests/perf/s2n-quic from `29e5e15` to `6aa9975` by @dependabot in https://github.com/model-checking/kani/pull/4054
 * Automatic cargo update to 2025-05-05 by @github-actions in https://github.com/model-checking/kani/pull/4053
 * Automatic toolchain upgrade to nightly-2025-04-24 by @zhassan-aws in https://github.com/model-checking/kani/pull/4042
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Overflow operators can also be used with vectors by @tautschnig in https://github.com/model-checking/kani/pull/4049
 * Remove bool typedef by @zhassan-aws in https://github.com/model-checking/kani/pull/4058
 * Update CBMC dependency to 6.6.0 by @qinheping in https://github.com/model-checking/kani/pull/4050
-* Automatic cargo update to 2025-05-05 by @github-actions in https://github.com/model-checking/kani/pull/4053
 * Automatic toolchain upgrade to nightly-2025-04-24 by @zhassan-aws in https://github.com/model-checking/kani/pull/4042
 
 ## New Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.62.0]
+
+### What's Changed
+* Introduce BoundedArbitrary trait and macro for bounded proofs by @sgpthomas in https://github.com/model-checking/kani/pull/4000
+* Add an option to skip codegen by @zhassan-aws in https://github.com/model-checking/kani/pull/4002
+* Avoid spurious action failures in forks by @tautschnig in https://github.com/model-checking/kani/pull/4005
+* Add support for loop loop-loops by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4011
+* Autoharness: enable function-contracts and loop-contracts features by default by @carolynzech in https://github.com/model-checking/kani/pull/4016
+* Autoharness: Harness Generation Improvements by @carolynzech in https://github.com/model-checking/kani/pull/4017
+* Analyze unsafe code reachability @carolynzech in https://github.com/model-checking/kani/pull/4037
+* Upgrade toolchain to nightly-2025-04-24 in https://github.com/model-checking/kani/pull/4042
+* Autoharness: exit code 1 upon harness failure by @carolynzech in https://github.com/model-checking/kani/pull/4043
+* Overflow operators can also be used with vectors by @tautschnig in https://github.com/model-checking/kani/pull/4049
+* Update CBMC dependency to 6.6.0 by @qinheping in https://github.com/model-checking/kani/pull/4050
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.61.0...kani-0.62.0
+
 ## [0.61.0]
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,55 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## [0.62.0]
 
-### What's Changed
-* Introduce BoundedArbitrary trait and macro for bounded proofs by @sgpthomas in https://github.com/model-checking/kani/pull/4000
-* Add an option to skip codegen by @zhassan-aws in https://github.com/model-checking/kani/pull/4002
+## What's Changed
+* Disable llbc feature by default by @zhassan-aws in https://github.com/model-checking/kani/pull/3980
+* Automatic toolchain upgrade to nightly-2025-04-04 by @github-actions in https://github.com/model-checking/kani/pull/3991
+* Automatic cargo update to 2025-04-07 by @github-actions in https://github.com/model-checking/kani/pull/3992
+* Fix release schedule in docs by @carolynzech in https://github.com/model-checking/kani/pull/3994
+* Automatic toolchain upgrade to nightly-2025-04-05 by @github-actions in https://github.com/model-checking/kani/pull/3996
+* Bump tests/perf/s2n-quic from `d0aff82` to `9f7e0a9` by @dependabot in https://github.com/model-checking/kani/pull/3995
+* Automatic toolchain upgrade to nightly-2025-04-06 by @github-actions in https://github.com/model-checking/kani/pull/4004
+* Fix the package docker job in the release workflow by @zhassan-aws in https://github.com/model-checking/kani/pull/4003
 * Avoid spurious action failures in forks by @tautschnig in https://github.com/model-checking/kani/pull/4005
-* Add support for loop loop-loops by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4011
+* Add an option to skip codegen by @zhassan-aws in https://github.com/model-checking/kani/pull/4002
+* Automatic toolchain upgrade to nightly-2025-04-07 by @github-actions in https://github.com/model-checking/kani/pull/4006
+* Add support for loop-contract historic values by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3951
+* Automatic cargo update to 2025-04-14 by @github-actions in https://github.com/model-checking/kani/pull/4013
+* Clarify Rust intrinsic assumption error message by @carolynzech in https://github.com/model-checking/kani/pull/4015
+* Bump tests/perf/s2n-quic from `9f7e0a9` to `0413d9a` by @dependabot in https://github.com/model-checking/kani/pull/4014
 * Autoharness: enable function-contracts and loop-contracts features by default by @carolynzech in https://github.com/model-checking/kani/pull/4016
 * Autoharness: Harness Generation Improvements by @carolynzech in https://github.com/model-checking/kani/pull/4017
-* Analyze unsafe code reachability @carolynzech in https://github.com/model-checking/kani/pull/4037
-* Upgrade toolchain to nightly-2025-04-24 in https://github.com/model-checking/kani/pull/4042
+* Add support for Loop-loops by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4011
+* Clarify installation instructions by @zhassan-aws in https://github.com/model-checking/kani/pull/4023
+* Fix the bug of while loop invariant contains no local variables by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4022
+* List Subcommand: include crate name by @carolynzech in https://github.com/model-checking/kani/pull/4024
+* Autoharness: Update Filtering Options by @carolynzech in https://github.com/model-checking/kani/pull/4025
+* CI Formatting Fixes by @carolynzech in https://github.com/model-checking/kani/pull/4028
+* Update toolchain to 2025-04-14 by @zhassan-aws in https://github.com/model-checking/kani/pull/4018
+* Upgrade toolchain to 2025-04-18 by @zhassan-aws in https://github.com/model-checking/kani/pull/4031
+* Automatic toolchain upgrade to nightly-2025-04-19 by @github-actions in https://github.com/model-checking/kani/pull/4033
+* Automatic toolchain upgrade to nightly-2025-04-20 by @github-actions in https://github.com/model-checking/kani/pull/4034
+* Automatic cargo update to 2025-04-21 by @github-actions in https://github.com/model-checking/kani/pull/4036
+* Bump tests/perf/s2n-quic from `0413d9a` to `f42521d` by @dependabot in https://github.com/model-checking/kani/pull/4038
+* Automatic toolchain upgrade to nightly-2025-04-21 by @github-actions in https://github.com/model-checking/kani/pull/4035
+* Automatic toolchain upgrade to nightly-2025-04-22 by @github-actions in https://github.com/model-checking/kani/pull/4039
+* Introduce BoundedArbitrary trait and macro for bounded proofs by @sgpthomas in https://github.com/model-checking/kani/pull/4000
+* Support `trait_upcasting` by @clubby789 in https://github.com/model-checking/kani/pull/4001
+* Automatic toolchain upgrade to nightly-2025-04-23 by @github-actions in https://github.com/model-checking/kani/pull/4040
+* Analyze unsafe code reachability by @carolynzech in https://github.com/model-checking/kani/pull/4037
+* Automatic toolchain upgrade to nightly-2025-04-24 by @github-actions in https://github.com/model-checking/kani/pull/4042
+* Scanner: log crate-level visibility of functions by @tautschnig in https://github.com/model-checking/kani/pull/4041
 * Autoharness: exit code 1 upon harness failure by @carolynzech in https://github.com/model-checking/kani/pull/4043
+* Automatic cargo update to 2025-04-28 by @github-actions in https://github.com/model-checking/kani/pull/4047
+* Bump tests/perf/s2n-quic from `f42521d` to `29e5e15` by @dependabot in https://github.com/model-checking/kani/pull/4048
 * Overflow operators can also be used with vectors by @tautschnig in https://github.com/model-checking/kani/pull/4049
 * Update CBMC dependency to 6.6.0 by @qinheping in https://github.com/model-checking/kani/pull/4050
+* Automatic cargo update to 2025-05-05 by @github-actions in https://github.com/model-checking/kani/pull/4053
+* Bump tests/perf/s2n-quic from `29e5e15` to `6aa9975` by @dependabot in https://github.com/model-checking/kani/pull/4054
+
+## New Contributors
+* @sgpthomas made their first contribution in https://github.com/model-checking/kani/pull/4000
+* @clubby789 made their first contribution in https://github.com/model-checking/kani/pull/4001
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.61.0...kani-0.62.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -824,7 +824,7 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "kani"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "kani_core",
  "kani_macros",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "kani-compiler"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "charon",
  "clap",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "home",
@@ -906,14 +906,14 @@ dependencies = [
 
 [[package]]
 name = "kani_core"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani_macros"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "std"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_core/Cargo.toml
+++ b/library/kani_core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_core"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Description of changes:
Bumps version of Kani crates to 0.62.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
