### PR TITLE
Fix the error that Kani panics when there is no external parameter in quantifier's closure.

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -568,6 +568,7 @@ impl GotocCtx<'_> {
     ///
     /// N.B. public only because instrinsics use this directly, too.
     pub(crate) fn codegen_funcall_args(&mut self, fn_abi: &FnAbi, args: &[Operand]) -> Vec<Expr> {
+        //println!("funcall_args: {:?}",args);
         let fargs: Vec<Expr> = args
             .iter()
             .enumerate()
@@ -575,9 +576,13 @@ impl GotocCtx<'_> {
                 // Functions that require caller info will have an extra parameter.
                 let arg_abi = &fn_abi.args.get(i);
                 let ty = self.operand_ty_stable(op);
+                //println!("funcall_args ty: {:?}",ty.kind().is_closure());
+                //println!("funcall_args abi: {:?}",arg_abi.unwrap().mode);
                 if ty.kind().is_bool() {
                     Some(self.codegen_operand_stable(op).cast_to(Type::c_bool()))
                 } else if arg_abi.is_none_or(|abi| abi.mode != PassMode::Ignore) {
+                    Some(self.codegen_operand_stable(op))
+                } else if ty.kind().is_closure(){
                     Some(self.codegen_operand_stable(op))
                 } else {
                     None
@@ -585,6 +590,7 @@ impl GotocCtx<'_> {
             })
             .collect();
         debug!(?fargs, args_abi=?fn_abi.args, "codegen_funcall_args");
+        //println!("trans funcall_args: {:?}",fargs);
         fargs
     }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -582,7 +582,7 @@ impl GotocCtx<'_> {
                     Some(self.codegen_operand_stable(op).cast_to(Type::c_bool()))
                 } else if arg_abi.is_none_or(|abi| abi.mode != PassMode::Ignore) {
                     Some(self.codegen_operand_stable(op))
-                } else if ty.kind().is_closure(){
+                } else if ty.kind().is_closure() {
                     Some(self.codegen_operand_stable(op))
                 } else {
                     None

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -573,7 +573,6 @@ impl GotocCtx<'_> {
         fn_abi: &FnAbi,
         args: &[Operand],
     ) -> Vec<Expr> {
-        //println!("funcall_args: {:?}",args);
         let fargs: Vec<Expr> = args
             .iter()
             .enumerate()
@@ -581,8 +580,6 @@ impl GotocCtx<'_> {
                 // Functions that require caller info will have an extra parameter.
                 let arg_abi = &fn_abi.args.get(i);
                 let ty = self.operand_ty_stable(op);
-                //println!("funcall_args ty: {:?}",ty.kind().is_closure());
-                //println!("funcall_args abi: {:?}",arg_abi.unwrap().mode);
                 if ty.kind().is_bool() {
                     Some(self.codegen_operand_stable(op).cast_to(Type::c_bool()))
                 } else if ty.kind().is_closure()
@@ -595,7 +592,6 @@ impl GotocCtx<'_> {
             })
             .collect();
         debug!(?fargs, args_abi=?fn_abi.args, "codegen_funcall_args");
-        //println!("trans funcall_args: {:?}",fargs);
         fargs
     }
 
