### PR TITLE
Revert "Cache dependencies for CI jobs (#4181)"

### DIFF
--- a/.github/workflows/bench-compiler.yml
+++ b/.github/workflows/bench-compiler.yml
@@ -39,18 +39,6 @@ jobs:
           ref: ${{ env.NEW_REF }}
           fetch-depth: 1
 
-      - name: Cache Kani build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          shared-key: "kani-rust-cache-bench"
-          workspaces: |
-            new
-            new/tools/compile-timer
-            old
-            old/tools/compile-timer
-          cache-directories: "~/.rustup"
-
       - name: Set up Kani Dependencies (old variant)
         uses: ./old/.github/actions/setup
         with:
@@ -114,18 +102,6 @@ jobs:
           path: ./new
           ref: ${{ env.NEW_REF }}
           fetch-depth: 1
-
-      - name: Cache Kani build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          shared-key: "kani-rust-cache-bench"
-          workspaces: |
-            new
-            new/tools/compile-timer
-            old
-            old/tools/compile-timer
-          cache-directories: "~/.rustup"
 
       - name: Set up Kani Dependencies (old variant)
         uses: ./old/.github/actions/setup

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -23,13 +23,6 @@ jobs:
       - name: Checkout Kani
         uses: actions/checkout@v5
 
-      - name: Cache Kani build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          shared-key: "kani-rust-cache-dev"
-          cache-directories: "~/.rustup"
-
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
@@ -50,13 +43,6 @@ jobs:
           sudo apt-get install -y python3-pip
           pushd tools/benchcomp && pip3 install -r requirements.txt
 
-      - name: Cache Kani build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          shared-key: "kani-rust-cache-release"
-          cache-directories: "~/.rustup"
-
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
@@ -74,13 +60,6 @@ jobs:
       - name: Checkout Kani
         uses: actions/checkout@v5
 
-      - name: Cache Kani build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          shared-key: "kani-rust-cache-release"
-          cache-directories: "~/.rustup"
-
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup
         with:
@@ -96,12 +75,6 @@ jobs:
     steps:
       - name: Checkout Kani
         uses: actions/checkout@v5
-
-      - name: Cache Kani build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-directories: "~/.rustup"
 
       - name: Setup Kani Dependencies
         uses: ./.github/actions/setup

--- a/.github/workflows/verify-std-check.yml
+++ b/.github/workflows/verify-std-check.yml
@@ -43,14 +43,6 @@ jobs:
           path: kani
           fetch-depth: 0
 
-      - name: Cache Kani build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          workspaces: kani
-          shared-key: "kani-rust-cache-dev"
-          cache-directories: "~/.rustup"
-
       - name: Setup Kani Dependencies
         uses: ./kani/.github/actions/setup
         with:


### PR DESCRIPTION
This reverts commit ada8ed3d9b3e22f7005ed18746fe8372644c2122: caching .rustup means we just keep piling up toolchains. We already have 6 GB as cache size, and will eventually just hit the 10 GB limit and not be caching anything anymore.

We could revisit caching to build something more effective, but also possible effects of caching are somewhat negligible anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
