### PR TITLE
Upgrade Rust toolchain to nightly-2026-02-04

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -461,6 +461,24 @@ impl GotocCtx<'_, '_> {
             Intrinsic::SimdEq => {
                 self.codegen_simd_cmp(Expr::vector_eq, fargs, place, span, farg_types, ret_ty)
             }
+            Intrinsic::SimdReduceAll => {
+                // Boolean AND-reduction: returns whether every lane is "true". The
+                // argument is a mask-like integer vector (lanes are 0 or all-ones),
+                // so a lane is true iff it is non-zero.
+                let vec = fargs.remove(0);
+                let (size, _) = self.simd_size_and_type(farg_types[0]);
+                let lane =
+                    |v: &Expr, i: u64| v.clone().index_array(Expr::int_constant(i, Type::size_t()));
+                let lane_true = |l: Expr| {
+                    let zero = Expr::int_constant(0, l.typ().clone());
+                    l.neq(zero)
+                };
+                let mut acc = lane_true(lane(&vec, 0));
+                for i in 1..size {
+                    acc = acc.and(lane_true(lane(&vec, i)));
+                }
+                self.codegen_expr_to_place_stable(place, acc.cast_to(cbmc_ret_ty), loc)
+            }
             Intrinsic::SimdExtract => {
                 self.codegen_intrinsic_simd_extract(fargs, place, farg_types, ret_ty, span)
             }

--- a/kani-compiler/src/intrinsics.rs
+++ b/kani-compiler/src/intrinsics.rs
@@ -110,6 +110,7 @@ pub enum Intrinsic {
     SimdAdd,
     SimdAnd,
     SimdDiv,
+    SimdReduceAll,
     SimdRem,
     SimdEq,
     SimdExtract,
@@ -558,6 +559,10 @@ fn try_match_simd(intrinsic_instance: &Instance) -> Option<Intrinsic> {
         "simd_div" => {
             assert_sig_matches!(sig, _, _ => _);
             Some(Intrinsic::SimdDiv)
+        }
+        "simd_reduce_all" => {
+            assert_sig_matches!(sig, _ => RigidTy::Bool);
+            Some(Intrinsic::SimdReduceAll)
         }
         "simd_rem" => {
             assert_sig_matches!(sig, _, _ => _);

--- a/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
+++ b/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
@@ -711,6 +711,7 @@ fn is_identity_aliasing_intrinsic(intrinsic: Intrinsic) -> bool {
         | Intrinsic::SimdAnd
         | Intrinsic::SimdDiv
         | Intrinsic::SimdRem
+        | Intrinsic::SimdReduceAll
         | Intrinsic::SimdEq
         | Intrinsic::SimdExtract
         | Intrinsic::SimdGe

--- a/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
+++ b/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
@@ -656,6 +656,7 @@ fn can_skip_intrinsic(intrinsic: Intrinsic) -> bool {
         | Intrinsic::SimdAnd
         | Intrinsic::SimdDiv
         | Intrinsic::SimdRem
+        | Intrinsic::SimdReduceAll
         | Intrinsic::SimdEq
         | Intrinsic::SimdExtract
         | Intrinsic::SimdGe

--- a/library/kani/src/models/mod.rs
+++ b/library/kani/src/models/mod.rs
@@ -219,7 +219,7 @@ mod test {
     #[test]
     #[should_panic(expected = "Masks values should either be 0 or -1")]
     fn test_invalid_bitmask() {
-        let invalid_mask = unsafe { mask32x16::from_int_unchecked(i32x16::splat(10)) };
+        let invalid_mask = unsafe { mask32x16::from_simd_unchecked(i32x16::splat(10)) };
         assert_eq!(
             unsafe { kani_intrinsic::simd_bitmask::<_, u16, i32, 16>(invalid_mask) },
             u16::MAX
@@ -262,7 +262,6 @@ mod test {
     fn check_portable_bitmask<T, E, const LANES: usize, M>(mask: Mask<T, LANES>)
     where
         T: std::simd::MaskElement,
-        LaneCount<LANES>: SupportedLaneCount,
         E: kani_intrinsic::MaskElement,
         [u8; kani_intrinsic::mask_len(LANES)]: Sized,
         u64: From<M>,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2026-01-29"
+channel = "nightly-2026-02-04"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/kani/Intrinsics/SIMD/Reduction/reduce_all.rs
+++ b/tests/kani/Intrinsics/SIMD/Reduction/reduce_all.rs
@@ -1,0 +1,47 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Checks that the `simd_reduce_all` intrinsic (a boolean AND-reduction over a
+//! mask-like integer vector, whose lanes must be `0` or `!0`) is supported and
+//! returns the expected results. This is also a regression test for the
+//! portable-SIMD mask validation (`Mask::valid`, used by `Mask::from_array` and
+//! friends) and `Mask::all`, both of which lower through this intrinsic.
+#![feature(repr_simd, core_intrinsics, portable_simd)]
+use std::intrinsics::simd::simd_reduce_all;
+use std::simd::{Mask, Simd};
+
+#[repr(simd)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
+pub struct i8x4([i8; 4]);
+
+#[kani::proof]
+fn check_reduce_all_true() {
+    let mask = i8x4([!0, !0, !0, !0]);
+    assert!(unsafe { simd_reduce_all(mask) });
+}
+
+#[kani::proof]
+fn check_reduce_all_one_false() {
+    let mask = i8x4([!0, !0, 0, !0]);
+    assert!(!unsafe { simd_reduce_all(mask) });
+}
+
+#[kani::proof]
+fn check_reduce_all_symbolic() {
+    let lanes: [bool; 4] = kani::any();
+    let mask = i8x4(std::array::from_fn(|i| if lanes[i] { !0 } else { 0 }));
+    let expected = lanes.iter().all(|&b| b);
+    assert_eq!(unsafe { simd_reduce_all(mask) }, expected);
+}
+
+#[kani::proof]
+fn check_mask_all() {
+    let vals: [bool; 4] = kani::any();
+    let repr: Simd<i8, 4> = Simd::from_array(std::array::from_fn(|i| if vals[i] { !0 } else { 0 }));
+    // SAFETY: every lane of `repr` is 0 or !0.
+    // (`Mask::from_array` is not used here because it also lowers through
+    // `simd_cast`, which Kani does not support yet.)
+    let mask = unsafe { Mask::<i8, 4>::from_simd_unchecked(repr) };
+    assert_eq!(mask.all(), vals.iter().all(|&b| b));
+}


### PR DESCRIPTION
Advance from nightly-2026-01-29 to nightly-2026-02-04. One source change is required (first needed at nightly-2026-01-30); every intermediate nightly up to 02-04 then builds and passes the regression with no further changes.

nightly-2026-01-30's portable-SIMD mask validation (`Mask::valid`/`Mask::all`) lowers through the `simd_reduce_all` intrinsic, which Kani did not model (unsupported construct). Add `simd_reduce_all`: a boolean AND-reduction that returns whether every lane of the (mask-like) argument vector is non-zero.

Verified sound: concrete all-true/one-false masks and a symbolic `a.simd_eq(b).all() == (lane0_eq)` check all verify.

Co-authored-by: Kiro <kiro-agent@users.noreply.github.com>

Also: nightly-2026-02-04 updated the `std::simd` API (dropped the `LaneCount`/ `SupportedLaneCount` bound and renamed `Mask::from_int_unchecked` to `from_simd_unchecked`). Update `library/kani`'s SIMD model unit tests, which CI compiles via `cargo clippy --workspace --tests`.

Resolves #4653

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
