### PR TITLE
bump kani vesion 0.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 ## [0.65.0]
 
 ### Breaking Changes
-* Added new `--prove-safety-only` option for focused safety verification, allowing you to concentrate on memory safety and undefined behavior detection by @tautschnig in https://github.com/model-checking/kani/pull/4239
-* Extended autoharness support to handle references, making it easier to automatically generate verification harnesses by @tautschnig in https://github.com/model-checking/kani/pull/4234
-* Multiple performance improvements including parallel goto binary writing, lazy debug info evaluation, and optimized quantifier handling for faster verification times
 * Removed unstable list feature and default memory checks by @carolynzech in https://github.com/model-checking/kani/pull/4258
 
 ### Major Changes
 * Added support for a few SMT solvers (bitwuzla, cvc5, and z3) as solver attribute values (**not** packaged with Kani) by @tautschnig in https://github.com/model-checking/kani/pull/4218
 * Improved support for contracts and stubs in trait implementations, expanding verification capabilities for trait-based code by @carolynzech in https://github.com/model-checking/kani/pull/4250
+* Added new `--prove-safety-only` option for focused safety verification, allowing you to concentrate on memory safety and undefined behavior detection by @tautschnig in https://github.com/model-checking/kani/pull/4239
+* Extended autoharness support to handle references, making it easier to automatically generate verification harnesses by @tautschnig in https://github.com/model-checking/kani/pull/4234
+* Multiple performance improvements including parallel goto binary writing, lazy debug info evaluation, and optimized quantifier handling for faster verification times
 
 ### What's Changed
 * Fixed issue related to the handling of contract closures which was preventing writing contracts for functions that return mutable references by @vonaka in https://github.com/model-checking/kani/pull/4151

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.65.0]
+
+## Major Changes
+* Added support for bitwuzla, cvc5, and z3 as solver attribute values, giving you more options for verification backends by @tautschnig in https://github.com/model-checking/kani/pull/4218
+* Improved support for contracts and stubs in trait implementations, expanding verification capabilities for trait-based code by @carolynzech in https://github.com/model-checking/kani/pull/4250
+* Added new `--prove-safety-only` option for focused safety verification, allowing you to concentrate on memory safety and undefined behavior detection by @tautschnig in https://github.com/model-checking/kani/pull/4239
+* Extended autoharness support to handle references, making it easier to automatically generate verification harnesses by @tautschnig in https://github.com/model-checking/kani/pull/4234
+* Multiple performance improvements including parallel goto binary writing, lazy debug info evaluation, and optimized quantifier handling for faster verification times
+* Removed unstable list feature and default memory checks by @carolynzech in https://github.com/model-checking/kani/pull/4258
+
+## What's Changed
+* Fixed contract closures to ensure they are FnOnce by @vonaka in https://github.com/model-checking/kani/pull/4151
+* Improved memory predicate hierarchy for better verification by @tautschnig in https://github.com/model-checking/kani/pull/4193
+* Enhanced pointer offset arithmetic for more accurate verification by @tautschnig in https://github.com/model-checking/kani/pull/4180
+* Fixed assign clause inference bug for nested loops by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4179
+* Fixed crash when using multiple quantifiers in one proof by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4221
+* Added support for Cargo.toml's default-members configuration by @tautschnig in https://github.com/model-checking/kani/pull/4201
+* Improved memset handling to avoid zero-count invocations by @tautschnig in https://github.com/model-checking/kani/pull/4205
+* Enhanced vector operations with CBMC's shuffle_vector expression by @tautschnig in https://github.com/model-checking/kani/pull/4204
+* Improved performance by skipping codegen for unneeded harnesses by @AlexanderPortland in https://github.com/model-checking/kani/pull/4213
+* Fixed loop contract unwinding bug in generic functions by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4232
+* Improved byte extraction with proper bits_per_byte setting by @tautschnig in https://github.com/model-checking/kani/pull/4255
+* Improved performance by disabling debug assertions under prove-safety-only by @tautschnig in https://github.com/model-checking/kani/pull/4262
+* Enhanced performance with parallel goto binary writing by @AlexanderPortland in https://github.com/model-checking/kani/pull/4236
+* Improved quantifier handling performance by avoiding irrelevant symbol updates by @AlexanderPortland in https://github.com/model-checking/kani/pull/4268
+* Enhanced performance with lazy debug info evaluation by @AlexanderPortland in https://github.com/model-checking/kani/pull/4269
+* Improved MIR constant handling by marking them as static constants by @vonaka in https://github.com/model-checking/kani/pull/4233
+
+## New Contributors
+* @vonaka made their first contribution in https://github.com/model-checking/kani/pull/4151
+
+## Version Updates
+* Updated to Rust edition 2024 by @tautschnig in https://github.com/model-checking/kani/pull/4197
+* Rust toolchain upgraded to 2025-08-06 by @tautschnig and @thanhnguyen-aws
+* Updated CBMC dependency to 6.7.1 by @tautschnig in https://github.com/model-checking/kani/pull/4178
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.64.0...kani-0.65.0
+
 ## [0.64.0]
 
 ### Major Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,36 +6,34 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## [0.65.0]
 
