### PR TITLE
Run benchmark workflows on pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/bench-compiler.yml
+++ b/.github/workflows/bench-compiler.yml
@@ -20,6 +20,9 @@ jobs:
         run: |
           echo "NEW_REF=${{ github.event.after}}" | tee -a "$GITHUB_ENV"
           echo "OLD_REF=${{ github.event.before }}" | tee -a "$GITHUB_ENV"
+      # Note: in reusable workflows, github.event_name and github.event are
+      # those of the caller; when invoked from bench-pr.yml this is a
+      # pull_request event.
       - name: Save pull request HEAD and base to environment variables
         if: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -83,6 +86,9 @@ jobs:
         run: |
           echo "NEW_REF=${{ github.event.after}}" | tee -a "$GITHUB_ENV"
           echo "OLD_REF=${{ github.event.before }}" | tee -a "$GITHUB_ENV"
+      # Note: in reusable workflows, github.event_name and github.event are
+      # those of the caller; when invoked from bench-pr.yml this is a
+      # pull_request event.
       - name: Save pull request HEAD and base to environment variables
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/.github/workflows/bench-compiler.yml
+++ b/.github/workflows/bench-compiler.yml
@@ -21,7 +21,7 @@ jobs:
           echo "NEW_REF=${{ github.event.after}}" | tee -a "$GITHUB_ENV"
           echo "OLD_REF=${{ github.event.before }}" | tee -a "$GITHUB_ENV"
       - name: Save pull request HEAD and base to environment variables
-        if: ${{ contains(fromJSON('["pull_request", "pull_request_target"]'), github.event_name) }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           echo "OLD_REF=${{ github.event.pull_request.base.sha }}" | tee -a "$GITHUB_ENV"
           echo "NEW_REF=${{ github.event.pull_request.head.sha }}" | tee -a "$GITHUB_ENV"
@@ -84,7 +84,7 @@ jobs:
           echo "NEW_REF=${{ github.event.after}}" | tee -a "$GITHUB_ENV"
           echo "OLD_REF=${{ github.event.before }}" | tee -a "$GITHUB_ENV"
       - name: Save pull request HEAD and base to environment variables
-        if: ${{ contains(fromJSON('["pull_request", "pull_request_target"]'), github.event_name) }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           echo "OLD_REF=${{ github.event.pull_request.base.sha }}" | tee -a "$GITHUB_ENV"
           echo "NEW_REF=${{ github.event.pull_request.head.sha }}" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -25,6 +25,9 @@ jobs:
           echo "NEW_REF=${{ github.event.after}}" | tee -a "$GITHUB_ENV"
           echo "OLD_REF=${{ github.event.before }}" | tee -a "$GITHUB_ENV"
 
+      # Note: in reusable workflows, github.event_name and github.event are
+      # those of the caller; when invoked from bench-pr.yml this is a
+      # pull_request event.
       - name: Save pull request HEAD and base to environment variables
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -26,7 +26,7 @@ jobs:
           echo "OLD_REF=${{ github.event.before }}" | tee -a "$GITHUB_ENV"
 
       - name: Save pull request HEAD and base to environment variables
-        if: ${{ contains(fromJSON('["pull_request", "pull_request_target"]'), github.event_name) }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           echo "OLD_REF=${{ github.event.pull_request.base.sha }}" | tee -a "$GITHUB_ENV"
           echo "NEW_REF=${{ github.event.pull_request.head.sha }}" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,0 +1,40 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Run the performance benchmark workflows for pull requests that carry the
+# corresponding Z-*BenchCI label (applied automatically by the labeler in
+# extra_jobs.yml based on the changed files, or manually).
+#
+# This runs on `pull_request` (not `pull_request_target`) on purpose: the
+# benchmark workflows build and execute the code proposed in the pull
+# request, which must not happen in the trusted `pull_request_target`
+# context (actions/checkout v6.1.0/v5.1.0/v4.4.0 refuse to do so; see
+# https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/).
+#
+# Note on the `labeled` trigger: labels added by the auto-labeler do not
+# re-trigger this workflow (events created with the default GITHUB_TOKEN
+# never trigger new workflow runs), so on freshly opened pull requests the
+# benchmarks only start with the next push to the pull request. Manually
+# adding the label triggers them immediately.
+
+name: Kani Benchmarks
+permissions:
+  contents: read
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  end-to-end-bench:
+    name: End-to-End Benchmarks
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'Z-EndToEndBenchCI') }}
+    uses: ./.github/workflows/bench-e2e.yml
+
+  compiler-bench:
+    name: Compiler Benchmarks
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'Z-CompilerBenchCI') }}
+    uses: ./.github/workflows/bench-compiler.yml

