### PR TITLE
Automatic Derivation Fixes

### DIFF
--- a/kani-compiler/src/kani_middle/mod.rs
+++ b/kani-compiler/src/kani_middle/mod.rs
@@ -224,7 +224,13 @@ fn can_derive_arbitrary(
             let fields = variant.fields();
             let mut fields_impl_arbitrary = true;
             for ty in fields.iter().map(|field| field.ty_with_args(&args)) {
-                fields_impl_arbitrary &= implements_arbitrary(ty, kani_any_def, ty_arbitrary_cache);
+                if let TyKind::RigidTy(RigidTy::Adt(..)) = ty.kind() {
+                    fields_impl_arbitrary &=
+                        can_derive_arbitrary(ty, kani_any_def, ty_arbitrary_cache);
+                } else {
+                    fields_impl_arbitrary &=
+                        implements_arbitrary(ty, kani_any_def, ty_arbitrary_cache);
+                }
             }
             if !fields_impl_arbitrary {
                 return false;

--- a/kani-compiler/src/kani_middle/mod.rs
+++ b/kani-compiler/src/kani_middle/mod.rs
@@ -188,6 +188,10 @@ fn implements_arbitrary(
         return *v;
     }
 
+    if ty.kind().rigid().is_none() {
+        return false;
+    }
+
     let kani_any_body =
         Instance::resolve(kani_any_def, &GenericArgs(vec![GenericArgKind::Type(ty)]))
             .unwrap()
@@ -230,6 +234,12 @@ fn can_derive_arbitrary(
     };
 
     if let TyKind::RigidTy(RigidTy::Adt(def, args)) = ty.kind() {
+        for arg in &args.0 {
+            if let GenericArgKind::Lifetime(..) = arg {
+                return false;
+            }
+        }
+
         match def.kind() {
             AdtKind::Enum => {
                 // Enums with no variants cannot be instantiated

--- a/kani-compiler/src/kani_middle/transform/automatic.rs
+++ b/kani-compiler/src/kani_middle/transform/automatic.rs
@@ -14,6 +14,7 @@ use crate::kani_middle::kani_functions::{KaniHook, KaniIntrinsic, KaniModel};
 use crate::kani_middle::transform::body::{InsertPosition, MutableBody, SourceInstruction};
 use crate::kani_middle::transform::{TransformPass, TransformationType};
 use crate::kani_queries::QueryDb;
+use fxhash::FxHashMap;
 use rustc_middle::ty::TyCtxt;
 use stable_mir::CrateDef;
 use stable_mir::mir::mono::Instance;
@@ -109,7 +110,7 @@ impl TransformPass for AutomaticArbitraryPass {
         let binding = instance.args();
         let ty = binding.0[0].expect_ty();
 
-        if implements_arbitrary(*ty, self.kani_any) {
+        if implements_arbitrary(*ty, self.kani_any, &mut FxHashMap::default()) {
             return (false, body);
         }
 

--- a/kani-compiler/src/kani_middle/transform/automatic.rs
+++ b/kani-compiler/src/kani_middle/transform/automatic.rs
@@ -175,7 +175,7 @@ impl AutomaticArbitraryPass {
         );
         let mut assign_instr = SourceInstruction::Terminator { bb: source.bb() - 1 };
         let rvalue = Rvalue::Aggregate(
-            AggregateKind::Adt(adt_def, variant.idx, GenericArgs(vec![]), None, None),
+            AggregateKind::Adt(adt_def, variant.idx, adt_args.clone(), None, None),
             field_locals.into_iter().map(|lcl| Operand::Move(lcl.into())).collect(),
         );
         body.assign_to(Place::from(0), rvalue, &mut assign_instr, InsertPosition::Before);

--- a/kani-compiler/src/kani_middle/transform/mod.rs
+++ b/kani-compiler/src/kani_middle/transform/mod.rs
@@ -75,7 +75,7 @@ impl BodyTransformation {
         let safety_check_type = CheckType::new_safety_check_assert_assume(queries);
         let unsupported_check_type = CheckType::new_unsupported_check_assert_assume_false(queries);
         // This has to come first, since creating harnesses affects later stubbing and contract passes.
-        transformer.add_pass(queries, AutomaticHarnessPass::new(unit, queries));
+        transformer.add_pass(queries, AutomaticHarnessPass::new(queries));
         transformer.add_pass(queries, AutomaticArbitraryPass::new(unit, queries));
         transformer.add_pass(queries, FnStubPass::new(&unit.stubs));
         transformer.add_pass(queries, ExternFnStubPass::new(&unit.stubs));

--- a/tests/script-based-pre/autoderive_arbitrary_enums/enums.expected
+++ b/tests/script-based-pre/autoderive_arbitrary_enums/enums.expected
@@ -1,13 +1,21 @@
-Kani generated automatic harnesses for 3 function(s):
-+----------------------------+-------------------------------+
-| Crate                      | Selected Function             |
-+============================================================+
-| autoderive_arbitrary_enums | should_derive::alignment_fail |
-|----------------------------+-------------------------------|
-| autoderive_arbitrary_enums | should_derive::alignment_pass |
-|----------------------------+-------------------------------|
-| autoderive_arbitrary_enums | should_derive::foo            |
-+----------------------------+-------------------------------+
+Kani generated automatic harnesses for 7 function(s):
++----------------------------+---------------------------------------------+
+| Crate                      | Selected Function                           |
++==========================================================================+
+| autoderive_arbitrary_enums | should_derive::alignment_fail               |
+|----------------------------+---------------------------------------------|
+| autoderive_arbitrary_enums | should_derive::alignment_pass               |
+|----------------------------+---------------------------------------------|
+| autoderive_arbitrary_enums | should_derive::foo                          |
+|----------------------------+---------------------------------------------|
+| autoderive_arbitrary_enums | should_derive::generic_recursively_eligible |
+|----------------------------+---------------------------------------------|
+| autoderive_arbitrary_enums | should_derive::multiple_generics_test       |
+|----------------------------+---------------------------------------------|
+| autoderive_arbitrary_enums | should_derive::partially_used_generics_test |
+|----------------------------+---------------------------------------------|
+| autoderive_arbitrary_enums | should_derive::recursively_eligible         |
++----------------------------+---------------------------------------------+          
 
 Kani did not generate automatic harnesses for 7 function(s).
 +----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------+
@@ -17,15 +25,15 @@ Kani did not generate automatic harnesses for 7 function(s).
 |----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
 | autoderive_arbitrary_enums | <should_derive::AlignmentEnum as std::cmp::PartialEq>::eq                   | Missing Arbitrary implementation for argument(s) self: &should_derive::AlignmentEnum, other: &should_derive::AlignmentEnum |
 |----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
+| autoderive_arbitrary_enums | should_not_derive::generic_unsupported_arg                                  | Missing Arbitrary implementation for argument(s) unsupported: should_not_derive::UnsupportedGenericField<char>             |
+|----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
 | autoderive_arbitrary_enums | should_not_derive::never                                                    | Missing Arbitrary implementation for argument(s) n: should_not_derive::Never                                               |
 |----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
 | autoderive_arbitrary_enums | should_not_derive::no_variants_eligible                                     | Missing Arbitrary implementation for argument(s) val: should_not_derive::NoVariantsEligible                                |
 |----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
 | autoderive_arbitrary_enums | should_not_derive::not_all_variants_eligible                                | Missing Arbitrary implementation for argument(s) val: should_not_derive::NotAllVariantsEligible                            |
 |----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
-| autoderive_arbitrary_enums | should_not_derive::recursively_eligible                                     | Missing Arbitrary implementation for argument(s) val: should_not_derive::RecursivelyEligible                               |
-|----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
-| autoderive_arbitrary_enums | should_not_derive::some_arguments_support                                   | Missing Arbitrary implementation for argument(s) val: should_not_derive::NotAllVariantsEligible                            |
+| autoderive_arbitrary_enums | should_not_derive::some_arguments_support                                   | Missing Arbitrary implementation for argument(s) unsupported_2: should_not_derive::NotAllVariantsEligible                  |
 +----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------+
 
 should_derive::alignment_pass\
@@ -48,13 +56,29 @@ should_derive::foo.assertion\
 	 - Status: FAILURE\
 	 - Description: "foo held an i28, but it didn't divide evenly"
 
+should_derive::partially_used_generics_test.assertion\
+	 - Status: SUCCESS\
+	 - Description: "attempt to add with overflow"
+
+multiple_generics_test.assertion\
+	 - Status: FAILURE\
+	 - Description: "assertion failed: n % 2 > 0"
+
 Autoharness Summary:
-+----------------------------+-------------------------------+-----------------------------+---------------------+
-| Crate                      | Selected Function             | Kind of Automatic Harness   | Verification Result |
-+================================================================================================================+
-| autoderive_arbitrary_enums | should_derive::alignment_pass | #[kani::proof_for_contract] | Success             |
-|----------------------------+-------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_enums | should_derive::alignment_fail | #[kani::proof]              | Failure             |
-|----------------------------+-------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_enums | should_derive::foo            | #[kani::proof]              | Failure             |
-+----------------------------+-------------------------------+-----------------------------+---------------------+
++----------------------------+---------------------------------------------+-----------------------------+---------------------+
+| Crate                      | Selected Function                           | Kind of Automatic Harness   | Verification Result |
++==============================================================================================================================+
+| autoderive_arbitrary_enums | should_derive::alignment_pass               | #[kani::proof_for_contract] | Success             |
+|----------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_enums | should_derive::generic_recursively_eligible | #[kani::proof]              | Success             |
+|----------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_enums | should_derive::partially_used_generics_test | #[kani::proof]              | Success             |
+|----------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_enums | should_derive::recursively_eligible         | #[kani::proof]              | Success             |
+|----------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_enums | should_derive::alignment_fail               | #[kani::proof]              | Failure             |
+|----------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_enums | should_derive::foo                          | #[kani::proof]              | Failure             |
+|----------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_enums | should_derive::multiple_generics_test       | #[kani::proof]              | Failure             |
++----------------------------+---------------------------------------------+-----------------------------+---------------------+

--- a/tests/script-based-pre/autoderive_arbitrary_enums/enums.expected
+++ b/tests/script-based-pre/autoderive_arbitrary_enums/enums.expected
@@ -1,37 +1,21 @@
-Kani generated automatic harnesses for 8 function(s):
-+----------------------------+------------------------------------------------+
-| Crate                      | Selected Function                              |
-+=============================================================================+
-| autoderive_arbitrary_enums | should_derive::Foo::AnonMultipleVariant        |
-|----------------------------+------------------------------------------------|
-| autoderive_arbitrary_enums | should_derive::Foo::AnonVariant                |
-|----------------------------+------------------------------------------------|
-| autoderive_arbitrary_enums | should_derive::alignment_fail                  |
-|----------------------------+------------------------------------------------|
-| autoderive_arbitrary_enums | should_derive::alignment_pass                  |
-|----------------------------+------------------------------------------------|
-| autoderive_arbitrary_enums | should_derive::foo                             |
-|----------------------------+------------------------------------------------|
-| autoderive_arbitrary_enums | should_not_derive::NotAllVariantsEligible::Num |
-|----------------------------+------------------------------------------------|
-| autoderive_arbitrary_enums | should_not_derive::NotAllVariantsEligible::Pin |
-|----------------------------+------------------------------------------------|
-| autoderive_arbitrary_enums | should_not_derive::RecursivelyEligible::Foo    |
-+----------------------------+------------------------------------------------+
+Kani generated automatic harnesses for 3 function(s):
++----------------------------+-------------------------------+
+| Crate                      | Selected Function             |
++============================================================+
+| autoderive_arbitrary_enums | should_derive::alignment_fail |
+|----------------------------+-------------------------------|
+| autoderive_arbitrary_enums | should_derive::alignment_pass |
+|----------------------------+-------------------------------|
+| autoderive_arbitrary_enums | should_derive::foo            |
++----------------------------+-------------------------------+
 
-Kani did not generate automatic harnesses for 10 function(s).
+Kani did not generate automatic harnesses for 7 function(s).
 +----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------+
 | Crate                      | Skipped Function                                                            | Reason for Skipping                                                                                                        |
 +=======================================================================================================================================================================================================================================+
 | autoderive_arbitrary_enums | <should_derive::AlignmentEnum as std::cmp::Eq>::assert_receiver_is_total_eq | Missing Arbitrary implementation for argument(s) self: &should_derive::AlignmentEnum                                       |
 |----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
 | autoderive_arbitrary_enums | <should_derive::AlignmentEnum as std::cmp::PartialEq>::eq                   | Missing Arbitrary implementation for argument(s) self: &should_derive::AlignmentEnum, other: &should_derive::AlignmentEnum |
-|----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
-| autoderive_arbitrary_enums | should_not_derive::NoVariantsEligible::Ptr                                  | Missing Arbitrary implementation for argument(s) _: *const i8                                                              |
-|----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
-| autoderive_arbitrary_enums | should_not_derive::NoVariantsEligible::Str                                  | Missing Arbitrary implementation for argument(s) _: &str                                                                   |
-|----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
-| autoderive_arbitrary_enums | should_not_derive::NotAllVariantsEligible::Ref                              | Missing Arbitrary implementation for argument(s) _: &mut i32                                                               |
 |----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
 | autoderive_arbitrary_enums | should_not_derive::never                                                    | Missing Arbitrary implementation for argument(s) n: should_not_derive::Never                                               |
 |----------------------------+-----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------|
@@ -65,22 +49,12 @@ should_derive::foo.assertion\
 	 - Description: "foo held an i28, but it didn't divide evenly"
 
 Autoharness Summary:
-+----------------------------+------------------------------------------------+-----------------------------+---------------------+
-| Crate                      | Selected Function                              | Kind of Automatic Harness   | Verification Result |
-+=================================================================================================================================+
-| autoderive_arbitrary_enums | should_derive::Foo::AnonMultipleVariant        | #[kani::proof]              | Success             |
-|----------------------------+------------------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_enums | should_derive::Foo::AnonVariant                | #[kani::proof]              | Success             |
-|----------------------------+------------------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_enums | should_derive::alignment_pass                  | #[kani::proof_for_contract] | Success             |
-|----------------------------+------------------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_enums | should_not_derive::NotAllVariantsEligible::Num | #[kani::proof]              | Success             |
-|----------------------------+------------------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_enums | should_not_derive::NotAllVariantsEligible::Pin | #[kani::proof]              | Success             |
-|----------------------------+------------------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_enums | should_not_derive::RecursivelyEligible::Foo    | #[kani::proof]              | Success             |
-|----------------------------+------------------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_enums | should_derive::alignment_fail                  | #[kani::proof]              | Failure             |
-|----------------------------+------------------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_enums | should_derive::foo                             | #[kani::proof]              | Failure             |
-+----------------------------+------------------------------------------------+-----------------------------+---------------------+
++----------------------------+-------------------------------+-----------------------------+---------------------+
+| Crate                      | Selected Function             | Kind of Automatic Harness   | Verification Result |
++================================================================================================================+
+| autoderive_arbitrary_enums | should_derive::alignment_pass | #[kani::proof_for_contract] | Success             |
+|----------------------------+-------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_enums | should_derive::alignment_fail | #[kani::proof]              | Failure             |
+|----------------------------+-------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_enums | should_derive::foo            | #[kani::proof]              | Failure             |
++----------------------------+-------------------------------+-----------------------------+---------------------+

--- a/tests/script-based-pre/autoderive_arbitrary_structs/src/lib.rs
+++ b/tests/script-based-pre/autoderive_arbitrary_structs/src/lib.rs
@@ -19,6 +19,17 @@ mod should_derive {
         char: char,
     }
 
+    pub struct MultipleGenerics<T, U> {
+        first: T,
+        second: U,
+    }
+
+    pub struct PartiallyUsedGenerics<T, U> {
+        data: T,
+        count: usize,
+        optional: Option<U>,
+    }
+
     fn unit_struct(foo: UnitStruct, bar: UnitStruct) -> UnitStruct {
         assert_eq!(foo, bar);
         foo
@@ -46,6 +57,17 @@ mod should_derive {
         if foo.num % divisor != 0 {
             panic!("foo held an i28, but it didn't divide evenly");
         }
+    }
+
+    fn multiple_generics_test(foo: MultipleGenerics<usize, char>) -> usize {
+        assert!(foo.first % 2 > 0);
+        foo.first % 2
+    }
+
+    fn partially_used_generics_test(
+        foo: PartiallyUsedGenerics<Option<Option<(u64, u32)>>, bool>,
+    ) -> usize {
+        foo.data.unwrap_or(Some((0, 0))).unwrap_or((0, 0)).1 as usize + 100
     }
 
     #[derive(Eq, PartialEq)]
@@ -80,6 +102,16 @@ mod should_derive {
         let int = 7;
         assert_eq!(std::mem::align_of_val(&int) % align.0, 0);
     }
+
+    struct RecursiveFoo(NamedMultipleStruct);
+    pub struct ComplexGenerics<T, U, V> {
+        data: Result<T, V>,
+        mapping: MultipleGenerics<U, V>,
+        pair: (T, U),
+    }
+
+    fn recursively_eligible(val: RecursiveFoo) {}
+    fn generic_recursively_eligible(val: ComplexGenerics<char, u32, i8>) {}
 }
 
 mod should_not_derive {
@@ -88,9 +120,18 @@ mod should_not_derive {
     struct StrStruct(&'static str);
     struct PtrStruct(*const i8);
     struct RefStruct(&'static mut i32);
-    struct RecursiveFoo(NamedMultipleStruct);
+
+    pub struct UnsupportedGenericField<T> {
+        outer: T,
+        inner: Vec<T>,
+    }
 
     fn no_structs_eligible(val: StrStruct, val2: PtrStruct) {}
-    fn recursively_eligible(val: RecursiveFoo) {}
-    fn some_arguments_support(supported: NamedMultipleStruct, unsupported: RefStruct) {}
+    fn some_arguments_support(
+        supported: NamedMultipleStruct,
+        supported_2: MultipleGenerics<char, i8>,
+        unsupported: RefStruct,
+    ) {
+    }
+    fn generic_unsupported_arg(unsupported: UnsupportedGenericField<char>) {}
 }

--- a/tests/script-based-pre/autoderive_arbitrary_structs/structs.expected
+++ b/tests/script-based-pre/autoderive_arbitrary_structs/structs.expected
@@ -1,13 +1,7 @@
-Kani generated automatic harnesses for 11 function(s):
+Kani generated automatic harnesses for 7 function(s):
 +------------------------------+-------------------------------------+
 | Crate                        | Selected Function                   |
 +====================================================================+
-| autoderive_arbitrary_structs | should_derive::AlignmentStruct      |
-|------------------------------+-------------------------------------|
-| autoderive_arbitrary_structs | should_derive::AnonMultipleStruct   |
-|------------------------------+-------------------------------------|
-| autoderive_arbitrary_structs | should_derive::AnonStruct           |
-|------------------------------+-------------------------------------|
 | autoderive_arbitrary_structs | should_derive::alignment_fail       |
 |------------------------------+-------------------------------------|
 | autoderive_arbitrary_structs | should_derive::alignment_pass       |
@@ -21,11 +15,9 @@ Kani generated automatic harnesses for 11 function(s):
 | autoderive_arbitrary_structs | should_derive::named_struct         |
 |------------------------------+-------------------------------------|
 | autoderive_arbitrary_structs | should_derive::unit_struct          |
-|------------------------------+-------------------------------------|
-| autoderive_arbitrary_structs | should_not_derive::RecursiveFoo     |
 +------------------------------+-------------------------------------+
 
-Kani did not generate automatic harnesses for 10 function(s).
+Kani did not generate automatic harnesses for 7 function(s).
 +------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
 | Crate                        | Skipped Function                                                              | Reason for Skipping                                                                                                            |
 +===============================================================================================================================================================================================================================================+
@@ -36,12 +28,6 @@ Kani did not generate automatic harnesses for 10 function(s).
 | autoderive_arbitrary_structs | <should_derive::UnitStruct as std::cmp::Eq>::assert_receiver_is_total_eq      | Missing Arbitrary implementation for argument(s) self: &should_derive::UnitStruct                                              |
 |------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------|
 | autoderive_arbitrary_structs | <should_derive::UnitStruct as std::cmp::PartialEq>::eq                        | Missing Arbitrary implementation for argument(s) self: &should_derive::UnitStruct, other: &should_derive::UnitStruct           |
-|------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------|
-| autoderive_arbitrary_structs | should_not_derive::PtrStruct                                                  | Missing Arbitrary implementation for argument(s) _: *const i8                                                                  |
-|------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------|
-| autoderive_arbitrary_structs | should_not_derive::RefStruct                                                  | Missing Arbitrary implementation for argument(s) _: &mut i32                                                                   |
-|------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------|
-| autoderive_arbitrary_structs | should_not_derive::StrStruct                                                  | Missing Arbitrary implementation for argument(s) _: &str                                                                       |
 |------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------|
 | autoderive_arbitrary_structs | should_not_derive::no_structs_eligible                                        | Missing Arbitrary implementation for argument(s) val: should_not_derive::StrStruct, val2: should_not_derive::PtrStruct         |
 |------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------|
@@ -106,17 +92,9 @@ Autoharness Summary:
 +------------------------------+-------------------------------------+-----------------------------+---------------------+
 | Crate                        | Selected Function                   | Kind of Automatic Harness   | Verification Result |
 +========================================================================================================================+
-| autoderive_arbitrary_structs | should_derive::AlignmentStruct      | #[kani::proof]              | Success             |
-|------------------------------+-------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_structs | should_derive::AnonMultipleStruct   | #[kani::proof]              | Success             |
-|------------------------------+-------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_structs | should_derive::AnonStruct           | #[kani::proof]              | Success             |
-|------------------------------+-------------------------------------+-----------------------------+---------------------|
 | autoderive_arbitrary_structs | should_derive::alignment_pass       | #[kani::proof_for_contract] | Success             |
 |------------------------------+-------------------------------------+-----------------------------+---------------------|
 | autoderive_arbitrary_structs | should_derive::unit_struct          | #[kani::proof]              | Success             |
-|------------------------------+-------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_structs | should_not_derive::RecursiveFoo     | #[kani::proof]              | Success             |
 |------------------------------+-------------------------------------+-----------------------------+---------------------|
 | autoderive_arbitrary_structs | should_derive::alignment_fail       | #[kani::proof]              | Failure             |
 |------------------------------+-------------------------------------+-----------------------------+---------------------|

--- a/tests/script-based-pre/autoderive_arbitrary_structs/structs.expected
+++ b/tests/script-based-pre/autoderive_arbitrary_structs/structs.expected
@@ -1,21 +1,29 @@
-Kani generated automatic harnesses for 7 function(s):
-+------------------------------+-------------------------------------+
-| Crate                        | Selected Function                   |
-+====================================================================+
-| autoderive_arbitrary_structs | should_derive::alignment_fail       |
-|------------------------------+-------------------------------------|
-| autoderive_arbitrary_structs | should_derive::alignment_pass       |
-|------------------------------+-------------------------------------|
-| autoderive_arbitrary_structs | should_derive::anon_multiple_struct |
-|------------------------------+-------------------------------------|
-| autoderive_arbitrary_structs | should_derive::anon_struct          |
-|------------------------------+-------------------------------------|
-| autoderive_arbitrary_structs | should_derive::named_multiple       |
-|------------------------------+-------------------------------------|
-| autoderive_arbitrary_structs | should_derive::named_struct         |
-|------------------------------+-------------------------------------|
-| autoderive_arbitrary_structs | should_derive::unit_struct          |
-+------------------------------+-------------------------------------+
+Kani generated automatic harnesses for 11 function(s):
++------------------------------+---------------------------------------------+
+| Crate                        | Selected Function                           |
++============================================================================+
+| autoderive_arbitrary_structs | should_derive::alignment_fail               |
+|------------------------------+---------------------------------------------|
+| autoderive_arbitrary_structs | should_derive::alignment_pass               |
+|------------------------------+---------------------------------------------|
+| autoderive_arbitrary_structs | should_derive::anon_multiple_struct         |
+|------------------------------+---------------------------------------------|
+| autoderive_arbitrary_structs | should_derive::anon_struct                  |
+|------------------------------+---------------------------------------------|
+| autoderive_arbitrary_structs | should_derive::multiple_generics_test       |
+|------------------------------+---------------------------------------------|
+| autoderive_arbitrary_structs | should_derive::named_multiple               |
+|------------------------------+---------------------------------------------|
+| autoderive_arbitrary_structs | should_derive::named_struct                 |
+|------------------------------+---------------------------------------------|
+| autoderive_arbitrary_structs | should_derive::partially_used_generics_test |
+|------------------------------+---------------------------------------------|
+| autoderive_arbitrary_structs | should_derive::unit_struct                  |
+|------------------------------+---------------------------------------------|
+| autoderive_arbitrary_structs | should_derive::recursively_eligible         |
+|------------------------------+---------------------------------------------|
+| autoderive_arbitrary_structs | should_derive::generic_recursively_eligible |
+|------------------------------+---------------------------------------------|
 
 Kani did not generate automatic harnesses for 7 function(s).
 +------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
@@ -29,9 +37,9 @@ Kani did not generate automatic harnesses for 7 function(s).
 |------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------|
 | autoderive_arbitrary_structs | <should_derive::UnitStruct as std::cmp::PartialEq>::eq                        | Missing Arbitrary implementation for argument(s) self: &should_derive::UnitStruct, other: &should_derive::UnitStruct           |
 |------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------|
-| autoderive_arbitrary_structs | should_not_derive::no_structs_eligible                                        | Missing Arbitrary implementation for argument(s) val: should_not_derive::StrStruct, val2: should_not_derive::PtrStruct         |
+| autoderive_arbitrary_structs | should_not_derive::generic_unsupported_arg                                    | Missing Arbitrary implementation for argument(s) unsupported: should_not_derive::UnsupportedGenericField<char>                 |
 |------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------|
-| autoderive_arbitrary_structs | should_not_derive::recursively_eligible                                       | Missing Arbitrary implementation for argument(s) val: should_not_derive::RecursiveFoo                                          |
+| autoderive_arbitrary_structs | should_not_derive::no_structs_eligible                                        | Missing Arbitrary implementation for argument(s) val: should_not_derive::StrStruct, val2: should_not_derive::PtrStruct         |
 |------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------|
 | autoderive_arbitrary_structs | should_not_derive::some_arguments_support                                     | Missing Arbitrary implementation for argument(s) unsupported: should_not_derive::RefStruct                                     |
 +------------------------------+-------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
@@ -88,21 +96,37 @@ should_derive::unit_struct.assertion\
 	 - Status: SUCCESS\
 	 - Description: "assertion failed: foo == bar"
 
+should_derive::partially_used_generics_test.assertion\
+	 - Status: SUCCESS\
+	 - Description: "attempt to add with overflow"
+
+multiple_generics_test.assertion\
+	 - Status: FAILURE\
+	 - Description: "assertion failed: foo.first % 2 > 0"
+
 Autoharness Summary:
-+------------------------------+-------------------------------------+-----------------------------+---------------------+
-| Crate                        | Selected Function                   | Kind of Automatic Harness   | Verification Result |
-+========================================================================================================================+
-| autoderive_arbitrary_structs | should_derive::alignment_pass       | #[kani::proof_for_contract] | Success             |
-|------------------------------+-------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_structs | should_derive::unit_struct          | #[kani::proof]              | Success             |
-|------------------------------+-------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_structs | should_derive::alignment_fail       | #[kani::proof]              | Failure             |
-|------------------------------+-------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_structs | should_derive::anon_multiple_struct | #[kani::proof]              | Failure             |
-|------------------------------+-------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_structs | should_derive::anon_struct          | #[kani::proof]              | Failure             |
-|------------------------------+-------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_structs | should_derive::named_multiple       | #[kani::proof]              | Failure             |
-|------------------------------+-------------------------------------+-----------------------------+---------------------|
-| autoderive_arbitrary_structs | should_derive::named_struct         | #[kani::proof]              | Failure             |
-+------------------------------+-------------------------------------+-----------------------------+---------------------+
++------------------------------+---------------------------------------------+-----------------------------+---------------------+
+| Crate                        | Selected Function                           | Kind of Automatic Harness   | Verification Result |
++================================================================================================================================+
+| autoderive_arbitrary_structs | should_derive::alignment_pass               | #[kani::proof_for_contract] | Success             |
+|------------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_structs | should_derive::partially_used_generics_test | #[kani::proof]              | Success             |
+|------------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_structs | should_derive::unit_struct                  | #[kani::proof]              | Success             |
+|------------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_structs | should_derive::recursively_eligible         | #[kani::proof]              | Success             |
+|------------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_structs | should_derive::alignment_fail               | #[kani::proof]              | Failure             |
+|------------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_structs | should_derive::anon_multiple_struct         | #[kani::proof]              | Failure             |
+|------------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_structs | should_derive::anon_struct                  | #[kani::proof]              | Failure             |
+|------------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_structs | should_derive::multiple_generics_test       | #[kani::proof]              | Failure             |
+|------------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_structs | should_derive::named_multiple               | #[kani::proof]              | Failure             |
+|------------------------------+---------------------------------------------+-----------------------------+---------------------|
+| autoderive_arbitrary_structs | should_derive::named_struct                 | #[kani::proof]              | Failure             |
++------------------------------+---------------------------------------------+-----------------------------+---------------------+
+| autoderive_arbitrary_structs | should_derive::generic_recursively_eligible | #[kani::proof]              | Success             |
+|------------------------------+---------------------------------------------+-----------------------------+---------------------|

--- a/tests/script-based-pre/cargo_autoharness_contracts/contracts.expected
+++ b/tests/script-based-pre/cargo_autoharness_contracts/contracts.expected
@@ -1,10 +1,8 @@
-Kani generated automatic harnesses for 7 function(s):
+Kani generated automatic harnesses for 6 function(s):
 +-----------------------------+---------------------------------------------+
 | Crate                       | Selected Function                           |
 +===========================================================================+
 | cargo_autoharness_contracts | should_fail::max                            |
-|-----------------------------+---------------------------------------------|
-| cargo_autoharness_contracts | should_pass::alignment::Alignment           |
 |-----------------------------+---------------------------------------------|
 | cargo_autoharness_contracts | should_pass::alignment::Alignment::as_usize |
 |-----------------------------+---------------------------------------------|
@@ -57,8 +55,6 @@ Autoharness Summary:
 +-----------------------------+---------------------------------------------+-----------------------------+---------------------+
 | Crate                       | Selected Function                           | Kind of Automatic Harness   | Verification Result |
 +===============================================================================================================================+
-| cargo_autoharness_contracts | should_pass::alignment::Alignment           | #[kani::proof]              | Success             |
-|-----------------------------+---------------------------------------------+-----------------------------+---------------------|
 | cargo_autoharness_contracts | should_pass::alignment::Alignment::as_usize | #[kani::proof_for_contract] | Success             |
 |-----------------------------+---------------------------------------------+-----------------------------+---------------------|
 | cargo_autoharness_contracts | should_pass::div                            | #[kani::proof_for_contract] | Success             |
@@ -73,4 +69,4 @@ Autoharness Summary:
 +-----------------------------+---------------------------------------------+-----------------------------+---------------------+
 Note that `kani autoharness` sets default --harness-timeout of 60s and --default-unwind of 20.
 If verification failed because of timing out or too low of an unwinding bound, try passing larger values for these arguments (or, if possible, writing a loop contract).
-Complete - 6 successfully verified functions, 1 failures, 7 total.
+Complete - 5 successfully verified functions, 1 failures, 6 total.

--- a/tests/script-based-pre/cargo_autoharness_type_invariant/type-invariant.expected
+++ b/tests/script-based-pre/cargo_autoharness_type_invariant/type-invariant.expected
@@ -1,4 +1,4 @@
-Kani generated automatic harnesses for 7 function(s):
+Kani generated automatic harnesses for 6 function(s):
 +----------------------------------+----------------------------+
 | Crate                            | Selected Function          |
 +===============================================================+
@@ -9,8 +9,6 @@ Kani generated automatic harnesses for 7 function(s):
 | cargo_autoharness_type_invariant | Duration::checked_sub      |
 |----------------------------------+----------------------------|
 | cargo_autoharness_type_invariant | Duration::new              |
-|----------------------------------+----------------------------|
-| cargo_autoharness_type_invariant | Nanoseconds                |
 |----------------------------------+----------------------------|
 | cargo_autoharness_type_invariant | Nanoseconds::as_inner      |
 |----------------------------------+----------------------------|
@@ -97,8 +95,6 @@ Autoharness Summary:
 |----------------------------------+----------------------------+-----------------------------+---------------------|
 | cargo_autoharness_type_invariant | Duration::checked_sub      | #[kani::proof_for_contract] | Success             |
 |----------------------------------+----------------------------+-----------------------------+---------------------|
-| cargo_autoharness_type_invariant | Nanoseconds                | #[kani::proof]              | Success             |
-|----------------------------------+----------------------------+-----------------------------+---------------------|
 | cargo_autoharness_type_invariant | Nanoseconds::as_inner      | #[kani::proof]              | Success             |
 |----------------------------------+----------------------------+-----------------------------+---------------------|
 | cargo_autoharness_type_invariant | Nanoseconds::new_unchecked | #[kani::proof_for_contract] | Success             |
@@ -107,4 +103,4 @@ Autoharness Summary:
 +----------------------------------+----------------------------+-----------------------------+---------------------+
 Note that `kani autoharness` sets default --harness-timeout of 60s and --default-unwind of 20.
 If verification failed because of timing out or too low of an unwinding bound, try passing larger values for these arguments (or, if possible, writing a loop contract).
-Complete - 6 successfully verified functions, 1 failures, 7 total.
+Complete - 5 successfully verified functions, 1 failures, 6 total.


### PR DESCRIPTION
Fixes and improvements to the derivation of Arbitrary in the compiler introduced in #4167, along with a fix for #4189 and some other small improvements to autoharness that I noticed along the way. Best reviewed commit by commit.

Resolves #4189
Towards #3832 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
