### PR TITLE
Use CBMC's shuffle_vector expression

### DIFF
--- a/cprover_bindings/src/irep/irep_id.rs
+++ b/cprover_bindings/src/irep/irep_id.rs
@@ -836,6 +836,7 @@ pub enum IrepId {
     VectorGt,
     VectorLt,
     FloatbvRoundToIntegral,
+    ShuffleVector,
 }
 
 impl IrepId {
@@ -1731,6 +1732,7 @@ impl IrepId {
             IrepId::VectorGt => "vector->",
             IrepId::VectorLt => "vector-<",
             IrepId::FloatbvRoundToIntegral => "floatbv_round_to_integral",
+            IrepId::ShuffleVector => "shuffle_vector",
         }
     }
 }

--- a/cprover_bindings/src/irep/to_irep.rs
+++ b/cprover_bindings/src/irep/to_irep.rs
@@ -408,6 +408,19 @@ impl ToIrep for ExprValue {
                 ],
                 named_sub: linear_map![],
             },
+            ExprValue::ShuffleVector { vector1, vector2, indexes } => Irep {
+                id: IrepId::ShuffleVector,
+                sub: vec![
+                    vector1.to_irep(mm),
+                    vector2.to_irep(mm),
+                    Irep {
+                        id: IrepId::EmptyString,
+                        sub: indexes.iter().map(|x| x.to_irep(mm)).collect(),
+                        named_sub: linear_map![],
+                    },
+                ],
+                named_sub: linear_map![],
+            },
         }
     }
 }


### PR DESCRIPTION
Ever since CBMC 5.51.0 it is no longer necessary to lower this expression in Kani.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
