### PR TITLE
Handle enums with zero or one variants

### DIFF
--- a/tests/expected/derive-bounded-arbitrary/enum_one_variant.expected
+++ b/tests/expected/derive-bounded-arbitrary/enum_one_variant.expected
@@ -1,0 +1,7 @@
+Checking harness check_enum...
+
+ ** 5 of 5 cover properties satisfied
+
+VERIFICATION:- SUCCESSFUL
+
+Complete - 1 successfully verified harnesses, 0 failures, 1 total.

--- a/tests/expected/derive-bounded-arbitrary/enum_one_variant.rs
+++ b/tests/expected/derive-bounded-arbitrary/enum_one_variant.rs
@@ -1,0 +1,23 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Check that derive BoundedArbitrary macro works on enums with a single variant
+//! See https://github.com/model-checking/kani/issues/4170
+
+#[allow(unused)]
+#[derive(kani::BoundedArbitrary)]
+enum Foo {
+    A(#[bounded] String),
+}
+
+#[kani::proof]
+#[kani::unwind(6)]
+fn check_enum() {
+    let any_enum: Foo = kani::bounded_any::<_, 4>();
+    let Foo::A(s) = any_enum;
+    kani::cover!(s.len() == 0);
+    kani::cover!(s.len() == 1);
+    kani::cover!(s.len() == 2);
+    kani::cover!(s.len() == 3);
+    kani::cover!(s.len() == 4);
+}


### PR DESCRIPTION
Handle enums with zero or one variants when deriving `BoundedArbitrary`.

Resolves #4170

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
