### PR TITLE
Upgrade Rust toolchain to 2025-08-18

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -16,6 +16,7 @@ use crate::unwrap_or_return_codegen_unimplemented_stmt;
 use cbmc::goto_program::CIntType;
 use cbmc::goto_program::Symbol as GotoSymbol;
 use cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, Type};
+use rustc_hir::LangItem;
 use rustc_middle::ty::TyCtxt;
 use rustc_public::mir::mono::Instance;
 use rustc_public::mir::{BasicBlockIdx, Place};
@@ -332,7 +333,7 @@ impl GotocHook for Panic {
         // panic functions we've stubbed too
         kani_tool_attr.is_some_and(|kani| kani.contains("PanicStub"))
             || Some(def_id) == tcx.lang_items().panic_fn()
-            || tcx.has_attr(def_id, rustc_span::sym::rustc_const_panic_str)
+            || tcx.is_lang_item(def_id, LangItem::PanicDisplay)
             || Some(def_id) == tcx.lang_items().panic_fmt()
             || Some(def_id) == tcx.lang_items().begin_panic_fn()
     }

--- a/kani-compiler/src/kani_middle/transform/rustc_intrinsics.rs
+++ b/kani-compiler/src/kani_middle/transform/rustc_intrinsics.rs
@@ -13,6 +13,7 @@ use crate::kani_middle::transform::body::{
 };
 use crate::kani_middle::transform::{TransformPass, TransformationType};
 use crate::kani_queries::QueryDb;
+use rustc_hir::LangItem;
 use rustc_middle::ty::TyCtxt;
 use rustc_public::mir::mono::Instance;
 use rustc_public::mir::{
@@ -65,7 +66,7 @@ impl TransformPass for RustcIntrinsicsPass {
 fn is_panic_function(tcx: &TyCtxt, def_id: rustc_public::DefId) -> bool {
     let def_id = rustc_internal::internal(*tcx, def_id);
     Some(def_id) == tcx.lang_items().panic_fn()
-        || tcx.has_attr(def_id, rustc_span::sym::rustc_const_panic_str)
+        || tcx.is_lang_item(def_id, LangItem::PanicDisplay)
         || Some(def_id) == tcx.lang_items().panic_fmt()
         || Some(def_id) == tcx.lang_items().begin_panic_fn()
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-08-16"
+channel = "nightly-2025-08-18"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Relevant upstream PR:
- https://github.com/rust-lang/rust/pull/145304 (Revert "Partially outline code inside the panic! macro".)

Resolves: #4301

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
