### PR TITLE
Cache dependencies for CI jobs

### DIFF
--- a/.github/workflows/bench-compiler.yml
+++ b/.github/workflows/bench-compiler.yml
@@ -37,6 +37,18 @@ jobs:
           ref: ${{ env.NEW_REF }}
           fetch-depth: 1
 
+      - name: Cache Kani build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: "kani-rust-cache-bench"
+          workspaces: |
+            new
+            new/tools/compile-timer
+            old
+            old/tools/compile-timer
+          cache-directories: "~/.rustup"
+
       - name: Set up Kani Dependencies (old variant)
         uses: ./old/.github/actions/setup
         with:
@@ -100,6 +112,18 @@ jobs:
           path: ./new
           ref: ${{ env.NEW_REF }}
           fetch-depth: 1
+
+      - name: Cache Kani build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: "kani-rust-cache-bench"
+          workspaces: |
+            new
+            new/tools/compile-timer
+            old
+            old/tools/compile-timer
+          cache-directories: "~/.rustup"
 
       - name: Set up Kani Dependencies (old variant)
         uses: ./old/.github/actions/setup

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Checkout Kani
         uses: actions/checkout@v4
 
+      - name: Cache Kani build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: "kani-rust-cache-dev"
+          cache-directories: "~/.rustup"
+
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
@@ -43,6 +50,13 @@ jobs:
           sudo apt-get install -y python3-pip
           pushd tools/benchcomp && pip3 install -r requirements.txt
 
+      - name: Cache Kani build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: "kani-rust-cache-release"
+          cache-directories: "~/.rustup"
+
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
@@ -60,6 +74,13 @@ jobs:
       - name: Checkout Kani
         uses: actions/checkout@v4
 
+      - name: Cache Kani build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: "kani-rust-cache-release"
+          cache-directories: "~/.rustup"
+
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
@@ -75,6 +96,12 @@ jobs:
     steps:
       - name: Checkout Kani
         uses: actions/checkout@v4
+
+      - name: Cache Kani build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-directories: "~/.rustup"
 
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup

--- a/.github/workflows/verify-std-check.yml
+++ b/.github/workflows/verify-std-check.yml
@@ -41,6 +41,14 @@ jobs:
           path: kani
           fetch-depth: 0
 
+      - name: Cache Kani build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          workspaces: kani
+          shared-key: "kani-rust-cache-dev"
+          cache-directories: "~/.rustup"
+
       - name: Setup Kani Dependencies
         uses: ./kani/.github/actions/setup
         with:


### PR DESCRIPTION
Adds a simple cache of the `~/.cargo/registry` directory and Kani's `target` directory to reduce compilation times of our dependencies in CI. This also caches the `~/.rustup` directory to avoid having to re-download toolchains and re-compile the standard library every CI run. Caches are shared between workflows that compile Kani in the same way (e.g. between the `benchcomp-tests` & `perf` jobs since they both compile in release mode).

Based on testing on my local fork, this change seems to make a minor, but not insignificant impact on runtimes. Although lost in the noise on longer jobs, `llbc-regression` & `benchcomp-tests` got noticeably faster, as did the compiler benchmarking workflows which have to compile Kani for each commit they are comparing.

**Test runs:**
General Kani CI workflow: [before](https://github.com/AlexanderPortland/kani/actions/runs/15886762745) | [after](https://github.com/AlexanderPortland/kani/actions/runs/15887740017)
Compiler bench workflow: [before](https://github.com/AlexanderPortland/kani/actions/runs/15888031249) | [after](https://github.com/AlexanderPortland/kani/actions/runs/15889545021)

Resolves #4153 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
