### PR TITLE
Bump Kani version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ This file contains notable changes (e.g. breaking changes, major changes, etc.) 
 
 This file was introduced starting Kani 0.23.0, so it only contains changes from version 0.23.0 onwards.
 
+## [0.66.0]
+
+### Breaking Changes
+* Fail if stub verified doesn't have a contract harness by @carolynzech in https://github.com/model-checking/kani/pull/4295
+
+### What's Changed
+* Add loop invariant support for `while let` loop  by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4279
+* Update README by @carolynzech in https://github.com/model-checking/kani/pull/4291
+* Kani Book Documentation Improvements by @carolynzech in https://github.com/model-checking/kani/pull/4296
+* Share body cache between harnesses within a codegen unit by @AlexanderPortland in https://github.com/model-checking/kani/pull/4276
+* Add loop-contracts support for `for` loop by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4143
+* RFC: Partitioned proofs by @AlexanderPortland in https://github.com/model-checking/kani/pull/4228
+* Handle const generics in stubbing code by @zhassan-aws in https://github.com/model-checking/kani/pull/4323
+* Replace fxhash with rustc-hash by @zhassan-aws in https://github.com/model-checking/kani/pull/4341
+* Fix LLBC regressions by @zhassan-aws in https://github.com/model-checking/kani/pull/4338
+* Combo of small performance changes by @AlexanderPortland in https://github.com/model-checking/kani/pull/4314
+* Implement BoundedArbitrary for boxed slices by @zhassan-aws in https://github.com/model-checking/kani/pull/4340
+* Autoharness: use SHA-1 to produce codegen unit file names by @tautschnig in https://github.com/model-checking/kani/pull/4370
+* Update attributes.md by @0xsecaas in https://github.com/model-checking/kani/pull/4376
+* Switch macos-13 CI jobs to macos-15-intel by @tautschnig in https://github.com/model-checking/kani/pull/4442
+* Incrementally update charon submodule with LLBC backend adaptations by @tautschnig in https://github.com/model-checking/kani/pull/4445
+* Rust toolchain upgraded to 2025-11-05 by @carolynzech, @tautschnig, @thanhnguyen-aws, @zhassan-aws
+
+### New Contributors
+* @0xsecaas made their first contribution in https://github.com/model-checking/kani/pull/4376
+
+**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.65.0...kani-0.66.0
+
 ## [0.65.0]
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "build-kani"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -424,7 +424,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cprover_bindings"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "lazy_static",
  "linear-map",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "kani"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "kani_core",
  "kani_macros",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "kani-compiler"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "charon",
  "clap",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "kani-driver"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "kani-verifier"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "home",
@@ -1012,14 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "kani_core"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "kani_macros",
 ]
 
 [[package]]
 name = "kani_macros"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "kani_metadata"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "clap",
  "cprover_bindings",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "std"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "kani",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-verifier"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2024"
 description = "A bit-precise model checker for Rust."
 readme = "README.md"

--- a/cprover_bindings/Cargo.toml
+++ b/cprover_bindings/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cprover_bindings"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-compiler/Cargo.toml
+++ b/kani-compiler/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-compiler"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/kani-driver/Cargo.toml
+++ b/kani-driver/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani-driver"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2024"
 description = "Build a project with Kani and run all proof harnesses"
 license = "MIT OR Apache-2.0"

--- a/kani_metadata/Cargo.toml
+++ b/kani_metadata/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_metadata"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani/Cargo.toml
+++ b/library/kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_core/Cargo.toml
+++ b/library/kani_core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_core"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/kani_macros/Cargo.toml
+++ b/library/kani_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kani_macros"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -5,7 +5,7 @@
 # Note: this package is intentionally named std to make sure the names of
 # standard library symbols are preserved
 name = "std"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false

--- a/tools/build-kani/Cargo.toml
+++ b/tools/build-kani/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "build-kani"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2024"
 description = "Builds Kani, Sysroot and release bundle."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Raw release notes:
