### PR TITLE
Make kani::assert non-fatal

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -139,7 +139,7 @@ impl GotocHook for Assert {
         Stmt::block(
             vec![
                 reach_stmt,
-                gcx.codegen_assert_assume(cond, PropertyClass::Assertion, &msg, caller_loc),
+                gcx.codegen_assert(cond, PropertyClass::Assertion, &msg, caller_loc),
                 Stmt::goto(bb_label(target), caller_loc),
             ],
             caller_loc,

--- a/tests/expected/debug-assert/expected
+++ b/tests/expected/debug-assert/expected
@@ -1,0 +1,11 @@
+Check 1: foo.assertion.1\
+	 - Status: FAILURE\
+	 - Description: ""will fail""\
+
+Check 2: foo.assertion.2\
+	 - Status: FAILURE\
+	 - Description: ""will fail""\
+
+Check 3: foo.assertion.3\
+	 - Status: UNREACHABLE\
+	 - Description: ""not reached""

--- a/tests/expected/debug-assert/main.rs
+++ b/tests/expected/debug-assert/main.rs
@@ -1,0 +1,6 @@
+#[kani::proof]
+fn foo() {
+    std::debug_assert!(false, "will fail");
+    std::assert!(false, "will fail");
+    std::debug_assert!(false, "not reached");
+}


### PR DESCRIPTION
This makes it possible to have `debug_assert` failures continue execution as `debug_assert` compiles to a no-op in non-debug builds. Thereby we can spot undefined behaviour masked by panics in debug mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
