### PR TITLE
Fix the bug that assign clause cannot be inferred for the inner loop of nested loops

### DIFF
--- a/kani-compiler/src/kani_middle/transform/loop_contracts.rs
+++ b/kani-compiler/src/kani_middle/transform/loop_contracts.rs
@@ -17,7 +17,7 @@ use rustc_span::Symbol;
 use stable_mir::mir::mono::Instance;
 use stable_mir::mir::{
     AggregateKind, BasicBlock, BasicBlockIdx, Body, ConstOperand, Operand, Rvalue, Statement,
-    StatementKind, Terminator, TerminatorKind, VarDebugInfoContents,
+    StatementKind, SwitchTargets, Terminator, TerminatorKind, VarDebugInfoContents,
 };
 use stable_mir::ty::{FnDef, GenericArgKind, MirConst, RigidTy, TyKind, UintTy};
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -30,6 +30,42 @@ pub struct LoopContractPass {
     /// The map from original loop head to the new loop latch.
     /// We use this map to redirect all original loop latches to a new single loop latch.
     new_loop_latches: HashMap<usize, usize>,
+}
+
+//Useful for debugging
+#[allow(dead_code)]
+pub fn print_stable_mir_body(body: &Body) {
+    println!("=== MIR Body Start ===");
+    // Print basic blocks
+    for (idx, block) in body.blocks.iter().enumerate() {
+        println!("bb{idx}: {{");
+        // Print statements
+        for stmt in &block.statements {
+            println!(" {stmt:?}");
+        }
+        // Print terminator
+        println!(" {:?}", block.terminator);
+        println!("}}");
+    }
+    println!("=== MIR Body End ===");
+}
+
+//Useful for debugging
+#[allow(dead_code)]
+pub fn print_mutablebody(body: &MutableBody) {
+    println!("=== MIR Body Start ===");
+    // Print basic blocks
+    for (idx, block) in body.blocks().iter().enumerate() {
+        println!("bb{idx}: {{");
+        // Print statements
+        for stmt in &block.statements {
+            println!(" {stmt:?}");
+        }
+        // Print terminator
+        println!(" {:?}", block.terminator);
+        println!("}}");
+    }
+    println!("=== MIR Body End ===");
 }
 
 impl TransformPass for LoopContractPass {
@@ -206,18 +242,20 @@ impl LoopContractPass {
         }
     }
 
+    //Get all loop-positions: (loop_head_id, loop_latch_id) in the body
     fn get_loop_positions(&self, body: &MutableBody, tcx: TyCtxt) -> Vec<(usize, usize)> {
         let mut loop_pos: Vec<(usize, usize)> = Vec::new();
         for (block_idx, _) in body.blocks().iter().enumerate() {
             if self.is_loop_head(body, tcx, block_idx) {
-                let loop_latch_id = self.get_loop_latch_id(body, block_idx);
+                let loop_latch_id = self.get_last_loop_latch_id(body, block_idx);
                 loop_pos.push((block_idx, loop_latch_id));
             }
         }
         loop_pos
     }
 
