### PR TITLE
docs: Correct `default-unwind` Cargo.toml examples

### DIFF
--- a/docs/src/tutorial-loop-unwinding.md
+++ b/docs/src/tutorial-loop-unwinding.md
@@ -112,7 +112,7 @@ You can do this by putting this into your `Cargo.toml` file:
 
 ```toml
 [workspace.metadata.kani.flags]
-default-unwind = 1
+default-unwind = "1"
 ```
 
 ## Bounded proof

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -61,7 +61,7 @@ For example, if you want to set a default loop unwinding bound (when it's not ot
 
 ```toml
 [package.metadata.kani.flags]
-default-unwind = 1
+default-unwind = "1"
 ```
 
 The options here are the same as on the command line (`cargo kani --help`), and flags (that is, command line arguments that don't take a value) are enabled by setting them to `true`.


### PR DESCRIPTION
The examples for configuring `default-unwind` inside Cargo.toml files use unquoted integers. This isn't how they are actually expected to be written, and following these examples leads to kani failing to run.

This corrects the examples in the documentation to align with the expected configuration format.

Resolves #4495

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.