### PR TITLE
Ensuring that MIR constants are marked as static consts

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/static_var.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/static_var.rs
@@ -24,6 +24,7 @@ impl GotocCtx<'_> {
             symbol_name,
             self.codegen_span_stable(def.span()),
             is_interior_mut(self.tcx, def.ty()),
+            false,
         );
     }
 

--- a/tests/expected/function-contract/const_block.expected
+++ b/tests/expected/function-contract/const_block.expected
@@ -1,0 +1,9 @@
+assertion\
+	- Status: SUCCESS\
+	- Description: "|result| *result == Enum::Second"\
+
+assertion\
+	- Status: SUCCESS\
+	- Description: "|result| *result == Enum::First"\
+
+VERIFICATION:- SUCCESSFUL

--- a/tests/expected/function-contract/const_block.rs
+++ b/tests/expected/function-contract/const_block.rs
@@ -1,0 +1,32 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-flags: -Z function-contracts
+
+//! Checking that constant blocks are correctly verified in contracts.
+//! See https://github.com/model-checking/kani/issues/3905
+
+#[derive(PartialEq)]
+enum Enum {
+    First,
+    Second,
+}
+
+#[kani::ensures(|result| *result == Enum::First)]
+const fn first() -> Enum {
+    const { Enum::First }
+}
+
+#[kani::ensures(|result| *result == Enum::Second)]
+const fn second() -> Enum {
+    Enum::Second
+}
+
+#[kani::proof_for_contract(first)]
+pub fn check_first() {
+    let _ = first();
+}
+
+#[kani::proof_for_contract(second)]
+pub fn check_second() {
+    let _ = second();
+}


### PR DESCRIPTION
This is an attempt to resolve #3905

Currently, we rely on the `mutability` of the `Allocation` when marking constants. However, my understanding is that for various internal reasons the compiler may use mutable allocations even for constants. Instead, we should probably track whether a variable is constant ourselves.

Currently, some tests are failing. Specifically, `tests/expected/function-contract/valid_ptr.rs` fails because, while checking `pre_condition::harness_invalid_ptr`, the output doesn't include

> Failed Checks: assertion failed: unsafe { read_ptr(ptr) } == -20

Instead, the assertion is `UNREACHABLE`, which honestly makes perfect sense to me (since the precondition doesn't hold for any input, we'll never get a chance to actually verify this assertion).

`tests/kani-fixme/FunctionContracts/modify_slice_elem_fixme.rs` also fails, which [hopefully indicates](https://github.com/model-checking/kani/issues/3905#issuecomment-3074072252) that this also resolves #4029 (though the relation between the issue and the PR is not obvious to me).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
