### PR TITLE
Upgrade Rust toolchain to nightly-2026-01-29

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -498,6 +498,26 @@ impl GotocCtx<'_, '_> {
                 let n: u64 = self.simd_shuffle_length(stripped.as_str(), farg_types, span);
                 self.codegen_intrinsic_simd_shuffle(fargs, place, farg_types, ret_ty, n, span)
             }
+            Intrinsic::SimdSplat => {
+                // Broadcast the scalar argument to every lane of the result vector.
+                let val = fargs.remove(0);
+                let (size, ret_base_type) = self.simd_size_and_type(ret_ty);
+                // `simd_splat<T, U>(value: U) -> T` has independent generic parameters,
+                // so a monomorphization where `U` is not `T`'s element type can reach
+                // codegen. Emit an error like rustc's backends (and like `simd_extract`
+                // and `simd_insert` above) rather than silently casting the value.
+                if farg_types[0] != ret_base_type {
+                    let err_msg = format!(
+                        "expected argument type `{ret_base_type}` (element of output `{ret_ty}`), found `{}`",
+                        farg_types[0]
+                    );
+                    utils::span_err(self.tcx, span, err_msg);
+                }
+                self.tcx.dcx().abort_if_errors();
+                let elem_ty = cbmc_ret_ty.base_type().unwrap().clone();
+                let elems = vec![val.cast_to(elem_ty); size as usize];
+                self.codegen_expr_to_place_stable(place, Expr::vector_expr(cbmc_ret_ty, elems), loc)
+            }
             Intrinsic::SimdSub => self.codegen_simd_op_with_overflow(
                 Expr::sub,
                 Expr::sub_overflow_p,

--- a/kani-compiler/src/intrinsics.rs
+++ b/kani-compiler/src/intrinsics.rs
@@ -124,6 +124,7 @@ pub enum Intrinsic {
     SimdShl,
     SimdShr,
     SimdShuffle(String),
+    SimdSplat,
     SimdSub,
     SimdXor,
     SizeOf,
@@ -609,6 +610,10 @@ fn try_match_simd(intrinsic_instance: &Instance) -> Option<Intrinsic> {
         "simd_shr" => {
             assert_sig_matches!(sig, _, _ => _);
             Some(Intrinsic::SimdShr)
+        }
+        "simd_splat" => {
+            assert_sig_matches!(sig, _ => _);
+            Some(Intrinsic::SimdSplat)
         }
         "simd_sub" => {
             assert_sig_matches!(sig, _, _ => _);

--- a/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
+++ b/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
@@ -724,6 +724,7 @@ fn is_identity_aliasing_intrinsic(intrinsic: Intrinsic) -> bool {
         | Intrinsic::SimdShl
         | Intrinsic::SimdShr
         | Intrinsic::SimdShuffle(_)
+        | Intrinsic::SimdSplat
         | Intrinsic::SimdSub
         | Intrinsic::SimdXor => {
             /* SIMD operations */

--- a/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
+++ b/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
@@ -669,6 +669,7 @@ fn can_skip_intrinsic(intrinsic: Intrinsic) -> bool {
         | Intrinsic::SimdShl
         | Intrinsic::SimdShr
         | Intrinsic::SimdShuffle(_)
+        | Intrinsic::SimdSplat
         | Intrinsic::SimdSub
         | Intrinsic::SimdXor => {
             /* SIMD operations */

--- a/kani-compiler/src/kani_middle/transform/check_uninit/ty_layout.rs
+++ b/kani-compiler/src/kani_middle/transform/check_uninit/ty_layout.rs
@@ -259,14 +259,8 @@ fn data_bytes_for_ty(
                                     for (index, variant) in variants.iter().enumerate() {
                                         let mut field_data_bytes_for_variant = vec![];
                                         let fields = ty_variants[index].fields();
-                                        // Get offsets of all fields in a variant.
-                                        let FieldsShape::Arbitrary { offsets: field_offsets } =
-                                            variant.fields.clone()
-                                        else {
-                                            unreachable!()
-                                        };
-                                        for field_idx in variant.fields.fields_by_offset_order() {
-                                            let field_offset = field_offsets[field_idx].bytes();
+                                        for field_idx in variant.fields_by_offset_order() {
+                                            let field_offset = variant.offsets[field_idx].bytes();
                                             let field_ty = fields[field_idx].ty_with_args(args);
                                             field_data_bytes_for_variant.append(
                                                 &mut data_bytes_for_ty(

--- a/kani-compiler/src/kani_middle/transform/check_values.rs
+++ b/kani-compiler/src/kani_middle/transform/check_values.rs
@@ -978,8 +978,8 @@ pub fn ty_validity_per_offset(
                                     let mut fields_validity = vec![];
                                     for (index, variant) in variants.iter().enumerate() {
                                         let fields = ty_variants[index].fields();
-                                        for field_idx in variant.fields.fields_by_offset_order() {
-                                            let field_offset = offsets[field_idx].bytes();
+                                        for field_idx in variant.fields_by_offset_order() {
+                                            let field_offset = variant.offsets[field_idx].bytes();
                                             let field_ty = fields[field_idx].ty_with_args(args);
                                             fields_validity.append(&mut ty_validity_per_offset(
                                                 machine_info,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2026-01-27"
+channel = "nightly-2026-01-29"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/expected/intrinsics/simd-splat-wrong-type/expected
+++ b/tests/expected/intrinsics/simd-splat-wrong-type/expected
@@ -1,0 +1,2 @@
+expected argument type `i64` (element of output `i64x2`), found `i32`
+error: aborting due to 1 previous error

--- a/tests/expected/intrinsics/simd-splat-wrong-type/main.rs
+++ b/tests/expected/intrinsics/simd-splat-wrong-type/main.rs
@@ -1,0 +1,27 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test checks that we emit an error when the argument of `simd_splat`
+//! (the value to be broadcast) has a type different to the return vector's
+//! element type. `simd_splat<T, U>(value: U) -> T` has independent generic
+//! parameters, so such an instantiation type-checks in the frontend and must
+//! be rejected during codegen, like rustc's own backends do.
+#![feature(repr_simd, core_intrinsics)]
+use std::intrinsics::simd::simd_splat;
+
+#[repr(simd)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
+pub struct i64x2([i64; 2]);
+
+#[kani::proof]
+fn main() {
+    let _: i64x2 = unsafe { simd_splat(0_i32) };
+    // ^^^^ The value to broadcast has type `i32`, but the element type of
+    // `i64x2` is `i64`. It can be fixed by annotating the value with the
+    // type `i64`:
+    //
+    // ```rust
+    // let _: i64x2 = unsafe { simd_splat(0_i64) };
+    // ```
+}


### PR DESCRIPTION
Advance from nightly-2026-01-27 to nightly-2026-01-29. Two source changes are required (both first needed at nightly-2026-01-28); 01-29 then also passes with no further changes.

- rust-lang/rust#151040 ("public-variant-layout") reworked `VariantsShape::Multiple`: its `variants` are now `VariantFields` values that expose `offsets` and `fields_by_offset_order()` directly, instead of `LayoutShape`s whose `fields: FieldsShape` had to be destructured. Update the two enum-layout walkers (check_uninit/ty_layout.rs and check_values.rs) to use the per-variant `offsets` directly (the latter previously indexed the enum's top-level offsets, which only cover the tag).

- nightly-2026-01-28's HashMap/SwissTable lowers `Simd::splat` through the `simd_splat` intrinsic, which Kani did not model (unsupported construct). Add `simd_splat` support: broadcast the scalar argument to every lane of the result vector.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
