### PR TITLE
Fix codegen panic for calls through a function pointer returning `!`

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -791,7 +791,7 @@ impl GotocCtx<'_, '_> {
                 Stmt::block(
                     vec![
                         self.codegen_expr_to_place_stable(destination, func_expr.call(fargs), loc),
-                        Stmt::goto(bb_label(target.unwrap()), loc),
+                        self.codegen_end_call(*target, loc),
                     ],
                     loc,
                 )

--- a/tests/kani/Never/fn_ptr_never_return.rs
+++ b/tests/kani/Never/fn_ptr_never_return.rs
@@ -1,0 +1,22 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// kani-verify-fail
+
+//! Regression test for https://github.com/model-checking/kani/issues/4577
+//!
+//! Calling a function pointer whose return type is the never type `!` used to
+//! panic the Kani compiler in `codegen_funcall`: the function-pointer path
+//! unconditionally unwrapped the call's return target, but a diverging call
+//! has no return target. Codegen must instead treat the missing target like a
+//! direct call to a never-returning function does. Here the callee panics, so
+//! verification reaches the panic and fails (rather than the compiler crashing).
+
+fn diverge() -> ! {
+    panic!("EXPECTED FAIL: diverging function was called");
+}
+
+#[kani::proof]
+fn check_fnptr_never() {
+    let f: fn() -> ! = diverge;
+    f();
+}


### PR DESCRIPTION
### Description

Fixes a compiler panic when Kani codegens a call through a function pointer
whose return type is the never type `!`.

### Context

Given the minimal reproducer from #4577:

```rust
fn diverge() -> ! {
    loop {}
}

#[kani::proof]
fn check_fnptr_never() {
    let f: fn() -> ! = diverge;
    f();
}
```

Kani panicked during codegen:

```
thread 'rustc' panicked at kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs:
called `Option::unwrap()` on a `None` value
  ...
  <GotocCtx>::codegen_funcall
```

In `codegen_funcall`, the function-pointer (`RigidTy::FnPtr`) branch ended the
call with:

```rust
Stmt::goto(bb_label(target.unwrap()), loc)
```

A call whose callee returns `!` diverges, so MIR gives it no return target and
`target` is `None`;  the unconditional `unwrap()` then panics.  The sibling
branch for direct (`RigidTy::FnDef`) calls does not have this problem because
it ends the call with `codegen_end_call`, which already handles a missing
target by emitting an unreachable "Unexpected return from Never function"
sanity check instead of a goto.

### Change

Route the function-pointer branch through the same `codegen_end_call` helper,
so a diverging call through a function pointer is handled exactly like a
diverging direct call.  This is a one-line change;  the diverging case is now
covered by the existing, tested code path.

### Testing

- Added `tests/kani/Never/fn_ptr_never_return.rs`, a regression test that calls
  a `fn() -> !` pointer.  The callee panics, so the harness reaches the panic
  and verification fails as expected (`// kani-verify-fail`);  before this fix
  the compiler crashed instead of producing any verification result.  Built
  Kani (`cargo build-dev`) and ran it: the harness reports
  `VERIFICATION:- FAILED` with `Failed Checks: EXPECTED FAIL: diverging
  function was called`, i.e. codegen completes and CBMC runs.
- Ran the exact reproducer from the issue (the `loop {}` variant) against the
  built Kani: it no longer panics during codegen and proceeds into CBMC.
- `cargo check -p kani-compiler` passes.

Resolves #4577

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
