### PR TITLE
Set bits_per_byte in byte_extract expressions

### DIFF
--- a/cprover_bindings/src/irep/to_irep.rs
+++ b/cprover_bindings/src/irep/to_irep.rs
@@ -225,7 +225,7 @@ impl ToIrep for ExprValue {
                     IrepId::ByteExtractLittleEndian
                 },
                 sub: vec![e.to_irep(mm), Expr::int_constant(*offset, Type::ssize_t()).to_irep(mm)],
-                named_sub: linear_map![],
+                named_sub: linear_map![(IrepId::BitsPerByte, Irep::just_int_id(8u8))],
             },
             ExprValue::CBoolConstant(i) => Irep {
                 id: IrepId::Constant,


### PR DESCRIPTION
CBMC expected the number of bits-in-a-byte to be set as part of a byte_extract expression ever since diffblue/cbmc@a8631c514be3c5, but seemingly produces correct verification results even when CBMC finds that value to be 0 (but might fail to apply certain optimisations). An upcoming change on the CBMC side adds additional sanity checks, which uncovered this omission on Kani's part.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
