### PR TITLE
Arrays with more than 64 elements no longer cause spurious failures

### DIFF
--- a/tests/kani/Array/array_64.rs
+++ b/tests/kani/Array/array_64.rs
@@ -1,0 +1,16 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Check that CBMC (as invoked via Kani) does not spuriously fail with arrays of more 64 elements.
+
+#[derive(PartialEq, Eq)]
+enum Foo {
+    A,
+    B([u8; 65]),
+}
+
+#[kani::proof]
+fn main() {
+    let x: Foo = Foo::B([42; 65]);
+    let y: Foo = Foo::B([42; 65]);
+    assert!(x == y);
+}


### PR DESCRIPTION
With #4448 merged (upgrade to CBMC 6.8.0) we have the necessary fix in place to avoid spurious failures with arrays that have more than 64 elements.

Resolves: #2416
Resolves: #4408

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
