### PR TITLE
Fix the git log command in the toolchain update script

### DIFF
--- a/scripts/toolchain_update.sh
+++ b/scripts/toolchain_update.sh
@@ -50,7 +50,7 @@ then
   EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
   echo "git_log<<$EOF" >> $GITHUB_ENV
 
-  git log --oneline $current_toolchain_hash..$next_toolchain_hash | \
+  git log --oneline --ancestry-path $current_toolchain_hash..$next_toolchain_hash | \
     sed 's#^#https://github.com/rust-lang/rust/commit/#' >> $GITHUB_ENV
   echo "$EOF" >> $GITHUB_ENV
 


### PR DESCRIPTION
The `git log` command used in the toolchain update script generated commits that are not between the current and next toolchain commits. This PR fixes the command through adding the `--ancestry-path` option:
```
       --ancestry-path
           When given a range of commits to display (e.g.  commit1..commit2 or commit2 ^commit1), only display commits that exist directly on the ancestry chain between the commit1 and commit2, i.e. commits that are both descendants of commit1, and ancestors of commit2.
```
Resolves #4128 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