-### Major Changes
-* Added support for bitwuzla, cvc5, and z3 as solver attribute values, giving you more options for verification backends by @tautschnig in https://github.com/model-checking/kani/pull/4218
-* Improved support for contracts and stubs in trait implementations, expanding verification capabilities for trait-based code by @carolynzech in https://github.com/model-checking/kani/pull/4250
+### Breaking Changes
 * Added new `--prove-safety-only` option for focused safety verification, allowing you to concentrate on memory safety and undefined behavior detection by @tautschnig in https://github.com/model-checking/kani/pull/4239
 * Extended autoharness support to handle references, making it easier to automatically generate verification harnesses by @tautschnig in https://github.com/model-checking/kani/pull/4234
 * Multiple performance improvements including parallel goto binary writing, lazy debug info evaluation, and optimized quantifier handling for faster verification times
 * Removed unstable list feature and default memory checks by @carolynzech in https://github.com/model-checking/kani/pull/4258
 
-## What's Changed
-* Fixed contract closures to ensure they are FnOnce by @vonaka in https://github.com/model-checking/kani/pull/4151
-* Improved memory predicate hierarchy for better verification by @tautschnig in https://github.com/model-checking/kani/pull/4193
-* Enhanced pointer offset arithmetic for more accurate verification by @tautschnig in https://github.com/model-checking/kani/pull/4180
+### Major Changes
+* Added support for a few SMT solvers (bitwuzla, cvc5, and z3) as solver attribute values (**not** packaged with Kani) by @tautschnig in https://github.com/model-checking/kani/pull/4218
+* Improved support for contracts and stubs in trait implementations, expanding verification capabilities for trait-based code by @carolynzech in https://github.com/model-checking/kani/pull/4250
+
+### What's Changed
+* Fixed issue related to the handling of contract closures which was preventing writing contracts for functions that return mutable references by @vonaka in https://github.com/model-checking/kani/pull/4151
+* Relaxed the constraint on the pointer type for Kani's memory predicates by @tautschnig in https://github.com/model-checking/kani/pull/4193
+* Changed the model for `ptr_offset_from` to enhance verification performance by @tautschnig in https://github.com/model-checking/kani/pull/4180
 * Fixed assign clause inference bug for nested loops by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4179
 * Fixed crash when using multiple quantifiers in one proof by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4221
 * Added support for Cargo.toml's default-members configuration by @tautschnig in https://github.com/model-checking/kani/pull/4201
 * Improved memset handling to avoid zero-count invocations by @tautschnig in https://github.com/model-checking/kani/pull/4205
-* Enhanced vector operations with CBMC's shuffle_vector expression by @tautschnig in https://github.com/model-checking/kani/pull/4204
-* Improved performance by skipping codegen for unneeded harnesses by @AlexanderPortland in https://github.com/model-checking/kani/pull/4213
-* Fixed loop contract unwinding bug in generic functions by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4232
-* Improved byte extraction with proper bits_per_byte setting by @tautschnig in https://github.com/model-checking/kani/pull/4255
-* Improved performance by disabling debug assertions under prove-safety-only by @tautschnig in https://github.com/model-checking/kani/pull/4262
+* Enhanced safety by disabling debug assertions under prove-safety-only by @tautschnig in https://github.com/model-checking/kani/pull/4262
 * Enhanced performance with parallel goto binary writing by @AlexanderPortland in https://github.com/model-checking/kani/pull/4236
 * Improved quantifier handling performance by avoiding irrelevant symbol updates by @AlexanderPortland in https://github.com/model-checking/kani/pull/4268
 * Enhanced performance with lazy debug info evaluation by @AlexanderPortland in https://github.com/model-checking/kani/pull/4269
 * Improved MIR constant handling by marking them as static constants by @vonaka in https://github.com/model-checking/kani/pull/4233
 
