### PR TITLE
Upgrade Rust toolchain to nightly-2026-02-05

### DIFF
--- a/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
@@ -26,7 +26,7 @@ use rustc_codegen_ssa::back::link::link_binary;
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::{CodegenResults, CrateInfo};
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
-use rustc_errors::{DEFAULT_LOCALE_RESOURCE, ErrorGuaranteed};
+use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::{DefId as InternalDefId, LOCAL_CRATE};
 use rustc_metadata::EncodedMetadata;
 use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
@@ -196,11 +196,6 @@ impl CodegenBackend for LlbcCodegenBackend {
 
     fn name(&self) -> &'static str {
         "kani-llbc"
-    }
-
-    fn locale_resource(&self) -> &'static str {
-        // We don't currently support multiple languages.
-        DEFAULT_LOCALE_RESOURCE
     }
 
     fn codegen_crate(&self, tcx: TyCtxt) -> Box<dyn Any> {

--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -29,7 +29,6 @@ use rustc_codegen_ssa::back::link::link_binary;
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::{CodegenResults, CrateInfo, TargetConfig};
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
-use rustc_errors::DEFAULT_LOCALE_RESOURCE;
 use rustc_hir::def_id::{DefId as InternalDefId, LOCAL_CRATE};
 use rustc_metadata::EncodedMetadata;
 use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
@@ -290,11 +289,6 @@ impl CodegenBackend for GotocCodegenBackend {
 
     fn name(&self) -> &'static str {
         "kani-cprover"
-    }
-
-    fn locale_resource(&self) -> &'static str {
-        // We don't currently support multiple languages.
-        DEFAULT_LOCALE_RESOURCE
     }
 
     fn target_config(&self, sess: &Session) -> TargetConfig {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2026-02-04"
+channel = "nightly-2026-02-05"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
rust-lang/rust#152102 ("inline_fluent_codegen_backends") removed the `locale_resource` method from the `CodegenBackend` trait (fluent resources are now handled internally). Drop Kani's `locale_resource` implementation and the now-unused `rustc_errors::DEFAULT_LOCALE_RESOURCE` import.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
