### PR TITLE
Upgrade Rust toolchain to nightly-2026-02-12

### DIFF
--- a/kani-compiler/src/session.rs
+++ b/kani-compiler/src/session.rs
@@ -7,7 +7,6 @@ use crate::args::Arguments;
 use rustc_driver::default_translator;
 use rustc_errors::{
     ColorConfig, DiagInner, emitter::Emitter, emitter::HumanReadableErrorType, json::JsonEmitter,
-    registry::Registry as ErrorRegistry,
 };
 use rustc_session::EarlyDiagCtxt;
 use rustc_session::config::ErrorOutputType;
@@ -62,9 +61,8 @@ static JSON_PANIC_HOOK: LazyLock<Box<dyn Fn(&panic::PanicHookInfo<'_>) + Sync + 
                 HumanReadableErrorType { short: false, unicode: false },
                 ColorConfig::Never,
             );
-            let registry = ErrorRegistry::new(&[]);
             let diagnostic = DiagInner::new(rustc_errors::Level::Bug, msg);
-            emitter.emit_diagnostic(diagnostic, &registry);
+            emitter.emit_diagnostic(diagnostic);
             (*JSON_PANIC_HOOK)(info);
         }));
         hook

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2026-02-06"
+channel = "nightly-2026-02-12"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Advance from nightly-2026-02-06 to nightly-2026-02-12. One source change is required (first needed at nightly-2026-02-07); every intermediate nightly up to 02-12 then builds and passes the regression with no further changes.

rust-lang/rust removed the error-code `Registry` from the diagnostics emitter: `rustc_errors::registry` is gone and `Emitter::emit_diagnostic` no longer takes a registry argument. Drop the `ErrorRegistry` import/creation in the panic hook and call `emit_diagnostic(diagnostic)` with a single argument.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
