### PR TITLE
Upgrade Rust toolchain to 2025-06-17

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-06-16"
+channel = "nightly-2025-06-17"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Relevant upstream PR:
- https://github.com/rust-lang/rust/pull/141769 (Move metadata object generation for dylibs to the linker code)

Resolves: #4162

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
