### PR TITLE
Upgrade Rust toolchain to 2025-09-30

### DIFF
--- a/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
@@ -198,6 +198,10 @@ impl CodegenBackend for LlbcCodegenBackend {
         println!("Kani-llbc version: {}", env!("CARGO_PKG_VERSION"));
     }
 
+    fn name(&self) -> &'static str {
+        "kani-llbc"
+    }
+
     fn locale_resource(&self) -> &'static str {
         // We don't currently support multiple languages.
         DEFAULT_LOCALE_RESOURCE
@@ -324,7 +328,14 @@ impl CodegenBackend for LlbcCodegenBackend {
     ) {
         let requested_crate_types = &codegen_results.crate_info.crate_types.clone();
         let local_crate_name = codegen_results.crate_info.local_crate_name;
-        link_binary(sess, &ArArchiveBuilderBuilder, codegen_results, rustc_metadata, outputs);
+        link_binary(
+            sess,
+            &ArArchiveBuilderBuilder,
+            codegen_results,
+            rustc_metadata,
+            outputs,
+            self.name(),
+        );
         for crate_type in requested_crate_types {
             let out_fname = out_filename(sess, *crate_type, outputs, local_crate_name);
             let out_path = out_fname.as_path();

--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -290,6 +290,10 @@ impl CodegenBackend for GotocCodegenBackend {
         println!("Kani-goto version: {}", env!("CARGO_PKG_VERSION"));
     }
 
+    fn name(&self) -> &'static str {
+        "kani-cprover"
+    }
+
     fn locale_resource(&self) -> &'static str {
         // We don't currently support multiple languages.
         DEFAULT_LOCALE_RESOURCE
@@ -525,7 +529,14 @@ impl CodegenBackend for GotocCodegenBackend {
         let local_crate_name = codegen_results.crate_info.local_crate_name;
         // Create the rlib if one was requested.
         if requested_crate_types.contains(&CrateType::Rlib) {
-            link_binary(sess, &ArArchiveBuilderBuilder, codegen_results, rustc_metadata, outputs);
+            link_binary(
+                sess,
+                &ArArchiveBuilderBuilder,
+                codegen_results,
+                rustc_metadata,
+                outputs,
+                self.name(),
+            );
         }
 
         // But override all the other outputs.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-09-29"
+channel = "nightly-2025-09-30"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Relevant upstream PRs:
- https://github.com/rust-lang/rust/pull/147127 (Add a leading dash to linker plugin arguments in the gcc codegen)

Resolves: #4387

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
