### PR TITLE
Store the git log in a file

### DIFF
--- a/.github/workflows/toolchain-upgrade.yml
+++ b/.github/workflows/toolchain-upgrade.yml
@@ -64,7 +64,7 @@ jobs:
                 https://github.com/rust-lang/rust/commit/${{ env.next_toolchain_hash }}. The log
                 for this commit range is:
 
-                ` + process.env.git_log
+                ` + $(cat process.env.git_log_filename)
             })
 
       - name: Create Issue
@@ -86,4 +86,4 @@ jobs:
             https://github.com/rust-lang/rust/commit/${{ env.next_toolchain_hash }}. The log
             for this commit range is:
 
-            ${{ env.git_log }}
+            $(cat ${{ env.git_log_filename }})

--- a/scripts/toolchain_update.sh
+++ b/scripts/toolchain_update.sh
@@ -48,11 +48,11 @@ then
   echo "next_toolchain_hash=$next_toolchain_hash" >> $GITHUB_ENV
 
   EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-  echo "git_log<<$EOF" >> $GITHUB_ENV
+  git_log_filename=GIT_LOG_$EOF
+  echo "git_log_filename=$git_log_filename" >> $GITHUB_ENV
 
   git log --oneline $current_toolchain_hash..$next_toolchain_hash | \
-    sed 's#^#https://github.com/rust-lang/rust/commit/#' >> $GITHUB_ENV
-  echo "$EOF" >> $GITHUB_ENV
+    sed 's#^#https://github.com/rust-lang/rust/commit/#' >> $git_log_filename
 
   cd ..
   rm -rf rust.git


### PR DESCRIPTION
Switch from using an environment variable for storing the git log to using a file.

Resolves #4128 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
