### PR TITLE
Upgrade Rust toolchain to 2025-08-01

### DIFF
--- a/kani-compiler/src/kani_middle/attributes.rs
+++ b/kani-compiler/src/kani_middle/attributes.rs
@@ -171,7 +171,7 @@ impl<'tcx> KaniAttributes<'tcx> {
     }
 
     pub fn for_item(tcx: TyCtxt<'tcx>, def_id: DefId) -> Self {
-        let all_attributes = tcx.get_attrs_unchecked(def_id);
+        let all_attributes = tcx.get_all_attrs(def_id);
         let map = all_attributes.iter().fold(
             <BTreeMap<KaniAttributeKind, Vec<&'tcx Attribute>>>::default(),
             |mut result, attribute| {
@@ -767,7 +767,7 @@ fn has_kani_attribute<F: Fn(KaniAttributeKind) -> bool>(
     def_id: DefId,
     predicate: F,
 ) -> bool {
-    tcx.get_attrs_unchecked(def_id).iter().filter_map(|a| attr_kind(tcx, a)).any(predicate)
+    tcx.get_all_attrs(def_id).iter().filter_map(|a| attr_kind(tcx, a)).any(predicate)
 }
 
 /// Same as [`KaniAttributes::is_proof_harness`] but more efficient because less

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-07-31"
+channel = "nightly-2025-08-01"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Relevant upstream PR:
- https://github.com/rust-lang/rust/pull/144713 (`rustc_middle::ty` cleanups) (and specifically the commit Remove `TyCtxt::get_attrs_unchecked`. therein)

Resolves: #4260 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
