### PR TITLE
Bump Kani Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## [0.63.0]
 
+### Breaking Changes
+* Finish deprecating `--enable-unstable`, `--restrict-vtable`, and `--write-json-symtab` by @carolynzech in https://github.com/model-checking/kani/pull/4110
+
 ### Major Changes
 * Add support for quantifiers by @qinheping in https://github.com/model-checking/kani/pull/3993
 
@@ -21,7 +24,6 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Update `kani::mem` pointer validity documentation by @carolynzech in https://github.com/model-checking/kani/pull/4092
 * Add support for edition 2018 crates using assert! (Fixes #3717) by @sintemal in https://github.com/model-checking/kani/pull/4096
 * Handle generic defaults in BoundedArbitrary derives by @zhassan-aws in https://github.com/model-checking/kani/pull/4117
-* Finish deprecating `--enable-unstable`, `--restrict-vtable`, and `--write-json-symtab` by @carolynzech in https://github.com/model-checking/kani/pull/4110
 * `ty_mangled_name`: only use non-mangled name if `-Zcffi` is enabled. by @carolynzech in https://github.com/model-checking/kani/pull/4114
 * Improve Help Menu by @carolynzech in https://github.com/model-checking/kani/pull/4109
 * Start stabilizing `--jobs` and `list`; deprecate default memory checks by @carolynzech in https://github.com/model-checking/kani/pull/4108

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Set target features depending on the target architecture by @zhassan-aws in https://github.com/model-checking/kani/pull/4127
 * Improve linking error output for `#[no_std]` crates by @AlexanderPortland in https://github.com/model-checking/kani/pull/4126
 * Gate quantifiers behind an experimental feature by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4141
+* Autoharness: change `pattern` options to accept regexes by @carolynzech in https://github.com/model-checking/kani/pull/4144
 * Rust toolchain upgraded to 2025-06-03 by @carolynzech @thanhnguyen-aws @zhassan-aws
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.62.0...kani-0.63.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,25 +13,29 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Add support for quantifiers by @qinheping in https://github.com/model-checking/kani/pull/3993
 
 ### What's Changed
-* Enable target features: x87 and sse2 by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4062
-* Fix the bug: Loop contracts are not composable with function contracts by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3979
-* Autoharness argument validation: only error on `--quiet` if `--list` was passed by @carolynzech in https://github.com/model-checking/kani/pull/4069
-* Add setup scripts for Ubuntu 20.04 by @zhassan-aws in https://github.com/model-checking/kani/pull/4082
-* Fix the error that Kani panics when there is no external parameter in quantifier's closure. by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4088
-* Use our toolchain when invoking `cargo metadata` by @carolynzech in https://github.com/model-checking/kani/pull/4090
-* Fix a bug codegening `SwitchInt`s with only an otherwise branch by @bkirwi in https://github.com/model-checking/kani/pull/4095
-* Update `kani::mem` pointer validity documentation by @carolynzech in https://github.com/model-checking/kani/pull/4092
-* Add support for edition 2018 crates using assert! (Fixes #3717) by @sintemal in https://github.com/model-checking/kani/pull/4096
-* Handle generic defaults in BoundedArbitrary derives by @zhassan-aws in https://github.com/model-checking/kani/pull/4117
-* `ty_mangled_name`: only use non-mangled name if `-Zcffi` is enabled. by @carolynzech in https://github.com/model-checking/kani/pull/4114
-* Improve Help Menu by @carolynzech in https://github.com/model-checking/kani/pull/4109
-* Start stabilizing `--jobs` and `list`; deprecate default memory checks by @carolynzech in https://github.com/model-checking/kani/pull/4108
-* Refactor simd_bitmask to reduce the number of iterations by @zhassan-aws in https://github.com/model-checking/kani/pull/4129
-* Set target features depending on the target architecture by @zhassan-aws in https://github.com/model-checking/kani/pull/4127
-* Improve linking error output for `#[no_std]` crates by @AlexanderPortland in https://github.com/model-checking/kani/pull/4126
-* Gate quantifiers behind an experimental feature by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4141
-* Autoharness: change `pattern` options to accept regexes by @carolynzech in https://github.com/model-checking/kani/pull/4144
-* Rust toolchain upgraded to 2025-06-03 by @carolynzech @thanhnguyen-aws @zhassan-aws
+* Improvements to autoharness feature:
+  * Autoharness argument validation: only error on `--quiet` if `--list` was passed by @carolynzech in https://github.com/model-checking/kani/pull/4069
+  * Autoharness: change `pattern` options to accept regexes by @carolynzech in https://github.com/model-checking/kani/pull/4144
+* Target feature changes:
+  * Enable target features: x87 and sse2 by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4062
+  * Set target features depending on the target architecture by @zhassan-aws in https://github.com/model-checking/kani/pull/4127
+* Support for quantifiers:
+  * Fix the error that Kani panics when there is no external parameter in quantifier's closure. by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4088
+  * Gate quantifiers behind an experimental feature by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4141
+* Other:
+  * Fix the bug: Loop contracts are not composable with function contracts by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3979
+  * Add setup scripts for Ubuntu 20.04 by @zhassan-aws in https://github.com/model-checking/kani/pull/4082
+  * Use our toolchain when invoking `cargo metadata` by @carolynzech in https://github.com/model-checking/kani/pull/4090
+  * Fix a bug codegening `SwitchInt`s with only an otherwise branch by @bkirwi in https://github.com/model-checking/kani/pull/4095
+  * Update `kani::mem` pointer validity documentation by @carolynzech in https://github.com/model-checking/kani/pull/4092
+  * Add support for edition 2018 crates using assert! (Fixes #3717) by @sintemal in https://github.com/model-checking/kani/pull/4096
+  * Handle generic defaults in BoundedArbitrary derives by @zhassan-aws in https://github.com/model-checking/kani/pull/4117
+  * `ty_mangled_name`: only use non-mangled name if `-Zcffi` is enabled. by @carolynzech in https://github.com/model-checking/kani/pull/4114
+  * Improve Help Menu by @carolynzech in https://github.com/model-checking/kani/pull/4109
+  * Start stabilizing `--jobs` and `list`; deprecate default memory checks by @carolynzech in https://github.com/model-checking/kani/pull/4108
+  * Refactor simd_bitmask to reduce the number of iterations by @zhassan-aws in https://github.com/model-checking/kani/pull/4129
+  * Improve linking error output for `#[no_std]` crates by @AlexanderPortland in https://github.com/model-checking/kani/pull/4126
+  * Rust toolchain upgraded to 2025-06-03 by @carolynzech @thanhnguyen-aws @zhassan-aws
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.62.0...kani-0.63.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.63.0]
+
+### Major Changes
+* Add support for quantifiers by @qinheping in https://github.com/model-checking/kani/pull/3993
+
+### What's Changed
+* Enable target features: x87 and sse2 by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4062
+* Fix the bug: Loop contracts are not composable with function contracts  by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3979
+* Fix stabilization instructions in RFC intro by @carolynzech in https://github.com/model-checking/kani/pull/4067
+* Autoharness argument validation: only error on `--quiet` if `--list` was passed by @carolynzech in https://github.com/model-checking/kani/pull/4069
+* Add setup scripts for Ubuntu 20.04 by @zhassan-aws in https://github.com/model-checking/kani/pull/4082
+* Fix the error that Kani panics when there is no external parameter in quantifier's closure. by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4088
+* Use our toolchain when invoking `cargo metadata` by @carolynzech in https://github.com/model-checking/kani/pull/4090
+* Fix a bug codegening `SwitchInt`s with only an otherwise branch by @bkirwi in https://github.com/model-checking/kani/pull/4095
+* Update `kani::mem` pointer validity documentation by @carolynzech in https://github.com/model-checking/kani/pull/4092
+* Add support for edition 2018 crates using assert! (Fixes #3717) by @sintemal in https://github.com/model-checking/kani/pull/4096
+* Handle generic defaults in BoundedArbitrary derives by @zhassan-aws in https://github.com/model-checking/kani/pull/4117
+* Finish deprecating `--enable-unstable`, `--restrict-vtable`, and `--write-json-symtab` by @carolynzech in https://github.com/model-checking/kani/pull/4110
+* `ty_mangled_name`: only use non-mangled name if `-Zcffi` is enabled. by @carolynzech in https://github.com/model-checking/kani/pull/4114
+* Improve Help Menu by @carolynzech in https://github.com/model-checking/kani/pull/4109
+* Start stabilizing `--jobs` and `list`; deprecate default memory checks by @carolynzech in https://github.com/model-checking/kani/pull/4108
+* Refactor simd_bitmask to reduce the number of iterations by @zhassan-aws in https://github.com/model-checking/kani/pull/4129
+* Set target features depending on the target architecture by @zhassan-aws in https://github.com/model-checking/kani/pull/4127
+* Improve linking error output for `#[no_std]` crates by @AlexanderPortland in https://github.com/model-checking/kani/pull/4126
+* Gate quantifiers behind an experimental feature by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4141
+* Rust toolchain upgraded to 2025-06-03 by @carolynzech @thanhnguyen-aws @zhassan-aws
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.62.0...kani-0.63.0
+
 ## [0.62.0]
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 ### What's Changed
 * Enable target features: x87 and sse2 by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4062
 * Fix the bug: Loop contracts are not composable with function contracts by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3979
-* Fix stabilization instructions in RFC intro by @carolynzech in https://github.com/model-checking/kani/pull/4067
 * Autoharness argument validation: only error on `--quiet` if `--list` was passed by @carolynzech in https://github.com/model-checking/kani/pull/4069
 * Add setup scripts for Ubuntu 20.04 by @zhassan-aws in https://github.com/model-checking/kani/pull/4082
 * Fix the error that Kani panics when there is no external parameter in quantifier's closure. by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4088

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ### What's Changed
 * Enable target features: x87 and sse2 by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4062
-* Fix the bug: Loop contracts are not composable with function contracts  by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3979
+* Fix the bug: Loop contracts are not composable with function contracts by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3979
 * Fix stabilization instructions in RFC intro by @carolynzech in https://github.com/model-checking/kani/pull/4067
 * Autoharness argument validation: only error on `--quiet` if `--list` was passed by @carolynzech in https://github.com/model-checking/kani/pull/4069
 * Add setup scripts for Ubuntu 20.04 by @zhassan-aws in https://github.com/model-checking/kani/pull/4082

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "cprover_bindings"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -973,7 +973,7 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "kani"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "kani_core",
  "kani_macros",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "kani-compiler"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "charon",
  "clap",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "anyhow",
  "home",
@@ -1055,14 +1055,14 @@ dependencies = [
 
 [[package]]
 name = "kani_core"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani_macros"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "std"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_core/Cargo.toml
+++ b/library/kani_core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_core"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
These are the automatically-generated release notes:
```
## What's Changed
* Toolchain upgrade to nightly-2025-05-04 by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4059
* Automatic toolchain upgrade to nightly-2025-05-05 by @github-actions in https://github.com/model-checking/kani/pull/4060
* Automatic toolchain upgrade to nightly-2025-05-06 by @github-actions in https://github.com/model-checking/kani/pull/4061
* Enable target features: x87 and sse2 by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4062
* Fix the bug: Loop contracts are not composable with function contracts  by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/3979
* Automatic cargo update to 2025-05-12 by @github-actions in https://github.com/model-checking/kani/pull/4066
* Bump tests/perf/s2n-quic from `6aa9975` to `5f323b7` by @dependabot in https://github.com/model-checking/kani/pull/4068
* Fix stabilization instructions in RFC intro by @carolynzech in https://github.com/model-checking/kani/pull/4067
* Add support for quantifiers by @qinheping in https://github.com/model-checking/kani/pull/3993
* Toolchain upgrade to nightly-2025-05-07 by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4070
* Automatic toolchain upgrade to nightly-2025-05-08 by @github-actions in https://github.com/model-checking/kani/pull/4071
* Automatic toolchain upgrade to nightly-2025-05-09 by @github-actions in https://github.com/model-checking/kani/pull/4072
* Automatic toolchain upgrade to nightly-2025-05-10 by @github-actions in https://github.com/model-checking/kani/pull/4073
* Clippy/Stylistic Fixes by @carolynzech in https://github.com/model-checking/kani/pull/4074
* Upgrade toolchain to 2025-05-14 by @zhassan-aws in https://github.com/model-checking/kani/pull/4076
* Autoharness argument validation: only error on `--quiet` if `--list` was passed by @carolynzech in https://github.com/model-checking/kani/pull/4069
* Upgrade Rust toolchain to 2025-05-16 by @zhassan-aws in https://github.com/model-checking/kani/pull/4080
* Automatic toolchain upgrade to nightly-2025-05-17 by @github-actions in https://github.com/model-checking/kani/pull/4081
* Add setup scripts for Ubuntu 20.04 by @zhassan-aws in https://github.com/model-checking/kani/pull/4082
* Automatic toolchain upgrade to nightly-2025-05-18 by @github-actions in https://github.com/model-checking/kani/pull/4083
* Automatic cargo update to 2025-05-19 by @github-actions in https://github.com/model-checking/kani/pull/4086
* Automatic toolchain upgrade to nightly-2025-05-19 by @github-actions in https://github.com/model-checking/kani/pull/4085
* Automatic toolchain upgrade to nightly-2025-05-20 by @github-actions in https://github.com/model-checking/kani/pull/4091
* Bump tests/perf/s2n-quic from `5f323b7` to `22434aa` by @dependabot in https://github.com/model-checking/kani/pull/4089
* Fix the error that Kani panics when there is no external parameter in quantifier's closure. by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4088
* Update toolchain to 2025-05-22 by @carolynzech in https://github.com/model-checking/kani/pull/4098
* Use our toolchain when invoking `cargo metadata` by @carolynzech in https://github.com/model-checking/kani/pull/4090
* Automatic toolchain upgrade to nightly-2025-05-23 by @github-actions in https://github.com/model-checking/kani/pull/4099
* Automatic toolchain upgrade to nightly-2025-05-24 by @github-actions in https://github.com/model-checking/kani/pull/4101
* Automatic toolchain upgrade to nightly-2025-05-25 by @github-actions in https://github.com/model-checking/kani/pull/4102
* Fix a bug codegening `SwitchInt`s with only an otherwise branch by @bkirwi in https://github.com/model-checking/kani/pull/4095
* Automatic toolchain upgrade to nightly-2025-05-26 by @github-actions in https://github.com/model-checking/kani/pull/4104
* Automatic cargo update to 2025-05-26 by @github-actions in https://github.com/model-checking/kani/pull/4105
* Bump tests/perf/s2n-quic from `22434aa` to `550afb3` by @dependabot in https://github.com/model-checking/kani/pull/4106
* Automatic toolchain upgrade to nightly-2025-05-27 by @github-actions in https://github.com/model-checking/kani/pull/4107
* Update `kani::mem` pointer validity documentation by @carolynzech in https://github.com/model-checking/kani/pull/4092
* Add support for edition 2018 crates using assert! (Fixes #3717) by @sintemal in https://github.com/model-checking/kani/pull/4096
* Automatic toolchain upgrade to nightly-2025-05-28 by @github-actions in https://github.com/model-checking/kani/pull/4113
* Automatic toolchain upgrade to nightly-2025-05-29 by @github-actions in https://github.com/model-checking/kani/pull/4115
* Automatic toolchain upgrade to nightly-2025-05-30 by @github-actions in https://github.com/model-checking/kani/pull/4118
* Handle generic defaults in BoundedArbitrary derives by @zhassan-aws in https://github.com/model-checking/kani/pull/4117
* Automatic cargo update to 2025-06-02 by @github-actions in https://github.com/model-checking/kani/pull/4121
* Bump tests/perf/s2n-quic from `550afb3` to `8f54b57` by @dependabot in https://github.com/model-checking/kani/pull/4122
* Upgrade Rust toolchain to 2025-06-02 by @zhassan-aws in https://github.com/model-checking/kani/pull/4123
* Automatic toolchain upgrade to nightly-2025-06-03 by @github-actions in https://github.com/model-checking/kani/pull/4125
* Finish deprecating `--enable-unstable`, `--restrict-vtable`, and `--write-json-symtab` by @carolynzech in https://github.com/model-checking/kani/pull/4110
* `ty_mangled_name`: only use non-mangled name if `-Zcffi` is enabled. by @carolynzech in https://github.com/model-checking/kani/pull/4114
* Improve Help Menu by @carolynzech in https://github.com/model-checking/kani/pull/4109
* Start stabilizing `--jobs` and `list`; deprecate default memory checks by @carolynzech in https://github.com/model-checking/kani/pull/4108
* Refactor simd_bitmask to reduce the number of iterations by @zhassan-aws in https://github.com/model-checking/kani/pull/4129
* Set target features depending on the target architecture by @zhassan-aws in https://github.com/model-checking/kani/pull/4127
* Bump some versions suggested by cargo-outdated by @zhassan-aws in https://github.com/model-checking/kani/pull/4131
* Improve linking error output for `#[no_std]` crates by @AlexanderPortland in https://github.com/model-checking/kani/pull/4126
* Fix the git log command in the toolchain update script by @zhassan-aws in https://github.com/model-checking/kani/pull/4139
* Gate quantifiers behind an experimental feature by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4141
* Automatic cargo update to 2025-06-09 by @github-actions in https://github.com/model-checking/kani/pull/4145

## New Contributors
* @bkirwi made their first contribution in https://github.com/model-checking/kani/pull/4095
* @sintemal made their first contribution in https://github.com/model-checking/kani/pull/4096
* @AlexanderPortland made their first contribution in https://github.com/model-checking/kani/pull/4126

**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.62.0...kani-0.63.0
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