@@ -603,16 +599,12 @@ impl GotocCtx<'_> {
     ///
     /// N.B. public only because instrinsics use this directly, too.
     pub(crate) fn codegen_funcall_args(&mut self, fn_abi: &FnAbi, args: &[Operand]) -> Vec<Expr> {
-        //println!("funcall_args: {:?}",args);
         let fargs: Vec<Expr> = args
             .iter()
             .enumerate()
             .filter_map(|(i, op)| {
-                // Functions that require caller info will have an extra parameter.
                 let arg_abi = &fn_abi.args.get(i);
                 let ty = self.operand_ty_stable(op);
-                //println!("funcall_args ty: {:?}",ty.kind().is_closure());
-                //println!("funcall_args abi: {:?}",arg_abi.unwrap().mode);
                 if ty.kind().is_bool() {
                     Some(self.codegen_operand_stable(op).cast_to(Type::c_bool()))
                 } else if arg_abi.is_none_or(|abi| abi.mode != PassMode::Ignore) {
@@ -623,7 +615,6 @@ impl GotocCtx<'_> {
             })
             .collect();
         debug!(?fargs, args_abi=?fn_abi.args, "codegen_funcall_args");
-        //println!("trans funcall_args: {:?}",fargs);
         fargs
     }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -580,9 +580,9 @@ impl GotocCtx<'_> {
                 //println!("funcall_args abi: {:?}",arg_abi.unwrap().mode);
                 if ty.kind().is_bool() {
                     Some(self.codegen_operand_stable(op).cast_to(Type::c_bool()))
-                } else if arg_abi.is_none_or(|abi| abi.mode != PassMode::Ignore) {
-                    Some(self.codegen_operand_stable(op))
-                } else if ty.kind().is_closure() {
+                } else if ty.kind().is_closure()
+                    || (arg_abi.is_none_or(|abi| abi.mode != PassMode::Ignore))
+                {
                     Some(self.codegen_operand_stable(op))
                 } else {
                     None

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -823,7 +823,6 @@ fn handle_quantifier(
     let upper_bound = &fargs[1];
     let closure_call_expr = find_closure_call_expr(&instance, gcx, loc)
         .unwrap_or_else(|| unreachable!("Failed to find closure call expression"));
-
     let closure_arg = fargs[2].clone();
     let predicate = if closure_arg.is_symbol() {
         Expr::address_of(closure_arg)

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -823,7 +823,7 @@ fn handle_quantifier(
     let upper_bound = &fargs[1];
     let closure_call_expr = find_closure_call_expr(&instance, gcx, loc)
         .unwrap_or_else(|| unreachable!("Failed to find closure call expression"));
-    
+
     let closure_arg = fargs[2].clone();
     let predicate = if closure_arg.is_symbol() {
         Expr::address_of(closure_arg)
@@ -831,7 +831,7 @@ fn handle_quantifier(
         let predicate_ty = fargs[2].typ().clone().to_pointer();
         Expr::nondet(predicate_ty)
     };
-    
+
     // Quantified variable.
     let base_name = "kani_quantified_var".to_string();
     let mut counter = 0;

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -823,9 +823,15 @@ fn handle_quantifier(
     let upper_bound = &fargs[1];
     let closure_call_expr = find_closure_call_expr(&instance, gcx, loc)
         .unwrap_or_else(|| unreachable!("Failed to find closure call expression"));
-
-    let predicate = Expr::address_of(fargs[2].clone());
-
+    
+    let closure_arg = fargs[2].clone();
+    let predicate = if closure_arg.is_symbol() {
+        Expr::address_of(closure_arg)
+    } else {
+        let predicate_ty = fargs[2].typ().clone().to_pointer();
+        Expr::nondet(predicate_ty)
+    };
+    
     // Quantified variable.
     let base_name = "kani_quantified_var".to_string();
     let mut counter = 0;

--- a/tests/expected/quantifiers/quantifier_with_no_external_variable.expected
+++ b/tests/expected/quantifiers/quantifier_with_no_external_variable.expected
@@ -1,0 +1,5 @@
+- Status: SUCCESS\
+- Description: "assertion failed: quan"
+
+VERIFICATION:- SUCCESSFUL
+

--- a/tests/expected/quantifiers/quantifier_with_no_external_variable.rs
+++ b/tests/expected/quantifiers/quantifier_with_no_external_variable.rs
@@ -5,6 +5,6 @@
 
 #[kani::proof]
 fn test() {
-    let quan1 = kani::forall!(|j in (0, 100)| j == 0);
+    let quan1 = kani::exists!(|j in (0, 100)| j == 0);
     assert!(quan1);
 }

--- a/tests/expected/quantifiers/quantifier_with_no_external_variable.rs
+++ b/tests/expected/quantifiers/quantifier_with_no_external_variable.rs
@@ -1,0 +1,10 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Quantifier with no external variable in the closure
+
+#[kani::proof]
+fn test() {
+    let quan1 = kani::forall!(|j in (0, 100)| j == 0);
+    assert!(quan1);
+}

--- a/tests/expected/quantifiers/quantifier_with_no_external_variable.rs
+++ b/tests/expected/quantifiers/quantifier_with_no_external_variable.rs
@@ -5,6 +5,6 @@
 
 #[kani::proof]
 fn test() {
-    let quan1 = kani::exists!(|j in (0, 100)| j == 0);
-    assert!(quan1);
+    let quan = kani::exists!(|j in (0, 100)| j == 0);
+    assert!(quan);
 }


### PR DESCRIPTION
Previously, if we run Kani on the following harness:
```Rust
#[kani::proof]
fn test() {
    let quan = kani::forall!(|j in (0, 100)| j < 100);
    assert!(quan);
}
```
it will panic: 
```
thread 'rustc' panicked at kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs:827:43:
index out of bounds: the len is 2 but the index is 2
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
