### PR TITLE
[DRAFT] Use arena allocator when exporting goto binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -460,7 +460,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "cprover_bindings"
 version = "0.63.0"
 dependencies = [
+ "bumpalo",
  "fxhash",
+ "hashbrown 0.15.4",
  "lazy_static",
  "linear-map",
  "memuse",

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -21,6 +21,8 @@ string-interner = "0.19"
 tracing = "0.1"
 linear-map = {version = "1.2", features = ["serde_impl"]}
 fxhash = "0.2.1"
+bumpalo = { version = "3", features = ["allocator_api"] }
+hashbrown = { version = "0.15.4", features = ["nightly"], default-features = false }
 
 [dev-dependencies]
 serde_test = "1"

--- a/cprover_bindings/src/irep/irep.rs
+++ b/cprover_bindings/src/irep/irep.rs
@@ -6,24 +6,27 @@ use super::super::MachineModel;
 use super::super::goto_program::{Location, Type};
 use super::{IrepId, ToIrep};
 use crate::cbmc_string::InternedString;
-use crate::linear_map;
-use linear_map::LinearMap;
+use crate::irep::to_irep::hash_collect_into;
+use bumpalo::Bump;
+use hashbrown::{DefaultHashBuilder, HashMap};
 use num::BigInt;
 use std::fmt::Debug;
+use std::mem::ManuallyDrop;
 
 /// The CBMC serialization format for goto-programs.
 /// CBMC implementation code is at:
 /// <https://github.com/diffblue/cbmc/blob/develop/src/util/irep.h>
-#[derive(Clone, Debug, PartialEq)]
-pub struct Irep {
+#[derive(Clone, PartialEq, Debug)]
+pub struct Irep<'b> {
     pub id: IrepId,
-    pub sub: Vec<Irep>,
-    pub named_sub: LinearMap<IrepId, Irep>,
+    pub sub: std::mem::ManuallyDrop<Vec<Irep<'b>, &'b Bump>>,
+    // Note we use [hashbrown::HashMap] here because the std::collections::HashMap is not generic over its allocator yet.
+    pub named_sub: std::mem::ManuallyDrop<HashMap<IrepId, Irep<'b>, DefaultHashBuilder, &'b Bump>>,
 }
 
 /// Getters
-impl Irep {
-    pub fn lookup(&self, key: IrepId) -> Option<&Irep> {
+impl<'b> Irep<'b> {
+    pub fn lookup(&self, key: IrepId) -> Option<&Irep<'b>> {
         self.named_sub.get(&key)
     }
 
@@ -36,10 +39,20 @@ impl Irep {
 }
 
 /// Fluent Builders
-impl Irep {
-    pub fn with_location(self, l: &Location, mm: &MachineModel) -> Self {
+impl<'b> Irep<'b> {
+    pub fn with_location(self, l: &'b Location, mm: &MachineModel) -> Self {
+        let arena = *self.sub.allocator();
         if !l.is_none() {
-            self.with_named_sub(IrepId::CSourceLocation, l.to_irep(mm))
+            self.with_named_sub(IrepId::CSourceLocation, l.to_irep(arena, mm))
+        } else {
+            self
+        }
+    }
+
+    pub fn with_owned_location(self, l: Location, mm: &MachineModel) -> Self {
+        let arena = *self.sub.allocator();
+        if !l.is_none() {
+            self.with_named_sub(IrepId::CSourceLocation, l.to_irep(arena, mm))
         } else {
             self
         }
@@ -48,31 +61,37 @@ impl Irep {
     /// Adds a `comment` sub to the irep.
     /// Note that there might be comments both on the irep itself and
     /// inside the location sub of the irep.
-    pub fn with_comment<T: Into<InternedString>>(self, c: T) -> Self {
-        self.with_named_sub(IrepId::Comment, Irep::just_string_id(c))
+    pub fn with_comment<T: Into<InternedString>>(self, arena: &'b Bump, c: T) -> Irep<'b> {
+        self.with_named_sub(IrepId::Comment, Irep::just_string_id(arena, c))
     }
 
-    pub fn with_named_sub(mut self, key: IrepId, value: Irep) -> Self {
+    pub fn with_named_sub(mut self, key: IrepId, value: Irep<'b>) -> Self {
         if !value.is_nil() {
             self.named_sub.insert(key, value);
         }
         self
     }
 
-    pub fn with_named_sub_option(self, key: IrepId, value: Option<Irep>) -> Self {
+    pub fn with_named_sub_option(self, key: IrepId, value: Option<Irep<'b>>) -> Self {
         match value {
             Some(value) => self.with_named_sub(key, value),
             _ => self,
         }
     }
 
-    pub fn with_type(self, t: &Type, mm: &MachineModel) -> Self {
-        self.with_named_sub(IrepId::Type, t.to_irep(mm))
+    pub fn with_type(self, t: &'b Type, mm: &MachineModel) -> Self {
+        let arena = *self.sub.allocator();
+        self.with_named_sub(IrepId::Type, t.to_irep(arena, mm))
+    }
+
+    pub fn with_owned_type(self, t: Type, mm: &MachineModel) -> Self {
+        let arena = *self.sub.allocator();
+        self.with_named_sub(IrepId::Type, t.to_irep(arena, mm))
     }
 }
 
 /// Predicates
-impl Irep {
+impl Irep<'_> {
     pub fn is_just_id(&self) -> bool {
         self.sub.is_empty() && self.named_sub.is_empty()
     }
@@ -91,63 +110,81 @@ impl Irep {
 }
 
 /// Constructors
-impl Irep {
+impl<'b> Irep<'b> {
     /// `__attribute__(constructor)`. Only valid as a function return type.
     /// <https://gcc.gnu.org/onlinedocs/gcc-4.7.0/gcc/Function-Attributes.html>
-    pub fn constructor() -> Irep {
-        Irep::just_id(IrepId::Constructor)
+    pub fn constructor(arena: &'b Bump) -> Irep<'b> {
+        Irep::just_id(arena, IrepId::Constructor)
     }
 
-    pub fn empty() -> Irep {
-        Irep::just_id(IrepId::Empty)
+    pub fn empty(arena: &'b Bump) -> Irep<'b> {
+        Irep::just_id(arena, IrepId::Empty)
     }
 
-    pub fn just_bitpattern_id<T>(i: T, width: u64, signed: bool) -> Irep
+    pub fn just_bitpattern_id<T>(arena: &'b Bump, i: T, width: u64, signed: bool) -> Irep<'b>
     where
         T: Into<BigInt>,
     {
-        Irep::just_id(IrepId::bitpattern_from_int(i, width, signed))
+        Irep::just_id(arena, IrepId::bitpattern_from_int(i, width, signed))
     }
 
-    pub fn just_id(id: IrepId) -> Irep {
-        Irep { id, sub: Vec::new(), named_sub: LinearMap::new() }
+    pub fn just_id(arena: &'b Bump, id: IrepId) -> Irep<'b> {
+        Irep {
+            id,
+            sub: std::mem::ManuallyDrop::new(Vec::new_in(arena)),
+            named_sub: std::mem::ManuallyDrop::new(hashbrown::HashMap::new_in(arena)),
+        }
     }
 
-    pub fn just_int_id<T>(i: T) -> Irep
+    pub fn just_int_id<T>(arena: &'b Bump, i: T) -> Irep<'b>
     where
         T: Into<BigInt>,
     {
-        Irep::just_id(IrepId::from_int(i))
+        Irep::just_id(arena, IrepId::from_int(i))
     }
-    pub fn just_named_sub(named_sub: LinearMap<IrepId, Irep>) -> Irep {
-        Irep { id: IrepId::EmptyString, sub: vec![], named_sub }
-    }
-
-    pub fn just_string_id<T: Into<InternedString>>(s: T) -> Irep {
-        Irep::just_id(IrepId::from_string(s))
-    }
-
-    pub fn just_sub(sub: Vec<Irep>) -> Irep {
-        Irep { id: IrepId::EmptyString, sub, named_sub: LinearMap::new() }
-    }
-
-    pub fn nil() -> Irep {
-        Irep::just_id(IrepId::Nil)
+    pub fn just_named_sub(
+        arena: &'b Bump,
+        named_sub: ManuallyDrop<HashMap<IrepId, Irep<'b>, DefaultHashBuilder, &'b Bump>>,
+    ) -> Irep<'b> {
+        Irep {
+            id: IrepId::EmptyString,
+            sub: std::mem::ManuallyDrop::new(Vec::new_in(arena)),
+            named_sub,
+        }
     }
 
-    pub fn one() -> Irep {
-        Irep::just_id(IrepId::Id1)
+    pub fn just_string_id<T: Into<InternedString>>(arena: &'b Bump, s: T) -> Irep<'b> {
+        Irep::just_id(arena, IrepId::from_string(s))
     }
 
-    pub fn zero() -> Irep {
-        Irep::just_id(IrepId::Id0)
+    pub fn just_sub(sub: std::mem::ManuallyDrop<Vec<Irep<'b>, &'b Bump>>) -> Irep<'b> {
+        Irep {
+            id: IrepId::EmptyString,
+            named_sub: ManuallyDrop::new(hashbrown::HashMap::new_in(sub.allocator())),
+            sub,
+        }
     }
 
-    pub fn tuple(sub: Vec<Irep>) -> Self {
+    pub fn nil(arena: &'b Bump) -> Irep<'b> {
+        Irep::just_id(arena, IrepId::Nil)
+    }
+
+    pub fn one(arena: &'b Bump) -> Irep<'b> {
+        Irep::just_id(arena, IrepId::Id1)
+    }
+
+    pub fn zero(arena: &'b Bump) -> Irep<'b> {
+        Irep::just_id(arena, IrepId::Id0)
+    }
+
+    pub fn tuple(sub: std::mem::ManuallyDrop<Vec<Irep<'b>, &'b Bump>>) -> Self {
         Irep {
             id: IrepId::Tuple,
+            named_sub: hash_collect_into(
+                [(IrepId::Type, Irep::just_id(sub.allocator(), IrepId::Tuple))],
+                sub.allocator(),
+            ),
             sub,
-            named_sub: linear_map![(IrepId::Type, Irep::just_id(IrepId::Tuple))],
         }
     }
 }

--- a/cprover_bindings/src/irep/irep_id.rs
+++ b/cprover_bindings/src/irep/irep_id.rs
@@ -10,7 +10,7 @@ use num::bigint::{BigInt, BigUint, Sign};
 
 use std::borrow::Cow;
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Hash)]
 pub enum IrepId {
     /// In addition to the standard enums defined below, CBMC also allows ids to be strings.
     /// For e.g, to store the id of a variable. This enum variant captures those strings.

--- a/cprover_bindings/src/irep/symbol.rs
+++ b/cprover_bindings/src/irep/symbol.rs
@@ -6,10 +6,10 @@ use crate::InternedString;
 /// <https://github.com/diffblue/cbmc/blob/develop/src/util/symbol.h>
 // TODO: do we want these members to be public?
 #[derive(Clone, Debug, PartialEq)]
-pub struct Symbol {
-    pub typ: Irep,
-    pub value: Irep,
-    pub location: Irep,
+pub struct Symbol<'b> {
+    pub typ: Irep<'b>,
+    pub value: Irep<'b>,
+    pub location: Irep<'b>,
     /// Unique identifier, same as key in symbol table `foo::x`
     pub name: InternedString,
     /// Only used by verilog

--- a/cprover_bindings/src/irep/symbol_table.rs
+++ b/cprover_bindings/src/irep/symbol_table.rs
@@ -2,31 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use super::Symbol;
 use crate::InternedString;
+use bumpalo::Bump;
 use std::collections::BTreeMap;
 
 /// A direct implementation of the CBMC serilization format for symbol tables implemented in
 /// <https://github.com/diffblue/cbmc/blob/develop/src/util/symbol_table.h>
 #[derive(Debug, PartialEq)]
-pub struct SymbolTable {
-    pub symbol_table: BTreeMap<InternedString, Symbol>,
+pub struct SymbolTable<'b> {
+    pub symbol_table: BTreeMap<InternedString, Symbol<'b>, &'b bumpalo::Bump>,
 }
 
-/// Constructors
-impl Default for SymbolTable {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SymbolTable {
-    pub fn new() -> SymbolTable {
-        SymbolTable { symbol_table: BTreeMap::new() }
+impl<'b> SymbolTable<'b> {
+    pub fn new_in(arena: &'b Bump) -> SymbolTable<'b> {
+        SymbolTable { symbol_table: BTreeMap::new_in(arena) }
     }
 }
 
 /// Setters
-impl SymbolTable {
-    pub fn insert(&mut self, symbol: Symbol) {
+impl<'b> SymbolTable<'b> {
+    pub fn insert(&mut self, symbol: Symbol<'b>) {
         self.symbol_table.insert(symbol.name, symbol);
     }
 }

--- a/cprover_bindings/src/irep/to_irep.rs
+++ b/cprover_bindings/src/irep/to_irep.rs
@@ -1,47 +1,100 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Converts a typed goto-program into the `Irep` serilization format of CBMC
+use std::hash::Hash;
+use std::mem::ManuallyDrop;
+
 // TODO: consider making a macro to replace `linear_map![])` for initilizing btrees.
 use super::super::MachineModel;
 use super::super::goto_program;
 use super::{Irep, IrepId};
 use crate::InternedString;
 use crate::linear_map;
+use bumpalo::Bump;
 use goto_program::{
     BinaryOperator, CIntType, DatatypeComponent, Expr, ExprValue, Lambda, Location, Parameter,
     SelfOperator, Stmt, StmtBody, SwitchCase, SymbolValues, Type, UnaryOperator,
 };
+use hashbrown::DefaultHashBuilder;
+use hashbrown::HashMap;
 
 pub trait ToIrep {
-    fn to_irep(&self, mm: &MachineModel) -> Irep;
+    fn to_irep<'b>(&self, arena: &'b Bump, mm: &MachineModel) -> Irep<'b>;
+}
+
+pub(crate) fn collect_into<T: IntoIterator>(
+    t: T,
+    arena: &Bump,
+) -> std::mem::ManuallyDrop<Vec<T::Item, &Bump>> {
+    let mut v = Vec::new_in(arena);
+    let i = t.into_iter();
+
+    for t in i {
+        v.push(t);
+    }
+    std::mem::ManuallyDrop::new(v)
+}
+
+pub fn hash_collect_into<K: Eq + Hash, V, T: IntoIterator<Item = (K, V)>>(
+    t: T,
+    arena: &Bump,
+) -> std::mem::ManuallyDrop<HashMap<K, V, DefaultHashBuilder, &Bump>> {
+    let mut h = HashMap::new_in(arena);
+    let i = t.into_iter();
+    for (k, v) in i {
+        h.insert(k, v);
+    }
+    std::mem::ManuallyDrop::new(h)
+}
+
+#[macro_export]
+macro_rules! vec_in {
+    ($arena:expr $(,)?) => {
+        std::mem::ManuallyDrop::new(Vec::new_in($arena))
+    };
+    ($arena:expr, $($x:expr),+ $(,)?) => {
+        collect_into([$($x),+], $arena)
+    }
 }
 
 /// Utility functions
-fn arguments_irep<'a>(arguments: impl Iterator<Item = &'a Expr>, mm: &MachineModel) -> Irep {
+fn arguments_irep<'b, 'a>(
+    arena: &'b Bump,
+    arguments: impl Iterator<Item = &'a Expr>,
+    mm: &MachineModel,
+) -> Irep<'b> {
     Irep {
         id: IrepId::Arguments,
-        sub: arguments.map(|x| x.to_irep(mm)).collect(),
-        named_sub: linear_map![],
+        sub: collect_into(arguments.map(|x| x.to_irep(arena, mm)), arena),
+        named_sub: ManuallyDrop::new(HashMap::new_in(arena)),
     }
 }
-fn code_irep(kind: IrepId, ops: Vec<Irep>) -> Irep {
+fn code_irep<'b>(
+    arena: &'b Bump,
+    kind: IrepId,
+    ops: std::mem::ManuallyDrop<Vec<Irep<'b>, &'b Bump>>,
+) -> Irep<'b> {
     Irep {
         id: IrepId::Code,
         sub: ops,
-        named_sub: linear_map![(IrepId::Statement, Irep::just_id(kind))],
+        named_sub: hash_collect_into([(IrepId::Statement, Irep::just_id(arena, kind))], arena),
     }
 }
-fn side_effect_irep(kind: IrepId, ops: Vec<Irep>) -> Irep {
+fn side_effect_irep<'b>(
+    arena: &'b Bump,
+    kind: IrepId,
+    ops: std::mem::ManuallyDrop<Vec<Irep<'b>, &'b Bump>>,
+) -> Irep<'b> {
     Irep {
         id: IrepId::SideEffect,
+        named_sub: linear_map![arena, (IrepId::Statement, Irep::just_id(arena, kind))],
         sub: ops,
-        named_sub: linear_map![(IrepId::Statement, Irep::just_id(kind))],
     }
 }
-fn switch_default_irep(body: &Stmt, mm: &MachineModel) -> Irep {
-    code_irep(IrepId::SwitchCase, vec![Irep::nil(), body.to_irep(mm)])
-        .with_named_sub(IrepId::Default, Irep::one())
-        .with_location(body.location(), mm)
+fn switch_default_irep<'b>(arena: &'b Bump, body: &Stmt, mm: &MachineModel) -> Irep<'b> {
+    code_irep(arena, IrepId::SwitchCase, vec_in![arena, Irep::nil(arena), body.to_irep(arena, mm)])
+        .with_named_sub(IrepId::Default, Irep::one(arena))
+        .with_owned_location(*body.location(), mm)
 }
 
 /// ID Converters
@@ -129,94 +182,123 @@ impl ToIrepId for UnaryOperator {
 
 /// The main converters
 impl ToIrep for DatatypeComponent {
-    fn to_irep(&self, mm: &MachineModel) -> Irep {
+    fn to_irep<'b>(&self, arena: &'b Bump, mm: &MachineModel) -> Irep<'b> {
         match self {
-            DatatypeComponent::Field { name, typ } => Irep::just_named_sub(linear_map![
-                (IrepId::Name, Irep::just_string_id(name.to_string())),
-                (IrepId::CPrettyName, Irep::just_string_id(name.to_string())),
-                (IrepId::Type, typ.to_irep(mm)),
-            ]),
-            DatatypeComponent::UnionField { name, typ: _, padded_typ } => {
-                Irep::just_named_sub(linear_map![
-                    (IrepId::Name, Irep::just_string_id(name.to_string())),
-                    (IrepId::CPrettyName, Irep::just_string_id(name.to_string())),
-                    (IrepId::Type, padded_typ.to_irep(mm)),
-                ])
-            }
-            DatatypeComponent::Padding { name, bits } => Irep::just_named_sub(linear_map![
-                (IrepId::CIsPadding, Irep::one()),
-                (IrepId::Name, Irep::just_string_id(name.to_string())),
-                (IrepId::Type, Type::unsigned_int(*bits).to_irep(mm)),
-            ]),
+            DatatypeComponent::Field { name, typ } => Irep::just_named_sub(
+                arena,
+                linear_map![
+                    arena,
+                    (IrepId::Name, Irep::just_string_id(arena, name.to_string())),
+                    (IrepId::CPrettyName, Irep::just_string_id(arena, name.to_string())),
+                    (IrepId::Type, typ.to_irep(arena, mm)),
+                ],
+            ),
+            DatatypeComponent::UnionField { name, typ: _, padded_typ } => Irep::just_named_sub(
+                arena,
+                linear_map![
+                    arena,
+                    (IrepId::Name, Irep::just_string_id(arena, name.to_string())),
+                    (IrepId::CPrettyName, Irep::just_string_id(arena, name.to_string())),
+                    (IrepId::Type, padded_typ.to_irep(arena, mm)),
+                ],
+            ),
+            DatatypeComponent::Padding { name, bits } => Irep::just_named_sub(
+                arena,
+                linear_map![
+                    arena,
+                    (IrepId::CIsPadding, Irep::one(arena)),
+                    (IrepId::Name, Irep::just_string_id(arena, name.to_string())),
+                    (IrepId::Type, Type::unsigned_int(*bits).to_irep(arena, mm)),
+                ],
+            ),
         }
     }
 }
 
 impl ToIrep for Expr {
-    fn to_irep(&self, mm: &MachineModel) -> Irep {
+    fn to_irep<'b>(&self, arena: &'b Bump, mm: &MachineModel) -> Irep<'b> {
         if let ExprValue::IntConstant(i) = self.value() {
             let typ_width = self.typ().native_width(mm);
             let irep_value = if let Some(width) = typ_width {
-                Irep::just_bitpattern_id(i.clone(), width, self.typ().is_signed(mm))
+                Irep::just_bitpattern_id(arena, i.clone(), width, self.typ().is_signed(mm))
             } else {
-                Irep::just_int_id(i.clone())
+                Irep::just_int_id(arena, i.clone())
             };
             Irep {
                 id: IrepId::Constant,
-                sub: vec![],
-                named_sub: linear_map![(IrepId::Value, irep_value,)],
+                sub: vec_in![arena],
+                named_sub: linear_map![arena, (IrepId::Value, irep_value,)],
             }
-            .with_location(self.location(), mm)
-            .with_type(self.typ(), mm)
+            .with_owned_location(*self.location(), mm)
+            .with_owned_type(self.typ().clone(), mm)
         } else {
-            self.value().to_irep(mm).with_location(self.location(), mm).with_type(self.typ(), mm)
+            self.value()
+                .to_irep(arena, mm)
+                .with_owned_location(*self.location(), mm)
+                .with_owned_type(self.typ().clone(), mm)
         }
         .with_named_sub_option(
             IrepId::CCSizeofType,
-            self.size_of_annotation().map(|ty| ty.to_irep(mm)),
+            self.size_of_annotation().map(|ty| ty.to_irep(arena, mm)),
         )
     }
 }
 
-impl Irep {
-    pub fn symbol(identifier: InternedString) -> Self {
+impl<'b> Irep<'b> {
+    pub fn symbol(arena: &'b Bump, identifier: InternedString) -> Self {
         Irep {
             id: IrepId::Symbol,
-            sub: vec![],
-            named_sub: linear_map![(IrepId::Identifier, Irep::just_string_id(identifier))],
+            sub: vec_in![arena],
+            named_sub: linear_map![
+                arena,
+                (IrepId::Identifier, Irep::just_string_id(arena, identifier))
+            ],
         }
     }
 }
 
 impl ToIrep for ExprValue {
-    fn to_irep(&self, mm: &MachineModel) -> Irep {
+    fn to_irep<'b>(&self, arena: &'b Bump, mm: &MachineModel) -> Irep<'b> {
         match self {
-            ExprValue::AddressOf(e) => {
-                Irep { id: IrepId::AddressOf, sub: vec![e.to_irep(mm)], named_sub: linear_map![] }
-            }
+            ExprValue::AddressOf(e) => Irep {
+                id: IrepId::AddressOf,
+                sub: vec_in![arena, e.to_irep(arena, mm)],
+                named_sub: linear_map![arena],
+            },
             ExprValue::Array { elems } => Irep {
                 id: IrepId::Array,
-                sub: elems.iter().map(|x| x.to_irep(mm)).collect(),
-                named_sub: linear_map![],
+                sub: collect_into(elems.iter().map(|x| x.to_irep(arena, mm)), arena),
+                named_sub: linear_map![arena],
             },
-            ExprValue::ArrayOf { elem } => {
-                Irep { id: IrepId::ArrayOf, sub: vec![elem.to_irep(mm)], named_sub: linear_map![] }
-            }
-            ExprValue::Assign { left, right } => {
-                side_effect_irep(IrepId::Assign, vec![left.to_irep(mm), right.to_irep(mm)])
-            }
+            ExprValue::ArrayOf { elem } => Irep {
+                id: IrepId::ArrayOf,
+                sub: vec_in![arena, elem.to_irep(arena, mm)],
+                named_sub: linear_map![arena],
+            },
+            ExprValue::Assign { left, right } => side_effect_irep(
+                arena,
+                IrepId::Assign,
+                vec_in![arena, left.to_irep(arena, mm), right.to_irep(arena, mm)],
+            ),
             ExprValue::BinOp { op, lhs, rhs } => Irep {
                 id: op.to_irep_id(),
-                sub: vec![lhs.to_irep(mm), rhs.to_irep(mm)],
-                named_sub: linear_map![],
+                sub: vec_in![arena, lhs.to_irep(arena, mm), rhs.to_irep(arena, mm)],
+                named_sub: linear_map![arena],
             },
             ExprValue::BoolConstant(c) => Irep {
                 id: IrepId::Constant,
-                sub: vec![],
-                named_sub: linear_map![(
-                    IrepId::Value,
-                    if *c { Irep::just_id(IrepId::True) } else { Irep::just_id(IrepId::False) },
-                )],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (
+                        IrepId::Value,
+                        if *c {
+                            Irep::just_id(arena, IrepId::True)
+                        } else {
+                            Irep::just_id(arena, IrepId::False)
+                        },
+                    )
+                ],
             },
             ExprValue::ByteExtract { e, offset } => Irep {
                 id: if mm.is_big_endian {
@@ -224,203 +306,258 @@ impl ToIrep for ExprValue {
                 } else {
                     IrepId::ByteExtractLittleEndian
                 },
-                sub: vec![e.to_irep(mm), Expr::int_constant(*offset, Type::ssize_t()).to_irep(mm)],
-                named_sub: linear_map![],
+                sub: vec_in![
+                    arena,
+                    e.to_irep(arena, mm),
+                    Expr::int_constant(*offset, Type::ssize_t()).to_irep(arena, mm)
+                ],
+                named_sub: linear_map![arena],
             },
             ExprValue::CBoolConstant(i) => Irep {
                 id: IrepId::Constant,
-                sub: vec![],
-                named_sub: linear_map![(
-                    IrepId::Value,
-                    Irep::just_bitpattern_id(if *i { 1u8 } else { 0 }, mm.bool_width, false)
-                )],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (
+                        IrepId::Value,
+                        Irep::just_bitpattern_id(
+                            arena,
+                            if *i { 1u8 } else { 0 },
+                            mm.bool_width,
+                            false
+                        )
+                    )
+                ],
             },
-            ExprValue::Dereference(e) => {
-                Irep { id: IrepId::Dereference, sub: vec![e.to_irep(mm)], named_sub: linear_map![] }
-            }
+            ExprValue::Dereference(e) => Irep {
+                id: IrepId::Dereference,
+                sub: vec_in![arena, e.to_irep(arena, mm)],
+                named_sub: linear_map![arena],
+            },
             //TODO, determine if there is an endineness problem here
             ExprValue::DoubleConstant(i) => {
                 let c: u64 = i.to_bits();
                 Irep {
                     id: IrepId::Constant,
-                    sub: vec![],
-                    named_sub: linear_map![(
-                        IrepId::Value,
-                        Irep::just_bitpattern_id(c, mm.double_width, false)
-                    )],
+                    sub: vec_in![arena],
+                    named_sub: linear_map![
+                        arena,
+                        (IrepId::Value, Irep::just_bitpattern_id(arena, c, mm.double_width, false))
+                    ],
                 }
             }
-            ExprValue::EmptyUnion => Irep::just_id(IrepId::EmptyUnion),
+            ExprValue::EmptyUnion => Irep::just_id(arena, IrepId::EmptyUnion),
             ExprValue::FloatConstant(i) => {
                 let c: u32 = i.to_bits();
                 Irep {
                     id: IrepId::Constant,
-                    sub: vec![],
-                    named_sub: linear_map![(
-                        IrepId::Value,
-                        Irep::just_bitpattern_id(c, mm.float_width, false)
-                    )],
+                    sub: vec_in![arena],
+                    named_sub: linear_map![
+                        arena,
+                        (IrepId::Value, Irep::just_bitpattern_id(arena, c, mm.float_width, false))
+                    ],
                 }
             }
             ExprValue::Float16Constant(i) => {
                 let c: u16 = i.to_bits();
                 Irep {
                     id: IrepId::Constant,
-                    sub: vec![],
-                    named_sub: linear_map![(IrepId::Value, Irep::just_bitpattern_id(c, 16, false))],
+                    sub: vec_in![arena],
+                    named_sub: linear_map![
+                        arena,
+                        (IrepId::Value, Irep::just_bitpattern_id(arena, c, 16, false))
+                    ],
                 }
             }
             ExprValue::Float128Constant(i) => {
                 let c: u128 = i.to_bits();
                 Irep {
                     id: IrepId::Constant,
-                    sub: vec![],
-                    named_sub: linear_map![(
-                        IrepId::Value,
-                        Irep::just_bitpattern_id(c, 128, false)
-                    )],
+                    sub: vec_in![arena],
+                    named_sub: linear_map![
+                        arena,
+                        (IrepId::Value, Irep::just_bitpattern_id(arena, c, 128, false))
+                    ],
                 }
             }
             ExprValue::FunctionCall { function, arguments } => side_effect_irep(
+                arena,
                 IrepId::FunctionCall,
-                vec![function.to_irep(mm), arguments_irep(arguments.iter(), mm)],
+                vec_in![
+                    arena,
+                    function.to_irep(arena, mm),
+                    arguments_irep(arena, arguments.iter(), mm)
+                ],
             ),
             ExprValue::If { c, t, e } => Irep {
                 id: IrepId::If,
-                sub: vec![c.to_irep(mm), t.to_irep(mm), e.to_irep(mm)],
-                named_sub: linear_map![],
+                sub: vec_in![
+                    arena,
+                    c.to_irep(arena, mm),
+                    t.to_irep(arena, mm),
+                    e.to_irep(arena, mm)
+                ],
+                named_sub: linear_map![arena],
             },
             ExprValue::Index { array, index } => Irep {
                 id: IrepId::Index,
-                sub: vec![array.to_irep(mm), index.to_irep(mm)],
-                named_sub: linear_map![],
+                sub: vec_in![arena, array.to_irep(arena, mm), index.to_irep(arena, mm)],
+                named_sub: linear_map![arena],
             },
             ExprValue::IntConstant(_) => {
                 unreachable!("Should have been processed in previous step")
             }
             ExprValue::Member { lhs, field } => Irep {
                 id: IrepId::Member,
-                sub: vec![lhs.to_irep(mm)],
+                sub: vec_in![arena, lhs.to_irep(arena, mm)],
                 named_sub: linear_map![
-                    (IrepId::CLvalue, Irep::one()),
-                    (IrepId::ComponentName, Irep::just_string_id(field.to_string())),
+                    arena,
+                    (IrepId::CLvalue, Irep::one(arena)),
+                    (IrepId::ComponentName, Irep::just_string_id(arena, field.to_string())),
                 ],
             },
-            ExprValue::Nondet => side_effect_irep(IrepId::Nondet, vec![]),
+            ExprValue::Nondet => side_effect_irep(arena, IrepId::Nondet, vec_in![arena]),
             ExprValue::PointerConstant(0) => Irep {
                 id: IrepId::Constant,
-                sub: vec![],
-                named_sub: linear_map![(IrepId::Value, Irep::just_id(IrepId::NULL))],
+                sub: vec_in![arena],
+                named_sub: linear_map![arena, (IrepId::Value, Irep::just_id(arena, IrepId::NULL))],
             },
             ExprValue::PointerConstant(i) => Irep {
                 id: IrepId::Constant,
-                sub: vec![],
-                named_sub: linear_map![(
-                    IrepId::Value,
-                    Irep::just_bitpattern_id(*i, mm.pointer_width, false)
-                )],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::Value, Irep::just_bitpattern_id(arena, *i, mm.pointer_width, false))
+                ],
             },
             ExprValue::ReadOk { ptr, size } => Irep {
                 id: IrepId::ROk,
-                sub: vec![ptr.to_irep(mm), size.to_irep(mm)],
-                named_sub: linear_map![],
+                sub: vec_in![arena, ptr.to_irep(arena, mm), size.to_irep(arena, mm)],
+                named_sub: linear_map![arena],
             },
-            ExprValue::SelfOp { op, e } => side_effect_irep(op.to_irep_id(), vec![e.to_irep(mm)]),
+            ExprValue::SelfOp { op, e } => {
+                side_effect_irep(arena, op.to_irep_id(), vec_in![arena, e.to_irep(arena, mm)])
+            }
             ExprValue::StatementExpression { statements: ops, location: loc } => side_effect_irep(
+                arena,
                 IrepId::StatementExpression,
-                vec![Stmt::block(ops.to_vec(), *loc).to_irep(mm)],
+                vec_in![arena, Stmt::block(ops.to_vec(), *loc).to_irep(arena, mm)],
             ),
             ExprValue::StringConstant { s } => Irep {
                 id: IrepId::StringConstant,
-                sub: vec![],
-                named_sub: linear_map![(IrepId::Value, Irep::just_string_id(s.to_string()),)],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::Value, Irep::just_string_id(arena, s.to_string()),)
+                ],
             },
             ExprValue::Struct { values } => Irep {
                 id: IrepId::Struct,
-                sub: values.iter().map(|x| x.to_irep(mm)).collect(),
-                named_sub: linear_map![],
+                sub: collect_into(values.iter().map(|x| x.to_irep(arena, mm)), arena),
+                named_sub: linear_map![arena],
             },
-            ExprValue::Symbol { identifier } => Irep::symbol(*identifier),
-            ExprValue::Typecast(e) => {
-                Irep { id: IrepId::Typecast, sub: vec![e.to_irep(mm)], named_sub: linear_map![] }
-            }
+            ExprValue::Symbol { identifier } => Irep::symbol(arena, *identifier),
+            ExprValue::Typecast(e) => Irep {
+                id: IrepId::Typecast,
+                sub: vec_in![arena, e.to_irep(arena, mm)],
+                named_sub: linear_map![arena],
+            },
             ExprValue::Union { value, field } => Irep {
                 id: IrepId::Union,
-                sub: vec![value.to_irep(mm)],
-                named_sub: linear_map![(
-                    IrepId::ComponentName,
-                    Irep::just_string_id(field.to_string()),
-                )],
+                sub: vec_in![arena, value.to_irep(arena, mm)],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::ComponentName, Irep::just_string_id(arena, field.to_string()),)
+                ],
             },
             ExprValue::UnOp { op: UnaryOperator::Bswap, e } => Irep {
                 id: IrepId::Bswap,
-                sub: vec![e.to_irep(mm)],
-                named_sub: linear_map![(IrepId::BitsPerByte, Irep::just_int_id(8u8))],
+                sub: vec_in![arena, e.to_irep(arena, mm)],
+                named_sub: linear_map![arena, (IrepId::BitsPerByte, Irep::just_int_id(arena, 8u8))],
             },
-            ExprValue::UnOp { op: UnaryOperator::BitReverse, e } => {
-                Irep { id: IrepId::BitReverse, sub: vec![e.to_irep(mm)], named_sub: linear_map![] }
-            }
+            ExprValue::UnOp { op: UnaryOperator::BitReverse, e } => Irep {
+                id: IrepId::BitReverse,
+                sub: vec_in![arena, e.to_irep(arena, mm)],
+                named_sub: linear_map![arena],
+            },
             ExprValue::UnOp { op: UnaryOperator::CountLeadingZeros { allow_zero }, e } => Irep {
                 id: IrepId::CountLeadingZeros,
-                sub: vec![e.to_irep(mm)],
-                named_sub: linear_map![(
-                    IrepId::CBoundsCheck,
-                    if *allow_zero { Irep::zero() } else { Irep::one() }
-                )],
+                sub: vec_in![arena, e.to_irep(arena, mm)],
+                named_sub: linear_map![
+                    arena,
+                    (
+                        IrepId::CBoundsCheck,
+                        if *allow_zero { Irep::zero(arena) } else { Irep::one(arena) }
+                    )
+                ],
             },
             ExprValue::UnOp { op: UnaryOperator::CountTrailingZeros { allow_zero }, e } => Irep {
                 id: IrepId::CountTrailingZeros,
-                sub: vec![e.to_irep(mm)],
-                named_sub: linear_map![(
-                    IrepId::CBoundsCheck,
-                    if *allow_zero { Irep::zero() } else { Irep::one() }
-                )],
+                sub: vec_in![arena, e.to_irep(arena, mm)],
+                named_sub: linear_map![
+                    arena,
+                    (
+                        IrepId::CBoundsCheck,
+                        if *allow_zero { Irep::zero(arena) } else { Irep::one(arena) }
+                    )
+                ],
             },
-            ExprValue::UnOp { op, e } => {
-                Irep { id: op.to_irep_id(), sub: vec![e.to_irep(mm)], named_sub: linear_map![] }
-            }
+            ExprValue::UnOp { op, e } => Irep {
+                id: op.to_irep_id(),
+                sub: vec_in![arena, e.to_irep(arena, mm)],
+                named_sub: linear_map![arena],
+            },
             ExprValue::Vector { elems } => Irep {
                 id: IrepId::Vector,
-                sub: elems.iter().map(|x| x.to_irep(mm)).collect(),
-                named_sub: linear_map![],
+                sub: collect_into(elems.iter().map(|x| x.to_irep(arena, mm)), arena),
+                named_sub: linear_map![arena],
             },
             ExprValue::Forall { variable, domain } => Irep {
                 id: IrepId::Forall,
-                sub: vec![
+                sub: vec_in![
+                    arena,
                     Irep {
                         id: IrepId::Tuple,
-                        sub: vec![variable.to_irep(mm)],
-                        named_sub: linear_map![],
+                        sub: vec_in![arena, variable.to_irep(arena, mm)],
+                        named_sub: linear_map![arena],
                     },
-                    domain.to_irep(mm),
+                    domain.to_irep(arena, mm),
                 ],
-                named_sub: linear_map![],
+                named_sub: linear_map![arena],
             },
             ExprValue::Exists { variable, domain } => Irep {
                 id: IrepId::Exists,
-                sub: vec![
+                sub: vec_in![
+                    arena,
                     Irep {
                         id: IrepId::Tuple,
-                        sub: vec![variable.to_irep(mm)],
-                        named_sub: linear_map![],
+                        sub: vec_in![arena, variable.to_irep(arena, mm)],
+                        named_sub: linear_map![arena],
                     },
-                    domain.to_irep(mm),
+                    domain.to_irep(arena, mm),
                 ],
-                named_sub: linear_map![],
+                named_sub: linear_map![arena],
             },
         }
     }
 }
 
 impl ToIrep for Location {
-    fn to_irep(&self, _mm: &MachineModel) -> Irep {
+    fn to_irep<'b>(&self, arena: &'b Bump, _mm: &MachineModel) -> Irep<'b> {
         match self {
-            Location::None => Irep::nil(),
-            Location::BuiltinFunction { line, function_name } => Irep::just_named_sub(linear_map![
-                (IrepId::File, Irep::just_string_id(format!("<builtin-library-{function_name}>")),),
-                (IrepId::Function, Irep::just_string_id(function_name.to_string())),
-            ])
-            .with_named_sub_option(IrepId::Line, line.map(Irep::just_int_id)),
+            Location::None => Irep::nil(arena),
+            Location::BuiltinFunction { line, function_name } => Irep::just_named_sub(
+                arena,
+                linear_map![
+                    arena,
+                    (
+                        IrepId::File,
+                        Irep::just_string_id(arena, format!("<builtin-library-{function_name}>")),
+                    ),
+                    (IrepId::Function, Irep::just_string_id(arena, function_name.to_string())),
+                ],
+            )
+            .with_named_sub_option(IrepId::Line, line.map(|a| Irep::just_int_id(arena, a))),
             Location::Loc {
                 file,
                 function,
@@ -429,172 +566,262 @@ impl ToIrep for Location {
                 end_line: _,
                 end_col: _,
                 pragmas,
-            } => Irep::just_named_sub(linear_map![
-                (IrepId::File, Irep::just_string_id(file.to_string())),
-                (IrepId::Line, Irep::just_int_id(*start_line)),
-            ])
-            .with_named_sub_option(IrepId::Column, start_col.map(Irep::just_int_id))
-            .with_named_sub_option(IrepId::Function, function.map(Irep::just_string_id))
+            } => Irep::just_named_sub(
+                arena,
+                linear_map![
+                    arena,
+                    (IrepId::File, Irep::just_string_id(arena, file.to_string())),
+                    (IrepId::Line, Irep::just_int_id(arena, *start_line)),
+                ],
+            )
+            .with_named_sub_option(IrepId::Column, start_col.map(|a| Irep::just_int_id(arena, a)))
+            .with_named_sub_option(
+                IrepId::Function,
+                function.map(|s| Irep::just_string_id(arena, s)),
+            )
             .with_named_sub_option(
                 IrepId::Pragma,
                 Some(Irep::just_named_sub(
-                    pragmas
-                        .iter()
-                        .map(|pragma| {
-                            (IrepId::from_string(*pragma), Irep::just_id(IrepId::EmptyString))
-                        })
-                        .collect(),
+                    arena,
+                    hash_collect_into(
+                        pragmas.iter().map(|pragma| {
+                            (
+                                IrepId::from_string(*pragma),
+                                Irep::just_id(arena, IrepId::EmptyString),
+                            )
+                        }),
+                        arena,
+                    ),
                 )),
             ),
             Location::Property { file, function, line, col, property_class, comment, pragmas } => {
-                Irep::just_named_sub(linear_map![
-                    (IrepId::File, Irep::just_string_id(file.to_string())),
-                    (IrepId::Line, Irep::just_int_id(*line)),
-                ])
-                .with_named_sub_option(IrepId::Column, col.map(Irep::just_int_id))
-                .with_named_sub_option(IrepId::Function, function.map(Irep::just_string_id))
-                .with_named_sub(IrepId::Comment, Irep::just_string_id(comment.to_string()))
+                Irep::just_named_sub(
+                    arena,
+                    hash_collect_into(
+                        [
+                            (IrepId::File, Irep::just_string_id(arena, file.to_string())),
+                            (IrepId::Line, Irep::just_int_id(arena, *line)),
+                        ],
+                        arena,
+                    ),
+                )
+                .with_named_sub_option(IrepId::Column, col.map(|a| Irep::just_int_id(arena, a)))
+                .with_named_sub_option(
+                    IrepId::Function,
+                    function.map(|s| Irep::just_string_id(arena, s)),
+                )
+                .with_named_sub(IrepId::Comment, Irep::just_string_id(arena, comment.to_string()))
                 .with_named_sub(
                     IrepId::PropertyClass,
-                    Irep::just_string_id(property_class.to_string()),
+                    Irep::just_string_id(arena, property_class.to_string()),
                 )
                 .with_named_sub_option(
                     IrepId::Pragma,
                     Some(Irep::just_named_sub(
-                        pragmas
-                            .iter()
-                            .map(|pragma| {
-                                (IrepId::from_string(*pragma), Irep::just_id(IrepId::EmptyString))
-                            })
-                            .collect(),
+                        arena,
+                        hash_collect_into(
+                            pragmas.iter().map(|pragma| {
+                                (
+                                    IrepId::from_string(*pragma),
+                                    Irep::just_id(arena, IrepId::EmptyString),
+                                )
+                            }),
+                            arena,
+                        ),
                     )),
                 )
             }
-            Location::PropertyUnknownLocation { property_class, comment } => {
-                Irep::just_named_sub(linear_map![
-                    (IrepId::Comment, Irep::just_string_id(comment.to_string())),
-                    (IrepId::PropertyClass, Irep::just_string_id(property_class.to_string()))
-                ])
-            }
+            Location::PropertyUnknownLocation { property_class, comment } => Irep::just_named_sub(
+                arena,
+                linear_map![
+                    arena,
+                    (IrepId::Comment, Irep::just_string_id(arena, comment.to_string())),
+                    (
+                        IrepId::PropertyClass,
+                        Irep::just_string_id(arena, property_class.to_string())
+                    )
+                ],
+            ),
         }
     }
 }
 
 impl ToIrep for Parameter {
-    fn to_irep(&self, mm: &MachineModel) -> Irep {
+    fn to_irep<'b>(&self, arena: &'b Bump, mm: &MachineModel) -> Irep<'b> {
         Irep {
             id: IrepId::Parameter,
-            sub: vec![],
-            named_sub: linear_map![(IrepId::Type, self.typ().to_irep(mm))],
+            sub: vec_in![arena],
+            named_sub: linear_map![arena, (IrepId::Type, self.typ().to_irep(arena, mm))],
         }
-        .with_named_sub_option(IrepId::CIdentifier, self.identifier().map(Irep::just_string_id))
-        .with_named_sub_option(IrepId::CBaseName, self.base_name().map(Irep::just_string_id))
+        .with_named_sub_option(
+            IrepId::CIdentifier,
+            self.identifier().map(|s| Irep::just_string_id(arena, s)),
+        )
+        .with_named_sub_option(
+            IrepId::CBaseName,
+            self.base_name().map(|s| Irep::just_string_id(arena, s)),
+        )
     }
 }
 
 impl ToIrep for Stmt {
-    fn to_irep(&self, mm: &MachineModel) -> Irep {
-        self.body().to_irep(mm).with_location(self.location(), mm)
+    fn to_irep<'b>(&self, arena: &'b Bump, mm: &MachineModel) -> Irep<'b> {
+        self.body().to_irep(arena, mm).with_owned_location(*self.location(), mm)
     }
 }
 
 impl ToIrep for StmtBody {
-    fn to_irep(&self, mm: &MachineModel) -> Irep {
+    fn to_irep<'b>(&self, arena: &'b Bump, mm: &MachineModel) -> Irep<'b> {
         match self {
-            StmtBody::Assign { lhs, rhs } => {
-                code_irep(IrepId::Assign, vec![lhs.to_irep(mm), rhs.to_irep(mm)])
+            StmtBody::Assign { lhs, rhs } => code_irep(
+                arena,
+                IrepId::Assign,
+                vec_in![arena, lhs.to_irep(arena, mm), rhs.to_irep(arena, mm)],
+            ),
+            StmtBody::Assert { cond, .. } => {
+                code_irep(arena, IrepId::Assert, vec_in![arena, cond.to_irep(arena, mm)])
             }
-            StmtBody::Assert { cond, .. } => code_irep(IrepId::Assert, vec![cond.to_irep(mm)]),
-            StmtBody::Assume { cond } => code_irep(IrepId::Assume, vec![cond.to_irep(mm)]),
+            StmtBody::Assume { cond } => {
+                code_irep(arena, IrepId::Assume, vec_in![arena, cond.to_irep(arena, mm)])
+            }
             StmtBody::AtomicBlock(stmts) => {
-                let mut irep_stmts = vec![code_irep(IrepId::AtomicBegin, vec![])];
-                irep_stmts.append(&mut stmts.iter().map(|x| x.to_irep(mm)).collect());
-                irep_stmts.push(code_irep(IrepId::AtomicEnd, vec![]));
-                code_irep(IrepId::Block, irep_stmts)
+                let mut irep_stmts =
+                    vec_in![arena, code_irep(arena, IrepId::AtomicBegin, vec_in![arena])];
+                irep_stmts.extend(&mut stmts.iter().map(|x| x.to_irep(arena, mm)));
+                irep_stmts.push(code_irep(arena, IrepId::AtomicEnd, vec_in![arena]));
+                code_irep(arena, IrepId::Block, irep_stmts)
             }
-            StmtBody::Block(stmts) => {
-                code_irep(IrepId::Block, stmts.iter().map(|x| x.to_irep(mm)).collect())
+            StmtBody::Block(stmts) => code_irep(
+                arena,
+                IrepId::Block,
+                collect_into(stmts.iter().map(|x| x.to_irep(arena, mm)), arena),
+            ),
+            StmtBody::Break => code_irep(arena, IrepId::Break, vec_in![arena]),
+            StmtBody::Continue => code_irep(arena, IrepId::Continue, vec_in![arena]),
+            StmtBody::Dead(symbol) => {
+                code_irep(arena, IrepId::Dead, vec_in![arena, symbol.to_irep(arena, mm)])
             }
-            StmtBody::Break => code_irep(IrepId::Break, vec![]),
-            StmtBody::Continue => code_irep(IrepId::Continue, vec![]),
-            StmtBody::Dead(symbol) => code_irep(IrepId::Dead, vec![symbol.to_irep(mm)]),
             StmtBody::Decl { lhs, value } => {
                 if value.is_some() {
                     code_irep(
+                        arena,
                         IrepId::Decl,
-                        vec![lhs.to_irep(mm), value.as_ref().unwrap().to_irep(mm)],
+                        vec_in![
+                            arena,
+                            lhs.to_irep(arena, mm),
+                            value.as_ref().unwrap().to_irep(arena, mm)
+                        ],
                     )
                 } else {
-                    code_irep(IrepId::Decl, vec![lhs.to_irep(mm)])
+                    code_irep(arena, IrepId::Decl, vec_in![arena, lhs.to_irep(arena, mm)])
                 }
             }
             StmtBody::Deinit(place) => {
                 // CBMC doesn't yet have a notion of poison (https://github.com/diffblue/cbmc/issues/7014)
                 // So we translate identically to `nondet` here, but add a comment noting we wish it were poison
                 // potentially for other backends to pick up and treat specially.
-                code_irep(IrepId::Assign, vec![place.to_irep(mm), place.typ().nondet().to_irep(mm)])
-                    .with_comment("deinit")
+                code_irep(
+                    arena,
+                    IrepId::Assign,
+                    vec_in![
+                        arena,
+                        place.to_irep(arena, mm),
+                        place.typ().nondet().to_irep(arena, mm)
+                    ],
+                )
+                .with_comment(arena, "deinit")
             }
-            StmtBody::Expression(e) => code_irep(IrepId::Expression, vec![e.to_irep(mm)]),
+            StmtBody::Expression(e) => {
+                code_irep(arena, IrepId::Expression, vec_in![arena, e.to_irep(arena, mm)])
+            }
             StmtBody::For { init, cond, update, body } => code_irep(
+                arena,
                 IrepId::For,
-                vec![init.to_irep(mm), cond.to_irep(mm), update.to_irep(mm), body.to_irep(mm)],
+                vec_in![
+                    arena,
+                    init.to_irep(arena, mm),
+                    cond.to_irep(arena, mm),
+                    update.to_irep(arena, mm),
+                    body.to_irep(arena, mm)
+                ],
             ),
             StmtBody::FunctionCall { lhs, function, arguments } => code_irep(
+                arena,
                 IrepId::FunctionCall,
-                vec![
-                    lhs.as_ref().map_or(Irep::nil(), |x| x.to_irep(mm)),
-                    function.to_irep(mm),
-                    arguments_irep(arguments.iter(), mm),
+                vec_in![
+                    arena,
+                    lhs.as_ref().map_or(Irep::nil(arena), |x| x.to_irep(arena, mm)),
+                    function.to_irep(arena, mm),
+                    arguments_irep(arena, arguments.iter(), mm),
                 ],
             ),
             StmtBody::Goto { dest, loop_invariants } => {
-                let stmt_goto = code_irep(IrepId::Goto, vec![])
-                    .with_named_sub(IrepId::Destination, Irep::just_string_id(dest.to_string()));
+                let stmt_goto = code_irep(arena, IrepId::Goto, vec_in![arena]).with_named_sub(
+                    IrepId::Destination,
+                    Irep::just_string_id(arena, dest.to_string()),
+                );
                 if let Some(inv) = loop_invariants {
                     stmt_goto.with_named_sub(
                         IrepId::CSpecLoopInvariant,
-                        inv.clone().and(Expr::bool_true()).to_irep(mm),
+                        inv.clone().and(Expr::bool_true()).to_irep(arena, mm),
                     )
                 } else {
                     stmt_goto
                 }
             }
             StmtBody::Ifthenelse { i, t, e } => code_irep(
+                arena,
                 IrepId::Ifthenelse,
-                vec![
-                    i.to_irep(mm),
-                    t.to_irep(mm),
-                    e.as_ref().map_or(Irep::nil(), |x| x.to_irep(mm)),
+                vec_in![
+                    arena,
+                    i.to_irep(arena, mm),
+                    t.to_irep(arena, mm),
+                    e.as_ref().map_or(Irep::nil(arena), |x| x.to_irep(arena, mm)),
                 ],
             ),
-            StmtBody::Label { label, body } => code_irep(IrepId::Label, vec![body.to_irep(mm)])
-                .with_named_sub(IrepId::Label, Irep::just_string_id(label.to_string())),
-            StmtBody::Return(e) => {
-                code_irep(IrepId::Return, vec![e.as_ref().map_or(Irep::nil(), |x| x.to_irep(mm))])
+            StmtBody::Label { label, body } => {
+                code_irep(arena, IrepId::Label, vec_in![arena, body.to_irep(arena, mm)])
+                    .with_named_sub(IrepId::Label, Irep::just_string_id(arena, label.to_string()))
             }
-            StmtBody::Skip => code_irep(IrepId::Skip, vec![]),
+            StmtBody::Return(e) => code_irep(
+                arena,
+                IrepId::Return,
+                vec_in![arena, e.as_ref().map_or(Irep::nil(arena), |x| x.to_irep(arena, mm))],
+            ),
+            StmtBody::Skip => code_irep(arena, IrepId::Skip, vec_in![arena]),
             StmtBody::Switch { control, cases, default } => {
-                let mut switch_arms: Vec<Irep> = cases.iter().map(|x| x.to_irep(mm)).collect();
+                let mut switch_arms =
+                    collect_into(cases.iter().map(|x| x.to_irep(arena, mm)), arena);
                 if default.is_some() {
-                    switch_arms.push(switch_default_irep(default.as_ref().unwrap(), mm));
+                    switch_arms.push(switch_default_irep(arena, default.as_ref().unwrap(), mm));
                 }
                 code_irep(
+                    arena,
                     IrepId::Switch,
-                    vec![control.to_irep(mm), code_irep(IrepId::Block, switch_arms)],
+                    vec_in![
+                        arena,
+                        control.to_irep(arena, mm),
+                        code_irep(arena, IrepId::Block, switch_arms)
+                    ],
                 )
             }
-            StmtBody::While { cond, body } => {
-                code_irep(IrepId::While, vec![cond.to_irep(mm), body.to_irep(mm)])
-            }
+            StmtBody::While { cond, body } => code_irep(
+                arena,
+                IrepId::While,
+                vec_in![arena, cond.to_irep(arena, mm), body.to_irep(arena, mm)],
+            ),
         }
     }
 }
 
 impl ToIrep for SwitchCase {
-    fn to_irep(&self, mm: &MachineModel) -> Irep {
-        code_irep(IrepId::SwitchCase, vec![self.case().to_irep(mm), self.body().to_irep(mm)])
-            .with_location(self.body().location(), mm)
+    fn to_irep<'b>(&self, arena: &'b Bump, mm: &MachineModel) -> Irep<'b> {
+        code_irep(
+            arena,
+            IrepId::SwitchCase,
+            vec_in![arena, self.case().to_irep(arena, mm), self.body().to_irep(arena, mm)],
+        )
+        .with_owned_location(*self.body().location(), mm)
     }
 }
 
@@ -602,56 +829,61 @@ impl ToIrep for Lambda {
     /// At the moment this function assumes that this lambda is used for a
     /// `modifies` contract. It should work for any other lambda body, but
     /// the parameter names use "modifies" in their generated names.
-    fn to_irep(&self, mm: &MachineModel) -> Irep {
-        let (ops_ireps, types) = self
-            .arguments
-            .iter()
-            .enumerate()
-            .map(|(index, param)| {
-                let ty_rep = param.typ().to_irep(mm);
-                (
-                    Irep::symbol(
-                        param.identifier().unwrap_or_else(|| format!("_modifies_{index}").into()),
-                    )
-                    .with_named_sub(IrepId::Type, ty_rep.clone()),
-                    ty_rep,
+    fn to_irep<'b>(&self, arena: &'b Bump, mm: &MachineModel) -> Irep<'b> {
+        let (mut ops_ireps, mut types) = (vec_in![arena], vec_in![arena]);
+
+        for (op, ty) in self.arguments.iter().enumerate().map(|(index, param)| {
+            let ty_rep = param.typ().to_irep(arena, mm);
+            (
+                Irep::symbol(
+                    arena,
+                    param.identifier().unwrap_or_else(|| format!("_modifies_{index}").into()),
                 )
-            })
-            .unzip();
+                .with_named_sub(IrepId::Type, ty_rep.clone()),
+                ty_rep,
+            )
+        }) {
+            ops_ireps.push(op);
+            types.push(ty);
+        }
+
         let typ = Irep {
             id: IrepId::MathematicalFunction,
-            sub: vec![Irep::just_sub(types), self.body.typ().to_irep(mm)],
-            named_sub: Default::default(),
+            sub: vec_in![arena, Irep::just_sub(types), self.body.typ().to_irep(arena, mm)],
+            named_sub: ManuallyDrop::new(HashMap::new_in(arena)),
         };
         Irep {
             id: IrepId::Lambda,
-            sub: vec![Irep::tuple(ops_ireps), self.body.to_irep(mm)],
-            named_sub: linear_map!((IrepId::Type, typ)),
+            sub: vec_in![arena, Irep::tuple(ops_ireps), self.body.to_irep(arena, mm)],
+            named_sub: hash_collect_into([(IrepId::Type, typ)], arena),
         }
     }
 }
 
 impl goto_program::Symbol {
-    pub fn to_irep(&self, mm: &MachineModel) -> super::Symbol {
-        let mut typ = self.typ.to_irep(mm);
+    pub fn to_irep<'b>(&'b self, arena: &'b Bump, mm: &MachineModel) -> super::Symbol<'b> {
+        let mut typ = self.typ.to_irep(arena, mm);
         if let Some(contract) = &self.contract {
             typ = typ.with_named_sub(
                 IrepId::CSpecAssigns,
-                Irep::just_sub(contract.assigns.iter().map(|req| req.to_irep(mm)).collect()),
+                Irep::just_sub(collect_into(
+                    contract.assigns.iter().map(|req| req.to_irep(arena, mm)),
+                    arena,
+                )),
             );
         }
         if self.is_static_const {
             // Add a `const` to the type.
-            typ = typ.with_named_sub(IrepId::CConstant, Irep::just_id(IrepId::from_int(1)))
+            typ = typ.with_named_sub(IrepId::CConstant, Irep::just_id(arena, IrepId::from_int(1)))
         }
         super::Symbol {
             typ,
             value: match &self.value {
-                SymbolValues::Expr(e) => e.to_irep(mm),
-                SymbolValues::Stmt(s) => s.to_irep(mm),
-                SymbolValues::None => Irep::nil(),
+                SymbolValues::Expr(e) => e.to_irep(arena, mm),
+                SymbolValues::Stmt(s) => s.to_irep(arena, mm),
+                SymbolValues::None => Irep::nil(arena),
             },
-            location: self.location.to_irep(mm),
+            location: self.location.to_irep(arena, mm),
             // Unique identifier, same as key in symbol table `foo::x`
             name: self.name,
             // Only used by verilog
@@ -688,230 +920,274 @@ impl goto_program::Symbol {
 }
 
 impl goto_program::SymbolTable {
-    pub fn to_irep(&self) -> super::SymbolTable {
+    pub fn to_irep_in<'b>(&'b self, arena: &'b bumpalo::Bump) -> super::SymbolTable<'b> {
         let mm = self.machine_model();
-        let mut st = super::SymbolTable::new();
+        let mut st = super::SymbolTable::new_in(arena);
         for (_key, value) in self.iter() {
-            st.insert(value.to_irep(mm))
+            st.insert(value.to_irep(arena, mm))
         }
         st
     }
 }
 
 impl ToIrep for Type {
-    fn to_irep(&self, mm: &MachineModel) -> Irep {
+    fn to_irep<'b>(&self, arena: &'b Bump, mm: &MachineModel) -> Irep<'b> {
         match self {
             Type::Array { typ, size } => {
                 //CBMC expects the size to be a signed int constant.
                 let size = Expr::int_constant(*size, Type::ssize_t());
                 Irep {
                     id: IrepId::Array,
-                    sub: vec![typ.to_irep(mm)],
-                    named_sub: linear_map![(IrepId::Size, size.to_irep(mm))],
+                    sub: vec_in![arena, typ.to_irep(arena, mm)],
+                    named_sub: linear_map![arena, (IrepId::Size, size.to_irep(arena, mm))],
                 }
             }
             //TODO make from_irep that matches this.
             Type::CBitField { typ, width } => Irep {
                 id: IrepId::CBitField,
-                sub: vec![typ.to_irep(mm)],
-                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(*width))],
+                sub: vec_in![arena, typ.to_irep(arena, mm)],
+                named_sub: linear_map![arena, (IrepId::Width, Irep::just_int_id(arena, *width))],
             },
-            Type::Bool => Irep::just_id(IrepId::Bool),
+            Type::Bool => Irep::just_id(arena, IrepId::Bool),
             Type::CInteger(CIntType::Bool) => Irep {
                 id: IrepId::CBool,
-                sub: vec![],
-                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.bool_width))],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::Width, Irep::just_int_id(arena, mm.bool_width))
+                ],
             },
             Type::CInteger(CIntType::Char) => Irep {
                 id: if mm.char_is_unsigned { IrepId::Unsignedbv } else { IrepId::Signedbv },
-                sub: vec![],
-                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.char_width),)],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::Width, Irep::just_int_id(arena, mm.char_width),)
+                ],
             },
             Type::CInteger(CIntType::Int) => Irep {
                 id: IrepId::Signedbv,
-                sub: vec![],
-                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.int_width),)],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::Width, Irep::just_int_id(arena, mm.int_width),)
+                ],
             },
             Type::CInteger(CIntType::LongInt) => Irep {
                 id: IrepId::Signedbv,
-                sub: vec![],
-                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.long_int_width),)],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::Width, Irep::just_int_id(arena, mm.long_int_width),)
+                ],
             },
             Type::CInteger(CIntType::SizeT) => Irep {
                 id: IrepId::Unsignedbv,
-                sub: vec![],
-                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width),)],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::Width, Irep::just_int_id(arena, mm.pointer_width),)
+                ],
             },
             Type::CInteger(CIntType::SSizeT) => Irep {
                 id: IrepId::Signedbv,
-                sub: vec![],
-                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width),)],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::Width, Irep::just_int_id(arena, mm.pointer_width),)
+                ],
             },
             Type::Code { parameters, return_type } => Irep {
                 id: IrepId::Code,
-                sub: vec![],
+                sub: vec_in![arena],
                 named_sub: linear_map![
+                    arena,
                     (
                         IrepId::Parameters,
-                        Irep::just_sub(parameters.iter().map(|x| x.to_irep(mm)).collect()),
+                        Irep::just_sub(collect_into(
+                            parameters.iter().map(|x| x.to_irep(arena, mm)),
+                            arena
+                        )),
                     ),
-                    (IrepId::ReturnType, return_type.to_irep(mm)),
+                    (IrepId::ReturnType, return_type.to_irep(arena, mm)),
                 ],
             },
