### PR TITLE
Upgrade Rust toolchain to 2025-11-10

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -842,7 +842,7 @@ impl GotocCtx<'_, '_> {
                             .bytes(),
                         Type::size_t(),
                     ),
-                    NullOp::ContractChecks | NullOp::UbChecks => Expr::c_false(),
+                    NullOp::RuntimeChecks(_) => Expr::c_false(),
                 }
             }
             Rvalue::ShallowInitBox(operand, content_ty) => {

--- a/kani-compiler/src/kani_middle/transform/internal_mir.rs
+++ b/kani-compiler/src/kani_middle/transform/internal_mir.rs
@@ -12,9 +12,9 @@ use rustc_middle::ty::{self as rustc_ty, TyCtxt};
 use rustc_public::mir::{
     AggregateKind, AssertMessage, Body, BorrowKind, CastKind, ConstOperand, CopyNonOverlapping,
     CoroutineDesugaring, CoroutineKind, CoroutineSource, FakeBorrowKind, FakeReadCause, LocalDecl,
-    MutBorrowKind, NonDivergingIntrinsic, NullOp, Operand, PointerCoercion, RetagKind, Rvalue,
-    Statement, StatementKind, SwitchTargets, Terminator, TerminatorKind, UnwindAction,
-    UserTypeProjection, Variance,
+    MutBorrowKind, NonDivergingIntrinsic, NullOp, Operand, PointerCoercion, RetagKind,
+    RuntimeChecks, Rvalue, Statement, StatementKind, SwitchTargets, Terminator, TerminatorKind,
+    UnwindAction, UserTypeProjection, Variance,
 };
 use rustc_public::rustc_internal::internal;
 
@@ -209,8 +209,19 @@ impl RustcInternalMir for NullOp {
                         .as_slice(),
                 ),
             ),
-            NullOp::UbChecks => rustc_middle::mir::NullOp::UbChecks,
-            NullOp::ContractChecks => rustc_middle::mir::NullOp::ContractChecks,
+            NullOp::RuntimeChecks(RuntimeChecks::UbChecks) => {
+                rustc_middle::mir::NullOp::RuntimeChecks(rustc_middle::mir::RuntimeChecks::UbChecks)
+            }
+            NullOp::RuntimeChecks(RuntimeChecks::ContractChecks) => {
+                rustc_middle::mir::NullOp::RuntimeChecks(
+                    rustc_middle::mir::RuntimeChecks::ContractChecks,
+                )
+            }
+            NullOp::RuntimeChecks(RuntimeChecks::OverflowChecks) => {
+                rustc_middle::mir::NullOp::RuntimeChecks(
+                    rustc_middle::mir::RuntimeChecks::OverflowChecks,
+                )
+            }
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-11-09"
+channel = "nightly-2025-11-10"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Relevant upstream PR:
- https://github.com/rust-lang/rust/pull/128666 (Add `overflow_checks` intrinsic)

Resolves: #4458

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
