### PR TITLE
Only skip toolchain update upon exact issue match

### DIFF
--- a/scripts/toolchain_update.sh
+++ b/scripts/toolchain_update.sh
@@ -26,7 +26,7 @@ echo "- next: ${next_toolchain_date}"
 echo "---------------------------"
 
 if gh issue list -S \
-  "Toolchain upgrade to nightly-$next_toolchain_date failed" \
+  "\"Toolchain upgrade to nightly-$next_toolchain_date failed\"" \
   --json number,title | grep title
 then
   echo "Skip update: Found existing issue"


### PR DESCRIPTION
See https://github.com/model-checking/kani/actions/runs/18191307420 for a workflow that spuriously was a no-op: we were effectively doing https://github.com/model-checking/kani/issues?q=is%3Aissue%20state%3Aopen%20Toolchain%20upgrade%20to%20nightly-2025-10-02%20failed (which turns up https://github.com/model-checking/kani/issues/3881) when we should do
https://github.com/model-checking/kani/issues?q=is%3Aissue%20state%3Aopen%20%22Toolchain%20upgrade%20to%20nightly-2025-10-02%20failed%22

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