-            Type::Constructor => Irep::just_id(IrepId::Constructor),
+            Type::Constructor => Irep::just_id(arena, IrepId::Constructor),
             Type::Double => Irep {
                 id: IrepId::Floatbv,
-                sub: vec![],
+                sub: vec_in![arena],
                 named_sub: linear_map![
-                    (IrepId::F, Irep::just_int_id(52)),
-                    (IrepId::Width, Irep::just_int_id(64)),
-                    (IrepId::CCType, Irep::just_id(IrepId::Double)),
+                    arena,
+                    (IrepId::F, Irep::just_int_id(arena, 52)),
+                    (IrepId::Width, Irep::just_int_id(arena, 64)),
+                    (IrepId::CCType, Irep::just_id(arena, IrepId::Double)),
                 ],
             },
-            Type::Empty => Irep::just_id(IrepId::Empty),
+            Type::Empty => Irep::just_id(arena, IrepId::Empty),
             // CMBC currently represents these as 0 length arrays.
             Type::FlexibleArray { typ } => {
                 //CBMC expects the size to be a signed int constant.
                 let size = Type::ssize_t().zero();
                 Irep {
                     id: IrepId::Array,
-                    sub: vec![typ.to_irep(mm)],
-                    named_sub: linear_map![(IrepId::Size, size.to_irep(mm))],
+                    sub: vec_in![arena, typ.to_irep(arena, mm)],
+                    named_sub: linear_map![arena, (IrepId::Size, size.to_irep(arena, mm))],
                 }
             }
             Type::Float => Irep {
                 id: IrepId::Floatbv,
-                sub: vec![],
+                sub: vec_in![arena],
                 named_sub: linear_map![
-                    (IrepId::F, Irep::just_int_id(23)),
-                    (IrepId::Width, Irep::just_int_id(32)),
-                    (IrepId::CCType, Irep::just_id(IrepId::Float)),
+                    arena,
+                    (IrepId::F, Irep::just_int_id(arena, 23)),
+                    (IrepId::Width, Irep::just_int_id(arena, 32)),
+                    (IrepId::CCType, Irep::just_id(arena, IrepId::Float)),
                 ],
             },
             Type::Float16 => Irep {
                 id: IrepId::Floatbv,
-                sub: vec![],
+                sub: vec_in![arena],
                 // Fraction bits: 10
                 // Exponent width bits: 5
                 // Sign bit: 1
                 named_sub: linear_map![
-                    (IrepId::F, Irep::just_int_id(10)),
-                    (IrepId::Width, Irep::just_int_id(16)),
-                    (IrepId::CCType, Irep::just_id(IrepId::Float16)),
+                    arena,
+                    (IrepId::F, Irep::just_int_id(arena, 10)),
+                    (IrepId::Width, Irep::just_int_id(arena, 16)),
+                    (IrepId::CCType, Irep::just_id(arena, IrepId::Float16)),
                 ],
             },
             Type::Float128 => Irep {
                 id: IrepId::Floatbv,
-                sub: vec![],
+                sub: vec_in![arena],
                 // Fraction bits: 112
                 // Exponent width bits: 15
                 // Sign bit: 1
                 named_sub: linear_map![
-                    (IrepId::F, Irep::just_int_id(112)),
-                    (IrepId::Width, Irep::just_int_id(128)),
-                    (IrepId::CCType, Irep::just_id(IrepId::Float128)),
+                    arena,
+                    (IrepId::F, Irep::just_int_id(arena, 112)),
+                    (IrepId::Width, Irep::just_int_id(arena, 128)),
+                    (IrepId::CCType, Irep::just_id(arena, IrepId::Float128)),
                 ],
             },
             Type::IncompleteStruct { tag } => Irep {
                 id: IrepId::Struct,
-                sub: vec![],
+                sub: vec_in![arena],
                 named_sub: linear_map![
-                    (IrepId::Tag, Irep::just_string_id(tag.to_string())),
-                    (IrepId::Incomplete, Irep::one()),
+                    arena,
+                    (IrepId::Tag, Irep::just_string_id(arena, tag.to_string())),
+                    (IrepId::Incomplete, Irep::one(arena)),
                 ],
             },
             Type::IncompleteUnion { tag } => Irep {
                 id: IrepId::Union,
-                sub: vec![],
+                sub: vec_in![arena],
                 named_sub: linear_map![
-                    (IrepId::Tag, Irep::just_string_id(tag.to_string())),
-                    (IrepId::Incomplete, Irep::one()),
+                    arena,
+                    (IrepId::Tag, Irep::just_string_id(arena, tag.to_string())),
+                    (IrepId::Incomplete, Irep::one(arena)),
                 ],
             },
             Type::InfiniteArray { typ } => {
-                let infinity = Irep::just_id(IrepId::Infinity).with_type(&Type::ssize_t(), mm);
+                let infinity =
+                    Irep::just_id(arena, IrepId::Infinity).with_owned_type(Type::ssize_t(), mm);
                 Irep {
                     id: IrepId::Array,
-                    sub: vec![typ.to_irep(mm)],
-                    named_sub: linear_map![(IrepId::Size, infinity)],
+                    sub: vec_in![arena, typ.to_irep(arena, mm)],
+                    named_sub: linear_map![arena, (IrepId::Size, infinity)],
                 }
             }