```
## What's Changed
* Automatic toolchain upgrade to nightly-2025-08-07 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4278
* Add loop invariant support for `while let` loop  by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4279
* Automatic toolchain upgrade to nightly-2025-08-08 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4281
* Automatic toolchain upgrade to nightly-2025-08-09 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4283
* Automatic cargo update to 2025-08-11 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4285
* Bump tests/perf/s2n-quic from `8f510f0` to `c64faf9` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4288
* Bump actions/checkout from 4 to 5 by @dependabot[bot] in https://github.com/model-checking/kani/pull/4286
* Bump actions/download-artifact from 4 to 5 by @dependabot[bot] in https://github.com/model-checking/kani/pull/4287
* Upgrade toolchain to 2025-08-10 by @carolynzech in https://github.com/model-checking/kani/pull/4289
* Automatic toolchain upgrade to nightly-2025-08-11 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4290
* Automatic toolchain upgrade to nightly-2025-08-12 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4292
* Update README by @carolynzech in https://github.com/model-checking/kani/pull/4291
* Automatic toolchain upgrade to nightly-2025-08-13 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4297
* [Breaking Change] Fail if stub verified doesn't have a contract harness by @carolynzech in https://github.com/model-checking/kani/pull/4295
* Kani Book Documentation Improvements by @carolynzech in https://github.com/model-checking/kani/pull/4296
* Automatic toolchain upgrade to nightly-2025-08-14 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4298
* Automatic toolchain upgrade to nightly-2025-08-15 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4299
* Automatic toolchain upgrade to nightly-2025-08-16 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4300
* Automatic cargo update to 2025-08-18 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4302
* Upgrade Rust toolchain to 2025-08-18 by @tautschnig in https://github.com/model-checking/kani/pull/4304
* Automatic toolchain upgrade to nightly-2025-08-19 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4307
* Bump tests/perf/s2n-quic from `c64faf9` to `ff81604` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4306
* Automatic toolchain upgrade to nightly-2025-08-20 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4309
* Share body cache between harnesses within a codegen unit by @AlexanderPortland in https://github.com/model-checking/kani/pull/4276
* Add loop-contracts support for `for` loop by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4143
* RFC: Partitioned proofs by @AlexanderPortland in https://github.com/model-checking/kani/pull/4228
* Update toolchain to 08-25-2025 by @thanhnguyen-aws in https://github.com/model-checking/kani/pull/4316
* Automatic cargo update to 2025-08-25 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4315
* Automatic toolchain upgrade to nightly-2025-08-26 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4317
* Bump tests/perf/s2n-quic from `ff81604` to `fa30e8a` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4318
* Automatic toolchain upgrade to nightly-2025-08-27 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4319
* Handle const generics in stubbing code by @zhassan-aws in https://github.com/model-checking/kani/pull/4323
* Automatic toolchain upgrade to nightly-2025-08-28 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4324
* Automatic toolchain upgrade to nightly-2025-08-29 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4325
* Add import select_autoescape by @zhassan-aws in https://github.com/model-checking/kani/pull/4327
* Bump tracing-subscriber from 0.3.19 to 0.3.20 by @dependabot[bot] in https://github.com/model-checking/kani/pull/4328
* Bump ncipollo/release-action from 1.18.0 to 1.19.1 by @dependabot[bot] in https://github.com/model-checking/kani/pull/4331
* Bump tests/perf/s2n-quic from `fa30e8a` to `d2c0794` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4332
* Automatic cargo update to 2025-09-01 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4330
* Upgrade toolchain to 2025-09-02 by @zhassan-aws in https://github.com/model-checking/kani/pull/4333
* Automatic toolchain upgrade to nightly-2025-09-03 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4335
* Automatic toolchain upgrade to nightly-2025-09-04 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4336
* Automatic toolchain upgrade to nightly-2025-09-05 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4337
* Replace fxhash with rustc-hash by @zhassan-aws in https://github.com/model-checking/kani/pull/4341
* Fix LLBC regressions by @zhassan-aws in https://github.com/model-checking/kani/pull/4338
* Bump ncipollo/release-action from 1.19.1 to 1.20.0 by @dependabot[bot] in https://github.com/model-checking/kani/pull/4344
* Automatic cargo update to 2025-09-08 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4342
* Bump tests/perf/s2n-quic from `d2c0794` to `26e2402` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4346
* Automatic toolchain upgrade to nightly-2025-09-06 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4339
* Combo of small performance changes by @AlexanderPortland in https://github.com/model-checking/kani/pull/4314
* Upgrade cargo_metadata dependency by @tautschnig in https://github.com/model-checking/kani/pull/4308
* Bump actions/github-script from 7 to 8 by @dependabot[bot] in https://github.com/model-checking/kani/pull/4343
* Bump actions/labeler from 5 to 6 by @dependabot[bot] in https://github.com/model-checking/kani/pull/4345
* Automatic toolchain upgrade to nightly-2025-09-07 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4347
* Workaround sporadic git submodule failure by @tautschnig in https://github.com/model-checking/kani/pull/4349
* Implement BoundedArbitrary for boxed slices by @zhassan-aws in https://github.com/model-checking/kani/pull/4340
* Automatic toolchain upgrade to nightly-2025-09-08 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4350
* Contain CI permissions to avoid global read-write by @tautschnig in https://github.com/model-checking/kani/pull/4348
* Automatic toolchain upgrade to nightly-2025-09-09 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4352
* Upgrade Rust toolchain to 2025-09-10 by @tautschnig in https://github.com/model-checking/kani/pull/4354
* Automatic toolchain upgrade to nightly-2025-09-11 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4355
* Automatic toolchain upgrade to nightly-2025-09-12 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4356
* Do not run PR/issue-creating workflows in forks by @tautschnig in https://github.com/model-checking/kani/pull/4357
* Automatic toolchain upgrade to nightly-2025-09-13 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4358
* Automatic toolchain upgrade to nightly-2025-09-14 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4359
* Automatic toolchain upgrade to nightly-2025-09-15 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4360
* Automatic cargo update to 2025-09-15 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4361
* Bump tests/perf/s2n-quic from `26e2402` to `fc9b388` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4362
* Automatic toolchain upgrade to nightly-2025-09-16 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4363
* Automatic toolchain upgrade to nightly-2025-09-17 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4364
* Upgrade Rust toolchain to 2025-09-18 by @tautschnig in https://github.com/model-checking/kani/pull/4366
* Autoharness: use SHA-1 to produce codegen unit file names by @tautschnig in https://github.com/model-checking/kani/pull/4370
* Upgrade Rust toolchain to 2025-09-19 by @tautschnig in https://github.com/model-checking/kani/pull/4369
* Automatic toolchain upgrade to nightly-2025-09-20 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4371
* Automatic toolchain upgrade to nightly-2025-09-21 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4372
* Update attributes.md by @0xsecaas in https://github.com/model-checking/kani/pull/4376
* Bump tests/perf/s2n-quic from `fc9b388` to `b131854` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4377
* Automatic toolchain upgrade to nightly-2025-09-22 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4373
* Automatic cargo update to 2025-09-22 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4374
* Revert "Cache dependencies for CI jobs (#4181)" by @tautschnig in https://github.com/model-checking/kani/pull/4375
* Automatic toolchain upgrade to nightly-2025-09-23 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4378
* Automatic toolchain upgrade to nightly-2025-09-24 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4379
* Automatic toolchain upgrade to nightly-2025-09-25 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4380
* Automatic toolchain upgrade to nightly-2025-09-26 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4381
* Automatic toolchain upgrade to nightly-2025-09-27 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4382
* Automatic toolchain upgrade to nightly-2025-09-28 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4383
* Automatic toolchain upgrade to nightly-2025-09-29 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4384
* Automatic cargo update to 2025-09-29 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4385
* Bump tests/perf/s2n-quic from `b131854` to `1cca93b` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4386
* Upgrade Rust toolchain to 2025-09-30 by @tautschnig in https://github.com/model-checking/kani/pull/4388
* Automatic toolchain upgrade to nightly-2025-10-01 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4389
* Automatic toolchain upgrade to nightly-2025-10-02 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4391
* Upgrade Rust toolchain to 2025-10-03 by @tautschnig in https://github.com/model-checking/kani/pull/4393
* Complete CI permissions limiting by @tautschnig in https://github.com/model-checking/kani/pull/4394
* Automatic toolchain upgrade to nightly-2025-10-04 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4395
* Automatic toolchain upgrade to nightly-2025-10-05 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4396
* Automatic cargo update to 2025-10-06 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4398
* Automatic toolchain upgrade to nightly-2025-10-06 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4397
* Automatic toolchain upgrade to nightly-2025-10-07 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4401
* Automatic toolchain upgrade to nightly-2025-10-08 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4402
* Automatic toolchain upgrade to nightly-2025-10-09 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4403
* Automatic toolchain upgrade to nightly-2025-10-10 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4404
* Automatic toolchain upgrade to nightly-2025-10-11 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4405
* Bump tests/perf/s2n-quic from `1cca93b` to `995f37b` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4400
* Automatic cargo update to 2025-10-13 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4409
* Upgrade Rust toolchain to 2025-10-12 by @tautschnig in https://github.com/model-checking/kani/pull/4407
* Bump tests/perf/s2n-quic from `995f37b` to `5240fd6` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4410
* Automatic toolchain upgrade to nightly-2025-10-13 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4411
* Automatic toolchain upgrade to nightly-2025-10-14 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4412
* Automatic toolchain upgrade to nightly-2025-10-15 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4414
* Automatic toolchain upgrade to nightly-2025-10-16 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4415
* Automatic toolchain upgrade to nightly-2025-10-17 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4416
* Automatic cargo update to 2025-10-20 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4417
* Automatic toolchain upgrade to nightly-2025-10-18 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4418
* Bump tests/perf/s2n-quic from `5240fd6` to `73c9278` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4419
* Automatic toolchain upgrade to nightly-2025-10-19 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4420
* Automatic toolchain upgrade to nightly-2025-10-20 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4421
* Automatic toolchain upgrade to nightly-2025-10-21 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4422
* Automatic toolchain upgrade to nightly-2025-10-22 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4423
* Automatic toolchain upgrade to nightly-2025-10-23 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4424
* Automatic cargo update to 2025-10-27 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4428
* Bump tests/perf/s2n-quic from `73c9278` to `42fe409` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4429
* Bump actions/download-artifact from 5 to 6 by @dependabot[bot] in https://github.com/model-checking/kani/pull/4430
* Upgrade Rust toolchain to 2025-10-24 by @tautschnig in https://github.com/model-checking/kani/pull/4426
* Automatic toolchain upgrade to nightly-2025-10-25 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4431
* Automatic toolchain upgrade to nightly-2025-10-26 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4432
* Automatic toolchain upgrade to nightly-2025-10-27 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4433
* Automatic toolchain upgrade to nightly-2025-10-28 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4434
* Automatic toolchain upgrade to nightly-2025-10-29 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4435
* Automatic toolchain upgrade to nightly-2025-10-30 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4436
* Automatic toolchain upgrade to nightly-2025-10-31 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4437
* Automatic cargo update to 2025-11-03 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4441
* Upgrade Rust toolchain to 2025-11-03 by @tautschnig in https://github.com/model-checking/kani/pull/4440
* Bump tests/perf/s2n-quic from `42fe409` to `e726f08` by @dependabot[bot] in https://github.com/model-checking/kani/pull/4443
* Switch macos-13 CI jobs to macos-15-intel by @tautschnig in https://github.com/model-checking/kani/pull/4442
* Automatic toolchain upgrade to nightly-2025-11-04 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4444
* Incrementally update charon submodule with LLBC backend adaptations by @tautschnig in https://github.com/model-checking/kani/pull/4445
* Automatic toolchain upgrade to nightly-2025-11-05 by @github-actions[bot] in https://github.com/model-checking/kani/pull/4446
* Major-version update cargo dependencies by @tautschnig in https://github.com/model-checking/kani/pull/4447

## New Contributors
* @0xsecaas made their first contribution in https://github.com/model-checking/kani/pull/4376

**Full Changelog**: https://github.com/model-checking/kani/compare/kani-0.65.0...kani-0.66.0
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
