### PR TITLE
Fix compiler_builtins upstream monomorphizations errors by inlining kani_contract_mode

### DIFF
--- a/library/kani_macros/src/sysroot/contracts/bootstrap.rs
+++ b/library/kani_macros/src/sysroot/contracts/bootstrap.rs
@@ -71,7 +71,7 @@ impl<'a> ContractConditionsHandler<'a> {
                 }
                 // Dummy function that we replace to pick the contract mode.
                 // By default, return ORIGINAL
-                #[inline(never)]
+                #[inline]
                 #[kanitool::fn_marker = "kani_contract_mode"]
                 const fn kani_contract_mode() -> kani::internal::Mode {
                     kani::internal::ORIGINAL


### PR DESCRIPTION
Resolves https://github.com/model-checking/verify-rust-std/issues/477 
Resolves https://github.com/os-checker/distributed-verification/issues/111

kani_contract_mode with `inline(never)` will instantiate in libcore rather than compiler_builtins, which breaks the [requirement](https://github.com/rust-lang/rust/issues/137222#issuecomment-3208865566) that calls in compiler_builtins must be instantiated inside compiler_builtins. Rustc tools like [dv](https://github.com/os-checker/distributed-verification) will codegen such calls, while kani won't, [so](https://github.com/rust-lang/rust/issues/137222#issuecomment-3209938225) verify-rust-std doesn't  have the error.

```rust
error: `compiler_builtins` cannot call functions through upstream monomorphizations; 
encountered invalid call from `core::ops::index_range::IndexRange::next_unchecked` 
to `core::ops::index_range::IndexRange::next_unchecked::kani_contract_mode`
   --> /home/gh-zjp-CN/distributed-verification/verify-rust-std/library/core/src/ops/index_range.rs:63:5
    |
 63 |     #[cfg_attr(kani, kani::modifies(self))] // 👈 annotated on core::ops::index_range::IndexRange::next_unchecked
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ in this attribute macro expansion
```

This PR make kani_contract_mode inline to make kani annotated APIs that are called in `compiler_builtins` be instantiated in `compiler_builtins` rather than libcore. I've tested the fix and it works for me.

Not sure why functions like kani_force_fn_once are fine even if they're marked `#[inline(never)]` to cause the trouble.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