-            Type::Integer => Irep::just_id(IrepId::Integer),
+            Type::Integer => Irep::just_id(arena, IrepId::Integer),
             Type::Pointer { typ } => Irep {
                 id: IrepId::Pointer,
-                sub: vec![typ.to_irep(mm)],
-                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width),)],
+                sub: vec_in![arena, typ.to_irep(arena, mm)],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::Width, Irep::just_int_id(arena, mm.pointer_width),)
+                ],
             },
             Type::Signedbv { width } => Irep {
                 id: IrepId::Signedbv,
-                sub: vec![],
-                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(*width))],
+                sub: vec_in![arena],
+                named_sub: linear_map![arena, (IrepId::Width, Irep::just_int_id(arena, *width))],
             },
             Type::Struct { tag, components } => Irep {
                 id: IrepId::Struct,
-                sub: vec![],
+                sub: vec_in![arena],
                 named_sub: linear_map![
-                    (IrepId::Tag, Irep::just_string_id(tag.to_string())),
+                    arena,
+                    (IrepId::Tag, Irep::just_string_id(arena, tag.to_string())),
                     (
                         IrepId::Components,
-                        Irep::just_sub(components.iter().map(|x| x.to_irep(mm)).collect()),
+                        Irep::just_sub(collect_into(
+                            components.iter().map(|x| x.to_irep(arena, mm)),
+                            arena
+                        )),
                     ),
                 ],
             },
             Type::StructTag(name) => Irep {
                 id: IrepId::StructTag,
-                sub: vec![],
-                named_sub: linear_map![(
-                    IrepId::Identifier,
-                    Irep::just_string_id(name.to_string()),
-                )],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::Identifier, Irep::just_string_id(arena, name.to_string()),)
+                ],
             },
             Type::TypeDef { name, typ } => typ
