### PR TITLE
Upgrade syn dependency to the latest version

### DIFF
--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", optional = true }
 serde_json = "1"
 strum = "0.27.1"
 strum_macros = "0.27.1"
-syn = { version = "2.0.72", features = ["parsing", "extra-traits"] }
+syn = { version = "2.0", features = ["parsing", "extra-traits"] }
 tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-subscriber = {version = "0.3.8", features = ["env-filter", "json", "fmt"]}
 tracing-tree = "0.4.0"

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 proc-macro-error2 = { version = "2.0.0", features = ["nightly"] }
 quote = "1.0.20"
-syn = { version = "2.0.18", features = ["full", "visit-mut", "visit", "extra-traits"] }
+syn = { version = "2.0", features = ["full", "visit-mut", "visit", "extra-traits"] }
 strum = "0.27.1"
 strum_macros = "0.27.1"
 


### PR DESCRIPTION
Fixes compiling the standard library, and avoids pinning to a particular minor version.

Resolves: #4303

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
