### PR TITLE
Workaround sporadic git submodule failure

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -37,5 +37,7 @@ runs:
         run: |
           cd ${{ inputs.kani_dir }}
           git config --global --add safe.directory $(pwd)
-          git submodule update --init --depth 1
+          # Workaround for occasionally failing to copy a file in s2n-quic that we
+          # don't actually care about
+          GIT_LFS_SKIP_SMUDGE=1 git submodule update --init --depth 1
         shell: bash


### PR DESCRIPTION
This is to avoid sporadic failures when trying to download the fuzzing corpus for s2n-quic (a Kani submodule). See
https://github.com/model-checking/kani/actions/runs/17577959149/job/49927516847?pr=4348 for an example of such a run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