-                .to_irep(mm)
-                .with_named_sub(IrepId::CTypedef, Irep::just_string_id(name.to_string())),
+                .to_irep(arena, mm)
+                .with_named_sub(IrepId::CTypedef, Irep::just_string_id(arena, name.to_string())),
 
             Type::Union { tag, components } => Irep {
                 id: IrepId::Union,
-                sub: vec![],
+                sub: vec_in![arena],
                 named_sub: linear_map![
-                    (IrepId::Tag, Irep::just_string_id(tag.to_string())),
+                    arena,
+                    (IrepId::Tag, Irep::just_string_id(arena, tag.to_string())),
                     (
                         IrepId::Components,
-                        Irep::just_sub(components.iter().map(|x| x.to_irep(mm)).collect()),
+                        Irep::just_sub(collect_into(
+                            components.iter().map(|x| x.to_irep(arena, mm)),
+                            arena
+                        )),
                     ),
                 ],
             },
             Type::UnionTag(name) => Irep {
                 id: IrepId::UnionTag,
-                sub: vec![],
-                named_sub: linear_map![(
-                    IrepId::Identifier,
-                    Irep::just_string_id(name.to_string()),
-                )],
+                sub: vec_in![arena],
+                named_sub: linear_map![
+                    arena,
+                    (IrepId::Identifier, Irep::just_string_id(arena, name.to_string()),)
+                ],
             },
             Type::Unsignedbv { width } => Irep {
                 id: IrepId::Unsignedbv,
-                sub: Vec::new(),
-                named_sub: linear_map![(IrepId::Width, Irep::just_int_id(*width))],
+                sub: vec_in![arena],
+                named_sub: linear_map![arena, (IrepId::Width, Irep::just_int_id(arena, *width))],
             },
             Type::VariadicCode { parameters, return_type } => Irep {
                 id: IrepId::Code,
-                sub: vec![],
+                sub: vec_in![arena],
                 named_sub: linear_map![
+                    arena,
                     (
                         IrepId::Parameters,
-                        Irep::just_sub(parameters.iter().map(|x| x.to_irep(mm)).collect())
-                            .with_named_sub(IrepId::Ellipsis, Irep::one()),
+                        Irep::just_sub(collect_into(
+                            parameters.iter().map(|x| x.to_irep(arena, mm)),
+                            arena
+                        ))
+                        .with_named_sub(IrepId::Ellipsis, Irep::one(arena)),
                     ),
-                    (IrepId::ReturnType, return_type.to_irep(mm)),
+                    (IrepId::ReturnType, return_type.to_irep(arena, mm)),
                 ],
             },
             Type::Vector { typ, size } => {
                 let size = Expr::int_constant(*size, Type::ssize_t());
                 Irep {
                     id: IrepId::Vector,
-                    sub: vec![typ.to_irep(mm)],
-                    named_sub: linear_map![(IrepId::Size, size.to_irep(mm))],
+                    sub: vec_in![arena, typ.to_irep(arena, mm)],
+                    named_sub: linear_map![arena, (IrepId::Size, size.to_irep(arena, mm))],
                 }
             }
         }

