### PR TITLE
Autoharness argument validation: only error on `--quiet` if `--list` was passed

### DIFF
--- a/kani-driver/src/args/autoharness_args.rs
+++ b/kani-driver/src/args/autoharness_args.rs
@@ -94,7 +94,8 @@ impl ValidateArgs for CargoAutoharnessArgs {
             ));
         }
 
-        if self.common_autoharness_args.format == Format::Pretty
+        if self.common_autoharness_args.list
+            && self.common_autoharness_args.format == Format::Pretty
             && self.verify_opts.common_args.quiet
         {
             return Err(Error::raw(
@@ -141,7 +142,8 @@ impl ValidateArgs for StandaloneAutoharnessArgs {
             ));
         }
 
-        if self.common_autoharness_args.format == Format::Pretty
+        if self.common_autoharness_args.list
+            && self.common_autoharness_args.format == Format::Pretty
             && self.verify_opts.common_args.quiet
         {
             return Err(Error::raw(


### PR DESCRIPTION
The autoharness subcommand doesn't support the `--pretty` format with `--quiet` when running "autoharness --list," but we should only error if `--list` was actually passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
