### PR TITLE
Enable target features: x87 and sse2

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -253,7 +253,12 @@ impl CodegenBackend for GotocCodegenBackend {
     fn target_config(&self, _sess: &Session) -> TargetConfig {
         TargetConfig {
             target_features: vec![],
-            unstable_target_features: vec![Symbol::intern("sse"), Symbol::intern("neon"), Symbol::intern("x87"), Symbol::intern("sse2")],
+            unstable_target_features: vec![
+                Symbol::intern("sse"),
+                Symbol::intern("neon"),
+                Symbol::intern("x87"),
+                Symbol::intern("sse2"),
+            ],
             // `true` is used as a default so backends need to acknowledge when they do not
             // support the float types, rather than accidentally quietly skipping all tests.
             has_reliable_f16: true,

--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -253,7 +253,7 @@ impl CodegenBackend for GotocCodegenBackend {
     fn target_config(&self, _sess: &Session) -> TargetConfig {
         TargetConfig {
             target_features: vec![],
-            unstable_target_features: vec![Symbol::intern("sse"), Symbol::intern("neon")],
+            unstable_target_features: vec![Symbol::intern("sse"), Symbol::intern("neon"), Symbol::intern("x87"), Symbol::intern("sse2")],
             // `true` is used as a default so backends need to acknowledge when they do not
             // support the float types, rather than accidentally quietly skipping all tests.
             has_reliable_f16: true,


### PR DESCRIPTION
This PR add two target features: x87 and sse2 to target the warning from Rust compiler. 

Resolves https://github.com/model-checking/kani/issues/3878

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
