### PR TITLE
Update toolchain to 2025-05-22

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-05-20"
+channel = "nightly-2025-05-22"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/expected/valid-value-checks/maybe_uninit.expected
+++ b/tests/expected/valid-value-checks/maybe_uninit.expected
@@ -1,4 +1,3 @@
- ** 1 of 14 failed (1 unreachable)\
 Failed Checks: Undefined Behavior: Invalid value of type `std::num::NonZero<i64>`
 
 Verification failed for - check_invalid_zeroed

--- a/tests/expected/valid-value-checks/write_bytes.expected
+++ b/tests/expected/valid-value-checks/write_bytes.expected
@@ -1,4 +1,3 @@
- ** 1 of 11 failed (1 unreachable)\
 Failed Checks: Undefined Behavior: Invalid value of type `char`
 
 Verification failed for - check_invalid_write

--- a/tests/expected/valid-value-checks/write_invalid.expected
+++ b/tests/expected/valid-value-checks/write_invalid.expected
@@ -1,10 +1,5 @@
- ** 1 of 19 failed (2 unreachable)\
 Failed Checks: Kani currently doesn't support checking validity of `transmute` for `std::option::Option<std::num::NonZero<u8>>`
-
- ** 1 of 43 failed (2 unreachable)\
 Failed Checks: Kani currently doesn't support checking validity of `transmute` for `std::option::Option<std::num::NonZero<u8>>`
-
- ** 1 of 18 failed (1 unreachable)\
 Failed Checks: Kani currently doesn't support checking validity of `transmute` for `std::option::Option<std::num::NonZero<u8>>`
 
 Verification failed for - read_invalid_is_ub


### PR DESCRIPTION
Culprit PR: https://github.com/rust-lang/rust/pull/139916, which removed some of the debug assertions, and hence we have fewer property checks. I just deleted the numbers entirely to make the tests less brittle; it doesn't matter how many properties we check as long as we catch the UB.

Resolves #4093

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
