### PR TITLE
Bump Kani version to 0.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.64.0]
+
+### Major Changes
+* Add support for loop modifies in loop contracts by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4174
+* Autoharness: Derive `Arbitrary` for structs and enums by @carolynzech in https://github.com/model-checking/kani/pull/4167, https://github.com/model-checking/kani/pull/4194
+
+### What's Changed
+* Fix static union value crash by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4112
+* Fix loop invariant historical variables bug by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4150
+* Update quantifiers' documentation by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4142
+* Optimize goto binary exporting in `cprover_bindings` by @AlexanderPortland in https://github.com/model-checking/kani/pull/4148
+* Add the option to generate performance flamegraphs by @AlexanderPortland in https://github.com/model-checking/kani/pull/4138
+* Introduce compiler timing script & CI job by @AlexanderPortland in https://github.com/model-checking/kani/pull/4154
+* Optimize reachability with non-mutating global passes by @AlexanderPortland in https://github.com/model-checking/kani/pull/4177
+* Stub panics during MIR transformation by @AlexanderPortland in https://github.com/model-checking/kani/pull/4169
+* BoundedArbitrary: Handle enums with zero or one variants by @zhassan-aws in https://github.com/model-checking/kani/pull/4171
+* Remove `assess` subcommand by @carolynzech in https://github.com/model-checking/kani/pull/4111
+* Upgrade toolchain to 2025-07-02 by @carolynzech, @tautschnig in https://github.com/model-checking/kani/pull/4195
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.63.0...kani-0.64.0
+
 ## [0.63.0]
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 ### Major Changes
 * Add support for loop modifies in loop contracts by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4174
 * Autoharness: Derive `Arbitrary` for structs and enums by @carolynzech in https://github.com/model-checking/kani/pull/4167, https://github.com/model-checking/kani/pull/4194
+* Remove `assess` subcommand by @carolynzech in https://github.com/model-checking/kani/pull/4111
 
 ### What's Changed
 * Fix static union value crash by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4112
@@ -20,7 +21,6 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 * Optimize reachability with non-mutating global passes by @AlexanderPortland in https://github.com/model-checking/kani/pull/4177
 * Stub panics during MIR transformation by @AlexanderPortland in https://github.com/model-checking/kani/pull/4169
 * BoundedArbitrary: Handle enums with zero or one variants by @zhassan-aws in https://github.com/model-checking/kani/pull/4171
-* Remove `assess` subcommand by @carolynzech in https://github.com/model-checking/kani/pull/4111
 * Upgrade toolchain to 2025-07-02 by @carolynzech, @tautschnig in https://github.com/model-checking/kani/pull/4195
 
 **Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.63.0...kani-0.64.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -464,7 +464,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cprover_bindings"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "fxhash",
  "lazy_static",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "kani"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "kani_core",
  "kani_macros",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "kani-compiler"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "charon",
  "clap",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "home",
@@ -1164,14 +1164,14 @@ dependencies = [
 
 [[package]]
 name = "kani_core"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani_macros"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "std"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_core/Cargo.toml
+++ b/library/kani_core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_core"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Auto generated release notes:

## What's Changed
* Edit quantifiers' documentation. by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4142
* Fix the bug of using multiple hidden variables for the prev of the same Expr by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4150
* Remove `assess` subcommand by @carolynzech in https://github.com/model-checking/kani/pull/4111
* Optimize goto binary exporting in `cprover_bindings` by @AlexanderPortland in https://github.com/model-checking/kani/pull/4148
* Add the option to generate performance flamegraphs by @AlexanderPortland in https://github.com/model-checking/kani/pull/4138
* Fix the bug: Static union values can panic Kani by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4112
* Update toolchain to 2025-06-13 by @carolynzech in https://github.com/model-checking/kani/pull/4152
* Automatic cargo update to 2025-06-16 by @github-actions in https://github.com/model-checking/kani/pull/4156
* Major-version update cargo dependencies by @tautschnig in https://github.com/model-checking/kani/pull/4158
* Upgrade Rust toolchain to 2025-06-16 by @tautschnig in https://github.com/model-checking/kani/pull/4157
* Bump tests/perf/s2n-quic from `3129ad5` to `c6e694e` by @dependabot in https://github.com/model-checking/kani/pull/4160
* Bump tests/perf/s2n-quic from `c6e694e` to `b1b5bf8` by @dependabot in https://github.com/model-checking/kani/pull/4164
* Upgrade Rust toolchain to 2025-06-17 by @tautschnig in https://github.com/model-checking/kani/pull/4163
* Automatic cargo update to 2025-06-23 by @github-actions in https://github.com/model-checking/kani/pull/4172
* Stub panics during MIR transformation by @AlexanderPortland in https://github.com/model-checking/kani/pull/4169
* Bump tests/perf/s2n-quic from `b1b5bf8` to `32ba87d` by @dependabot in https://github.com/model-checking/kani/pull/4175
* Handle enums with zero or one variants by @zhassan-aws in https://github.com/model-checking/kani/pull/4171
* Introduce compiler timing script & CI job by @AlexanderPortland in https://github.com/model-checking/kani/pull/4154
* Upgrade Rust toolchain to 2025-06-18 by @tautschnig in https://github.com/model-checking/kani/pull/4166
* Cache dependencies for CI jobs by @AlexanderPortland in https://github.com/model-checking/kani/pull/4181
* Autoharness: Derive `Arbitrary` for structs and enums by @carolynzech in https://github.com/model-checking/kani/pull/4167
* Upgrade Rust toolchain to 2025-06-27 by @tautschnig in https://github.com/model-checking/kani/pull/4182
* Include wget in dependencies by @zhassan-aws in https://github.com/model-checking/kani/pull/4183
* Automatic cargo update to 2025-06-30 by @github-actions in https://github.com/model-checking/kani/pull/4186
* Add support for loop assigns in loop contracts by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4174
* Upgrade toolchain to 06/30 by @carolynzech in https://github.com/model-checking/kani/pull/4188
* Optimize reachability with non-mutating global passes by @AlexanderPortland in https://github.com/model-checking/kani/pull/4177
* Bump tests/perf/s2n-quic from `32ba87d` to `b8f8cca` by @dependabot in https://github.com/model-checking/kani/pull/4190
* Bump ncipollo/release-action from 1.16.0 to 1.18.0 by @dependabot in https://github.com/model-checking/kani/pull/4191
* Upgrade toolchain to 07/02 by @carolynzech in https://github.com/model-checking/kani/pull/4195
* Automatic Derivation Fixes by @carolynzech in https://github.com/model-checking/kani/pull/4194


**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.63.0...kani-0.64.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
