### PR TITLE
Re-enable debug_assert in our standard library build

### DIFF
--- a/tools/build-kani/src/sysroot.rs
+++ b/tools/build-kani/src/sysroot.rs
@@ -130,10 +130,6 @@ fn build_kani_lib(
         "host-config",
         "--profile",
         "dev",
-        // Disable debug assertions for now as a mitigation for
-        // https://github.com/model-checking/kani/issues/1740
-        "--config",
-        "profile.dev.debug-assertions=false",
         "--config",
         "host.rustflags=[\"--cfg=kani\", \"--cfg=kani_sysroot\"]",
         "--target",


### PR DESCRIPTION
The original tests no longer fail when re-enabling debug assertions. Open tasks:
- Figure out what change actually solved #1740
- Address the ICE we see in one test
- Figure out why two other tests newly fail

Resolves: #1740

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