--- a/.github/workflows/extra_jobs.yml
+++ b/.github/workflows/extra_jobs.yml
@@ -44,14 +44,8 @@ jobs:
       with:
         dot: true
 
-  end-to-end-bench:
-    name: End-to-End Benchmarks
-    needs: auto-label
-    if: ${{ contains(needs.auto-label.outputs.all-labels, 'Z-EndToEndBenchCI') && github.event_name != 'merge_group' }}
-    uses: ./.github/workflows/bench-e2e.yml
-
-  compiler-bench:
-    name: Compiler Benchmarks
-    needs: auto-label
-    if: ${{ contains(needs.auto-label.outputs.all-labels, 'Z-CompilerBenchCI') && github.event_name != 'merge_group' }}
-    uses: ./.github/workflows/bench-compiler.yml
+  # Note: the label-gated benchmark workflows (bench-pr.yml) used to be
+  # invoked from here, but they build and run the code proposed in the pull
+  # request, which must not happen in this workflow's trusted
+  # `pull_request_target` context. They now trigger on `pull_request`
+  # events directly.


### PR DESCRIPTION
Since 2026-07-20, the label-gated benchmark jobs (`End-to-End Benchmarks / perf-benchcomp`, `Compiler Benchmarks / compile-timer-{short,long}`) fail within seconds on every pull request from a fork, while pushes to `main` stay green.

**Root cause:** actions/checkout v6.1.0 was published on 2026-07-20 (with coordinated backports v5.1.0 and v4.4.0) and made the floating `v6` tag refuse to check out fork PR code from workflows running in the trusted `pull_request_target` context ([changelog](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/)):

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow. [...]
```

Our benchmark workflows are invoked via `workflow_call` from `extra_jobs.yml`, which runs on `pull_request_target` (the auto-labeler needs `pull-requests: write`). They check out `github.event.pull_request.head.sha` — fork code — and then build and execute it, which is precisely the pattern the new default blocks. Pushes to `main` run the same workflows via the `push` trigger comparing trusted `before`/`after` refs, hence unaffected.

**Fix:** rather than opting out via `allow-unsafe-pr-checkout: true`, move the benchmark invocations to a new `bench-pr.yml` workflow triggered by plain `pull_request` events, so fork code builds and runs in the untrusted, fork-scoped context as GitHub recommends. Label gating (`Z-EndToEndBenchCI` / `Z-CompilerBenchCI`) is preserved, now reading the labels from the event payload instead of the labeler job's outputs. The event-name conditions inside the reusable workflows are simplified accordingly, and `extra_jobs.yml` keeps only the auto-labeler.

**Behavioral difference:** labels added by the auto-labeler do not re-trigger workflows (events created with the default `GITHUB_TOKEN` never do), so on freshly opened PRs the benchmarks only start with the next push, or when someone adds the label manually (human-added labels do trigger via the `labeled` event type). Subsequent pushes to labeled PRs — the common case — behave exactly as before. A `concurrency` group cancels superseded benchmark runs.

Validated with actionlint 1.7.7 (clean) on all four touched workflow files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