-## New Contributors
+### New Contributors
 * @vonaka made their first contribution in https://github.com/model-checking/kani/pull/4151
 
-## Version Updates
+### Version Updates
 * Updated to Rust edition 2024 by @tautschnig in https://github.com/model-checking/kani/pull/4197
 * Rust toolchain upgraded to 2025-08-06 by @tautschnig and @thanhnguyen-aws
 * Updated CBMC dependency to 6.7.1 by @tautschnig in https://github.com/model-checking/kani/pull/4178

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file was introduced starting Kani 0.23.0, so it only contains changes from 
 
 ## [0.65.0]
 
-## Major Changes
+### Major Changes
 * Added support for bitwuzla, cvc5, and z3 as solver attribute values, giving you more options for verification backends by @tautschnig in https://github.com/model-checking/kani/pull/4218
 * Improved support for contracts and stubs in trait implementations, expanding verification capabilities for trait-based code by @carolynzech in https://github.com/model-checking/kani/pull/4250
 * Added new `--prove-safety-only` option for focused safety verification, allowing you to concentrate on memory safety and undefined behavior detection by @tautschnig in https://github.com/model-checking/kani/pull/4239

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -464,7 +464,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cprover_bindings"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "fxhash",
  "lazy_static",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "kani"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "kani_core",
  "kani_macros",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "kani-compiler"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "charon",
  "clap",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "home",
