### PR TITLE
Add loop-contracts support for `for` loop

### DIFF
--- a/docs/src/reference/experimental/loop-contracts.md
+++ b/docs/src/reference/experimental/loop-contracts.md
@@ -93,7 +93,7 @@ Complete - 1 successfully verified harnesses, 0 failures, 1 total.
 ```
 
 
-## Loop contracts for `while` loops
+## Loop contracts
 
 ### Syntax
 > 
@@ -168,10 +168,12 @@ Kani automatically contracts (instead of unwinds) all loops in the functions tha
 
 Loop contracts comes with the following limitations.
 
-1. `while` loops and `loop` loops are supported. The other kinds of loops are not supported: [`while let` loops](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops), and [`for` loops](https://doc.rust-lang.org/reference/expressions/loop-expr.html#iterator-loops).
-2. Kani infers *loop modifies* with alias analysis. Loop modifies are those variables we assume to be arbitrary in the inductive hypothesis, and should cover all memory locations that are written to during 
+1. `while` loops and `loop` loops are supported. The [`while let` loops](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops) are not supported. 
+2. [`for` loops](https://doc.rust-lang.org/reference/expressions/loop-expr.html#iterator-loops) are supported for some common types: `array`, `slice`, `Iter`, `Vec`. 
+The memory predicates feature must be enabled (`-Z loop-contracts -Z memory-predicates`).
+3. Kani infers *loop modifies* with alias analysis. Loop modifies are those variables we assume to be arbitrary in the inductive hypothesis, and should cover all memory locations that are written to during 
    the execution of the loops. A proof will fail if the inferred loop modifies misses some targets written in the loops.
    We observed this happens when some fields of structs are modified by some other functions called in the loops.
-3. Kani doesn't check if a loop will always terminate in proofs with loop contracts. So it could be that some properties are proved successfully with Kani but actually are unreachable due to the 
+4. Kani doesn't check if a loop will always terminate in proofs with loop contracts. So it could be that some properties are proved successfully with Kani but actually are unreachable due to the 
    non-termination of some loops.
-4. We don't check if loop invariants are side-effect free. A loop invariant with a side effect could lead to an unsound proof result. Make sure that the specified loop contracts are side-effect free.
+5. We don't check if loop invariants are side-effect free. A loop invariant with a side effect could lead to an unsound proof result. Make sure that the specified loop contracts are side-effect free.

--- a/library/kani_core/src/iter.rs
+++ b/library/kani_core/src/iter.rs
@@ -1,19 +1,17 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This macro generates implementations of the `Arbitrary` trait for various types. The `Arbitrary` trait defines
-//! methods for generating arbitrary (unconstrained) values of the implementing type.
-//! trivial_arbitrary and nonzero_arbitrary are implementations of Arbitrary for types that can be represented
-//! by an unconstrained symbolic value of their size (e.g., `u8`, `u16`, `u32`, etc.).
-//!
-//! TODO: Use this inside kani library so that we dont have to maintain two copies of the same proc macro for arbitrary.
+//! This macro generates implementations of the `KaniIntoIter` trait for various common types that are used in for loop.
+//! We use this trait to overwrite the Rust IntoIter trait to reduce call stacks and avoid complicated loop invariant specifications,
+//! while maintaining the semantic of the loop.
+
 
 #[macro_export]
 #[allow(clippy::crate_in_macro_def)]
 macro_rules! generate_iter {
     () => {
         use core_path::slice::Iter;
-        
+
         pub struct KaniIter<T> {
             pub iptr: *const T,
             pub len: usize,
@@ -52,7 +50,7 @@ macro_rules! generate_iter {
 
         impl<T> KaniIntoIter for Iter<'_, T> {
             type Item = T;
-            fn kani_into_iter(self) -> (*const Self::Item, usize){
+            fn kani_into_iter(self) -> (*const Self::Item, usize) {
                 (self.as_slice().as_ptr(), self.len())
             }
         }
@@ -73,11 +71,10 @@ macro_rules! generate_iter {
 
         impl<T> KaniIntoIter for Vec<T> {
             type Item = T;
-            fn kani_into_iter(self) -> (*const Self::Item, usize){
+            fn kani_into_iter(self) -> (*const Self::Item, usize) {
                 let s = self.iter();
                 (s.as_slice().as_ptr(), s.len())
             }
         }
-
     };
 }

--- a/library/kani_core/src/iter.rs
+++ b/library/kani_core/src/iter.rs
@@ -13,7 +13,7 @@
 macro_rules! generate_iter {
     () => {
         use core_path::slice::Iter;
-
+        
         pub struct KaniIter<T> {
             pub iptr: *const T,
             pub len: usize,
@@ -26,7 +26,7 @@ macro_rules! generate_iter {
             }
             pub fn next(&mut self) -> Option<&T> {
                 if self.current_pos < self.len {
-                    let elem = unsafe { &*self.iptr.offset(self.current_pos as isize) };
+                    let elem = unsafe { &*self.iptr.wrapping_add(self.current_pos) };
                     self.current_pos += 1;
                     Some(elem)
                 } else {
@@ -40,21 +40,44 @@ macro_rules! generate_iter {
             Self: Sized,
         {
             type Item;
-            fn kani_into_iter(self) -> KaniIter<Self::Item>;
+            fn kani_into_iter(self) -> (*const Self::Item, usize);
         }
 
         impl<T, const N: usize> KaniIntoIter for [T; N] {
             type Item = T;
-            fn kani_into_iter(self) -> KaniIter<Self::Item> {
-                KaniIter::new(self.as_ptr(), N)
+            fn kani_into_iter(self) -> (*const Self::Item, usize) {
+                (self.as_ptr(), N)
             }
         }
 
         impl<T> KaniIntoIter for Iter<'_, T> {
             type Item = T;
-            fn kani_into_iter(self) -> KaniIter<Self::Item> {
-                KaniIter::new(self.as_slice().as_ptr(), self.len())
+            fn kani_into_iter(self) -> (*const Self::Item, usize){
+                (self.as_slice().as_ptr(), self.len())
             }
         }
+
+        impl<'a, T> KaniIntoIter for &'a [T] {
+            type Item = T;
+            fn kani_into_iter(self) -> (*const Self::Item, usize) {
+                (self.as_ptr(), self.len())
+            }
+        }
+
+        impl<'a, T> KaniIntoIter for &'a mut [T] {
+            type Item = T;
+            fn kani_into_iter(self) -> (*const Self::Item, usize) {
+                (self.as_ptr(), self.len())
+            }
+        }
+
+        impl<T> KaniIntoIter for Vec<T> {
+            type Item = T;
+            fn kani_into_iter(self) -> (*const Self::Item, usize){
+                let s = self.iter();
+                (s.as_slice().as_ptr(), s.len())
+            }
+        }
+
     };
 }

--- a/library/kani_core/src/iter.rs
+++ b/library/kani_core/src/iter.rs
@@ -5,7 +5,6 @@
 //! We use this trait to overwrite the Rust IntoIter trait to reduce call stacks and avoid complicated loop invariant specifications,
 //! while maintaining the semantic of the loop.
 
-
 #[macro_export]
 #[allow(clippy::crate_in_macro_def)]
 macro_rules! generate_iter {

--- a/library/kani_core/src/iter.rs
+++ b/library/kani_core/src/iter.rs
@@ -1,0 +1,60 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This macro generates implementations of the `Arbitrary` trait for various types. The `Arbitrary` trait defines
+//! methods for generating arbitrary (unconstrained) values of the implementing type.
+//! trivial_arbitrary and nonzero_arbitrary are implementations of Arbitrary for types that can be represented
+//! by an unconstrained symbolic value of their size (e.g., `u8`, `u16`, `u32`, etc.).
+//!
+//! TODO: Use this inside kani library so that we dont have to maintain two copies of the same proc macro for arbitrary.
+
+#[macro_export]
+#[allow(clippy::crate_in_macro_def)]
+macro_rules! generate_iter {
+    () => {
+        use core_path::slice::Iter;
+
+        pub struct KaniIter<T> {
+            pub iptr: *const T,
+            pub len: usize,
+            pub current_pos: usize,
+        }
+
+        impl<T> KaniIter<T> {
+            pub fn new(iptr: *const T, len: usize) -> Self {
+                KaniIter { iptr, len, current_pos: 0 }
+            }
+            pub fn next(&mut self) -> Option<&T> {
+                if self.current_pos < self.len {
+                    let elem = unsafe { &*self.iptr.offset(self.current_pos as isize) };
+                    self.current_pos += 1;
+                    Some(elem)
+                } else {
+                    None
+                }
+            }
+        }
+
+        pub trait KaniIntoIter
+        where
+            Self: Sized,
+        {
+            type Item;
+            fn kani_into_iter(self) -> KaniIter<Self::Item>;
+        }
+
+        impl<T, const N: usize> KaniIntoIter for [T; N] {
+            type Item = T;
+            fn kani_into_iter(self) -> KaniIter<Self::Item> {
+                KaniIter::new(self.as_ptr(), N)
+            }
+        }
+
+        impl<T> KaniIntoIter for Iter<'_, T> {
+            type Item = T;
+            fn kani_into_iter(self) -> KaniIter<Self::Item> {
+                KaniIter::new(self.as_slice().as_ptr(), self.len())
+            }
+        }
+    };
+}

--- a/library/kani_core/src/lib.rs
+++ b/library/kani_core/src/lib.rs
@@ -23,6 +23,7 @@
 mod arbitrary;
 mod bounded_arbitrary;
 mod float;
+mod iter;
 mod mem;
 mod mem_init;
 mod models;
@@ -49,6 +50,7 @@ macro_rules! kani_lib {
             kani_core::generate_arbitrary!();
             kani_core::generate_bounded_arbitrary!();
             kani_core::generate_models!();
+            kani_core::generate_iter!();
 
             pub mod float {
                 kani_core::generate_float!(core);
@@ -72,6 +74,7 @@ macro_rules! kani_lib {
         kani_core::generate_arbitrary!();
         kani_core::generate_bounded_arbitrary!();
         kani_core::generate_models!();
+        kani_core::generate_iter!();
 
         pub mod float {
             //! This module contains functions useful for float-related checks

--- a/library/kani_core/src/mem.rs
+++ b/library/kani_core/src/mem.rs
@@ -226,7 +226,7 @@ macro_rules! kani_mem {
         /// Otherwise, it returns non-det boolean.
         #[kanitool::fn_marker = "IsAllocatedHook"]
         #[inline(never)]
-        unsafe fn is_allocated(_ptr: *const (), _size: usize) -> bool {
+        pub unsafe fn is_allocated(_ptr: *const (), _size: usize) -> bool {
             kani_intrinsic()
         }
 

--- a/library/kani_macros/src/sysroot/loop_contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/loop_contracts/mod.rs
@@ -4,14 +4,13 @@
 //! Implementation of the loop contracts code generation.
 //!
 
-use proc_macro::{Span, TokenStream};
+use proc_macro::TokenStream;
 use proc_macro_error2::abort_call_site;
 use quote::{format_ident, quote};
 use syn::spanned::Spanned;
 use syn::token::AndAnd;
 use syn::{
-    BinOp, Block, Expr, ExprBinary, ExprForLoop, ExprLoop, Ident, Pat, Stmt, parse_quote,
-    visit_mut::VisitMut,
+    BinOp, Block, Expr, ExprBinary, ExprForLoop, Ident, Stmt, parse_quote, visit_mut::VisitMut,
 };
 
 /*
@@ -227,25 +226,29 @@ fn transform_break_continue(block: &mut Block) {
     block.stmts.push(return_stmt);
 }
 
-pub fn transform_for_to_loop(for_loop: ExprForLoop) -> (Stmt, Option<Stmt>, Option<Stmt>) {
+pub fn transform_for_to_loop(
+    for_loop: ExprForLoop,
+    loop_id: &String,
+) -> (Stmt, Option<Stmt>, Option<Stmt>, Option<Stmt>, Option<Stmt>) {
     // Extract components from the for loop
     let pat = *for_loop.pat;
     let expr = for_loop.expr;
     let body = for_loop.body;
-    let attrs = for_loop.attrs;
 
     // Create an iterator variable name
-    let itername = "kaniiter_iter".to_owned();
+    let itername = "kaniiter".to_owned();
     let iter_ident = format_ident!("{}", itername);
 
-    let ptrname = "kaniiter_ptr".to_owned();
+    let mut ptrname = "kaniiter_ptr".to_owned();
+    ptrname.push_str(&loop_id);
     let ptr_ident = format_ident!("{}", ptrname);
 
-    let lenname = "kaniiter_len".to_owned();
+    let mut lenname = "kaniiter_len".to_owned();
+    lenname.push_str(&loop_id);
     let len_ident = format_ident!("{}", lenname);
 
     // Create initialization statement for the iterator
-    let init_stmt: Stmt = parse_quote! {
+    let init_ptr_stmt: Stmt = parse_quote! {
         let (#ptr_ident, #len_ident) = kani::KaniIntoIter::kani_into_iter(#expr);
     };
 
@@ -253,33 +256,30 @@ pub fn transform_for_to_loop(for_loop: ExprForLoop) -> (Stmt, Option<Stmt>, Opti
         let mut #iter_ident = 0;
     };
 
+    let init_pat_stmt: Stmt = parse_quote! {
+        let mut #pat = unsafe {*#ptr_ident};
+        //let mut #pat = 0;
+    };
+
     // Create the new loop body with iterator advancement
     let mut new_body_stmts = Vec::new();
 
-    // Add the pattern binding using next()
-    //let nextoptionname = "__nextoption".to_owned();
-    //let nextoption_ident = format_ident!("{}", nextoptionname);
-    let next_stmt: Stmt = parse_quote! {
+    let alloc_assume_stmt: Stmt = parse_quote! {
+        kani::assume(unsafe{kani::mem::is_allocated(#ptr_ident as *const (), #len_ident)});
+    };
+
+    // Increase the iter
+    let increase_iter_stmt: Stmt = parse_quote! {
         #iter_ident = #iter_ident + 1;
     };
 
-    //let check_stmt: Stmt = parse_quote! {
-    //    if #nextoption_ident.is_none() { break; };
-    //};
-
-    let next_ident = match pat {
-        Pat::Ident(ref patident) => patident.ident.clone(),
-        _ => abort_call_site!("Unsupported pattern in for loop"),
+    let pat_assign_stmt: Stmt = parse_quote! {
+        #pat = unsafe {*#ptr_ident.wrapping_add(#iter_ident)};
     };
 
-    let pat_assign: Stmt = parse_quote! {
-        let #pat = unsafe {*#ptr_ident.wrapping_add(#iter_ident)};
-    };
-
-    new_body_stmts.push(pat_assign);
-    new_body_stmts.push(next_stmt);
-    //new_body_stmts.push(check_stmt);
-    //new_body_stmts.push(next_unwrap_stmt);
+    new_body_stmts.push(alloc_assume_stmt.clone());
+    new_body_stmts.push(pat_assign_stmt);
+    new_body_stmts.push(increase_iter_stmt);
 
     // Add the original loop body statements
     new_body_stmts.extend(body.stmts.iter().cloned());
@@ -290,18 +290,21 @@ pub fn transform_for_to_loop(for_loop: ExprForLoop) -> (Stmt, Option<Stmt>, Opti
                 #(#new_body_stmts)*
             }
     };
-    (loop_loop, Some(init_stmt), Some(init_iter_stmt))
+    (loop_loop, Some(init_ptr_stmt), Some(init_iter_stmt), Some(init_pat_stmt), Some(alloc_assume_stmt))
 }
 
 pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
     // parse the stmt of the loop
     let mut loop_stmt: Stmt = syn::parse(item.clone()).unwrap();
     let loop_id = generate_unique_id_from_span(&loop_stmt);
-    let mut initstmt: Option<Stmt> = None;
-    let mut init_iter_stmto: Option<Stmt> = None;
+    let mut init_ptr_stmt: Option<Stmt> = None;
+    let mut init_iter_stmt: Option<Stmt> = None;
+    let mut init_pat_stmt: Option<Stmt> = None;
+    let mut alloc_assume_stmt: Option<Stmt> = None;
     if let Stmt::Expr(ref e, _) = loop_stmt {
         if let Expr::ForLoop(for_loop) = e {
-            (loop_stmt, initstmt, init_iter_stmto) = transform_for_to_loop(for_loop.clone());
+            (loop_stmt, init_ptr_stmt, init_iter_stmt, init_pat_stmt, alloc_assume_stmt) =
+                transform_for_to_loop(for_loop.clone(), &loop_id);
         }
     }
 
@@ -400,7 +403,7 @@ pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
             note = "for now, loop contracts is only supported for while-loops.";
         ),
     }
-    let ret: TokenStream = if initstmt.is_none() {
+    let ret: TokenStream = if init_ptr_stmt.is_none() {
         if has_prev {
             quote!(
             {
@@ -447,15 +450,19 @@ pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
             .into()
         }
     } else {
-        let inititer = initstmt.unwrap();
-        let init_iter_stmt = init_iter_stmto.unwrap();
+        let init_ptr_stmt = init_ptr_stmt.unwrap();
+        let init_iter_stmt = init_iter_stmt.unwrap();
+        let init_pat_stmt = init_pat_stmt.unwrap();
+        let alloc_assume_stmt = alloc_assume_stmt.unwrap();
         if has_prev {
             quote!(
             {
             #(#onentry_decl_stms)*
             #(#prev_decl_stms)*
             #init_iter_stmt
-            #inititer
+            #init_ptr_stmt
+            #alloc_assume_stmt
+            #init_pat_stmt
             let mut #loop_body_closure = ||
             #loop_body;
             let (#loop_body_closure_ret_1, #loop_body_closure_ret_2) = #loop_body_closure ();
@@ -491,7 +498,9 @@ pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
                 true
             }
             #init_iter_stmt
-            #inititer
+            #init_ptr_stmt
+            #alloc_assume_stmt
+            #init_pat_stmt
             #loop_stmt
             })
             .into()

--- a/library/kani_macros/src/sysroot/loop_contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/loop_contracts/mod.rs
@@ -290,7 +290,13 @@ pub fn transform_for_to_loop(
                 #(#new_body_stmts)*
             }
     };
-    (loop_loop, Some(init_ptr_stmt), Some(init_iter_stmt), Some(init_pat_stmt), Some(alloc_assume_stmt))
+    (
+        loop_loop,
+        Some(init_ptr_stmt),
+        Some(init_iter_stmt),
+        Some(init_pat_stmt),
+        Some(alloc_assume_stmt),
+    )
 }
 
 pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -506,7 +512,6 @@ pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
             .into()
         }
     };
-    println!("{}", ret.to_string());
     ret
 }
 

--- a/library/kani_macros/src/sysroot/loop_contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/loop_contracts/mod.rs
@@ -4,12 +4,15 @@
 //! Implementation of the loop contracts code generation.
 //!
 
-use proc_macro::TokenStream;
+use proc_macro::{Span, TokenStream};
 use proc_macro_error2::abort_call_site;
 use quote::{format_ident, quote};
 use syn::spanned::Spanned;
 use syn::token::AndAnd;
-use syn::{BinOp, Block, Expr, ExprBinary, Ident, Stmt, parse_quote, visit_mut::VisitMut};
+use syn::{
+    BinOp, Block, Expr, ExprBinary, ExprForLoop, ExprLoop, Ident, Pat, Stmt, parse_quote,
+    visit_mut::VisitMut,
+};
 
 /*
     Transform the loop to support on_entry(expr) : the value of expr before entering the loop
@@ -224,14 +227,75 @@ fn transform_break_continue(block: &mut Block) {
     block.stmts.push(return_stmt);
 }
 
+pub fn transform_for_to_loop(for_loop: ExprForLoop) -> (Stmt, Option<Stmt>) {
+    // Extract components from the for loop
+    let pat = *for_loop.pat;
+    let expr = for_loop.expr;
+    let body = for_loop.body;
+    let attrs = for_loop.attrs;
+
+    // Create an iterator variable name
+    let itername = "kaniiter".to_owned();
+    let iter_ident = format_ident!("{}", itername);
+
+    // Create initialization statement for the iterator
+    let init_stmt: Stmt = parse_quote! {
+        let mut #iter_ident = kani::KaniIntoIter::kani_into_iter(#expr);
+    };
+
+    // Create the new loop body with iterator advancement
+    let mut new_body_stmts = Vec::new();
+
+    // Add the pattern binding using next()
+    let nextoptionname = "__nextoption".to_owned();
+    let nextoption_ident = format_ident!("{}", nextoptionname);
+    let next_stmt: Stmt = parse_quote! {
+        let #nextoption_ident = #iter_ident.next();
+    };
+
+    let check_stmt: Stmt = parse_quote! {
+        if #nextoption_ident.is_none() { break; };
+    };
+
+    let next_ident = match pat {
+        Pat::Ident(ref patident) => patident.ident.clone(),
+        _ => abort_call_site!("Unsupported pattern in for loop"),
+    };
+
+    let next_unwrap_stmt: Stmt = parse_quote! {
+        let #pat = #nextoption_ident.unwrap();
+    };
+
+    new_body_stmts.push(next_stmt);
+    new_body_stmts.push(check_stmt);
+    new_body_stmts.push(next_unwrap_stmt);
+
+    // Add the original loop body statements
+    new_body_stmts.extend(body.stmts.iter().cloned());
+
+    // Create the final expression with the iterator initialization
+    let loop_loop: Stmt = parse_quote! {
+            loop{
+                #(#new_body_stmts)*
+            }
+    };
+    (loop_loop, Some(init_stmt))
+}
+
 pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
     // parse the stmt of the loop
     let mut loop_stmt: Stmt = syn::parse(item.clone()).unwrap();
+    let loop_id = generate_unique_id_from_span(&loop_stmt);
+    let mut initstmt: Option<Stmt> = None;
+    if let Stmt::Expr(ref e, _) = loop_stmt {
+        if let Expr::ForLoop(for_loop) = e {
+            (loop_stmt, initstmt) = transform_for_to_loop(for_loop.clone());
+        }
+    }
 
     // name of the loop invariant as closure of the form
     // __kani_loop_invariant_#startline_#startcol_#endline_#endcol
     let mut inv_name: String = "__kani_loop_invariant".to_owned();
-    let loop_id = generate_unique_id_from_span(&loop_stmt);
     inv_name.push_str(&loop_id);
 
     // expr of the loop invariant
@@ -324,52 +388,102 @@ pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
             note = "for now, loop contracts is only supported for while-loops.";
         ),
     }
-
-    if has_prev {
-        quote!(
-        {
-        if (#loop_guard) {
-        #(#onentry_decl_stms)*
-        #(#prev_decl_stms)*
-        let mut #loop_body_closure = ||
-        #loop_body;
-        let (#loop_body_closure_ret_1, #loop_body_closure_ret_2) = #loop_body_closure ();
-        if #loop_body_closure_ret_2.is_some() {
-            return #loop_body_closure_ret_2.unwrap();
-        }
-        if #loop_body_closure_ret_1 {
-        // Dummy function used to force the compiler to capture the environment.
-        // We cannot call closures inside constant functions.
-        // This function gets replaced by `kani::internal::call_closure`.
+    let ret: TokenStream = if initstmt.is_none() {
+        if has_prev {
+            quote!(
+            {
+            if (#loop_guard) {
+            #(#onentry_decl_stms)*
+            #(#prev_decl_stms)*
+            let mut #loop_body_closure = ||
+            #loop_body;
+            let (#loop_body_closure_ret_1, #loop_body_closure_ret_2) = #loop_body_closure ();
+            if #loop_body_closure_ret_2.is_some() {
+                return #loop_body_closure_ret_2.unwrap();
+            }
+            if #loop_body_closure_ret_1 {
+            // Dummy function used to force the compiler to capture the environment.
+            // We cannot call closures inside constant functions.
+            // This function gets replaced by `kani::internal::call_closure`.
+                #[inline(never)]
+                #[kanitool::fn_marker = "kani_register_loop_contract"]
+                const fn #register_ident<F: Fn() -> bool>(_f: &F, _transformed: usize) -> bool {
+                    true
+                }
+                #loop_stmt
+            }
+            else {
+                assert!(#inv_expr);
+            };
+            }
+            })
+            .into()
+        } else {
+            quote!(
+            {
+            #(#onentry_decl_stms)*
+            // Dummy function used to force the compiler to capture the environment.
+            // We cannot call closures inside constant functions.
+            // This function gets replaced by `kani::internal::call_closure`.
             #[inline(never)]
             #[kanitool::fn_marker = "kani_register_loop_contract"]
             const fn #register_ident<F: Fn() -> bool>(_f: &F, _transformed: usize) -> bool {
                 true
             }
             #loop_stmt
+            })
+            .into()
         }
-        else {
-            assert!(#inv_expr);
-        };
-        }
-        })
-        .into()
     } else {
-        quote!(
-        {
-        #(#onentry_decl_stms)*
-        // Dummy function used to force the compiler to capture the environment.
-        // We cannot call closures inside constant functions.
-        // This function gets replaced by `kani::internal::call_closure`.
-        #[inline(never)]
-        #[kanitool::fn_marker = "kani_register_loop_contract"]
-        const fn #register_ident<F: Fn() -> bool>(_f: &F, _transformed: usize) -> bool {
-            true
+        let inititer = initstmt.unwrap();
+        if has_prev {
+            quote!(
+            {
+            #(#onentry_decl_stms)*
+            #(#prev_decl_stms)*
+            #inititer
+            let mut #loop_body_closure = ||
+            #loop_body;
+            let (#loop_body_closure_ret_1, #loop_body_closure_ret_2) = #loop_body_closure ();
+            if #loop_body_closure_ret_2.is_some() {
+                return #loop_body_closure_ret_2.unwrap();
+            }
+            if #loop_body_closure_ret_1 {
+            // Dummy function used to force the compiler to capture the environment.
+            // We cannot call closures inside constant functions.
+            // This function gets replaced by `kani::internal::call_closure`.
+                #[inline(never)]
+                #[kanitool::fn_marker = "kani_register_loop_contract"]
+                const fn #register_ident<F: Fn() -> bool>(_f: &F, _transformed: usize) -> bool {
+                    true
+                }
+                #loop_stmt
+            }
+            else {
+                assert!(#inv_expr);
+            };
+            })
+            .into()
+        } else {
+            quote!(
+            {
+            #(#onentry_decl_stms)*
+            // Dummy function used to force the compiler to capture the environment.
+            // We cannot call closures inside constant functions.
+            // This function gets replaced by `kani::internal::call_closure`.
+            #[inline(never)]
+            #[kanitool::fn_marker = "kani_register_loop_contract"]
+            const fn #register_ident<F: Fn() -> bool>(_f: &F, _transformed: usize) -> bool {
+                true
+            }
+            #inititer
+            #loop_stmt
+            })
+            .into()
         }
-        #loop_stmt
-        })
-        .into()
-    }
+    };
+    println!("{}", ret.to_string());
+    ret
 }
 
 fn generate_unique_id_from_span(stmt: &Stmt) -> String {

--- a/library/kani_macros/src/sysroot/loop_contracts/mod.rs
+++ b/library/kani_macros/src/sysroot/loop_contracts/mod.rs
@@ -227,7 +227,7 @@ fn transform_break_continue(block: &mut Block) {
     block.stmts.push(return_stmt);
 }
 
-pub fn transform_for_to_loop(for_loop: ExprForLoop) -> (Stmt, Option<Stmt>) {
+pub fn transform_for_to_loop(for_loop: ExprForLoop) -> (Stmt, Option<Stmt>, Option<Stmt>) {
     // Extract components from the for loop
     let pat = *for_loop.pat;
     let expr = for_loop.expr;
@@ -235,51 +235,62 @@ pub fn transform_for_to_loop(for_loop: ExprForLoop) -> (Stmt, Option<Stmt>) {
     let attrs = for_loop.attrs;
 
     // Create an iterator variable name
-    let itername = "kaniiter".to_owned();
+    let itername = "kaniiter_iter".to_owned();
     let iter_ident = format_ident!("{}", itername);
+
+    let ptrname = "kaniiter_ptr".to_owned();
+    let ptr_ident = format_ident!("{}", ptrname);
+
+    let lenname = "kaniiter_len".to_owned();
+    let len_ident = format_ident!("{}", lenname);
 
     // Create initialization statement for the iterator
     let init_stmt: Stmt = parse_quote! {
-        let mut #iter_ident = kani::KaniIntoIter::kani_into_iter(#expr);
+        let (#ptr_ident, #len_ident) = kani::KaniIntoIter::kani_into_iter(#expr);
+    };
+
+    let init_iter_stmt: Stmt = parse_quote! {
+        let mut #iter_ident = 0;
     };
 
     // Create the new loop body with iterator advancement
     let mut new_body_stmts = Vec::new();
 
     // Add the pattern binding using next()
-    let nextoptionname = "__nextoption".to_owned();
-    let nextoption_ident = format_ident!("{}", nextoptionname);
+    //let nextoptionname = "__nextoption".to_owned();
+    //let nextoption_ident = format_ident!("{}", nextoptionname);
     let next_stmt: Stmt = parse_quote! {
-        let #nextoption_ident = #iter_ident.next();
+        #iter_ident = #iter_ident + 1;
     };
 
-    let check_stmt: Stmt = parse_quote! {
-        if #nextoption_ident.is_none() { break; };
-    };
+    //let check_stmt: Stmt = parse_quote! {
+    //    if #nextoption_ident.is_none() { break; };
+    //};
 
     let next_ident = match pat {
         Pat::Ident(ref patident) => patident.ident.clone(),
         _ => abort_call_site!("Unsupported pattern in for loop"),
     };
 
-    let next_unwrap_stmt: Stmt = parse_quote! {
-        let #pat = #nextoption_ident.unwrap();
+    let pat_assign: Stmt = parse_quote! {
+        let #pat = unsafe {*#ptr_ident.wrapping_add(#iter_ident)};
     };
 
+    new_body_stmts.push(pat_assign);
     new_body_stmts.push(next_stmt);
-    new_body_stmts.push(check_stmt);
-    new_body_stmts.push(next_unwrap_stmt);
+    //new_body_stmts.push(check_stmt);
+    //new_body_stmts.push(next_unwrap_stmt);
 
     // Add the original loop body statements
     new_body_stmts.extend(body.stmts.iter().cloned());
 
     // Create the final expression with the iterator initialization
     let loop_loop: Stmt = parse_quote! {
-            loop{
+            while (#iter_ident < #len_ident) {
                 #(#new_body_stmts)*
             }
     };
-    (loop_loop, Some(init_stmt))
+    (loop_loop, Some(init_stmt), Some(init_iter_stmt))
 }
 
 pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -287,9 +298,10 @@ pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut loop_stmt: Stmt = syn::parse(item.clone()).unwrap();
     let loop_id = generate_unique_id_from_span(&loop_stmt);
     let mut initstmt: Option<Stmt> = None;
+    let mut init_iter_stmto: Option<Stmt> = None;
     if let Stmt::Expr(ref e, _) = loop_stmt {
         if let Expr::ForLoop(for_loop) = e {
-            (loop_stmt, initstmt) = transform_for_to_loop(for_loop.clone());
+            (loop_stmt, initstmt, init_iter_stmto) = transform_for_to_loop(for_loop.clone());
         }
     }
 
@@ -436,11 +448,13 @@ pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     } else {
         let inititer = initstmt.unwrap();
+        let init_iter_stmt = init_iter_stmto.unwrap();
         if has_prev {
             quote!(
             {
             #(#onentry_decl_stms)*
             #(#prev_decl_stms)*
+            #init_iter_stmt
             #inititer
             let mut #loop_body_closure = ||
             #loop_body;
@@ -476,6 +490,7 @@ pub fn loop_invariant(attr: TokenStream, item: TokenStream) -> TokenStream {
             const fn #register_ident<F: Fn() -> bool>(_f: &F, _transformed: usize) -> bool {
                 true
             }
+            #init_iter_stmt
             #inititer
             #loop_stmt
             })

--- a/tests/expected/loop-contract/for_loop_with_quantifier.expected
+++ b/tests/expected/loop-contract/for_loop_with_quantifier.expected
@@ -1,0 +1,15 @@
+forloop::{closure#1}.assertion.1\
+         - Status: SUCCESS\
+         - Description: "attempt to multiply with overflow"
+
+
+forloop.loop_invariant_step.1\
+         - Status: SUCCESS\
+         - Description: "Check invariant after step for loop forloop.0"
+
+
+forloop.assertion.3\
+	 - Status: SUCCESS\
+	 - Description: "assertion failed: sum <= 100"
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/loop-contract/for_loop_with_quantifier.rs
+++ b/tests/expected/loop-contract/for_loop_with_quantifier.rs
@@ -1,0 +1,22 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags: -Z loop-contracts -Z mem-predicates
+
+//! Check if for-loop invariant is correctly applied.
+
+#![feature(proc_macro_hygiene)]
+#![feature(stmt_expr_attributes)]
+
+#[kani::proof]
+fn forloop() {
+    let mut sum: u32 = 0;
+    let a: [u8; 10] = kani::any();
+    kani::assume(kani::forall!(|i in (0,10)| a[i] <= 10));
+
+    #[kani::loop_invariant( kaniiter <= 10 && sum <= (kaniiter as u32 * 10) )]
+    for j in a.iter() {
+        sum = sum + (j as u32);
+    }
+    assert!(sum <= 100);
+}

--- a/tests/expected/loop-contract/simple_for_loop.expected
+++ b/tests/expected/loop-contract/simple_for_loop.expected
@@ -1,0 +1,13 @@
+forloop::{closure#0}.assertion.1\
+         - Status: SUCCESS\
+         - Description: "attempt to multiply with overflow"
+
+forloop.loop_invariant_step.2\
+         - Status: SUCCESS\
+         - Description: "Check invariant after step for loop forloop.0"
+
+forloop.assertion.3\
+         - Status: SUCCESS\
+         - Description: "assertion failed: sum <= 2550"
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/loop-contract/simple_for_loop.rs
+++ b/tests/expected/loop-contract/simple_for_loop.rs
@@ -1,0 +1,20 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags: -Z loop-contracts -Z mem-predicates
+
+//! Check if for-loop invariant is correctly applied.
+
+#![feature(proc_macro_hygiene)]
+#![feature(stmt_expr_attributes)]
+
+#[kani::proof]
+fn forloop() {
+    let mut sum: u32 = 0;
+    let a: [u8; 10] = kani::any();
+    #[kani::loop_invariant( kaniiter <= 10 && sum <= (kaniiter as u32 * u8::MAX as u32) )]
+    for j in a {
+        sum = sum + (j as u32);
+    }
+    assert!(sum <= 2550);
+}


### PR DESCRIPTION
This PR adds loop-contracts support for `for` loop for 4 types: array, slice, Iter, and Vec.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
