### PR TITLE
Update Charon submodule to v0.1.76

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "charon"
-version = "0.1.73"
+version = "0.1.76"
 dependencies = [
  "annotate-snippets",
  "anstream 0.6.21",

--- a/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
@@ -439,6 +439,7 @@ fn get_translate_options(tcx: &TranslatedCrate, error_ctx: &mut ErrorCtx) -> Tra
     TranslateOptions {
         mir_level: MirLevel::Built,
         translate_all_methods: false,
+        monomorphize: false,
         no_code_duplication: false,
         hide_marker_traits: true,
         no_merge_goto_chains: false,

--- a/kani-compiler/src/codegen_aeneas_llbc/mir_to_ullbc/mod.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/mir_to_ullbc/mod.rs
@@ -1194,7 +1194,7 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
         let span = self.translate_span(mir_body.span);
         let arg_count = self.instance.fn_abi().unwrap().args.len();
         let vars = self.translate_body_locals(&mir_body);
-        let locals = CharonLocals { vars, arg_count };
+        let locals = CharonLocals { locals: vars, arg_count };
         let body: CharonBodyContents =
             mir_body.blocks.iter().map(|bb| self.translate_block(bb)).collect();
 

--- a/scripts/charon-patch.diff
+++ b/scripts/charon-patch.diff
@@ -1,10 +1,10 @@
 diff --git a/charon/Cargo.toml b/charon/Cargo.toml
-index 84b956a9..d425bbb5 100644
+index 76e38f7e..33b47bc2 100644
 --- a/charon/Cargo.toml
 +++ b/charon/Cargo.toml
 @@ -2,7 +2,7 @@
  name = "charon"
- version = "0.1.73"
+ version = "0.1.76"
  authors = ["Son Ho <hosonmarc@gmail.com>", "Guillaume Boisseau <nadrieril+git@gmail.com>"]
 -edition = "2021"
 +edition = "2024"
@@ -12,7 +12,7 @@ index 84b956a9..d425bbb5 100644
  
  [lib]
 diff --git a/charon/src/ids/vector.rs b/charon/src/ids/vector.rs
-index 24dd1083..3ef70b0b 100644
+index dbc354e2..aecb95b2 100644
 --- a/charon/src/ids/vector.rs
 +++ b/charon/src/ids/vector.rs
 @@ -260,7 +260,7 @@ where
@@ -25,18 +25,18 @@ index 24dd1083..3ef70b0b 100644
      }
  
 diff --git a/charon/src/transform/expand_associated_types.rs b/charon/src/transform/expand_associated_types.rs
-index ebd8c684..79095adf 100644
+index 28be9543..7cf2d870 100644
 --- a/charon/src/transform/expand_associated_types.rs
 +++ b/charon/src/transform/expand_associated_types.rs
-@@ -768,7 +768,7 @@ impl<'a> ComputeItemModifications<'a> {
+@@ -794,7 +794,7 @@ impl<'a> ComputeItemModifications<'a> {
          &'b mut self,
          clause: &TraitClause,
-         clause_to_path: F,
--    ) -> impl Iterator<Item = AssocTypePath> + use<'b, F>
-+    ) -> impl Iterator<Item = AssocTypePath> + use<'a, 'b, F>
-     where
-         F: Fn(TraitClauseId) -> TraitRefPath,
-     {
+         clause_to_path: fn(TraitClauseId) -> TraitRefPath,
+-    ) -> impl Iterator<Item = AssocTypePath> + use<'b> {
++    ) -> impl Iterator<Item = AssocTypePath> + use<'a, 'b> {
+         let trait_id = clause.trait_.skip_binder.trait_id;
+         let clause_path = clause_to_path(clause.clause_id);
+         self.compute_extra_params_for_trait(trait_id)
 diff --git a/charon/src/transform/simplify_constants.rs b/charon/src/transform/simplify_constants.rs
 index a0ba23eb..75b96d08 100644
 --- a/charon/src/transform/simplify_constants.rs


### PR DESCRIPTION
Advance the Charon pin from v0.1.73 (dee66030) to v0.1.76 (b360b5d8), continuing the incremental effort to catch the pinned Charon up with upstream (the endgame is dropping scripts/charon-patch.diff entirely).

Charon v0.1.74-76 add `TranslateOptions::monomorphize` (kept off; Kani already translates monomorphized instances) and rename the `Locals::vars` field to `locals`.

Refresh scripts/charon-patch.diff so its hunks apply against the v0.1.76 sources (context-line drift only; the patch content is unchanged).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
