### PR TITLE
Cache codegen of Spans

### DIFF
--- a/cprover_bindings/src/goto_program/location.rs
+++ b/cprover_bindings/src/goto_program/location.rs
@@ -90,6 +90,23 @@ impl Location {
             Location::PropertyUnknownLocation { .. } => "<none>".to_string(),
         }
     }
+
+    /// Tries to set the `function` field of a [Location::Loc], returning `None` if the location
+    /// is of a different variant and the field couldn't be set.
+    pub fn try_set_function(
+        &mut self,
+        new_function: Option<impl Into<InternedString>>,
+    ) -> Option<()> {
+        if let Location::Loc { function, .. } = self {
+            if let Some(new_function) = new_function {
+                *function = Some(new_function.into());
+            }
+
+            Some(())
+        } else {
+            None
+        }
+    }
 }
 
 /// Constructors

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/span.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/span.rs
@@ -4,7 +4,6 @@
 //! MIR Span related functions
 
 use crate::codegen_cprover_gotoc::GotocCtx;
-use crate::codegen_cprover_gotoc::context::SpanWrapper;
 use cbmc::goto_program::Location;
 use lazy_static::lazy_static;
 use rustc_hir::Attribute;
@@ -39,7 +38,7 @@ impl GotocCtx<'_> {
 
     pub fn codegen_span_stable(&self, sp: SpanStable) -> Location {
         // First query the cache to see if we've already done codegen for this span.
-        if let Some(cached_loc) = self.span_cache.borrow_mut().get(&SpanWrapper(sp)) {
+        if let Some(cached_loc) = self.span_cache.borrow_mut().get(&sp) {
             let mut new_loc = *cached_loc;
 
             // Recalculate the `current_fn` since it could be different than when we cached.
@@ -91,7 +90,7 @@ impl GotocCtx<'_> {
         );
 
         // Insert codegened Location into the cache and sanity check it doesn't already exist.
-        let existing = self.span_cache.borrow_mut().insert(SpanWrapper(sp), new_loc);
+        let existing = self.span_cache.borrow_mut().insert(sp, new_loc);
         debug_assert!(
             existing.is_none(),
             "if there was already an entry for this in the cache, we should've used that!"

--- a/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/goto_ctx.rs
@@ -63,19 +63,6 @@ pub struct MinimalGotocCtx {
     pub has_loop_contracts: bool,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct OurSpan(usize);
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct SpanWrapper(pub rustc_public::ty::Span);
-
-impl std::hash::Hash for SpanWrapper {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        let our_span: OurSpan = unsafe { std::mem::transmute(self.0) };
-        our_span.0.hash(state);
-    }
-}
-
 pub struct GotocCtx<'tcx> {
     /// the typing context
     pub tcx: TyCtxt<'tcx>,
@@ -92,7 +79,7 @@ pub struct GotocCtx<'tcx> {
     /// map a global allocation to a name in the symbol table
     pub alloc_map: FxHashMap<Allocation, String>,
     /// a cache of [Span](rustc_public::Span)s and their codegened [Location]s
-    pub span_cache: RefCell<FxHashMap<SpanWrapper, Location>>,
+    pub span_cache: RefCell<FxHashMap<rustc_public::ty::Span, Location>>,
     /// map (trait, method) pairs to possible implementations
     pub vtable_ctx: VtableCtx,
     pub current_fn: Option<CurrentFnCtx<'tcx>>,

--- a/kani-compiler/src/codegen_cprover_gotoc/context/mod.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/mod.rs
@@ -10,5 +10,5 @@ mod current_fn;
 mod goto_ctx;
 mod vtable_ctx;
 
-pub use goto_ctx::{GotocCtx, MinimalGotocCtx};
+pub use goto_ctx::{GotocCtx, MinimalGotocCtx, SpanWrapper};
 pub use vtable_ctx::VtableCtx;

--- a/kani-compiler/src/codegen_cprover_gotoc/context/mod.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/context/mod.rs
@@ -10,5 +10,5 @@ mod current_fn;
 mod goto_ctx;
 mod vtable_ctx;
 
-pub use goto_ctx::{GotocCtx, MinimalGotocCtx, SpanWrapper};
+pub use goto_ctx::{GotocCtx, MinimalGotocCtx};
 pub use vtable_ctx::VtableCtx;


### PR DESCRIPTION
Profiling showed that `codegen_span_stable` was a significant bottleneck for Kani, as it has to do all the queries to `rustc_public` and logic to construct a `Location` for a given `Span`. However, I tested and found that the function was typically being called multiple (~500) times on the exact same `Span` throughout an execution.

This PR introduces a new cache to store the result of those calculations for future use.

Since the key to this cache is a `rustc_public::Span`, it's dependent on the type being `Hash`, something which will hopefully be implemented in rust-lang/rust#145018. For now, I've tested the change using a hacky transmute to implement `Hash` myself.

### Results
Caching span codegen led to a nice **9.4% reduction in the end to end compilation** of the standard library (@ commit [177d0fd](https://github.com/model-checking/verify-rust-std/commit/177d0fd25fbf3cb82c7b8408140158af1e408ede), assuming #4276 lands).

Like #4276, this is a caching change and will have an associated memory overhead. Based on the max capacity of the map during execution, I estimate its **peak size to be ~4.4MB** when run on the standard library, which is around 0.13%-0.17% of Kani's total memory usage on the same run. This seems acceptable for the measured performance benefit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
