### PR TITLE
Upgrade Rust toolchain to nightly-2026-01-27

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -354,6 +354,24 @@ impl GotocCtx<'_, '_> {
             Intrinsic::Exp2F64 => codegen_simple_intrinsic!(Exp2),
             Intrinsic::ExpF32 => codegen_simple_intrinsic!(Expf),
             Intrinsic::ExpF64 => codegen_simple_intrinsic!(Exp),
+            // CBMC models neither `fabsf16` nor `fabsf128`, so compute the absolute
+            // value by clearing the IEEE sign bit. This is exactly `fabs` for every
+            // input (NaN, +/-0, and +/-inf included).
+            Intrinsic::FabsF16 => {
+                let arg = fargs.remove(0);
+                let bits = arg.transmute_to(Type::unsigned_int(16), &self.symbol_table);
+                let abs_bits = bits.bitand(Expr::int_constant(0x7fff, Type::unsigned_int(16)));
+                let result = abs_bits.transmute_to(Type::float16(), &self.symbol_table);
+                self.codegen_expr_to_place_stable(place, result, loc)
+            }
+            Intrinsic::FabsF128 => {
+                let arg = fargs.remove(0);
+                let bits = arg.transmute_to(Type::unsigned_int(128), &self.symbol_table);
+                // `i128::MAX` (== `u128::MAX >> 1`) clears only the sign bit (bit 127).
+                let abs_bits = bits.bitand(Expr::int_constant(i128::MAX, Type::unsigned_int(128)));
+                let result = abs_bits.transmute_to(Type::float128(), &self.symbol_table);
+                self.codegen_expr_to_place_stable(place, result, loc)
+            }
             Intrinsic::FabsF32 => codegen_simple_intrinsic!(Fabsf),
             Intrinsic::FabsF64 => codegen_simple_intrinsic!(Fabs),
             Intrinsic::FaddFast => {

--- a/kani-compiler/src/intrinsics.rs
+++ b/kani-compiler/src/intrinsics.rs
@@ -61,6 +61,8 @@ pub enum Intrinsic {
     Exp2F64,
     ExpF32,
     ExpF64,
+    FabsF128,
+    FabsF16,
     FabsF32,
     FabsF64,
     FaddFast,
@@ -653,6 +655,10 @@ fn try_match_f32(intrinsic_instance: &Instance) -> Option<Intrinsic> {
             assert_sig_matches!(sig, RigidTy::Float(FloatTy::F32) => RigidTy::Float(FloatTy::F32));
             Some(Intrinsic::ExpF32)
         }
+        "fabsf16" => {
+            assert_sig_matches!(sig, RigidTy::Float(FloatTy::F16) => RigidTy::Float(FloatTy::F16));
+            Some(Intrinsic::FabsF16)
+        }
         "fabsf32" => {
             assert_sig_matches!(sig, RigidTy::Float(FloatTy::F32) => RigidTy::Float(FloatTy::F32));
             Some(Intrinsic::FabsF32)
@@ -746,6 +752,10 @@ fn try_match_f64(intrinsic_instance: &Instance) -> Option<Intrinsic> {
         "fabsf64" => {
             assert_sig_matches!(sig, RigidTy::Float(FloatTy::F64) => RigidTy::Float(FloatTy::F64));
             Some(Intrinsic::FabsF64)
+        }
+        "fabsf128" => {
+            assert_sig_matches!(sig, RigidTy::Float(FloatTy::F128) => RigidTy::Float(FloatTy::F128));
+            Some(Intrinsic::FabsF128)
         }
         "floorf64" => {
             assert_sig_matches!(sig, RigidTy::Float(FloatTy::F64) => RigidTy::Float(FloatTy::F64));

--- a/kani-compiler/src/kani_compiler.rs
+++ b/kani-compiler/src/kani_compiler.rs
@@ -32,7 +32,7 @@ use rustc_interface::interface::Compiler;
 use rustc_middle::ty::TyCtxt;
 use rustc_parse::lexer::StripTokens;
 use rustc_parse::new_parser_from_source_str;
-use rustc_parse::parser::ForceCollect;
+use rustc_parse::parser::{AllowConstBlockItems, ForceCollect};
 use rustc_public::rustc_internal;
 use rustc_session::config::ErrorOutputType;
 use rustc_span::{FileName, sym};
@@ -220,7 +220,7 @@ fn inject_kani_macro_overrides(compiler: &Compiler, krate: &mut ast::Crate) {
             return;
         }
     };
-    match parser.parse_item(ForceCollect::No) {
+    match parser.parse_item(ForceCollect::No, AllowConstBlockItems::No) {
         Ok(Some(item)) => krate.items.insert(0, item),
         Ok(None) => unreachable!("failed to parse Kani's macro-override injection"),
         Err(error) => {

--- a/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
+++ b/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
@@ -643,6 +643,8 @@ fn is_identity_aliasing_intrinsic(intrinsic: Intrinsic) -> bool {
         | Intrinsic::Exp2F64
         | Intrinsic::ExpF32
         | Intrinsic::ExpF64
+        | Intrinsic::FabsF128
+        | Intrinsic::FabsF16
         | Intrinsic::FabsF32
         | Intrinsic::FabsF64
         | Intrinsic::FaddFast

--- a/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
+++ b/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
@@ -590,6 +590,8 @@ fn can_skip_intrinsic(intrinsic: Intrinsic) -> bool {
         | Intrinsic::Exp2F64
         | Intrinsic::ExpF32
         | Intrinsic::ExpF64
+        | Intrinsic::FabsF128
+        | Intrinsic::FabsF16
         | Intrinsic::FabsF32
         | Intrinsic::FabsF64
         | Intrinsic::FaddFast

--- a/kani-driver/src/coverage/cov_results.rs
+++ b/kani-driver/src/coverage/cov_results.rs
@@ -31,7 +31,7 @@ impl fmt::Display for CoverageResults {
             for (function, checks) in checks_by_function {
                 writeln!(f, "{file} ({function})")?;
                 let mut sorted_checks: Vec<CoverageCheck> = checks.to_vec();
-                sorted_checks.sort_by(|a, b| a.region.start.cmp(&b.region.start));
+                sorted_checks.sort_by_key(|a| a.region.start);
                 for check in sorted_checks.iter() {
                     writeln!(f, " * {} {}", check.region, check.status)?;
                 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2026-01-22"
+channel = "nightly-2026-01-27"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/expected/shadow/unsupported_num_objects/test.rs
+++ b/tests/expected/shadow/unsupported_num_objects/test.rs
@@ -18,13 +18,21 @@ fn check_max_objects<const N: usize>() {
     // numbering, so the `N` thresholds below may need to be adjusted when
     // upgrading CBMC.
     let mut have_42 = false;
+    // Push the boxes into a leaked `Vec` so that they are real heap allocations
+    // (escaping the loop body prevents stack promotion, which would otherwise let the
+    // compiler elide them) while avoiding the cost of symbolically executing a
+    // per-iteration deallocation. This keeps the test well under the per-test timeout
+    // on slower CI runners.
+    let mut boxes: Vec<Box<usize>> = Vec::with_capacity(N);
     while i < N {
         let x: Box<usize> = Box::new(kani::any());
         if *x == 42 {
             have_42 = true;
         }
+        boxes.push(x);
         i += 1;
     }
+    std::mem::forget(boxes);
 
     // create a new object whose ID is `N` + 3
     let x: i32 = have_42 as i32;

--- a/tests/kani/Intrinsics/Math/fabsf128.rs
+++ b/tests/kani/Intrinsics/Math/fabsf128.rs
@@ -1,0 +1,27 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `fabsf128` returns the expected results: absolute value if argument
+// is not NaN, otherwise NaN
+#![feature(core_intrinsics)]
+#![feature(f128)]
+
+#[kani::proof]
+fn test_abs_finite() {
+    let x: f128 = kani::any();
+    kani::assume(!x.is_nan());
+    let abs_x = unsafe { std::intrinsics::fabsf128(x) };
+    if x < 0.0 {
+        assert!(-x == abs_x);
+    } else {
+        assert!(x == abs_x);
+    }
+}
+
+#[kani::proof]
+fn test_abs_nan() {
+    let x: f128 = kani::any();
+    kani::assume(x.is_nan());
+    let abs_x = unsafe { std::intrinsics::fabsf128(x) };
+    assert!(abs_x.is_nan());
+}

--- a/tests/kani/Intrinsics/Math/fabsf16.rs
+++ b/tests/kani/Intrinsics/Math/fabsf16.rs
@@ -1,0 +1,27 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that `fabsf16` returns the expected results: absolute value if argument
+// is not NaN, otherwise NaN
+#![feature(core_intrinsics)]
+#![feature(f16)]
+
+#[kani::proof]
+fn test_abs_finite() {
+    let x: f16 = kani::any();
+    kani::assume(!x.is_nan());
+    let abs_x = unsafe { std::intrinsics::fabsf16(x) };
+    if x < 0.0 {
+        assert!(-x == abs_x);
+    } else {
+        assert!(x == abs_x);
+    }
+}
+
+#[kani::proof]
+fn test_abs_nan() {
+    let x: f16 = kani::any();
+    kani::assume(x.is_nan());
+    let abs_x = unsafe { std::intrinsics::fabsf16(x) };
+    assert!(abs_x.is_nan());
+}

--- a/tools/kani-cov/src/summary.rs
+++ b/tools/kani-cov/src/summary.rs
@@ -135,8 +135,8 @@ pub fn line_coverage_results(
 
     if let Some(res) = fun_results {
         let mut cur_results = res.1.clone();
-        // Sort the results by row
-        cur_results.sort_by(|a, b| b.region.start.0.cmp(&a.region.start.0));
+        // Sort the results by row (descending).
+        cur_results.sort_by_key(|a| std::cmp::Reverse(a.region.start.0));
 
         /// Checks if a line is relevant to a region.
         /// Here, we define "relevant" as the line appearing after/at the start


### PR DESCRIPTION
Advance from nightly-2026-01-22 to nightly-2026-01-27. One source change is required (first needed at nightly-2026-01-23); every intermediate nightly up to 01-27 then builds and passes the regression with no further changes.

nightly-2026-01-23 began routing f16 `float_to_int_unchecked` through the `fabsf16` intrinsic (and 01-27 does the same for f128 via `fabsf128`), which Kani did not model, so verification hit an unsupported construct. Add support for the `fabsf16` and `fabsf128` float-abs intrinsics.

CBMC models neither `fabsf16` nor `fabsf128`, so compute the absolute value by clearing the IEEE sign bit (transmute to the same-width unsigned integer, mask off the top bit, transmute back). This is exactly `fabs` for every input (NaN, +/-0, and +/-inf included) and does not depend on a CBMC library model.

Verified sound: harnesses asserting `a >= 0` and `a == x || a == -x` for `f16::abs`/`f128::abs` verify successfully (the results are precise, not nondet). Regression tests are added under `tests/kani/Intrinsics/Math/fabsf16.rs` and
`fabsf128.rs` (finite + NaN cases), mirroring the existing `fabsf32`/`fabsf64` tests.

Also: nightly-2026-01-27 is where clippy's `unnecessary_sort_by` lint begins firing, which CI enforces via `cargo clippy --workspace --tests -- -D warnings`. Replace `sort_by(|a, b| a.k.cmp(&b.k))` with `sort_by_key` in `kani-cov` and `kani-driver` to keep clippy clean.

Finally, speed up `tests/expected/shadow/unsupported_num_objects/test.rs`, which was timing out on the slower `macos-15-intel` CI runner: push the loop's boxes into a leaked `Vec` (so they remain real, distinct heap allocations that escape the loop body and are not elided) instead of dropping each one per iteration. This avoids symbolically executing 1024 deallocations, cutting symex time by roughly 10x while leaving the object count (and thus the thresholds) unchanged.

Co-authored-by: Kiro <kiro-agent@users.noreply.github.com>

Resolves #4650

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
