### PR TITLE
Update Charon submodule to v0.1.73

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "charon"
-version = "0.1.71"
+version = "0.1.73"
 dependencies = [
  "annotate-snippets",
  "anstream 0.6.21",
@@ -317,6 +317,7 @@ dependencies = [
  "serde_json",
  "serde_stacker",
  "stacker",
+ "strip-ansi-escapes",
  "take_mut",
  "toml 0.8.23",
  "tracing",
@@ -2101,6 +2102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,6 +2541,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
@@ -168,7 +168,7 @@ impl LlbcCodegenBackend {
             todo!()
         }
 
-        let crate_data: charon_lib::export::CrateData = charon_lib::export::CrateData::new(&ccx);
+        let crate_data: charon_lib::export::CrateData = charon_lib::export::CrateData::new(ccx);
 
         // No output should be generated if user selected no_codegen.
         if !tcx.sess.opts.unstable_opts.no_codegen && tcx.sess.opts.output_types.should_codegen() {

--- a/scripts/charon-patch.diff
+++ b/scripts/charon-patch.diff
@@ -1,18 +1,18 @@
 diff --git a/charon/Cargo.toml b/charon/Cargo.toml
-index 8af7fd79d..d12b89838 100644
+index 84b956a9..d425bbb5 100644
 --- a/charon/Cargo.toml
 +++ b/charon/Cargo.toml
 @@ -2,7 +2,7 @@
  name = "charon"
- version = "0.1.71"
- authors = ["Son Ho <hosonmarc@gmail.com>"]
+ version = "0.1.73"
+ authors = ["Son Ho <hosonmarc@gmail.com>", "Guillaume Boisseau <nadrieril+git@gmail.com>"]
 -edition = "2021"
 +edition = "2024"
  license = "Apache-2.0"
  
  [lib]
 diff --git a/charon/src/ids/vector.rs b/charon/src/ids/vector.rs
-index 24dd10839..3ef70b0bc 100644
+index 24dd1083..3ef70b0b 100644
 --- a/charon/src/ids/vector.rs
 +++ b/charon/src/ids/vector.rs
 @@ -260,7 +260,7 @@ where
@@ -25,7 +25,7 @@ index 24dd10839..3ef70b0bc 100644
      }
  
 diff --git a/charon/src/transform/expand_associated_types.rs b/charon/src/transform/expand_associated_types.rs
-index 2805ae0a1..23135dc5a 100644
+index ebd8c684..79095adf 100644
 --- a/charon/src/transform/expand_associated_types.rs
 +++ b/charon/src/transform/expand_associated_types.rs
 @@ -768,7 +768,7 @@ impl<'a> ComputeItemModifications<'a> {
@@ -37,3 +37,16 @@ index 2805ae0a1..23135dc5a 100644
      where
          F: Fn(TraitClauseId) -> TraitRefPath,
      {
+diff --git a/charon/src/transform/simplify_constants.rs b/charon/src/transform/simplify_constants.rs
+index a0ba23eb..75b96d08 100644
+--- a/charon/src/transform/simplify_constants.rs
++++ b/charon/src/transform/simplify_constants.rs
+@@ -11,7 +11,7 @@
+ //! handle the globals like function calls.
+ 
+ use itertools::Itertools;
+-use std::assert_matches::assert_matches;
++use std::assert_matches;
+ 
+ use crate::transform::TransformCtx;
+ use crate::ullbc_ast::*;


### PR DESCRIPTION
Advance the Charon pin from v0.1.71 (de910497) to v0.1.73 (dee66030), continuing the incremental effort to catch the pinned Charon up with upstream (the endgame is dropping scripts/charon-patch.diff entirely).

Charon v0.1.72/73 change `CrateData::new` to take the transformation context by value and introduce a `std::assert_matches` use in the simplify_constants pass, which needs adapting to the pinned toolchain's macro re-export; scripts/charon-patch.diff gains that hunk and is refreshed over context-line drift.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
