### PR TITLE
Upgrade Rust toolchain to 2025-09-18

### DIFF
--- a/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
+++ b/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
@@ -582,7 +582,7 @@ impl<'tcx> PointsToAnalysis<'_, 'tcx> {
                 // The same story from BinOp applies here, too. Need to track those things.
                 self.successors_for_operand(state, operand)
             }
-            Rvalue::NullaryOp(..) | Rvalue::Discriminant(..) | Rvalue::Len(_) => {
+            Rvalue::NullaryOp(..) | Rvalue::Discriminant(..) => {
                 // All of those should yield a constant.
                 HashSet::new()
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-09-17"
+channel = "nightly-2025-09-18"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Relevant upstream PR:
- https://github.com/rust-lang/rust/pull/146564 (Remove Rvalue::Len again.)

Resolves: #4365

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
