### PR TITLE
Major-version update cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,12 +40,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,8 +794,6 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash",
 ]
 
@@ -1525,18 +1517,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
-dependencies = [
- "fixedbitset 0.5.7",
- "hashbrown 0.15.4",
- "indexmap",
- "serde",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,7 +1797,7 @@ version = "0.0.0"
 dependencies = [
  "csv",
  "graph-cycles",
- "petgraph 0.8.2",
+ "petgraph 0.7.1",
  "serde",
  "strum",
  "strum_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,7 +208,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "which",
+ "which 8.0.0",
 ]
 
 [[package]]
@@ -321,7 +327,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-tree 0.4.0 (git+https://github.com/Nadrieril/tracing-tree)",
- "which",
+ "which 7.0.3",
 ]
 
 [[package]]
@@ -771,9 +777,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "graph-cycles"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3092eb8c0a52f9146161afd672f10fbb970daec4fa79d17b26f79f10139cba9e"
+checksum = "27b92c49194cd4f20bad0d9875503c951993f4249c0cfd210a49ed39ef072a0c"
 dependencies = [
  "ahash",
  "petgraph 0.7.1",
@@ -794,6 +800,8 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1132,7 +1140,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "which",
+ "which 8.0.0",
 ]
 
 [[package]]
@@ -1517,6 +1525,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.4",
+ "indexmap",
+ "serde",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,7 +1817,7 @@ version = "0.0.0"
 dependencies = [
  "csv",
  "graph-cycles",
- "petgraph 0.7.1",
+ "petgraph 0.8.2",
  "serde",
  "strum",
  "strum_macros",
@@ -2522,6 +2542,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
+ "env_home",
+ "rustix 1.0.7",
+ "winsafe",
+]
+
+[[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
  "env_home",
  "rustix 1.0.7",
  "winsafe",

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -13,7 +13,7 @@ test = true
 doctest = false
 
 [dependencies]
-lazy_static = "1.4.0"
+lazy_static = "1.5.0"
 num = "0.4.0"
 num-traits = "0.2"
 serde = {version = "1", features = ["derive"]}

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -32,7 +32,7 @@ strum_macros = {version = "0.27.1"}
 tempfile = "3"
 tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-subscriber = {version = "0.3.8", features = ["env-filter", "json", "fmt"]}
-which = "7"
+which = "8"
 time = {version = "0.3.36", features = ["formatting"]}
 tokio = { version = "1.40.0", features = ["io-util", "process", "rt", "time"] }
 chrono = { version = "0.4.41", default-features = false, features = [ "clock" ]}

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -13,4 +13,4 @@ publish = false
 anyhow = "1"
 cargo_metadata = "0.20"
 clap = { version = "4.4.11", features=["derive"] }
-which = "7"
+which = "8"

--- a/tools/scanner/Cargo.toml
+++ b/tools/scanner/Cargo.toml
@@ -15,8 +15,8 @@ csv = "1.3"
 serde = {version = "1", features = ["derive"]}
 strum = "0.27.1"
 strum_macros = "0.27.1"
-petgraph = "0.7.1"
-graph-cycles = "0.2.0"
+petgraph = "0.8.2"
+graph-cycles = "0.3.0"
 
 [package.metadata.rust-analyzer]
 # This crate uses rustc crates.

--- a/tools/scanner/Cargo.toml
+++ b/tools/scanner/Cargo.toml
@@ -15,7 +15,7 @@ csv = "1.3"
 serde = {version = "1", features = ["derive"]}
 strum = "0.27.1"
 strum_macros = "0.27.1"
-petgraph = "0.8.2"
+petgraph = "0.7.1"
 graph-cycles = "0.3.0"
 
 [package.metadata.rust-analyzer]


### PR DESCRIPTION
Updates as suggested by `cargo outdated --workspace`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
