### PR TITLE
Force-load the kani crate so no_std crates work out of the box

### DIFF
--- a/kani-driver/src/call_single_file.rs
+++ b/kani-driver/src/call_single_file.rs
@@ -23,8 +23,13 @@ impl LibConfig {
             sysroot.to_str().unwrap(),
             "-L",
             path.to_str().unwrap(),
+            // Use the `force` modifier so that the `kani` crate is resolved even if the code
+            // under verification never references it. `#[no_std]` crates do not link Kani's
+            // `std` (which would otherwise pull in `kani`), so without `force` the Kani
+            // library and its functions would be missing entirely, c.f.
+            // https://github.com/model-checking/kani/issues/3906.
             "--extern",
-            "kani",
+            "force:kani",
             "--extern",
             kani_std_wrapper.as_str(),
         ]

--- a/tests/cargo-ui/no-std-no-kani/expected
+++ b/tests/cargo-ui/no-std-no-kani/expected
@@ -1,3 +1,1 @@
-error: Failed to detect Kani functions.\
-  |\
-  = help: This project seems to be using #[no_std] but does not import Kani. Try adding `crate extern kani` to the crate root to explicitly import Kani.
+VERIFICATION:- SUCCESSFUL

--- a/tests/cargo-ui/no-std-no-kani/src/lib.rs
+++ b/tests/cargo-ui/no-std-no-kani/src/lib.rs
@@ -1,10 +1,20 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// Ensure that a no_std crate with no harnesses & no "extern crate kani" gets a useful error message.
+// Ensure that a no_std crate works without an explicit "extern crate kani":
+// the kani library is force-loaded by the driver (c.f.
+// https://github.com/model-checking/kani/issues/3906).
 
 #![no_std]
 
 fn add(x: u8, y: u8) -> u8 {
-    x + y
+    x.wrapping_add(y)
+}
+
+#[cfg(kani)]
+#[kani::proof]
+fn check_add() {
+    let x: u8 = kani::any();
+    let y: u8 = kani::any();
+    assert!(add(x, y) == x.wrapping_add(y));
 }


### PR DESCRIPTION
### Description

Kani passes `--extern kani`, which makes the `kani` crate *resolvable* but does not *load* it unless the code under verification references it. `#[no_std]` crates never link Kani's `std` (which is what otherwise pulls `kani` in transitively), so verifying them fails with "Failed to detect Kani functions" unless the user manually adds `extern crate kani` to their crate root — the workaround suggested by the error message introduced for #3906.

This PR uses the `force` extern modifier (unstable, like the `noprelude` modifier Kani already relies on) so the `kani` crate is always loaded. With this:
- a `no_std` crate with `#[cfg(kani)] #[kani::proof]` harnesses and no kani import verifies out of the box (`kani::` paths resolve via the forced extern), and
- `kani autoharness` works on unmodified `no_std` crates.

Context: while evaluating autoharness on the top-100 crates.io crates, roughly a third of the corpus is `no_std` and hit this error; each needed a source modification to proceed.

One pre-existing interaction is unchanged: crates that `deny(unused_crate_dependencies)` already fail on Kani's injected `noprelude:std` extern, with or without this change (verified against main). Fixing that lint interaction is a separate work item.

### Testing

Updated `tests/cargo-ui/no-std-no-kani` from expecting the error message to expecting successful verification of a `no_std` harness that uses `kani::any()` without any `extern crate kani`. Full `cargo-ui` suite passes (29 tests).

Manually verified: `cargo kani autoharness` on the unmodified `cfg-if` crate (previously failed) now runs; `deny(unused_crate_dependencies)` behavior is unchanged vs. main.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
