### PR TITLE
Contain CI permissions to avoid global read-write

### DIFF
--- a/.github/workflows/bench-compiler.yml
+++ b/.github/workflows/bench-compiler.yml
@@ -3,6 +3,8 @@
 #
 # Run performance benchmarks comparing the compiler performance of two different Kani versions.
 name: Kani Compiler Performance Benchmarks
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -7,6 +7,8 @@
 #  - Changes are pushed to 'main'.
 #  - Triggered by another workflow
 name: Kani End-To-End Performance Benchmarks
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/cbmc-latest.yml
+++ b/.github/workflows/cbmc-latest.yml
@@ -5,6 +5,9 @@
 name: >-
   Nightly: CBMC Latest
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 9 * * *" # Run this every day at 9 AM UTC (4 AM ET/1 AM PT)

--- a/.github/workflows/extra_jobs.yml
+++ b/.github/workflows/extra_jobs.yml
@@ -18,6 +18,8 @@
 # See https://github.com/actions/labeler?tab=readme-ov-file#recommended-permissions for more details.
 
 name: Kani Extra
+permissions:
+  contents: read
 on:
   pull_request_target:
   merge_group:
@@ -27,7 +29,6 @@ jobs:
   auto-label:
     name: Auto Label
     permissions:
-      contents: read
       pull-requests: write
     outputs:
       all-labels: ${{ steps.labeler.outputs.all-labels }}
@@ -46,13 +47,11 @@ jobs:
   end-to-end-bench:
     name: End-to-End Benchmarks
     needs: auto-label
-    permissions: {}
     if: ${{ contains(needs.auto-label.outputs.all-labels, 'Z-EndToEndBenchCI') && github.event_name != 'merge_group' }}
     uses: ./.github/workflows/bench-e2e.yml
 
   compiler-bench:
     name: Compiler Benchmarks
     needs: auto-label
-    permissions: {}
     if: ${{ contains(needs.auto-label.outputs.all-labels, 'Z-CompilerBenchCI') && github.event_name != 'merge_group' }}
     uses: ./.github/workflows/bench-compiler.yml

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,6 +1,8 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 name: Kani Format Check
+permissions:
+  contents: read
 on:
   pull_request:
   merge_group:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@
 # The release will create a draft release and upload the bundles to it, and it will only run when we push a new
 # release tag (i.e.: tag named `kani-*`).
 name: Release Bundle
+permissions:
+  contents: read
 on:
   pull_request:
   merge_group:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,6 +272,8 @@ jobs:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/kani-') }}
     name: Release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     needs: [build_bundle_macos_x86_64, build_bundle_macos_aarch64, build_bundle_linux_x86_64, build_bundle_linux_aarch64, test_bundle]
     outputs:
       version: ${{ steps.versioning.outputs.version }}

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -5,6 +5,9 @@
 name: >-
   Nightly: Slow tests
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "30 5 * * *" # Run this every day at 05:30 UTC

--- a/.github/workflows/verify-std-check.yml
+++ b/.github/workflows/verify-std-check.yml
@@ -13,6 +13,8 @@
 # Changes unrelated to the toolchain should match the current status of main.
 
 name: Check Std Verification
+permissions:
+  contents: read
 on:
   pull_request:
   workflow_call:


### PR DESCRIPTION
Addresses code scanning alert. Fix generated by Copilot Autofix.
