### PR TITLE
Update Charon submodule to v0.1.71

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "charon"
-version = "0.1.69"
+version = "0.1.71"
 dependencies = [
  "annotate-snippets",
  "anstream 0.6.21",

--- a/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
@@ -13,7 +13,7 @@ use crate::kani_middle::reachability::{collect_reachable_items, filter_crate_ite
 use crate::kani_middle::transform::{BodyTransformation, GlobalPasses};
 use crate::kani_queries::QUERY_DB;
 use charon_lib::ast::{AnyTransId, TranslatedCrate, meta::ItemOpacity::*, meta::Span};
-use charon_lib::errors::ErrorCtx;
+use charon_lib::errors::{ErrorCtx, Level};
 use charon_lib::name_matcher::NamePattern;
 use charon_lib::options::{MirLevel, TranslateOptions};
 use charon_lib::transform::TransformCtx;
@@ -399,7 +399,7 @@ fn get_translate_options(tcx: &TranslatedCrate, error_ctx: &mut ErrorCtx) -> Tra
         Ok(p) => Ok(p),
         Err(e) => {
             let msg = format!("failed to parse pattern `{s}` ({e})");
-            Err(error_ctx.span_err(&TranslatedCrate::default(), Span::dummy(), &msg))
+            Err(error_ctx.span_err(&TranslatedCrate::default(), Span::dummy(), &msg, Level::Error))
         }
     };
     let options = tcx.options.clone();

--- a/kani-compiler/src/codegen_aeneas_llbc/mir_to_ullbc/mod.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/mir_to_ullbc/mod.rs
@@ -44,7 +44,7 @@ use charon_lib::ast::{
     TypeVarId as CharonTypeVarId, UnOp as CharonUnOp, Var as CharonVar, VarId as CharonVarId,
     Variant as CharonVariant, VariantId as CharonVariantId,
 };
-use charon_lib::errors::{Error as CharonError, ErrorCtx as CharonErrorCtx};
+use charon_lib::errors::{Error as CharonError, ErrorCtx as CharonErrorCtx, Level as CharonLevel};
 use charon_lib::ids::Vector as CharonVector;
 use charon_lib::ullbc_ast::{
     BlockData as CharonBlockData, BlockId as CharonBlockId, BodyContents as CharonBodyContents,
@@ -115,8 +115,8 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
         self.tcx
     }
 
-    fn span_err(&mut self, span: CharonSpan, msg: &str) -> CharonError {
-        self.errors.span_err(self.translated, span, msg)
+    fn span_err(&mut self, span: CharonSpan, msg: &str, level: CharonLevel) -> CharonError {
+        self.errors.span_err(self.translated, span, msg, level)
     }
 
     fn translate_traitdecl(&mut self, trait_def: TraitDef) -> CharonTraitDeclId {
@@ -715,7 +715,15 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
         // For now, assume all items are transparent
         let opacity = CharonItemOpacity::Transparent;
 
-        Ok(CharonItemMeta { span, source_text, attr_info, name, is_local, opacity })
+        Ok(CharonItemMeta {
+            span,
+            source_text,
+            attr_info,
+            name,
+            is_local,
+            opacity,
+            lang_item: None,
+        })
     }
 
     fn translate_item_meta_from_defid(&mut self, defid: DefId) -> CharonItemMeta {
@@ -736,7 +744,7 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
         // For now, assume all items are transparent
         let opacity = CharonItemOpacity::Transparent;
 
-        CharonItemMeta { span, source_text, attr_info, name, is_local, opacity }
+        CharonItemMeta { span, source_text, attr_info, name, is_local, opacity, lang_item: None }
     }
 
     fn translate_item_meta_adt(&mut self, adt: AdtDef) -> Result<CharonItemMeta, CharonError> {
@@ -756,7 +764,15 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
         // For now, assume all items are transparent
         let opacity = CharonItemOpacity::Transparent;
 
-        Ok(CharonItemMeta { span, source_text, attr_info, name, is_local, opacity })
+        Ok(CharonItemMeta {
+            span,
+            source_text,
+            attr_info,
+            name,
+            is_local,
+            opacity,
+            lang_item: None,
+        })
     }
 
     fn is_builtin_fun(&mut self, func_def: InstanceDef) -> bool {

--- a/scripts/charon-patch.diff
+++ b/scripts/charon-patch.diff
@@ -1,10 +1,10 @@
 diff --git a/charon/Cargo.toml b/charon/Cargo.toml
-index cbba6280f..8b5b4ece8 100644
+index 8af7fd79d..d12b89838 100644
 --- a/charon/Cargo.toml
 +++ b/charon/Cargo.toml
 @@ -2,7 +2,7 @@
  name = "charon"
- version = "0.1.69"
+ version = "0.1.71"
  authors = ["Son Ho <hosonmarc@gmail.com>"]
 -edition = "2021"
 +edition = "2024"
@@ -25,10 +25,10 @@ index 24dd10839..3ef70b0bc 100644
      }
  
 diff --git a/charon/src/transform/expand_associated_types.rs b/charon/src/transform/expand_associated_types.rs
-index 2b8a5d162..4716da208 100644
+index 2805ae0a1..23135dc5a 100644
 --- a/charon/src/transform/expand_associated_types.rs
 +++ b/charon/src/transform/expand_associated_types.rs
-@@ -761,7 +761,7 @@ impl<'a> ComputeItemModifications<'a> {
+@@ -768,7 +768,7 @@ impl<'a> ComputeItemModifications<'a> {
          &'b mut self,
          clause: &TraitClause,
          clause_to_path: F,


### PR DESCRIPTION
Advance the Charon pin from v0.1.69 (485bd36e) to v0.1.71 (de910497), continuing the incremental effort to catch the pinned Charon up with upstream (the endgame is dropping scripts/charon-patch.diff entirely).

Charon v0.1.70/71 make error levels explicit (`span_err` takes a `Level`) and add `ItemMeta::lang_item` tracking (`None` for the items Kani translates, which carry no `#[lang]` attribute).

Refresh scripts/charon-patch.diff so its hunks apply against the v0.1.71 sources (context-line drift only; the patch content is unchanged).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