@@ -1175,14 +1175,14 @@ dependencies = [
 
 [[package]]
 name = "kani_core"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani_macros"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "std"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_core/Cargo.toml
+++ b/library/kani_core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_core"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
from the autogenerated : 

## What's Changed
* Ensure that contract closures are FnOnce by @vonaka in https://github.com/model-checking/kani/pull/4151
* Adjust sized hierarchy for Kani's memory predicates by @tautschnig in https://github.com/model-checking/kani/pull/4193
* Update to Rust edition 2024 by @tautschnig in https://github.com/model-checking/kani/pull/4197
* `ptr_offset_from`: Replace arithmetic over pointers by offset arithmetic by @tautschnig in https://github.com/model-checking/kani/pull/4180
* Automatic cargo update to 2025-07-07 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4208
* Bump tests/perf/s2n-quic from `b8f8cca` to `8715fdf` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4209
* Upgrade Rust toolchain to 2025-07-04 by @tautschnig in https://github.com/model-checking/kani/pull/4199
* Upgrade Rust toolchain to 2025-07-10 by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4215
* Update CBMC dependency to 6.7.1 by @tautschnig in https://github.com/model-checking/kani/pull/4178
* Split compiler flags to avoid dependency recompilation by @AlexanderPortland in https://github.com/model-checking/kani/pull/4211
* Fix the bug that assign clause cannot be inferred for the inner loop of nested loops by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4179
* Upgrade Rust toolchain to 2025-07-11 by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4219
* Automatic toolchain upgrade to nightly-2025-07-12 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4222
* Fix bug: `goto-cc` crash when there are two quantifers in one proof by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4221
* Automatic toolchain upgrade to nightly-2025-07-13 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4223
* Automatic cargo update to 2025-07-14 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4224
* Cleanup links to issues that have been addressed by @tautschnig in https://github.com/model-checking/kani/pull/4200
* Selectively enable and fix (slow) Tokio tests by @tautschnig in https://github.com/model-checking/kani/pull/4203
* Bump tests/perf/s2n-quic from `32ba87d` to `1cbd879` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4227
* Implement support for Cargo.toml's default-members by @tautschnig in https://github.com/model-checking/kani/pull/4201
* Do not invoke memset with count of zero by @tautschnig in https://github.com/model-checking/kani/pull/4205
* Support bitwuzla, cvc5, z3 as solver attribute values by @tautschnig in https://github.com/model-checking/kani/pull/4218
* Use CBMC's shuffle_vector expression by @tautschnig in https://github.com/model-checking/kani/pull/4204
* Move tests from slow/kani back to regular suite by @tautschnig in https://github.com/model-checking/kani/pull/4202
* Automatic toolchain upgrade to nightly-2025-07-14 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4225
* Enable GitHub Linux/Arm runners in CI by @tautschnig in https://github.com/model-checking/kani/pull/3841
* Automatic cargo update to 2025-07-21 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4231
* Skip codegen for unneeded harnesses by @AlexanderPortland in https://github.com/model-checking/kani/pull/4213
* Strongly type differing compiler args for clarity by @AlexanderPortland in https://github.com/model-checking/kani/pull/4220
* Remove StableMIR ICE workaround by @carolynzech in https://github.com/model-checking/kani/pull/4235
* Fix bug: Kani unwinds loops with contract in generic function (with -Z loop-contracts) by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4232
* Automatic cargo update to 2025-07-28 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4238
* Bump tests/perf/s2n-quic from `1cbd879` to `4938450` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4242
* Upgrade Rust toolchain to 2025-07-21 by @tautschnig in https://github.com/model-checking/kani/pull/4241
* Remove `pretty_ty` and use rustc_public's formatter instead by @tautschnig in https://github.com/model-checking/kani/pull/4243
* Upgrade Rust toolchain to 2025-07-24 by @tautschnig in https://github.com/model-checking/kani/pull/4244
* Documentation cleanup of UB detected by Kani by @tautschnig in https://github.com/model-checking/kani/pull/4245
* Upgrade Rust toolchain to 2025-07-29 by @tautschnig in https://github.com/model-checking/kani/pull/4247
* Automatic toolchain upgrade to nightly-2025-07-30 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4253
* Add unstable option prove-safety-only by @tautschnig in https://github.com/model-checking/kani/pull/4239
* Set bits_per_byte in byte_extract expressions by @tautschnig in https://github.com/model-checking/kani/pull/4255
* `KaniAttributes` Path Resolution Refactor by @carolynzech in https://github.com/model-checking/kani/pull/4249
* Automatic toolchain upgrade to nightly-2025-07-31 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4256
* Support contracts & stubs in trait implementations (partial fix) by @carolynzech in https://github.com/model-checking/kani/pull/4250
* [Breaking Changes] Remove unstable list feature and default memory checks by @carolynzech in https://github.com/model-checking/kani/pull/4258
* Upgrade Rust toolchain to 2025-08-01 by @tautschnig in https://github.com/model-checking/kani/pull/4261
* Autoharness: add support for references by @tautschnig in https://github.com/model-checking/kani/pull/4234
* Turn off debug assertions under `--prove-safety-only` by @tautschnig in https://github.com/model-checking/kani/pull/4262
* Automatic toolchain upgrade to nightly-2025-08-02 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4264
* Automatic toolchain upgrade to nightly-2025-08-03 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4265
* Automatic cargo update to 2025-08-04 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4267
* Automatic toolchain upgrade to nightly-2025-08-04 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4266
* Introduce thread pool for writing goto binaries in parallel by @AlexanderPortland in https://github.com/model-checking/kani/pull/4236
* Major-version update cargo dependencies by @tautschnig in https://github.com/model-checking/kani/pull/4240
* Bump tests/perf/s2n-quic from `4938450` to `8f510f0` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4270
* Automatic toolchain upgrade to nightly-2025-08-05 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4271
* Automatic toolchain upgrade to nightly-2025-08-06 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4272
* Avoid updating irrelevant symbols when handling quantifiers by @AlexanderPortland in https://github.com/model-checking/kani/pull/4268
* Lazily evaluate debug info by @AlexanderPortland in https://github.com/model-checking/kani/pull/4269
* Clone a template `BodyTransformer` to avoid re-initialization by @AlexanderPortland in https://github.com/model-checking/kani/pull/4259
* Ensuring that MIR constants are marked as static consts by @vonaka in https://github.com/model-checking/kani/pull/4233
* Fix release job dependencies by @tautschnig in https://github.com/model-checking/kani/pull/4273

## New Contributors
* @vonaka made their first contribution in https://github.com/model-checking/kani/pull/4151

**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.64.0...kani-0.65.0
