### PR TITLE
Fix ICE on ConstantIndex projection of DST trailing slice field

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
@@ -824,7 +824,12 @@ impl GotocCtx<'_, '_> {
                 } else {
                     offset_e
                 };
-                let expr = before.goto_expr.plus(idxe).dereference();
+                // The base expression is a pointer to the data if the slice was reached by
+                // dereferencing a fat pointer, but it is a flexible array if the slice was
+                // reached by a field projection on an unsized ADT (e.g. the trailing
+                // `data: [T]` field of `ArcInner<[T]>`). `Expr::index` dispatches on the type,
+                // handling both.
+                let expr = before.goto_expr.index(idxe);
                 let typ = TypeOrVariant::Type(elemt);
                 ProjectedPlace::try_new(
                     expr,

--- a/tests/kani/SliceDst/constant_index_dst_field.rs
+++ b/tests/kani/SliceDst/constant_index_dst_field.rs
@@ -1,0 +1,49 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Test that slice patterns (which generate `ConstantIndex` projections) work on a slice that
+// is the trailing field of an unsized ADT. Such a slice place is a flexible array member
+// rather than a pointer dereference, which used to make codegen panic with
+// "BinaryOperation Expression does not typecheck Plus" (e.g. on `Arc<[u8]>`'s `ArcInner`,
+// as hit by the regex crate).
+
+pub struct Inner<T: ?Sized> {
+    pub rc: usize,
+    pub data: T,
+}
+
+// `[x, y, ..]` generates ConstantIndex { offset, from_end: false } projections.
+pub fn first_two(p: &Inner<[u8]>) -> (u8, u8) {
+    match p.data {
+        [x, y, ..] => (x, y),
+        _ => (0, 0),
+    }
+}
+
+// `[.., y]` generates a ConstantIndex { from_end: true } projection.
+pub fn last(p: &Inner<[u8]>) -> u8 {
+    match p.data {
+        [.., y] => y,
+        _ => 0,
+    }
+}
+
+// Also exercise the same patterns through `Arc<[u8]>`, the standard-library case.
+pub fn arc_first(a: &std::sync::Arc<[u8]>) -> u8 {
+    match **a {
+        [x, ..] => x,
+        _ => 0,
+    }
+}
+
+#[kani::proof]
+fn check_dst_slice_patterns() {
+    let concrete: Inner<[u8; 3]> = Inner { rc: 1, data: [1, 2, 3] };
+    let unsized_ref: &Inner<[u8]> = &concrete;
+    let (x, y) = first_two(unsized_ref);
+    assert!(x == 1 && y == 2);
+    assert!(last(unsized_ref) == 3);
+
+    let a: std::sync::Arc<[u8]> = std::sync::Arc::from([7u8, 8].as_slice());
+    assert!(arc_first(&a) == 7);
+}


### PR DESCRIPTION
### Description

Fixes a compiler ICE: `BinaryOperation Expression does not typecheck Plus` in `cprover_bindings/src/goto_program/expr.rs:1301`, triggered by slice patterns (`ConstantIndex` projections) applied to a slice that is the trailing field of an unsized ADT.

The slice arm of the `ConstantIndex` codegen assumed the base expression is always a thin data pointer (the result of dereferencing a slice fat pointer) and emitted `ptr + idx` followed by a dereference. When the slice place is instead reached through a field projection on an unsized ADT — e.g. the trailing `data: [u8]` field of alloc's `ArcInner<[u8]>` — the base is a flexible array member, and constructing `Plus` on it panics.

The fix uses `Expr::index`, which dispatches on the base type: `index_ptr` for pointers (semantically identical `plus` + `dereference` to the previous code) and `index_array` for flexible arrays. This is exactly what the neighboring `ProjectionElem::Index` and `ProjectionElem::Subslice` arms already do.

Found while evaluating `kani autoharness` on the top-100 crates.io crates: the regex-1.13.1 crate ICE'd during codegen of `regex_automata::hybrid::dfa::Lazy::add_state` (which pattern-matches on a `State(Arc<[u8]>)`). I verified that regex-1.13.1 now compiles and verifies under `cargo kani autoharness`.

### Testing

New regression test `tests/kani/SliceDst/constant_index_dst_field.rs` covering `[x, y, ..]` (from-start) and `[.., y]` (from-end) patterns on a custom DST struct field and through `Arc<[u8]>`. Reduced from the regex crash; ICEs without the fix, verifies with it.

Ran the `Slice`/`Dst`/`Arc`/`Rc`/`Box`/`Str`/`Vec`/`Index`-related suites of the `kani` test suite (46 tests) and `kani-compiler` unit tests: all pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
