### PR TITLE
Upgrade Rust toolchain to 2025-11-06

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -43,7 +43,7 @@ use rustc_session::Session;
 use rustc_session::config::{CrateType, OutputFilenames, OutputType};
 use rustc_session::output::out_filename;
 use rustc_span::{Symbol, sym};
-use rustc_target::spec::PanicStrategy;
+use rustc_target::spec::{Arch, PanicStrategy};
 use std::any::Any;
 use std::cmp::min;
 use std::collections::BTreeMap;
@@ -302,10 +302,10 @@ impl CodegenBackend for GotocCodegenBackend {
     fn target_config(&self, sess: &Session) -> TargetConfig {
         // This code is adapted from the cranelift backend:
         // https://github.com/rust-lang/rust/blob/a124fb3cb7291d75872934f411d81fe298379ace/compiler/rustc_codegen_cranelift/src/lib.rs#L184
-        let target_features = if sess.target.arch == "x86_64" && sess.target.os != "none" {
+        let target_features = if sess.target.arch == Arch::X86_64 && sess.target.os != "none" {
             // x86_64 mandates SSE2 support and rustc requires the x87 feature to be enabled
             vec![sym::sse, sym::sse2, Symbol::intern("x87")]
-        } else if sess.target.arch == "aarch64" {
+        } else if sess.target.arch == Arch::AArch64 {
             match &*sess.target.os {
                 "none" => vec![],
                 // On macOS the aes, sha2 and sha3 features are enabled by default and ring
@@ -801,8 +801,8 @@ fn new_machine_model(sess: &Session) -> MachineModel {
     // see /tools/sizeofs/main.cpp.
     // For reference, the definition in CBMC:
     //https://github.com/diffblue/cbmc/blob/develop/src/util/config.cpp
-    match architecture.as_ref() {
-        "x86_64" => {
+    match architecture {
+        Arch::X86_64 => {
             let bool_width = 8;
             let char_is_unsigned = false;
             let char_width = 8;
@@ -841,7 +841,7 @@ fn new_machine_model(sess: &Session) -> MachineModel {
                 word_size: int_width,
             }
         }
-        "aarch64" => {
+        Arch::AArch64 => {
             let bool_width = 8;
             let char_is_unsigned = true;
             let char_width = 8;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-11-05"
+channel = "nightly-2025-11-06"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Relevant upstream PR:
- https://github.com/rust-lang/rust/pull/147645 (rustc_target: introduce Arch)

Resolves: #4450

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
