### PR TITLE
Do not inject macro overrides into external dependencies

### DIFF
--- a/kani-compiler/src/kani_compiler.rs
+++ b/kani-compiler/src/kani_compiler.rs
@@ -170,6 +170,20 @@ impl Callbacks for KaniCompiler {
             // injecting `extern crate std` there would pull in a *second* `std`
             // (and `core`), causing duplicate-lang-item errors (E0152).
             && compiler.sess.opts.externs.get("std").is_some()
+            // Do not inject into external (registry/git) dependencies: the
+            // `#[macro_use]` scope is ambiguous (E0659) with an explicit glob
+            // import of the same macro name, and external crates may
+            // legitimately do that (e.g. libc >= 0.2.188 re-exports
+            // `core::assert` in an internal prelude that its modules
+            // glob-import, and calls `assert!`). External dependencies thus
+            // use the real `assert!`/`panic!`/... macros, which Kani models
+            // soundly, consistent with `no_std` dependencies which never had
+            // the overrides. Cargo passes `--cap-lints allow` exactly for
+            // non-local dependencies, so use that as the discriminator (like
+            // rustc's `Session::opts` consumers do for dependency-only
+            // behavior); local path/workspace crates and standalone `kani`
+            // builds keep the overrides.
+            && compiler.sess.opts.lint_cap.is_none()
         {
             inject_kani_macro_overrides(compiler, krate);
         }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -32,8 +32,9 @@ pub mod prelude {
     // Kani's versions here makes `#![no_std]` dependencies that import this prelude
     // explicitly (`extern crate std; use std::prelude::v1::*;`, e.g. lazy_static)
     // ambiguous against the injected core prelude (E0659). Instead, kani-compiler
-    // injects those overrides only into the crate under verification (see
-    // kani_compiler's macro-override injection). The print family is defined in this
+    // injects those overrides only into local crates, not external (registry/git)
+    // dependencies (see kani_compiler's macro-override injection). The print family
+    // is defined in this
     // crate (std) with no core-prelude counterpart, so overriding it here is safe and
     // applies everywhere (dependencies included), which is important so that a
     // dependency's `println!` does not run real formatting/IO during verification.


### PR DESCRIPTION
Since libc 0.2.188 was published (2026-07-21 09:38 UTC), every crate graph containing it fails to compile under Kani with dozens of ``error[E0659]: `assert` is ambiguous`` errors — including Kani's own `regression` and `perf` CI jobs on every PR (the cargo-kani test manifests use a floating `libc = "0.2"`; pushes to `main` still pass only because their last dependency resolution predates the release). See #4665 for the full analysis.

**Root cause:** the macro-override injection introduced in #4643 (`#[macro_use] extern crate std as _kani_std_macros;`) puts Kani's `assert!`/`panic!`/… overrides in the macro_use-prelude scope of every `std` crate kani-compiler builds. That scope shadows the standard prelude silently (intended), but is *ambiguous* (E0659) against an explicit glob import of the same macro name. libc's internal prelude re-exports `core::assert` and its modules glob-import that prelude; libc 0.2.188 added `assert!` calls in such a module (type-size sanity checks in `src/types.rs`), turning the latent conflict into a hard error.

**Fix:** restrict the injection to local crates. Cargo passes `--cap-lints allow` exactly for non-local (registry/git) dependencies, so `Session::opts.lint_cap` is the discriminator. External dependencies then use the real `assert!`/`panic!`/… macros, which Kani models soundly — consistent with `no_std` dependencies, which never had the overrides. Local path/workspace dependencies and standalone `kani` builds keep the overrides, preserving the dependency reachability/message behavior pinned by the `assert-reach` and `stubbing-ws-packages` tests.

**Testing:**
* The existing `cargo-kani/libc` test acts as the regression test: with libc 0.2.188 it fails before this change and passes after (its floating version requirement is a feature — it surfaced this bug within hours of the libc release). I first prototyped a hermetic path-dependency reproducer, but local path deps *should* keep the overrides (as `assert-reach`/`stubbing-ws-packages` demonstrate), so the libc test is the accurate coverage.
* Full `cargo-kani` suite: 71 passed / 0 failed, including the five tests failing in CI today (`libc`, `chrono_dep`, `dependencies`, `cbmc-unknown-lang-mode`, `stubbing-validate-random`) and the two that pin local-dependency semantics.
* `expected/assert*` standalone tests pass (override still active outside cargo).

An earlier iteration used `CARGO_PRIMARY_PACKAGE` as the discriminator, but that also strips the overrides from workspace/path dependencies, breaking `assert-reach` and `stubbing-ws-packages`; `lint_cap` matches the desired local/external cut exactly.

Resolves #4665

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
