### PR TITLE
Upgrade Rust toolchain to nightly-2026-01-22

### DIFF
--- a/kani-compiler/src/kani_middle/provide.rs
+++ b/kani-compiler/src/kani_middle/provide.rs
@@ -17,7 +17,7 @@ pub fn provide(providers: &mut Providers, queries: &QueryDb) {
     let args = queries.args();
     if should_override(args) {
         // Don't override queries if we are only compiling our dependencies.
-        providers.optimized_mir = run_mir_passes;
+        providers.queries.optimized_mir = run_mir_passes;
         providers.extern_queries.optimized_mir = run_mir_passes_extern;
     }
 }
@@ -38,7 +38,7 @@ fn run_mir_passes_extern(tcx: TyCtxt<'_>, def_id: DefId) -> &Body<'_> {
 /// running rustc's optimization passes followed by Kani-specific passes.
 fn run_mir_passes(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &Body<'_> {
     tracing::debug!(?def_id, "run_mir_passes");
-    let body = (rustc_interface::DEFAULT_QUERY_PROVIDERS.optimized_mir)(tcx, def_id);
+    let body = (rustc_interface::DEFAULT_QUERY_PROVIDERS.queries.optimized_mir)(tcx, def_id);
     run_kani_mir_passes(tcx, def_id.to_def_id(), body)
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2026-01-14"
+channel = "nightly-2026-01-22"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/expected/float-to-int-in-range/invalid_float.expected
+++ b/tests/expected/float-to-int-in-range/invalid_float.expected
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `i32: std::convert::FloatToInt<u8>` is not satisfied
 invalid_float.rs:
 |     let _c = kani::float::float_to_int_in_range::<i32, u8>(i);
-|                                                   ^^^ the trait `std::convert::FloatToInt<u8>` is not implemented for `i32`
+|                                                   ^^^ the nightly-only, unstable trait `std::convert::FloatToInt<u8>` is not implemented for `i32`
 |

--- a/tests/expected/float-to-int-in-range/invalid_int.expected
+++ b/tests/expected/float-to-int-in-range/invalid_int.expected
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `f32: std::convert::FloatToInt<bool>` is not satisfied
 invalid_int.rs:
 |     let _c = kani::float::float_to_int_in_range::<f32, bool>(f);
-|                                                   ^^^ the trait `std::convert::FloatToInt<bool>` is not implemented for `f32`
+|                                                   ^^^ the nightly-only, unstable trait `std::convert::FloatToInt<bool>` is not implemented for `f32`
 |


### PR DESCRIPTION
Advance from nightly-2026-01-14 to nightly-2026-01-22. Two source changes are required (both first needed at nightly-2026-01-15); every intermediate nightly up to 01-22 then builds and passes the regression with no further changes.

- rust-lang/rust#151096 removed the `Deref`/`DerefMut` impl for `rustc_middle::util::Providers` (which forwarded to its inner `queries` field). Access the query providers explicitly in provide.rs: `providers.queries.optimized_mir` and `DEFAULT_QUERY_PROVIDERS.queries.optimized_mir`.
- rustc now renders unstable traits in `E0277` as "the nightly-only, unstable trait" rather than "the trait"; update the float-to-int-in-range expected files (`FloatToInt` is unstable).

Resolves #4646
Resolves #4603

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
