### PR TITLE
Finish deprecating `--enable-unstable`, `--restrict-vtable`, and `--write-json-symtab`

### DIFF
--- a/kani-driver/src/args/common.rs
+++ b/kani-driver/src/args/common.rs
@@ -1,7 +1,7 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Define arguments that should be common to all subcommands in Kani.
-use crate::args::{ValidateArgs, print_deprecated};
+use crate::args::ValidateArgs;
 use clap::{error::Error, error::ErrorKind};
 pub use kani_metadata::{EnabledUnstableFeatures, UnstableFeature};
 
@@ -18,7 +18,7 @@ pub struct CommonArgs {
     #[arg(long, short, default_value_if("debug", "true", Some("true")))]
     pub verbose: bool,
     /// Enable usage of unstable options
-    #[arg(long, hide_short_help = true)]
+    #[arg(long, hide = true)]
     pub enable_unstable: bool,
 
     /// We no longer support dry-run. Use `--verbose` to see the commands being printed during
@@ -53,7 +53,12 @@ impl CommonArgs {
         if enabled && !self.unstable_features.contains(required) {
             let z_feature = format!("-Z {required}");
             if self.enable_unstable {
-                print_deprecated(self, "--enable-unstable", &z_feature);
+                return Err(Error::raw(
+                    ErrorKind::ValueValidation,
+                    format!(
+                        "The `--enable-unstable` option is obsolete. Use `{z_feature}` instead.",
+                    ),
+                ));
             } else {
                 return Err(Error::raw(
                     ErrorKind::MissingRequiredArgument,

--- a/kani-driver/src/args/mod.rs
+++ b/kani-driver/src/args/mod.rs
@@ -299,7 +299,7 @@ pub struct VerificationArgs {
     pub ignore_global_asm: bool,
 
     /// Write the GotoC symbol table to a file in JSON format instead of goto binary format.
-    #[arg(long, hide_short_help = true)]
+    #[arg(long, hide = true)]
     pub write_json_symtab: bool,
 
     /// Execute CBMC's sanity checks to ensure the goto-program we generate is correct.
@@ -589,7 +589,10 @@ impl ValidateArgs for VerificationArgs {
         }
 
         if self.write_json_symtab {
-            print_obsolete(&self.common_args, "--write-json-symtab");
+            return Err(Error::raw(
+                ErrorKind::ValueValidation,
+                "The `--write-json-symtab` option is obsolete.",
+            ));
         }
 
         // TODO: these conflicting flags reflect what's necessary to pass current tests unmodified.

--- a/kani-driver/src/args/mod.rs
+++ b/kani-driver/src/args/mod.rs
@@ -728,13 +728,21 @@ impl ValidateArgs for VerificationArgs {
         if !self.c_lib.is_empty()
             && !self.common_args.unstable_features.contains(UnstableFeature::CFfi)
         {
+            let z_feature = "-Z c-ffi";
             if self.common_args.enable_unstable {
-                print_deprecated(&self.common_args, "`--enable-unstable`", "-Z c-ffi");
+                return Err(Error::raw(
+                    ErrorKind::ValueValidation,
+                    format!(
+                        "The `--enable-unstable` option is obsolete. Use `{z_feature}` instead.",
+                    ),
+                ));
             } else {
                 return Err(Error::raw(
                     ErrorKind::MissingRequiredArgument,
-                    "The `--c-lib` argument is unstable and requires `-Z c-ffi` to enable \
-                unstable C-FFI support.",
+                    format!(
+                        "The `--c-lib` argument is unstable and requires `{z_feature}` to enable \
+                unstable C-FFI support."
+                    ),
                 ));
             }
         }

--- a/kani-driver/src/args/mod.rs
+++ b/kani-driver/src/args/mod.rs
@@ -52,6 +52,7 @@ pub fn print_obsolete(verbosity: &CommonArgs, option: &str) {
     }
 }
 
+#[allow(dead_code)]
 pub fn print_deprecated(verbosity: &CommonArgs, option: &str, alternative: &str) {
     if !verbosity.quiet {
         warning(&format!(

--- a/kani-driver/src/call_goto_instrument.rs
+++ b/kani-driver/src/call_goto_instrument.rs
@@ -76,7 +76,7 @@ impl KaniSession {
         Ok(())
     }
 
-    /// Apply --restrict-vtable to a goto binary.
+    /// Apply -Z restrict-vtable to a goto binary.
     pub fn apply_vtable_restrictions(&self, goto_file: &Path, restrictions: &Path) -> Result<()> {
         let linked_restrictions = alter_extension(goto_file, "linked-restrictions.json");
         self.record_temporary_file(&linked_restrictions);

--- a/tests/cargo-kani/asm/global/Cargo.toml
+++ b/tests/cargo-kani/asm/global/Cargo.toml
@@ -12,5 +12,5 @@ edition = "2021"
 crate_with_global_asm = { path = "crate_with_global_asm" }
 
 [package.metadata.kani]
-# Issue with MIR Linker on static constant.
-flags = { enable-unstable = true, ignore-global-asm = true }
+flags = { ignore-global-asm = true}
+unstable = { unstable-options = true }

--- a/tests/kani/DynTrait/vtable_restrictions_fail_fixme.rs
+++ b/tests/kani/DynTrait/vtable_restrictions_fail_fixme.rs
@@ -6,7 +6,7 @@
 // FIXME until the corresponding CBMC path lands: https://github.com/diffblue/cbmc/pull/6376
 
 // kani-expect-fail
-// kani-flags: --restrict-vtable
+// kani-flags: -Z restrict-vtable
 
 #![feature(core_intrinsics)]
 #![feature(ptr_metadata)]


### PR DESCRIPTION
Make `--enable-unstable`, `--restrict-vtable`, and `--write-json-symtab` hard errors.

Resolves https://github.com/model-checking/kani/issues/3068
Towards https://github.com/model-checking/kani/issues/2279

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
