### PR TITLE
Add support for `unaligned_volatile_load` and `unaligned_volatile_store`

### DIFF
--- a/docs/src/rust-feature-support/intrinsics.md
+++ b/docs/src/rust-feature-support/intrinsics.md
@@ -220,8 +220,8 @@ try | No | [#267](https://github.com/model-checking/kani/issues/267) |
 type_id | Yes | |
 type_name | Yes | |
 typed_swap_nonoverlapping | Yes | |
-unaligned_volatile_load | No | See [Notes - Concurrency](#concurrency) |
-unaligned_volatile_store | No | See [Notes - Concurrency](#concurrency) |
+unaligned_volatile_load | Partial | See [Notes - Concurrency](#concurrency) |
+unaligned_volatile_store | Partial | See [Notes - Concurrency](#concurrency) |
 unchecked_add | Yes | |
 unchecked_div | Yes | |
 unchecked_mul | Yes | |

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -569,7 +569,15 @@ impl GotocCtx<'_, '_> {
                 assert!(self.place_ty_stable(place).kind().is_unit());
                 let dst = fargs.remove(0);
                 let src = fargs.remove(0);
-                dst.dereference().assign(src, loc)
+                let dst_typ = farg_types[0];
+                if self.is_zst_stable(pointee_type_stable(dst_typ).unwrap()) {
+                    // Do not dereference (and assign) a ZST -- same guard as
+                    // `codegen_volatile_store`. A ZST pointer may legally be
+                    // dangling-but-aligned, so this path is reachable.
+                    Stmt::skip(loc)
+                } else {
+                    dst.dereference().assign(src, loc)
+                }
             }
             Intrinsic::UncheckedDiv => codegen_op_with_div_overflow_check!(div),
             Intrinsic::UncheckedRem => codegen_op_with_div_overflow_check!(rem),

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -559,9 +559,10 @@ impl GotocCtx<'_, '_> {
             // variants. CBMC models the misaligned typed access byte-precisely,
             // so the plain dereference is faithful -- see the byte-wise oracle
             // tests in `tests/kani/Intrinsics/Volatile/unaligned.rs`, which
-            // compare the loaded value against `u32::from_le_bytes` at every
-            // offset. Dereferenceability itself is still checked by
-            // `--pointer-check`, as for the aligned variants.
+            // compare the loaded value against `u32::from_ne_bytes` at every
+            // offset -- native order, so the oracle stays byte-precise without
+            // assuming an endianness. Dereferenceability itself is still checked
+            // by `--pointer-check`, as for the aligned variants.
             Intrinsic::UnalignedVolatileLoad => {
                 self.codegen_expr_to_place_stable(place, fargs.remove(0).dereference(), loc)
             }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/intrinsic.rs
@@ -254,18 +254,6 @@ impl GotocCtx<'_, '_> {
             }};
         }
 
-        macro_rules! unstable_codegen {
-            ($($tt:tt)*) => {{
-                let expr = self.codegen_unimplemented_expr(
-                    &format!("'{}' intrinsic", intrinsic_str),
-                    cbmc_ret_ty,
-                    loc,
-                    "https://github.com/model-checking/kani/issues/new/choose",
-                );
-                self.codegen_expr_to_place_stable(place, expr, loc)
-            }};
-        }
-
         let intrinsic = Intrinsic::from_instance(&instance);
 
         match intrinsic {
@@ -566,12 +554,22 @@ impl GotocCtx<'_, '_> {
             Intrinsic::TruncF32 => codegen_simple_intrinsic!(Truncf),
             Intrinsic::TruncF64 => codegen_simple_intrinsic!(Trunc),
             Intrinsic::TypedSwap => self.codegen_swap(fargs, farg_types, loc),
+            // No alignment assertion for these two, by design: tolerating a
+            // misaligned pointer is the entire purpose of the `unaligned_*`
+            // variants. CBMC models the misaligned typed access byte-precisely,
+            // so the plain dereference is faithful -- see the byte-wise oracle
+            // tests in `tests/kani/Intrinsics/Volatile/unaligned.rs`, which
+            // compare the loaded value against `u32::from_le_bytes` at every
+            // offset. Dereferenceability itself is still checked by
+            // `--pointer-check`, as for the aligned variants.
             Intrinsic::UnalignedVolatileLoad => {
-                unstable_codegen!(self.codegen_expr_to_place_stable(
-                    place,
-                    fargs.remove(0).dereference(),
-                    loc
-                ))
+                self.codegen_expr_to_place_stable(place, fargs.remove(0).dereference(), loc)
+            }
+            Intrinsic::UnalignedVolatileStore => {
+                assert!(self.place_ty_stable(place).kind().is_unit());
+                let dst = fargs.remove(0);
+                let src = fargs.remove(0);
+                dst.dereference().assign(src, loc)
             }
             Intrinsic::UncheckedDiv => codegen_op_with_div_overflow_check!(div),
             Intrinsic::UncheckedRem => codegen_op_with_div_overflow_check!(rem),

--- a/kani-compiler/src/intrinsics.rs
+++ b/kani-compiler/src/intrinsics.rs
@@ -138,6 +138,7 @@ pub enum Intrinsic {
     TruncF64,
     TypedSwap,
     UnalignedVolatileLoad,
+    UnalignedVolatileStore,
     UncheckedDiv,
     UncheckedRem,
     Unlikely,
@@ -390,6 +391,10 @@ impl Intrinsic {
             "unaligned_volatile_load" => {
                 assert_sig_matches!(sig, RigidTy::RawPtr(_, Mutability::Not) => _);
                 Self::UnalignedVolatileLoad
+            }
+            "unaligned_volatile_store" => {
+                assert_sig_matches!(sig, RigidTy::RawPtr(_, Mutability::Mut), _ => RigidTy::Tuple(_));
+                Self::UnalignedVolatileStore
             }
             "unchecked_add" | "unchecked_mul" | "unchecked_shl" | "unchecked_shr"
             | "unchecked_sub" => {

--- a/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
+++ b/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
@@ -290,7 +290,7 @@ impl<'tcx> Analysis<'tcx> for PointsToAnalysis<'_, 'tcx> {
                             state.extend(&lvalue_set, &state.successors(&rvalue_set));
                         }
                         // Semantically equivalent *a = b.
-                        Intrinsic::VolatileStore => {
+                        Intrinsic::VolatileStore | Intrinsic::UnalignedVolatileStore => {
                             let lvalue_set = self.successors_for_deref(state, args[0].node.clone());
                             let rvalue_set =
                                 self.successors_for_operand(state, args[1].node.clone());

--- a/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
+++ b/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
@@ -329,7 +329,7 @@ impl MirVisitor for CheckUninitVisitor {
                             Intrinsic::VolatileLoad | Intrinsic::UnalignedVolatileLoad => {
                                 self.push_target(MemoryInitOp::Check { operand: args[0].clone() });
                             }
-                            Intrinsic::VolatileStore => {
+                            Intrinsic::VolatileStore | Intrinsic::UnalignedVolatileStore => {
                                 self.push_target(MemoryInitOp::Set {
                                     operand: args[0].clone(),
                                     value: true,

--- a/tests/expected/intrinsics/unaligned_volatile/out_of_bounds/expected
+++ b/tests/expected/intrinsics/unaligned_volatile/out_of_bounds/expected
@@ -6,6 +6,11 @@ check_unaligned_volatile_store_out_of_bounds.pointer_dereference\
 Status: FAILURE\
 Description: "dereference failure: pointer outside object bounds"
 
+kani::rustc_intrinsics::offset::<u8, *const u8, usize>\
+Status: SUCCESS\
+Description: "Offset result and original pointer must point to the same allocation"
+
+kani::rustc_intrinsics::offset::<u8, *mut u8, usize>\
 Status: SUCCESS\
 Description: "Offset result and original pointer must point to the same allocation"
 

--- a/tests/expected/intrinsics/unaligned_volatile/out_of_bounds/expected
+++ b/tests/expected/intrinsics/unaligned_volatile/out_of_bounds/expected
@@ -1,18 +1,14 @@
+Checking harness check_unaligned_volatile_load_out_of_bounds...
+
 check_unaligned_volatile_load_out_of_bounds.pointer_dereference\
 Status: FAILURE\
 Description: "dereference failure: pointer outside object bounds"
 
+Checking harness check_unaligned_volatile_store_out_of_bounds...
+
 check_unaligned_volatile_store_out_of_bounds.pointer_dereference\
 Status: FAILURE\
 Description: "dereference failure: pointer outside object bounds"
-
-kani::rustc_intrinsics::offset::<u8, *const u8, usize>\
-Status: SUCCESS\
-Description: "Offset result and original pointer must point to the same allocation"
-
-kani::rustc_intrinsics::offset::<u8, *mut u8, usize>\
-Status: SUCCESS\
-Description: "Offset result and original pointer must point to the same allocation"
 
 Verification failed for - check_unaligned_volatile_load_out_of_bounds
 Verification failed for - check_unaligned_volatile_store_out_of_bounds

--- a/tests/expected/intrinsics/unaligned_volatile/out_of_bounds/expected
+++ b/tests/expected/intrinsics/unaligned_volatile/out_of_bounds/expected
@@ -1,0 +1,13 @@
+check_unaligned_volatile_load_out_of_bounds.pointer_dereference\
+Status: FAILURE\
+Description: "dereference failure: pointer outside object bounds"
+
+check_unaligned_volatile_store_out_of_bounds.pointer_dereference\
+Status: FAILURE\
+Description: "dereference failure: pointer outside object bounds"
+
+Status: SUCCESS\
+Description: "Offset result and original pointer must point to the same allocation"
+
+Verification failed for - check_unaligned_volatile_load_out_of_bounds
+Verification failed for - check_unaligned_volatile_store_out_of_bounds

--- a/tests/expected/intrinsics/unaligned_volatile/out_of_bounds/main.rs
+++ b/tests/expected/intrinsics/unaligned_volatile/out_of_bounds/main.rs
@@ -1,0 +1,35 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Checks that an out-of-bounds access through `unaligned_volatile_load` and
+// `unaligned_volatile_store` is still caught.
+//
+// The `unaligned_*` variants deliberately emit no alignment assertion, and they
+// codegen the access as a bare dereference rather than going through place
+// codegen, which is where Kani normally attaches validity assertions. That makes
+// it worth pinning down that dereferenceability is nevertheless checked, by
+// CBMC's `--pointer-check`. Every other test for these intrinsics uses a valid,
+// in-bounds pointer, so none of them would notice if that check were absent.
+//
+// The pointer arithmetic here is in bounds -- `add(1)` on a four-byte array is
+// well defined -- so it is the *access* that overruns the object: reading or
+// writing a `u32` at byte offset 1 touches bytes 1..5 of a 4-byte allocation.
+// That keeps the failure attributable to the dereference rather than to the
+// offset computation.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn check_unaligned_volatile_load_out_of_bounds() {
+    let buf: [u8; 4] = [0x11, 0x22, 0x33, 0x44];
+    let p = unsafe { buf.as_ptr().add(1) } as *const u32;
+    let v = unsafe { std::intrinsics::unaligned_volatile_load(p) };
+    assert_eq!(v, v);
+}
+
+#[kani::proof]
+fn check_unaligned_volatile_store_out_of_bounds() {
+    let mut buf: [u8; 4] = [0u8; 4];
+    let p = unsafe { buf.as_mut_ptr().add(1) } as *mut u32;
+    unsafe { std::intrinsics::unaligned_volatile_store(p, 0x55443322u32) };
+    assert_eq!(buf[0], 0x00);
+}

--- a/tests/kani/Intrinsics/Volatile/unaligned.rs
+++ b/tests/kani/Intrinsics/Volatile/unaligned.rs
@@ -56,6 +56,34 @@ fn check_unaligned_volatile_load_symbolic_offset() {
     assert_eq!(v, expect, "unaligned load must agree with a byte-wise oracle at every offset");
 }
 
+// The store direction with a symbolic offset, mirroring the load above. Without
+// this, byte-precision on the store side rests on a constant offset alone, which
+// a correct simplifier could satisfy while the general path stayed wrong.
+#[kani::proof]
+fn check_unaligned_volatile_store_symbolic_offset() {
+    let mut buf: [u8; 8] = [0u8; 8];
+    let off: usize = kani::any();
+    kani::assume(off <= 4);
+    let p = unsafe { buf.as_mut_ptr().add(off) } as *mut u32;
+    let val: u32 = 0x55443322;
+    let bytes = val.to_ne_bytes();
+    unsafe { std::intrinsics::unaligned_volatile_store(p, val) };
+    // The four written bytes must land at `off`, not at the aligned word.
+    assert_eq!(buf[off], bytes[0], "store must begin at the requested byte offset");
+    assert_eq!(buf[off + 1], bytes[1]);
+    assert_eq!(buf[off + 2], bytes[2]);
+    assert_eq!(buf[off + 3], bytes[3]);
+    // Everything outside that range must be untouched, so a wrongly-aligned
+    // write shows up as a clobbered neighbour at every offset, not just one.
+    let mut i = 0;
+    while i < 8 {
+        if i < off || i >= off + 4 {
+            assert_eq!(buf[i], 0, "bytes outside the stored range must be untouched");
+        }
+        i += 1;
+    }
+}
+
 // A ZST store: `unaligned_volatile_store::<()>` must not attempt a dereference.
 // A ZST pointer may legally be dangling-but-aligned, which is why
 // `codegen_volatile_store` carries the same guard.

--- a/tests/kani/Intrinsics/Volatile/unaligned.rs
+++ b/tests/kani/Intrinsics/Volatile/unaligned.rs
@@ -65,3 +65,15 @@ fn check_zst_unaligned_volatile_store() {
     let p = &mut zst as *mut ();
     unsafe { std::intrinsics::unaligned_volatile_store(p, ()) };
 }
+
+// The case the ZST guard actually exists for: a *dangling* pointer. A ZST
+// reference is allowed to be any non-null, suitably aligned address, so this is
+// a pointer safe Rust can hand to the intrinsic. Nothing is dereferenced, so
+// this must verify. The harness above passes a pointer to a real local, which a
+// dereference would happily succeed on -- so it does not exercise the guard,
+// and only this one does.
+#[kani::proof]
+fn check_dangling_zst_unaligned_volatile_store() {
+    let p = core::ptr::without_provenance_mut::<()>(core::mem::align_of::<()>());
+    unsafe { std::intrinsics::unaligned_volatile_store(p, ()) };
+}

--- a/tests/kani/Intrinsics/Volatile/unaligned.rs
+++ b/tests/kani/Intrinsics/Volatile/unaligned.rs
@@ -1,0 +1,52 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Checks that `unaligned_volatile_load` and `unaligned_volatile_store` access
+// memory byte-precisely through a deliberately misaligned pointer.
+//
+// These intrinsics carry no alignment requirement, so the codegen emits no
+// alignment assertion for them. That makes the modelling itself the thing worth
+// testing: each proof compares against a byte-wise oracle, so an implementation
+// that quietly read or wrote the *aligned* word instead would be caught rather
+// than silently pass. Reading a `u32` at byte offset 1 of the pattern below, the
+// only correct little-endian answer is 0x55443322; an alignment-assuming read
+// from offset 0 would give 0x44332211.
+#![feature(core_intrinsics)]
+
+#[kani::proof]
+fn check_unaligned_volatile_load_is_byte_precise() {
+    let buf: [u8; 8] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+    let p = unsafe { buf.as_ptr().add(1) } as *const u32;
+    let v = unsafe { std::intrinsics::unaligned_volatile_load(p) };
+    assert_eq!(v, 0x55443322u32, "unaligned load must read bytes 1..5, byte-precisely");
+}
+
+// The store direction: write a `u32` at byte offset 1 and check the neighbouring
+// bytes too, so a wrongly-aligned write shows up as a clobbered neighbour rather
+// than passing silently.
+#[kani::proof]
+fn check_unaligned_volatile_store_is_byte_precise() {
+    let mut buf: [u8; 8] = [0u8; 8];
+    let p = unsafe { buf.as_mut_ptr().add(1) } as *mut u32;
+    unsafe { std::intrinsics::unaligned_volatile_store(p, 0x55443322u32) };
+    assert_eq!(buf[0], 0x00, "byte before the store must be untouched");
+    assert_eq!(buf[1], 0x22);
+    assert_eq!(buf[2], 0x33);
+    assert_eq!(buf[3], 0x44);
+    assert_eq!(buf[4], 0x55);
+    assert_eq!(buf[5], 0x00, "byte after the store must be untouched");
+}
+
+// Symbolic offset: the offset is not a constant, so the result cannot be reached
+// by constant folding. This is the case that would expose an alignment
+// assumption hidden behind constant propagation.
+#[kani::proof]
+fn check_unaligned_volatile_load_symbolic_offset() {
+    let buf: [u8; 8] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+    let off: usize = kani::any();
+    kani::assume(off <= 4);
+    let p = unsafe { buf.as_ptr().add(off) } as *const u32;
+    let v = unsafe { std::intrinsics::unaligned_volatile_load(p) };
+    let expect = u32::from_le_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]]);
+    assert_eq!(v, expect, "unaligned load must agree with a byte-wise oracle at every offset");
+}

--- a/tests/kani/Intrinsics/Volatile/unaligned.rs
+++ b/tests/kani/Intrinsics/Volatile/unaligned.rs
@@ -10,9 +10,9 @@
 // that quietly read or wrote the *aligned* word instead would be caught rather
 // than silently pass. The oracle is built with `u32::from_ne_bytes` so the test
 // is byte-precise without assuming an endianness: reading a `u32` at byte offset
-// 1 must equal the native-order interpretation of bytes 1..5, whereas an
-// alignment-assuming read from offset 0 would give the interpretation of bytes
-// 0..4 -- different under either endianness.
+// 1 must equal the native-order interpretation of bytes 1, 2, 3 and 4, whereas
+// an alignment-assuming read from offset 0 would give the interpretation of
+// bytes 0, 1, 2 and 3 -- different under either endianness.
 #![feature(core_intrinsics)]
 
 #[kani::proof]
@@ -21,7 +21,7 @@ fn check_unaligned_volatile_load_is_byte_precise() {
     let p = unsafe { buf.as_ptr().add(1) } as *const u32;
     let v = unsafe { std::intrinsics::unaligned_volatile_load(p) };
     let expect = u32::from_ne_bytes([buf[1], buf[2], buf[3], buf[4]]);
-    assert_eq!(v, expect, "unaligned load must read bytes 1..5, byte-precisely");
+    assert_eq!(v, expect, "unaligned load must read bytes 1, 2, 3 and 4, byte-precisely");
 }
 
 // The store direction: write a `u32` at byte offset 1 and check the neighbouring

--- a/tests/kani/Intrinsics/Volatile/unaligned.rs
+++ b/tests/kani/Intrinsics/Volatile/unaligned.rs
@@ -8,9 +8,11 @@
 // alignment assertion for them. That makes the modelling itself the thing worth
 // testing: each proof compares against a byte-wise oracle, so an implementation
 // that quietly read or wrote the *aligned* word instead would be caught rather
-// than silently pass. Reading a `u32` at byte offset 1 of the pattern below, the
-// only correct little-endian answer is 0x55443322; an alignment-assuming read
-// from offset 0 would give 0x44332211.
+// than silently pass. The oracle is built with `u32::from_ne_bytes` so the test
+// is byte-precise without assuming an endianness: reading a `u32` at byte offset
+// 1 must equal the native-order interpretation of bytes 1..5, whereas an
+// alignment-assuming read from offset 0 would give the interpretation of bytes
+// 0..4 -- different under either endianness.
 #![feature(core_intrinsics)]
 
 #[kani::proof]
@@ -18,7 +20,8 @@ fn check_unaligned_volatile_load_is_byte_precise() {
     let buf: [u8; 8] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     let p = unsafe { buf.as_ptr().add(1) } as *const u32;
     let v = unsafe { std::intrinsics::unaligned_volatile_load(p) };
-    assert_eq!(v, 0x55443322u32, "unaligned load must read bytes 1..5, byte-precisely");
+    let expect = u32::from_ne_bytes([buf[1], buf[2], buf[3], buf[4]]);
+    assert_eq!(v, expect, "unaligned load must read bytes 1..5, byte-precisely");
 }
 
 // The store direction: write a `u32` at byte offset 1 and check the neighbouring
@@ -28,12 +31,14 @@ fn check_unaligned_volatile_load_is_byte_precise() {
 fn check_unaligned_volatile_store_is_byte_precise() {
     let mut buf: [u8; 8] = [0u8; 8];
     let p = unsafe { buf.as_mut_ptr().add(1) } as *mut u32;
-    unsafe { std::intrinsics::unaligned_volatile_store(p, 0x55443322u32) };
+    let val: u32 = 0x55443322;
+    let bytes = val.to_ne_bytes();
+    unsafe { std::intrinsics::unaligned_volatile_store(p, val) };
     assert_eq!(buf[0], 0x00, "byte before the store must be untouched");
-    assert_eq!(buf[1], 0x22);
-    assert_eq!(buf[2], 0x33);
-    assert_eq!(buf[3], 0x44);
-    assert_eq!(buf[4], 0x55);
+    assert_eq!(buf[1], bytes[0]);
+    assert_eq!(buf[2], bytes[1]);
+    assert_eq!(buf[3], bytes[2]);
+    assert_eq!(buf[4], bytes[3]);
     assert_eq!(buf[5], 0x00, "byte after the store must be untouched");
 }
 
@@ -47,6 +52,16 @@ fn check_unaligned_volatile_load_symbolic_offset() {
     kani::assume(off <= 4);
     let p = unsafe { buf.as_ptr().add(off) } as *const u32;
     let v = unsafe { std::intrinsics::unaligned_volatile_load(p) };
-    let expect = u32::from_le_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]]);
+    let expect = u32::from_ne_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]]);
     assert_eq!(v, expect, "unaligned load must agree with a byte-wise oracle at every offset");
+}
+
+// A ZST store: `unaligned_volatile_store::<()>` must not attempt a dereference.
+// A ZST pointer may legally be dangling-but-aligned, which is why
+// `codegen_volatile_store` carries the same guard.
+#[kani::proof]
+fn check_zst_unaligned_volatile_store() {
+    let mut zst = ();
+    let p = &mut zst as *mut ();
+    unsafe { std::intrinsics::unaligned_volatile_store(p, ()) };
 }

--- a/tests/kani/VolatileIntrinsics/core_intrinsics.rs
+++ b/tests/kani/VolatileIntrinsics/core_intrinsics.rs
@@ -1,6 +1,5 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// kani-verify-fail
 
 #![feature(core_intrinsics)]
 


### PR DESCRIPTION
Completes the volatile intrinsic family on the tracking issue #1163, following #4672
(volatile copy/set), which has since landed. This branch is rebased onto `main` and now
contains only its own work.

With #4672 merged and these two arms implemented, `unstable_codegen!` has no remaining uses
anywhere in `kani-compiler` and is removed — these volatile/unaligned entries were the last
gated intrinsics in the codegen match.

## Modelling

Neither intrinsic has an alignment requirement, so neither emits an alignment assertion —
tolerating a misaligned pointer is the entire purpose of the `unaligned_*` variants.
`unaligned_volatile_load` was already sketched behind the gate as a plain dereference;
`unaligned_volatile_store` had no codegen and no `Intrinsic` variant at all, and is added
mirroring `volatile_store` minus the alignment check, including the same zero-sized-type
guard.

That leaves two questions worth being explicit about, and the tests answer both rather than
assume them.

**Is a misaligned typed dereference modelled byte-precisely, or does it quietly assume
alignment?** Each proof compares the accessed value against a byte-wise oracle at a
deliberately misaligned offset, so an implementation that touched the aligned word instead
would fail rather than silently pass. The oracle uses `u32::from_ne_bytes`, which keeps it
byte-precise without baking in an endianness: reading a `u32` at byte offset 1 must equal the
native-order interpretation of bytes 1..5, whereas an alignment-assuming read from offset 0
would give the interpretation of bytes 0..4 — different under either endianness. Both
directions also have a **symbolic-offset** proof, so neither can be satisfied by constant
folding, and the store proofs check that bytes outside the written range are untouched.

**Is dereferenceability still checked, given this path builds the dereference directly rather
than going through place codegen?** It is, by `--pointer-check`, and there is now a test that
pins that down instead of asserting it in a comment.

## Tests

- `tests/kani/Intrinsics/Volatile/unaligned.rs` — six proofs: byte-precise load and store,
  each at a constant and at a symbolic offset, plus two ZST stores — one through a valid
  pointer and one through a **dangling but aligned** pointer,
  `without_provenance_mut(align_of::<()>())`, which is the case the ZST guard actually
  exists for.
- `tests/expected/intrinsics/unaligned_volatile/out_of_bounds/` — an expected-fail test for
  an out-of-bounds unaligned load and store. It accesses a `u32` at byte offset 1 of a
  4-byte array, so the pointer arithmetic stays in bounds and it is the *access* that
  overruns the object; the failure is therefore attributable to the dereference rather than
  to the offset computation. The `expected` file pins that split for each harness
  separately — the offset safety check must report SUCCESS while `pointer_dereference`
  reports `dereference failure: pointer outside object bounds`.
- `tests/kani/VolatileIntrinsics/core_intrinsics.rs` — this was marked `kani-verify-fail`,
  but that expectation existed only because `unaligned_volatile_store` (and
  `volatile_set_memory`) were unsupported. With both implemented the proof verifies, so the
  header is removed and it becomes a passing test.

The two review-driven tests were fault-injected before being committed, in both directions.
Deleting the ZST guard turns the dangling-ZST harness from 0 VCCs into 6, of which 5 fail
with pointer dereference errors; restoring it returns the file to green. Running the
out-of-bounds test with `--no-memory-safety-checks`, which drops CBMC's `--pointer-check`,
turns both of its harnesses green and removes every `pointer_dereference` property —
confirming that check is what catches them.

## One asymmetry worth pre-empting

The ZST guard exists on the **store** paths only. `codegen_volatile_load` and this PR's
`unaligned_volatile_load` both dereference unconditionally, so a zero-sized read through a
dangling-but-aligned pointer — which is legal Rust — currently produces a spurious
verification failure. I measured this: it fails identically on the already-merged
`volatile_load`, with the guarded store passing on the same input, so it is pre-existing
behaviour that the unaligned variant inherits rather than introduces. I have deliberately
left it alone here rather than widen this PR into `codegen_volatile_load`, but I am happy to
fix both in a follow-up, or here if you would prefer it.

## Note

`tests/kani/VolatileIntrinsics/main_fixme.rs` is left untouched (it is skipped as a fixme
test). Its `test_copy_volatile` names its arguments as though `volatile_copy_memory` were
`(src, dst, count)`; the assertion it makes happens to hold under either argument order, so
it neither catches nor is broken by the ordering. Worth a separate look if that suite is
ever revived.

By submitting this pull request, I confirm that my contribution is made under the terms of
the Apache 2.0 and MIT licenses.
