### PR TITLE
Update toolchain to 08-25-2025

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-08-20"
+channel = "nightly-2025-08-25"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
This PR updates Rust toolchain to 08/25/2025

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
