### PR TITLE
Handle generic defaults in BoundedArbitrary derives

### DIFF
--- a/tests/expected/derive-bounded-arbitrary/generic_default.expected
+++ b/tests/expected/derive-bounded-arbitrary/generic_default.expected
@@ -1,0 +1,5 @@
+Checking harness check_my_vec...
+
+ ** 2 of 2 cover properties satisfied
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/derive-bounded-arbitrary/generic_default.rs
+++ b/tests/expected/derive-bounded-arbitrary/generic_default.rs
@@ -1,0 +1,24 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Check that derive BoundedArbitrary macro works on structs with a generic default
+//! which had an issue in the past:
+//! https://github.com/model-checking/kani/issues/4116
+
+extern crate kani;
+use kani::BoundedArbitrary;
+
+#[derive(BoundedArbitrary)]
+#[allow(unused)]
+struct MyVector<T = i32> {
+    #[bounded]
+    vector: Vec<T>,
+}
+
+#[kani::proof]
+#[kani::unwind(6)]
+fn check_my_vec() {
+    let my_vec: MyVector<u8> = kani::bounded_any::<_, 1>();
+    kani::cover!(my_vec.vector.len() == 0);
+    kani::cover!(my_vec.vector.len() == 1);
+}


### PR DESCRIPTION
For structs with defaults for the generic parameters, Kani's `#[derive(BoundedArbitrary)]` macro was generating incorrect code. This PR fixes the issue through ensuring that the defaults are not included in the where clause or the impl definition.

Resolves #4116

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
