### PR TITLE
Bump mdbook version

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,7 +6,6 @@ description = "Documentation for the Kani Rust Verifier"
 authors = ["Kani Developers"]
 src = "src"
 language = "en"
-multilingual = false
 
 [output.html]
 site-url = "/kani/"

--- a/rfc/book.toml
+++ b/rfc/book.toml
@@ -5,7 +5,6 @@ title = "Kani RFC Book"
 description = "Design documents for Kani Rust Verifier"
 authors = ["Kani Developers"]
 language = "en"
-multilingual = false
 src = "src"
 
 [output.html]

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -20,17 +20,16 @@ if [ $(uname -m) = "arm64" ]; then
   MDBOOK=mdbook
 else
   # Download mdbook release (vs spending time building it via cargo install)
-  MDBOOK_VERSION=v0.4.18
+  MDBOOK_VERSION=v0.5.2
   FILE="mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
   URL="https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/$FILE"
-  EXPECTED_HASH="d276b0e594d5980de6a7917ce74c348f28d3cb8b353ca4eaae344ae8a4c40bea"
-  if [ ! -x mdbook ]; then
+  EXPECTED_HASH="084e4342ba564db270108763e404a7d1f309d932651a22484e93c0dc1a071f6d"
+  MDBOOK=${SCRIPT_DIR}/mdbook
+  if [ ! -x ${MDBOOK} ]; then
       curl -sSL -o "$FILE" "$URL"
       echo "$EXPECTED_HASH $FILE" | sha256sum -c -
       tar zxf $FILE
       MDBOOK=${SCRIPT_DIR}/mdbook
-  else
-      MDBOOK=mdbook
   fi
 fi
 


### PR DESCRIPTION
All PRs are currently failing due to an old mdbook version (e.g. https://github.com/model-checking/kani/actions/runs/20437279164/job/58721585205?pr=4502). Upgrade to 0.5.2 and ensure the script uses the downloaded version and not the system one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
