### PR TITLE
Fix release job dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
 
   test-use-local-toolchain:
     name: TestLocalToolchain
-    needs: [build_bundle_macos_x86_64, build_bundle_macos_aarch64, build_bundle_linux, build_bundle_linux_arm]
+    needs: [build_bundle_macos_x86_64, build_bundle_macos_aarch64, build_bundle_linux_x86_64, build_bundle_linux_aarch64]
     strategy:
       matrix:
         os: [macos-13, macos-14, ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]


### PR DESCRIPTION
This is a fix-up to #3841 where the job names were not adjusted in one place.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
