### PR TITLE
Update Charon submodule to v0.1.68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "charon"
-version = "0.1.67"
+version = "0.1.68"
 dependencies = [
  "annotate-snippets",
  "anstream 0.6.21",

--- a/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
@@ -15,8 +15,9 @@ use crate::kani_queries::QUERY_DB;
 use charon_lib::ast::{AnyTransId, TranslatedCrate, meta::ItemOpacity::*, meta::Span};
 use charon_lib::errors::ErrorCtx;
 use charon_lib::name_matcher::NamePattern;
+use charon_lib::options::{MirLevel, TranslateOptions};
 use charon_lib::transform::TransformCtx;
-use charon_lib::transform::ctx::{TransformOptions, TransformPass};
+use charon_lib::transform::ctx::TransformPass;
 use kani_metadata::ArtifactType;
 use kani_metadata::{AssignsContract, CompilerArtifactStub};
 use rustc_codegen_ssa::back::archive::{
@@ -393,7 +394,7 @@ where
     ret
 }
 
-fn get_transform_options(tcx: &TranslatedCrate, error_ctx: &mut ErrorCtx) -> TransformOptions {
+fn get_translate_options(tcx: &TranslatedCrate, error_ctx: &mut ErrorCtx) -> TranslateOptions {
     let mut parse_pattern = |s: &str| match NamePattern::parse(s) {
         Ok(p) => Ok(p),
         Err(e) => {
@@ -435,7 +436,9 @@ fn get_transform_options(tcx: &TranslatedCrate, error_ctx: &mut ErrorCtx) -> Tra
             .filter_map(|(s, opacity)| parse_pattern(&s).ok().map(|pat| (pat, opacity)))
             .collect()
     };
-    TransformOptions {
+    TranslateOptions {
+        mir_level: MirLevel::Built,
+        translate_all_methods: false,
         no_code_duplication: false,
         hide_marker_traits: true,
         no_merge_goto_chains: false,
@@ -449,6 +452,6 @@ fn create_charon_transformation_context(tcx: TyCtxt) -> TransformCtx {
     let crate_name = tcx.crate_name(LOCAL_CRATE).as_str().into();
     let translated = TranslatedCrate { crate_name, ..TranslatedCrate::default() };
     let mut errors = ErrorCtx::new(true, false);
-    let options = get_transform_options(&translated, &mut errors);
+    let options = get_translate_options(&translated, &mut errors);
     TransformCtx { options, translated, errors: std::cell::RefCell::new(errors) }
 }

--- a/kani-compiler/src/codegen_aeneas_llbc/mir_to_ullbc/mod.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/mir_to_ullbc/mod.rs
@@ -130,8 +130,7 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
                 let types = Vec::new();
                 let type_clauses = Vec::new();
                 let type_defaults = IndexMap::new();
-                let required_methods = Vec::new();
-                let provided_methods = Vec::new();
+                let methods = Vec::new();
                 let parent_clauses = CharonVector::new();
                 let c_traitdecl = CharonTraitDecl {
                     def_id: trait_decl_id,
@@ -143,8 +142,7 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
                     const_defaults,
                     types,
                     type_defaults,
-                    required_methods,
-                    provided_methods,
+                    methods,
                 };
                 self.translated.trait_decls.set_slot(trait_decl_id, c_traitdecl);
                 trait_decl_id

--- a/scripts/charon-patch.diff
+++ b/scripts/charon-patch.diff
@@ -1,10 +1,10 @@
 diff --git a/charon/Cargo.toml b/charon/Cargo.toml
-index 20f8a9df..a1bf1ee6 100644
+index d76c223c..0b354b1c 100644
 --- a/charon/Cargo.toml
 +++ b/charon/Cargo.toml
 @@ -2,7 +2,7 @@
  name = "charon"
- version = "0.1.67"
+ version = "0.1.68"
  authors = ["Son Ho <hosonmarc@gmail.com>"]
 -edition = "2021"
 +edition = "2024"
@@ -12,10 +12,10 @@ index 20f8a9df..a1bf1ee6 100644
  
  [lib]
 diff --git a/charon/src/ids/vector.rs b/charon/src/ids/vector.rs
-index 59f7eaab..21508e19 100644
+index 141cabe3..37948679 100644
 --- a/charon/src/ids/vector.rs
 +++ b/charon/src/ids/vector.rs
-@@ -217,7 +217,7 @@ where
+@@ -254,7 +254,7 @@ where
          self.iter_indexed().map(|(id, _)| id)
      }
  
@@ -25,7 +25,7 @@ index 59f7eaab..21508e19 100644
      }
  
 diff --git a/charon/src/transform/expand_associated_types.rs b/charon/src/transform/expand_associated_types.rs
-index 19978d56..c98c8e0e 100644
+index 225da182..54370990 100644
 --- a/charon/src/transform/expand_associated_types.rs
 +++ b/charon/src/transform/expand_associated_types.rs
 @@ -761,7 +761,7 @@ impl<'a> ComputeItemModifications<'a> {


### PR DESCRIPTION
Advance the Charon pin from v0.1.67 (30cab882) to v0.1.68 (63f7749d). This is the first step of an incremental effort to catch the pinned Charon up with upstream; recent Charon releases build unpatched on current nightlies and ship per-nightly tags, so completing this march will eventually allow dropping scripts/charon-patch.diff (and the CI step applying it) entirely.

Charon v0.1.68 merges a trait's `required_methods` and `provided_methods` lists into a single `methods` list, and replaces `TransformOptions` with `TranslateOptions`, which gains `mir_level` and `translate_all_methods` fields. Adapt the LLBC backend accordingly, initializing the new fields with `MirLevel::Built` and `translate_all_methods: false`.

Refresh scripts/charon-patch.diff so its hunks apply against the v0.1.68 sources: the crate edition bump (let-chains require edition 2024 on current nightlies) and the impl-Trait capture annotations (`use<I, T>` on `all_indices`, `use<'a, 'b, F>` in expand_associated_types).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