--- a/cprover_bindings/src/lib.rs
+++ b/cprover_bindings/src/lib.rs
@@ -31,6 +31,8 @@
 
 #![feature(f128)]
 #![feature(f16)]
+#![feature(btreemap_alloc)]
+#![feature(allocator_api)]
 
 mod env;
 pub use env::global_dead_object;

--- a/cprover_bindings/src/utils.rs
+++ b/cprover_bindings/src/utils.rs
@@ -49,15 +49,11 @@ macro_rules! btree_map {
 /// Provides a useful shortcut for making BTreeMaps.
 #[macro_export]
 macro_rules! linear_map {
-    ($($x:expr),*) => {{
-        use linear_map::LinearMap;
-        use std::iter::FromIterator;
-        (LinearMap::from_iter(vec![$($x),*]))
-    }};
-    ($($x:expr,)*) => {{
-        use linear_map::LinearMap;
-        use std::iter::FromIterator;
-        (LinearMap::from_iter(vec![$($x),*]))
+    ($arena:ident $(,)?) => {
+        std::mem::ManuallyDrop::new(hashbrown::HashMap::new_in($arena))
+    };
+    ($arena:ident, $($x:expr),* $(,)?) => {{
+        (hash_collect_into([$($x),*], $arena))
     }}
 }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -47,6 +47,7 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::fs::File;
 use std::io::BufWriter;
+use std::io::Write as _;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -284,6 +285,7 @@ impl CodegenBackend for GotocCodegenBackend {
     }
 
     fn codegen_crate(&self, tcx: TyCtxt) -> Box<dyn Any> {
+        let codegen_start = Instant::now();
         let ret_val = rustc_internal::run(tcx, || {
             super::utils::init();
 
@@ -411,6 +413,17 @@ impl CodegenBackend for GotocCodegenBackend {
             }
             codegen_results(tcx, &results.machine_model)
         });
+        if std::env::var("TIME_COMPILER").is_ok() {
+            let name = tcx.crate_name(LOCAL_CRATE);
+            // let s = ;
+            let mut file = std::fs::OpenOptions::new()
+                .create(true) // Create file if it doesn't exist
+                .append(true) // Open in append mode
+                .open("out.txt")
+                .unwrap();
+            write!(file, "CODEGEN of {name:?} TOOK {:?}", codegen_start.elapsed()).unwrap();
+            // file.write_all(s).unwrap();
+        }
         ret_val.unwrap()
     }
 


### PR DESCRIPTION
### Motivation
A large portion (~7%) of our codegen time is spent simply deallocating the large `SymbolTable` struct that we generate when building each goto binary for CBMC. This ends up taking a while because the struct contains `Irep` structs which can each recursively contain multiple Vecs of even more `Irep`s, requiring a lot of small allocations to be individually handled over and over again.

### Approach
This PR switches all data structures within Kani's binary generation to use a shared bump allocator (using the Bumpalo crate) that ensures all allocations we use while serializing a given binary remain in a single large region of memory. Once a given binary has been serialized, we can then easily deallocate all the memory it used at once.

As part of this change, we also replace the `LinearMap` used to represent [named subs within an Irep](url) with a proper `hashbrown::HashMap`.

### Issues
Based on manual testing there is currently a small memory leak (I think because the underlying vectors for the `BigInt` & `BigUInt` types we use [here](https://github.com/AlexanderPortland/kani/blob/3d34482d21d292c4b1260bb9616346f2bc3cb94e/cprover_bindings/src/irep/irep_id.rs#L19-L21)) still use the global allocator and thus will not be deallocated with the memory arena. I'm looking into fixing this and improving code comments for the more involved changes, but wanted to make a draft PR to get preliminary performance results first.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
