### PR TITLE
Upgrade Rust toolchain to 2025-09-10

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -424,7 +424,7 @@ impl<'tcx, 'r> GotocCtx<'tcx, 'r> {
             if let Some(principal) = binder.principal() {
                 let poly = principal.with_self_ty(self.tcx, t);
                 let poly = self.tcx.instantiate_bound_regions_with_erased(poly);
-                let poly = self.tcx.erase_regions(poly);
+                let poly = self.tcx.erase_and_anonymize_regions(poly);
                 let mut flds = self
                     .tcx
                     .vtable_entries(poly)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-09-09"
+channel = "nightly-2025-09-10"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Relevant upstream PR:
- https://github.com/rust-lang/rust/pull/145717 (rename erase_regions to erase_and_anonymize_regions)

Resolves: #4353

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