-    fn get_closest_loop_head(
+    //Get the associated loop-head of a block_id
+    fn get_associated_loop_head(
         &self,
         block_idx: usize,
         loop_positions: &Vec<(usize, usize)>,
@@ -231,52 +269,188 @@ impl LoopContractPass {
         current_loop_head
     }
 
-    fn move_storagelive_to_loophead(
+    //Create a Hashmap for a block_id and its associated loop-head
+    fn get_associated_loop_head_hashmap(
+        &self,
+        body: &MutableBody,
+        tcx: TyCtxt,
+    ) -> HashMap<usize, usize> {
+        let loop_positions = self.get_loop_positions(body, tcx);
+        let mut loop_head_map: HashMap<usize, usize> = HashMap::new();
+        for (block_idx, _) in body.blocks().iter().enumerate() {
+            let loop_head = self.get_associated_loop_head(block_idx, &loop_positions);
+            if let Some(loop_head) = loop_head {
+                loop_head_map.insert(block_idx, loop_head);
+            }
+        }
+        loop_head_map
+    }
+
+    ///In case of nested loop, if a variable is declared and initiated inside a loop body, and assigned inside an inner-loop,
+    ///then CBMC cannot infer the assign clause for the inner-loop after the loop-contract transformation.
+    //Move all variables initiation using assign inside the loop body to the loop-head
+    fn move_storagelive_assign_to_loophead(
         &self,
         body: &mut MutableBody,
-        loop_positions: Vec<(usize, usize)>,
-    ) {
-        let mut move_list: Vec<(usize, usize, usize)> = Vec::new();
+        loop_head_map: &HashMap<usize, usize>,
+    ) -> Vec<usize> {
+        let mut add_assign_list: Vec<(usize, Statement)> = Vec::new();
+        let mut found_local_list: Vec<usize> = Vec::new();
         let localvars = self.get_user_defined_variables(body);
+        let mut blocks_stmts: Vec<(usize, Vec<Statement>)> = Vec::new();
         for (block_idx, block) in body.blocks().iter().enumerate() {
-            for (stmt_idx, stmt) in block.statements.iter().enumerate() {
+            if loop_head_map.get(&block_idx).is_none() {
+                blocks_stmts.push((block_idx, block.statements.clone()));
+                continue;
+            }
+            let closest_loop_head = *loop_head_map.get(&block_idx).unwrap();
+            let stmts_len = block.statements.len();
+            let mut new_stmts: Vec<Statement> = Vec::new();
+            let mut stmt_idx = 0;
+            while stmt_idx < stmts_len {
+                let stmt = block.statements[stmt_idx].clone();
+                if stmt_idx + 1 >= stmts_len {
+                    new_stmts.push(stmt.clone());
+                    break;
+                }
                 match stmt.kind {
-                    StatementKind::StorageLive(x) if localvars.contains(&x) => {
-                        move_list.push((block_idx, stmt_idx, x));
+                    StatementKind::StorageLive(local)
+                        if (localvars.contains(&local) && !found_local_list.contains(&local)) =>
+                    {
+                        let next_stmt = block.statements[stmt_idx + 1].clone();
+                        //Case 1: StorageLive followed by an assign
+                        if matches!(next_stmt.kind.clone(), StatementKind::Assign(lhs,_) if lhs.local == local)
+                        {
+                            found_local_list.push(local);
+                            add_assign_list.push((closest_loop_head, stmt.clone()));
+                            add_assign_list.push((closest_loop_head, next_stmt.clone()));
+                            new_stmts.push(next_stmt.clone());
+                            stmt_idx += 2;
+                            continue;
+                        }
+                        //Case 2: for Clone(): StorageLive followed by an StorageLive of a temp var, an assign ref of the temp var,
+                        //Then an assign of the current local, then a StorageDead of the temp var
+                        if let StatementKind::StorageLive(temp_local) = next_stmt.kind.clone()
+                            && let Some(third_stmt) = block.statements.get(stmt_idx + 2)
+                            && let Some(fourth_stmt) = block.statements.get(stmt_idx + 3)
+                            && let Some(fifth_stmt) = block.statements.get(stmt_idx + 4)
+                            && matches!(third_stmt.kind.clone(), StatementKind::Assign(lhs, _) if lhs.local == temp_local)
+                            && matches!(fourth_stmt.kind.clone(), StatementKind::Assign(lhs, _) if lhs.local == local)
+                            && matches!(fifth_stmt.kind.clone(), StatementKind::StorageDead(dead_local) if dead_local == temp_local)
+                        {
+                            found_local_list.push(local);
+                            add_assign_list.push((closest_loop_head, stmt.clone()));
+                            add_assign_list.push((closest_loop_head, next_stmt.clone()));
+                            add_assign_list.push((closest_loop_head, third_stmt.clone()));
+                            add_assign_list.push((closest_loop_head, fourth_stmt.clone()));
+                            add_assign_list.push((closest_loop_head, fifth_stmt.clone()));
+                            new_stmts.push(next_stmt.clone());
+                            new_stmts.push(third_stmt.clone());
+                            new_stmts.push(fourth_stmt.clone());
+                            new_stmts.push(fifth_stmt.clone());
+                            stmt_idx += 5;
+                            continue;
+                        }
+                    }
+                    _ => (),
+                }
+                new_stmts.push(stmt.clone());
+                stmt_idx += 1;
+            }
+            blocks_stmts.push((block_idx, new_stmts));
+        }
+
+        for (block_idx, new_stmts) in blocks_stmts {
+            body.replace_statements(&SourceInstruction::Terminator { bb: block_idx }, new_stmts);
+        }
+
+        for (block_idx, stmt) in add_assign_list {
+            body.insert_stmt(
+                stmt,
+                &mut SourceInstruction::Terminator { bb: block_idx },
+                InsertPosition::Before,
+            );
+        }
+        found_local_list
+    }
+
+    //Move all variables initiation using function-call inside the loop body to the loop-head
+    fn move_storagelive_call_to_loophead(
+        &self,
+        body: &mut MutableBody,
+        loop_head_map: &HashMap<usize, usize>,
+        found_local_list: Vec<usize>,
+    ) {
+        let mut found_local_list = found_local_list;
+        let localvars = self.get_user_defined_variables(body);
+        let mut move_call_list: Vec<(usize, usize, Statement, Terminator)> = Vec::new();
+        for (block_idx, block) in body.blocks().iter().enumerate() {
+            if let Some(stmt) = block.statements.last() {
+                match stmt.kind {
+                    StatementKind::StorageLive(local)
+                        if (localvars.contains(&local) && !found_local_list.contains(&local)) =>
+                    {
+                        let terminator = block.terminator.clone();
+                        let terminatorkind = block.terminator.kind.clone();
+                        if let TerminatorKind::Call { destination: dest, .. } = terminatorkind
+                            && dest.local == local
+                            && let Some(&closest_loop_head) = loop_head_map.get(&block_idx)
+                        {
+                            move_call_list.push((
+                                closest_loop_head,
+                                block_idx,
+                                stmt.clone(),
+                                terminator,
+                            ));
+                            found_local_list.push(local);
+                        }
                     }
                     _ => (),
                 }
             }
         }
-        let mut moved_list: Vec<usize> = Vec::new();
-        for (block_idx, stmt_idx, local) in move_list {
-            let storagelive_stmt = body.blocks()[block_idx].statements[stmt_idx].clone();
-            let next_stmt = body.blocks()[block_idx].statements[stmt_idx + 1].clone();
-            if (!moved_list.contains(&local))
-                && matches!(next_stmt.kind.clone(), StatementKind::Assign(lhs,_) if lhs.local == local)
+        let mut current_loop_head = 0;
+        move_call_list.sort_by_key(|(closest_loop_head, _, _, _)| *closest_loop_head);
+        for (loop_head, block_idx, stmt, ter) in move_call_list.iter() {
+            let remove_pos = body.blocks()[*block_idx].statements.len() - 1;
+            body.remove_stmt(*block_idx, remove_pos);
+            let mut terminator = ter.clone();
+            if let TerminatorKind::Call {
+                func: terminator_func,
+                args: terminator_args,
+                destination: terminator_destination,
+                target: _,
+                unwind: terminator_unwind,
+            } = &terminator.kind
             {
-                moved_list.push(local);
-                if let Some(closest_loop_head) =
-                    self.get_closest_loop_head(block_idx, &loop_positions)
-                {
-                    body.remove_stmt(block_idx, stmt_idx);
-                    body.remove_stmt(block_idx, stmt_idx);
-                    body.insert_stmt(
-                        storagelive_stmt,
-                        &mut SourceInstruction::Terminator { bb: closest_loop_head },
-                        InsertPosition::Before,
-                    );
-
-                    body.insert_stmt(
-                        next_stmt,
-                        &mut SourceInstruction::Terminator { bb: closest_loop_head },
-                        InsertPosition::Before,
-                    );
-                }
+                terminator.kind = TerminatorKind::Call {
+                    func: terminator_func.clone(),
+                    args: terminator_args.clone(),
+                    destination: terminator_destination.clone(),
+                    target: Some(*loop_head),
+                    unwind: *terminator_unwind,
+                };
+            }
+            let new_block = BasicBlock { statements: vec![stmt.clone()], terminator };
+            if current_loop_head != *loop_head {
+                body.insert_bb(
+                    new_block,
+                    &mut SourceInstruction::Terminator { bb: *loop_head },
+                    InsertPosition::Before,
+                );
+                current_loop_head = *loop_head;
+            } else {
+                let current_block_id = body.blocks().len() - 1;
+                body.insert_bb(
+                    new_block,
+                    &mut SourceInstruction::Terminator { bb: current_block_id },
+                    InsertPosition::After,
+                );
             }
         }
     }
 
+    //Move all storagedead inside the loop body to the loop termination block
     fn move_storagedead(&self, body: &mut MutableBody, src_block_idx: usize, dst_block_idx: usize) {
         let localvars = self.get_user_defined_variables(body);
         let storagedead_stmts: Vec<_> = body.blocks()[src_block_idx]
@@ -297,22 +471,45 @@ impl LoopContractPass {
             .collect();
         body.replace_statements(&SourceInstruction::Terminator { bb: src_block_idx }, other_stmts);
         let mut new_stmts = body.blocks()[dst_block_idx].statements.clone();
-        new_stmts.extend(storagedead_stmts);
+        let dst_block_stmt_kind: Vec<_> = new_stmts.iter().map(|st| st.kind.clone()).collect();
+        for stmt in storagedead_stmts.iter() {
+            if !dst_block_stmt_kind.contains(&stmt.kind) {
+                new_stmts.push(stmt.clone())
+            }
+        }
         body.replace_statements(&SourceInstruction::Terminator { bb: dst_block_idx }, new_stmts);
     }
 
-    fn get_loop_latch_id(&self, body: &MutableBody, loop_head_id: usize) -> usize {
+    //Get the associated final loop-latch-id of a loop-head-id
+    fn get_last_loop_latch_id(&self, body: &MutableBody, loop_head_id: usize) -> usize {
+        let mut loop_latch_id = loop_head_id;
         for (bb_idx, block) in body.blocks().iter().enumerate() {
             match block.terminator.kind {
                 TerminatorKind::Goto { target }
                     if (target == loop_head_id && bb_idx > loop_head_id) =>
                 {
-                    return bb_idx;
+                    loop_latch_id = bb_idx;
                 }
                 _ => (),
             }
         }
-        loop_head_id
+        loop_latch_id
+    }
+
+    //Get the all associated loop-latch-ids of a loop-head-id
+    fn get_all_loop_latch_ids(&self, body: &MutableBody, loop_head_id: usize) -> Vec<usize> {
+        let mut loop_latch_ids = Vec::new();
+        for (bb_idx, block) in body.blocks().iter().enumerate() {
+            match block.terminator.kind {
+                TerminatorKind::Goto { target }
+                    if (target == loop_head_id && bb_idx > loop_head_id) =>
+                {
+                    loop_latch_ids.push(bb_idx);
+                }
+                _ => (),
+            }
+        }
+        loop_latch_ids
     }
 
     /// We only support closure arguments that are either `copy`` or `move`` of reference of user variables.
@@ -328,8 +525,11 @@ impl LoopContractPass {
     /// It is the core of fn transform, and is separated just to avoid code repetition.
     fn transform_body_with_loop(&mut self, tcx: TyCtxt, body: Body) -> (bool, Body) {
         let mut new_body = MutableBody::from(body);
-        let loop_positions = self.get_loop_positions(&new_body, tcx);
-        self.move_storagelive_to_loophead(&mut new_body, loop_positions);
+        let loop_head_map = self.get_associated_loop_head_hashmap(&new_body, tcx);
+        let found_local_list =
+            self.move_storagelive_assign_to_loophead(&mut new_body, &loop_head_map);
+        //print_mutablebody(&new_body);
+        //assert!(1==0);
         let mut contain_loop_contracts: bool = false;
 
         // Visit basic blocks in control flow order (BFS).
@@ -359,6 +559,7 @@ impl LoopContractPass {
                 }
             }
         }
+        self.move_storagelive_call_to_loophead(&mut new_body, &loop_head_map, found_local_list);
         (contain_loop_contracts, new_body.into())
     }
 
@@ -417,6 +618,34 @@ impl LoopContractPass {
             );
         }
 
+        if let TerminatorKind::SwitchInt { discr, targets } = &terminator.kind {
+            let new_branches: Vec<_> = targets
+                .branches()
+                .map(|(a, b)| {
+                    if self.new_loop_latches.contains_key(&b) {
+                        (a, self.new_loop_latches[&b])
+                    } else {
+                        (a, b)
+                    }
+                })
+                .collect();
+
+            let new_otherwise = if self.new_loop_latches.contains_key(&targets.otherwise()) {
+                self.new_loop_latches[&targets.otherwise()]
+            } else {
+                targets.otherwise()
+            };
+
+            let new_targets = SwitchTargets::new(new_branches, new_otherwise);
+            new_body.replace_terminator(
+                &SourceInstruction::Terminator { bb: bb_idx },
+                Terminator {
+                    kind: TerminatorKind::SwitchInt { discr: discr.clone(), targets: new_targets },
+                    span: terminator.span,
+                },
+            );
+        }
+
         // Transform loop heads with loop contracts.
         if let TerminatorKind::Call {
             func: terminator_func,
@@ -440,15 +669,16 @@ impl LoopContractPass {
                 == Some(Symbol::intern("kani_register_loop_contract"))
                 && matches!(&terminator_args[1], Operand::Constant(op) if op.const_.eval_target_usize().unwrap() == 0)
             {
-                let loop_skip_block_id = *new_body.blocks()[terminator_target.unwrap()]
+                let loop_termination_block_id = *new_body.blocks()[terminator_target.unwrap()]
                     .terminator
                     .clone()
                     .successors()
                     .first()
                     .unwrap();
-                let loop_latch_id = self.get_loop_latch_id(new_body, bb_idx);
-
-                self.move_storagedead(new_body, loop_latch_id, loop_skip_block_id);
+                let loop_latch_ids = self.get_all_loop_latch_ids(new_body, bb_idx);
+                for loop_latch_id in loop_latch_ids {
+                    self.move_storagedead(new_body, loop_latch_id, loop_termination_block_id);
+                }
 
                 // Check if the MIR satisfy the assumptions of this transformation.
                 if !new_body.blocks()[terminator_target.unwrap()].statements.is_empty()

--- a/kani-compiler/src/kani_middle/transform/loop_contracts.rs
+++ b/kani-compiler/src/kani_middle/transform/loop_contracts.rs
@@ -32,42 +32,6 @@ pub struct LoopContractPass {
     new_loop_latches: HashMap<usize, usize>,
 }
 
-//Useful for debugging
-#[allow(dead_code)]
-pub fn print_stable_mir_body(body: &Body) {
-    println!("=== MIR Body Start ===");
-    // Print basic blocks
-    for (idx, block) in body.blocks.iter().enumerate() {
-        println!("bb{idx}: {{");
-        // Print statements
-        for stmt in &block.statements {
-            println!(" {stmt:?}");
-        }
-        // Print terminator
-        println!(" {:?}", block.terminator);
-        println!("}}");
-    }
-    println!("=== MIR Body End ===");
-}
-
-//Useful for debugging
-#[allow(dead_code)]
-pub fn print_mutablebody(body: &MutableBody) {
-    println!("=== MIR Body Start ===");
-    // Print basic blocks
-    for (idx, block) in body.blocks().iter().enumerate() {
-        println!("bb{idx}: {{");
-        // Print statements
-        for stmt in &block.statements {
-            println!(" {stmt:?}");
-        }
-        // Print terminator
-        println!(" {:?}", block.terminator);
-        println!("}}");
-    }
-    println!("=== MIR Body End ===");
-}
-
 impl TransformPass for LoopContractPass {
     /// The type of transformation that this pass implements.
     fn transformation_type() -> TransformationType
@@ -192,6 +156,9 @@ impl LoopContractPass {
         body.replace_statements(&SourceInstruction::Terminator { bb: bb_idx }, stmts);
     }
 
+    //Get all user defined variables in the function (not the compiler-generated ones)
+    //Note that there might be user defined variables with the same user defined names,
+    //but they are all have different MIR-generated names.
     fn get_user_defined_variables(&self, body: &MutableBody) -> Vec<usize> {
         let mut user_vars = Vec::new();
 

--- a/kani-compiler/src/kani_middle/transform/loop_contracts.rs
+++ b/kani-compiler/src/kani_middle/transform/loop_contracts.rs
@@ -495,8 +495,6 @@ impl LoopContractPass {
         let loop_head_map = self.get_associated_loop_head_hashmap(&new_body, tcx);
         let found_local_list =
             self.move_storagelive_assign_to_loophead(&mut new_body, &loop_head_map);
-        //print_mutablebody(&new_body);
-        //assert!(1==0);
         let mut contain_loop_contracts: bool = false;
 
         // Visit basic blocks in control flow order (BFS).

--- a/tests/expected/loop-contract/nested_loop_local_var_assign.expected
+++ b/tests/expected/loop-contract/nested_loop_local_var_assign.expected
@@ -1,0 +1,17 @@
+func.loop_invariant_base.1\
+	 - Status: SUCCESS\
+	 - Description: "Check invariant before entry for loop func.1"
+
+func.loop_assigns.1\
+	 - Status: SUCCESS\
+	 - Description: "Check assigns clause inclusion for loop func.1"
+
+func.assigns.1\
+	 - Status: SUCCESS\
+	 - Description: "Check that i is assignable"
+
+func.loop_invariant_base.2\
+	 - Status: SUCCESS\
+	 - Description: "Check invariant before entry for loop func.0"
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/loop-contract/nested_loop_local_var_assign.rs
+++ b/tests/expected/loop-contract/nested_loop_local_var_assign.rs
@@ -1,0 +1,31 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags: -Z loop-contracts
+
+//! Check if loop assign clause can be infered for inner-loop when there are local variables of outter-loop body.
+
+#![feature(proc_macro_hygiene)]
+#![feature(stmt_expr_attributes)]
+
+fn func(x: usize) {
+    let mut j = 0;
+    const CHUNK_SIZE: usize = 32;
+    #[kani::loop_invariant(j <=x )]
+    while j < x {
+        let mut i = 0;
+        let mut sum = 0_usize;
+        #[kani::loop_invariant(i <= CHUNK_SIZE && prev(i) <= CHUNK_SIZE && prev(i) + 1 == i && sum <= CHUNK_SIZE && on_entry(sum) + i >= sum )]
+        while i < CHUNK_SIZE {
+            sum += kani::any::<bool>() as usize;
+            i += 1;
+        }
+
+        j += 1;
+    }
+}
+
+#[kani::proof]
+fn harness() {
+    let _ = func(10);
+}

--- a/tests/expected/loop-contract/nested_loop_local_var_func_call.expected
+++ b/tests/expected/loop-contract/nested_loop_local_var_func_call.expected
@@ -1,0 +1,21 @@
+loop_invariant_base.1\
+	 - Status: SUCCESS\
+	 - Description: "Check invariant before entry for loop main.1"
+
+main.loop_assigns.2\
+	 - Status: SUCCESS\
+	 - Description: "Check assigns clause inclusion for loop main.0"
+
+main.assigns.1\
+	 - Status: SUCCESS\
+	 - Description: "Check that j is assignable"
+
+main.loop_invariant_base.2\
+	 - Status: SUCCESS\
+	 - Description: "Check invariant before entry for loop main.0"
+
+main.assertion.6\
+	 - Status: SUCCESS\
+	 - Description: "assertion failed: s == 100"
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/loop-contract/nested_loop_local_var_func_call.rs
+++ b/tests/expected/loop-contract/nested_loop_local_var_func_call.rs
@@ -1,0 +1,34 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// kani-flags: -Z loop-contracts
+
+//! Check if loop assign clause can be infered for inner-loop when there are local variables of outter-loop body.
+
+#![feature(proc_macro_hygiene)]
+#![feature(stmt_expr_attributes)]
+
+fn sum_pair(x: u32, y: u32) -> u32 {
+    x + y
+}
+
+#[kani::proof]
+fn main() {
+    let mut i: u32 = 0;
+    let mut s: u32 = 0;
+    let t1 = kani::any_where(|x| *x < 5);
+    let t2 = kani::any_where(|x| *x < 5);
+    #[kani::loop_invariant(i <= 5 && s == i * 20)]
+    while i < 5 {
+        let mut j = sum_pair(t1, t2);
+        let mut k = sum_pair(t2, t1);
+        #[kani::loop_invariant(j <= 10 && k ==j)]
+        while j < 10 {
+            j = j + 1;
+            k = k + 1;
+        }
+        s = s + j + k;
+        i = i + 1;
+    }
+    assert!(s == 100);
+}


### PR DESCRIPTION
This PR fixes the bug that assign clause cannot be inferred for the inner loop of nested loops.

General ideas: For local variables of the outer loop, after the loop-contracts transformation, if their StorageLive/StorageDead statements are still inside the outer loop body, CBMC cannot infer the assign clause for the inner loop if those variables are assigned inside the inner loop's body. We have to move their StorageLive to the loop head of the outer-loop and their StorageDead to the block right after where the outer loop terminates. Together with the StorageLive, we have to initiate the variables with the values they are initiated with inside the outer loop's body. Note that we handle three ways how a variable is initiated in MIR: by an assign statement following after a StorageLive one, by a Terminator for function call, and by a group of five statements which perform the `clone()` function.

Resolves #4159

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
