### PR TITLE
Gate quantifiers behind an experimental feature

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -817,9 +817,6 @@ fn handle_quantifier(
     span: Span,
     quantifier_kind: QuantifierKind,
 ) -> Stmt {
-    if gcx.queries.args().unstable_features.contains(&"loop-contracts".to_string()) {
-        panic!("Unstable feature Quantifier is not enable")
-    }
     let loc = gcx.codegen_span_stable(span);
     let target = target.unwrap();
     let lower_bound = &fargs[0];

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -817,6 +817,9 @@ fn handle_quantifier(
     span: Span,
     quantifier_kind: QuantifierKind,
 ) -> Stmt {
+    if gcx.queries.args().unstable_features.contains(&"loop-contracts".to_string()) {
+        panic!("Unstable feature Quantifier is not enable")
+    }
     let loc = gcx.codegen_span_stable(span);
     let target = target.unwrap();
     let lower_bound = &fargs[0];

--- a/kani_metadata/src/unstable.rs
+++ b/kani_metadata/src/unstable.rs
@@ -99,6 +99,8 @@ pub enum UnstableFeature {
     /// Allow replacing certain items with stubs (mocks).
     /// See [RFC-0002](https://model-checking.github.io/kani/rfc/rfcs/0002-function-stubbing.html)
     Stubbing,
+    /// Enable quantifiers [RFC 10](https://model-checking.github.io/kani/rfc/rfcs/0010-quantifiers.html)
+    Quantifiers,
     /// Automatically check that uninitialized memory is not used.
     UninitChecks,
     /// Enable an unstable option or subcommand.
@@ -106,8 +108,6 @@ pub enum UnstableFeature {
     /// Automatically check that no invalid value is produced which is considered UB in Rust.
     /// Note that this does not include checking uninitialized value.
     ValidValueChecks,
-    /// Enable quantifiers
-    Quantifiers,
 }
 
 impl UnstableFeature {

--- a/kani_metadata/src/unstable.rs
+++ b/kani_metadata/src/unstable.rs
@@ -106,6 +106,8 @@ pub enum UnstableFeature {
     /// Automatically check that no invalid value is produced which is considered UB in Rust.
     /// Note that this does not include checking uninitialized value.
     ValidValueChecks,
+    /// Enable quantifiers
+    Quantifiers,
 }
 
 impl UnstableFeature {

--- a/library/kani_core/src/lib.rs
+++ b/library/kani_core/src/lib.rs
@@ -629,7 +629,7 @@ macro_rules! kani_intrinsics {
 
             #[crate::kani::unstable_feature(
                 feature = "quantifiers",
-                issue = 4134,
+                issue = 2546,
                 reason = "experimental quantifiers"
             )]
             #[inline(never)]
@@ -643,7 +643,7 @@ macro_rules! kani_intrinsics {
 
             #[crate::kani::unstable_feature(
                 feature = "quantifiers",
-                issue = 4134,
+                issue = 2546,
                 reason = "experimental quantifiers"
             )]
             #[inline(never)]

--- a/library/kani_core/src/lib.rs
+++ b/library/kani_core/src/lib.rs
@@ -627,6 +627,11 @@ macro_rules! kani_intrinsics {
                 assert!(cond, "{}", msg);
             }
 
+            #[crate::kani::unstable_feature(
+                feature = "quantifiers",
+                issue = 4134,
+                reason = "experimental quantifiers"
+            )]
             #[inline(never)]
             #[kanitool::fn_marker = "ForallHook"]
             pub fn kani_forall<T, F>(lower_bound: T, upper_bound: T, predicate: F) -> bool
@@ -636,6 +641,11 @@ macro_rules! kani_intrinsics {
                 predicate(lower_bound)
             }
 
+            #[crate::kani::unstable_feature(
+                feature = "quantifiers",
+                issue = 4134,
+                reason = "experimental quantifiers"
+            )]
             #[inline(never)]
             #[kanitool::fn_marker = "ExistsHook"]
             pub fn kani_exists<T, F>(lower_bound: T, upper_bound: T, predicate: F) -> bool

--- a/tests/expected/quantifiers/assert_with_exists_fail.rs
+++ b/tests/expected/quantifiers/assert_with_exists_fail.rs
@@ -1,5 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z quantifiers
 
 #[kani::proof]
 fn exists_assert_harness() {

--- a/tests/expected/quantifiers/assert_with_exists_pass.rs
+++ b/tests/expected/quantifiers/assert_with_exists_pass.rs
@@ -1,5 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z quantifiers
 
 #[kani::proof]
 fn exists_assert_harness() {

--- a/tests/expected/quantifiers/assert_with_forall_fail.rs
+++ b/tests/expected/quantifiers/assert_with_forall_fail.rs
@@ -1,5 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z quantifiers
 
 #[kani::proof]
 fn forall_assert_harness() {

--- a/tests/expected/quantifiers/assert_with_forall_pass.rs
+++ b/tests/expected/quantifiers/assert_with_forall_pass.rs
@@ -1,5 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z quantifiers
 
 #[kani::proof]
 fn forall_assert_harness() {

--- a/tests/expected/quantifiers/assume_with_exists_fail.rs
+++ b/tests/expected/quantifiers/assume_with_exists_fail.rs
@@ -1,5 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z quantifiers
 
 #[kani::proof]
 fn exists_assume_harness() {

--- a/tests/expected/quantifiers/contracts_fail.rs
+++ b/tests/expected/quantifiers/contracts_fail.rs
@@ -1,6 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// kani-flags: -Zfunction-contracts
+// kani-flags: -Zfunction-contracts -Z quantifiers
 
 /// Copy only first 7 elements and left the last one unchanged.
 #[kani::ensures(|ret| { unsafe{

--- a/tests/expected/quantifiers/quantifier_with_no_external_variable.rs
+++ b/tests/expected/quantifiers/quantifier_with_no_external_variable.rs
@@ -1,6 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-
+// kani-flags: -Z quantifiers
 /// Quantifier with no external variable in the closure
 
 #[kani::proof]

--- a/tests/kani/Quantifiers/array.rs
+++ b/tests/kani/Quantifiers/array.rs
@@ -1,5 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z quantifiers
 
 #[kani::proof]
 fn vec_assert_forall_harness() {

--- a/tests/kani/Quantifiers/contracts.rs
+++ b/tests/kani/Quantifiers/contracts.rs
@@ -1,6 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// kani-flags: -Zfunction-contracts
+// kani-flags: -Zfunction-contracts -Zquantifiers
 
 #[kani::requires(i==0)]
 #[kani::ensures(|ret| {

--- a/tests/kani/Quantifiers/even.rs
+++ b/tests/kani/Quantifiers/even.rs
@@ -1,5 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z quantifiers
 
 #[kani::proof]
 fn quantifier_even_harness() {

--- a/tests/kani/Quantifiers/from_raw_part_fixme.rs
+++ b/tests/kani/Quantifiers/from_raw_part_fixme.rs
@@ -1,5 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z quantifiers
 
 //! FIXME: <https://github.com/model-checking/kani/issues/4020>
 

--- a/tests/kani/Quantifiers/no_array.rs
+++ b/tests/kani/Quantifiers/no_array.rs
@@ -1,5 +1,6 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z quantifiers
 
 #[kani::proof]
 fn forall_assert_harness() {


### PR DESCRIPTION
This PR put Quantifiers under unstable features. User must use the flag "-Z quantifiers" to enable it.

Resolves #4134

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
