### PR TITLE
Use our toolchain when invoking `cargo metadata`

### DIFF
--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -247,6 +247,9 @@ crate-type = ["lib"]
     pub fn cargo_metadata(&self, build_target: &str) -> Result<Metadata> {
         let mut cmd = MetadataCommand::new();
 
+        // Use Kani's toolchain when running `cargo metadata`
+        cmd.cargo_path(env!("CARGO"));
+
         // restrict metadata command to host platform. References:
         // https://github.com/rust-lang/rust-analyzer/issues/6908
         // https://github.com/rust-lang/rust-analyzer/pull/6912

--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -4,7 +4,9 @@
 use crate::args::VerificationArgs;
 use crate::call_single_file::{LibConfig, to_rustc_arg};
 use crate::project::Artifact;
-use crate::session::{KaniSession, lib_folder, lib_no_core_folder, setup_cargo_command};
+use crate::session::{
+    KaniSession, get_cargo_path, lib_folder, lib_no_core_folder, setup_cargo_command,
+};
 use crate::util;
 use anyhow::{Context, Result, bail};
 use cargo_metadata::diagnostic::{Diagnostic, DiagnosticLevel};
@@ -248,7 +250,8 @@ crate-type = ["lib"]
         let mut cmd = MetadataCommand::new();
 
         // Use Kani's toolchain when running `cargo metadata`
-        cmd.cargo_path(env!("CARGO"));
+        let cargo_path = get_cargo_path().unwrap();
+        cmd.cargo_path(cargo_path);
 
         // restrict metadata command to host platform. References:
         // https://github.com/rust-lang/rust-analyzer/issues/6908

--- a/kani-driver/src/session.rs
+++ b/kani-driver/src/session.rs
@@ -439,3 +439,17 @@ pub fn setup_cargo_command() -> Result<Command> {
 
     Ok(cmd)
 }
+
+// Get the cargo path corresponding to the toolchain version in rust-toolchain.toml.
+// If kani is being run in developer mode, then we use the compile-time toolchain, i.e. the one used during cargo build-dev.
+// For release versions of Kani, we use a version of cargo that's in the toolchain that's been symlinked during `cargo-kani` setup.
+pub fn get_cargo_path() -> Result<PathBuf> {
+    let install_type = InstallType::new()?;
+
+    let cargo_path = match install_type {
+        InstallType::DevRepo(_) => env!("CARGO").into(),
+        InstallType::Release(kani_dir) => kani_dir.join("toolchain").join("bin").join("cargo"),
+    };
+
+    Ok(cargo_path)
+}


### PR DESCRIPTION
## Summary
Change our invocation of `cargo metadata` to use Kani's toolchain.

## Explanation
Kani uses the [cargo_metadata](https://crates.io/crates/cargo_metadata) API to invoke `cargo metadata`. We were neglecting to override the Rust toolchain version with the one from our `rust-toolchain.toml` file, so the command would use the toolchain from the target crate. The issue is that Rust 1.77 [stabilized the package id format](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-177-2024-03-21), so Kani, which is past 1.77, would expect the new version, and therefore can do this:
https://github.com/model-checking/kani/blob/5d76510f8881153292124176d02300e6c13c2ffa/kani-driver/src/call_cargo.rs#L207

and know that the string representation of the package ID will work with `-p`. Pre-stabilization, Cargo made no such guarantees, so fetching the metadata with a pre 1.77 toolchain would return an id that's not compatible with the `-p` flag.

Resolves #3997

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
