### PR TITLE
Pass --compact-trace to CBMC for concrete playback

### DIFF
--- a/kani-driver/src/call_cbmc.rs
+++ b/kani-driver/src/call_cbmc.rs
@@ -198,6 +198,17 @@ impl KaniSession {
 
         if self.args.concrete_playback.is_some() {
             args.push("--trace".into());
+            // Concrete playback only consumes the values of `kani::any_raw_*`
+            // return-value assignments from the trace. CBMC's compact trace
+            // retains those (they are regular, non-hidden assignments) while
+            // dropping hidden instrumentation steps whose values can dominate
+            // the trace by orders of magnitude on contract-heavy harnesses
+            // (e.g. 427 MB -> 3 MB of JSON). Requires CBMC with
+            // https://github.com/diffblue/cbmc/pull/9135 to have an effect;
+            // CBMC versions that do not yet honor `--compact-trace` with
+            // `--json-ui` accept but ignore the option, so this is
+            // compatible either way.
+            args.push("--compact-trace".into());
         }
 
         args.extend(self.args.cbmc_args.iter().cloned());


### PR DESCRIPTION
Concrete playback disables --slice-formula (traces from sliced formulas contain arbitrary values, #1288) and requests a full trace. On contract-heavy harnesses the resulting JSON trace is dominated by the values of hidden instrumentation steps: for the write_bytes harness from model-checking/verify-rust-std the trace weighs 427 MB, of which Kani consumes only the kani::any_raw_* return-value assignments (57 KB)
- everything else is built, serialized and parsed for nothing, accounting for more than half of the end-to-end playback time.

Pass --compact-trace in playback mode: CBMC's compact trace drops hidden steps and actual-parameter assignments while retaining regular assignments - a strict superset of what the playback parser reads. With a CBMC that honors the option in JSON mode, the trace shrinks to 3 MB and end-to-end playback time halves (46s to 23s), producing an identical generated unit test. The CBMC-side change is https://github.com/diffblue/cbmc/pull/9135; CBMC versions that do not honor --compact-trace with --json-ui accept and ignore the option, so this change is compatible with the currently pinned CBMC and becomes effective once the CBMC pin reaches a release containing that fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
