### PR TITLE
Upgrade Rust toolchain to 2025-10-03

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
@@ -627,15 +627,13 @@ impl GotocCtx<'_, '_> {
                     self,
                 )
             }
-            ProjectionElem::OpaqueCast(ty) | ProjectionElem::Subtype(ty) => {
-                ProjectedPlace::try_new(
-                    before.goto_expr.cast_to(self.codegen_ty_stable(*ty)),
-                    TypeOrVariant::Type(*ty),
-                    before.fat_ptr_goto_expr,
-                    before.fat_ptr_mir_typ,
-                    self,
-                )
-            }
+            ProjectionElem::OpaqueCast(ty) => ProjectedPlace::try_new(
+                before.goto_expr.cast_to(self.codegen_ty_stable(*ty)),
+                TypeOrVariant::Type(*ty),
+                before.fat_ptr_goto_expr,
+                before.fat_ptr_mir_typ,
+                self,
+            ),
         }
     }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -794,7 +794,7 @@ impl GotocCtx<'_, '_> {
             Rvalue::Cast(CastKind::PointerCoercion(k), e, t) => {
                 self.codegen_pointer_cast(k, e, *t, loc)
             }
-            Rvalue::Cast(CastKind::Transmute, operand, ty) => {
+            Rvalue::Cast(CastKind::Transmute | CastKind::Subtype, operand, ty) => {
                 let src_ty = operand.ty(self.current_fn().locals()).unwrap();
                 // Transmute requires sized types.
                 let src_sz = LayoutOf::new(src_ty).size_of().unwrap();

--- a/kani-compiler/src/kani_middle/points_to/points_to_graph.rs
+++ b/kani-compiler/src/kani_middle/points_to/points_to_graph.rs
@@ -163,7 +163,6 @@ impl<'tcx> PointsToGraph<'tcx> {
                 | ProjectionElem::Subslice { .. }
                 | ProjectionElem::Downcast(..)
                 | ProjectionElem::OpaqueCast(..)
-                | ProjectionElem::Subtype(..)
                 | ProjectionElem::UnwrapUnsafeBinder(..) => {
                     /* There operations are no-ops w.r.t aliasing since we are tracking it on per-object basis. */
                 }

--- a/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
+++ b/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
@@ -488,7 +488,6 @@ impl MirVisitor for CheckUninitVisitor {
                 }
                 ProjectionElem::Downcast(_) => {}
                 ProjectionElem::OpaqueCast(_) => {}
-                ProjectionElem::Subtype(_) => {}
             }
         }
         self.super_place(place, ptx, location)

--- a/kani-compiler/src/kani_middle/transform/check_values.rs
+++ b/kani-compiler/src/kani_middle/transform/check_values.rs
@@ -549,7 +549,6 @@ impl MirVisitor for CheckValueVisitor<'_, '_> {
                 }
                 ProjectionElem::Downcast(_) => {}
                 ProjectionElem::OpaqueCast(_) => {}
-                ProjectionElem::Subtype(_) => {}
                 ProjectionElem::Index(_)
                 | ProjectionElem::ConstantIndex { .. }
                 | ProjectionElem::Subslice { .. } => { /* safe */ }
@@ -619,7 +618,7 @@ impl MirVisitor for CheckValueVisitor<'_, '_> {
                         })
                     }
                 }
-                CastKind::Transmute => {
+                CastKind::Transmute | CastKind::Subtype => {
                     debug!(?dest_ty, "transmute");
                     // For transmute, we care about the destination type only.
                     // This could be optimized to only add a check if the requirements of the
@@ -777,8 +776,7 @@ fn assignment_check_points(
             | ProjectionElem::ConstantIndex { .. }
             | ProjectionElem::Subslice { .. }
             | ProjectionElem::Downcast(_)
-            | ProjectionElem::OpaqueCast(_)
-            | ProjectionElem::Subtype(_) => ty = proj.ty(ty).unwrap(),
+            | ProjectionElem::OpaqueCast(_) => ty = proj.ty(ty).unwrap(),
         };
     }
     invalid_ranges

--- a/kani-compiler/src/kani_middle/transform/internal_mir.rs
+++ b/kani-compiler/src/kani_middle/transform/internal_mir.rs
@@ -146,6 +146,7 @@ impl RustcInternalMir for CastKind {
             CastKind::PtrToPtr => rustc_middle::mir::CastKind::PtrToPtr,
             CastKind::FnPtrToPtr => rustc_middle::mir::CastKind::FnPtrToPtr,
             CastKind::Transmute => rustc_middle::mir::CastKind::Transmute,
+            CastKind::Subtype => rustc_middle::mir::CastKind::Subtype,
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-10-02"
+channel = "nightly-2025-10-03"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tools/scanner/src/analysis.rs
+++ b/tools/scanner/src/analysis.rs
@@ -528,7 +528,6 @@ impl MirVisitor for BodyVisitor<'_> {
             }
             ProjectionElem::Downcast(_) => {}
             ProjectionElem::OpaqueCast(_) => {}
-            ProjectionElem::Subtype(_) => {}
             ProjectionElem::Index(_)
             | ProjectionElem::ConstantIndex { .. }
             | ProjectionElem::Subslice { .. } => { /* safe */ }


### PR DESCRIPTION
Relevant upstream PR:
- https://github.com/rust-lang/rust/pull/147055 (Turn ProjectionElem::Subtype into CastKind::Subtype)

Resolves: #4392

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
