### PR TITLE
Do not invoke memset with count of zero

### DIFF
--- a/tests/kani/NondetVectors/main.rs
+++ b/tests/kani/NondetVectors/main.rs
@@ -16,3 +16,20 @@ fn main() {
         assert!(_buf2[idx] == elt);
     }
 }
+
+#[kani::proof]
+fn minimal1() {
+    let v: Vec<i8> = vec![kani::any(); 0];
+}
+
+#[kani::proof]
+fn minimal2() {
+    let v: Vec<i8> = vec![5; 0];
+}
+
+#[kani::proof]
+fn vec3772() {
+    let value: u8 = 1; /* set to zero and it passes */
+    let count: u16 = kani::any();
+    let vector: Vec<u8> = vec![value; count as usize];
+}


### PR DESCRIPTION
We need to apply similar exclusion rules as we already do for intrinsics that invoke `memcmp`.

Resolves: #90
Resolves: #3772

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
