### PR TITLE
Upgrade Rust toolchain to 2025-11-12

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2025-11-11"
+channel = "nightly-2025-11-12"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/ui/derive-invariant/helper-side-effect/expected
+++ b/tests/ui/derive-invariant/helper-side-effect/expected
@@ -1,7 +1,7 @@
 error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
    |
 |     #[safety_constraint({*(x.as_mut()) = 0; true})]
-   |                            ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                            ^ `x` is a `&` reference, so it cannot be borrowed as mutable
    |
 help: consider specifying this binding's type
    |


### PR DESCRIPTION
Relevant upstream PR:
- https://github.com/rust-lang/rust/pull/148508 (Provide more context when mutably borrowing an imutably borrowed value)

Resolves: #4468

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
