### PR TITLE
Add --no-assert-overrides escape hatch for macro-override conflicts

### DIFF
--- a/kani-compiler/src/args.rs
+++ b/kani-compiler/src/args.rs
@@ -65,6 +65,12 @@ pub struct Arguments {
     /// Option used for suppressing global ASM error.
     #[clap(long)]
     pub ignore_global_asm: bool,
+    /// Do not inject Kani's macro overrides (`assert!`, `panic!`, ...) into the crate.
+    /// Assertion failures are then reported as generic panics rather than with the original
+    /// condition/message. This is an escape hatch for crates whose macro imports conflict
+    /// with the injected overrides (rustc E0659).
+    #[clap(long)]
+    pub no_assert_overrides: bool,
     /// Compute verification results under the assumption that no panic occurs.
     /// This feature is unstable, and it requires `-Z unstable-options` to be used
     #[clap(long)]

--- a/kani-compiler/src/kani_compiler.rs
+++ b/kani-compiler/src/kani_compiler.rs
@@ -95,12 +95,15 @@ struct KaniCompiler {
     /// macro overrides are not injected (the macros are defined in the standard
     /// library being built, and `kani` is not available).
     build_std: bool,
+    /// Whether the user requested to skip injecting Kani's macro overrides
+    /// (`--no-assert-overrides`).
+    no_assert_overrides: bool,
 }
 
 impl KaniCompiler {
     /// Create a new [KaniCompiler] instance.
     pub fn new() -> KaniCompiler {
-        KaniCompiler { build_std: false }
+        KaniCompiler { build_std: false, no_assert_overrides: false }
     }
 
     /// Compile the current crate with the given arguments.
@@ -126,6 +129,7 @@ impl Callbacks for KaniCompiler {
         // Remember whether we are building the standard library so that
         // `after_crate_root_parsing` can decide whether to inject Kani's macro overrides.
         self.build_std = args.build_std;
+        self.no_assert_overrides = args.no_assert_overrides;
 
         // Capture args in the closure so they're available when the backend is created
         // (potentially on a different thread).
@@ -163,6 +167,7 @@ impl Callbacks for KaniCompiler {
         krate: &mut ast::Crate,
     ) -> Compilation {
         if !self.build_std
+            && !self.no_assert_overrides
             && !attr::contains_name(&krate.attrs, sym::no_std)
             && !attr::contains_name(&krate.attrs, sym::no_core)
             // Only inject when an external `std` is available to import. The

--- a/kani-driver/src/args/mod.rs
+++ b/kani-driver/src/args/mod.rs
@@ -281,6 +281,13 @@ pub struct VerificationArgs {
     #[arg(long, hide_short_help = true)]
     pub ignore_global_asm: bool,
 
+    /// Do not replace `assert!`, `panic!`, and related macros with Kani's versions.
+    /// Assertion failures are then reported as generic panics, without the original condition
+    /// or message. Use this as an escape hatch if your crate's macro imports conflict with
+    /// Kani's injected overrides (error E0659: `assert` is ambiguous).
+    #[arg(long, hide_short_help = true)]
+    pub no_assert_overrides: bool,
+
     /// Number of threads to spawn to verify harnesses in parallel.
     /// Omit the flag entirely to run sequentially (i.e. one thread).
     /// Pass -j to run with the thread pool's default number of threads.

--- a/kani-driver/src/call_single_file.rs
+++ b/kani-driver/src/call_single_file.rs
@@ -116,6 +116,10 @@ impl KaniSession {
     pub fn kani_compiler_local_flags(&self) -> Vec<KaniArg> {
         let mut flags: Vec<KaniArg> = vec![];
 
+        if self.args.no_assert_overrides {
+            flags.push("--no-assert-overrides".into());
+        }
+
         if self.args.common_args.debug {
             flags.push("--log-level=debug".into());
         } else if self.args.common_args.verbose {

--- a/tests/script-based-pre/cargo_no_assert_overrides/Cargo.toml
+++ b/tests/script-based-pre/cargo_no_assert_overrides/Cargo.toml
@@ -1,0 +1,10 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+[package]
+name = "cargo_no_assert_overrides"
+version = "0.1.0"
+edition = "2021"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }

--- a/tests/script-based-pre/cargo_no_assert_overrides/config.yml
+++ b/tests/script-based-pre/cargo_no_assert_overrides/config.yml
@@ -1,0 +1,5 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: no-assert-overrides.sh
+expected: no-assert-overrides.expected
+exit_code: 1

--- a/tests/script-based-pre/cargo_no_assert_overrides/no-assert-overrides.expected
+++ b/tests/script-based-pre/cargo_no_assert_overrides/no-assert-overrides.expected
@@ -1,0 +1,5 @@
+[without flag]
+error[E0659]: `assert` is ambiguous
+[with flag]
+Verification failed for - verify::check_assert_still_fails
+Complete - 1 successfully verified harnesses, 1 failures, 2 total.

--- a/tests/script-based-pre/cargo_no_assert_overrides/no-assert-overrides.sh
+++ b/tests/script-based-pre/cargo_no_assert_overrides/no-assert-overrides.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+echo "[without flag]"
+cargo kani 2>&1 | grep -m1 'E0659'
+echo "[with flag]"
+cargo kani --no-assert-overrides

--- a/tests/script-based-pre/cargo_no_assert_overrides/no-assert-overrides.sh
+++ b/tests/script-based-pre/cargo_no_assert_overrides/no-assert-overrides.sh
@@ -2,7 +2,31 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
+set -euo pipefail
+
 echo "[without flag]"
-cargo kani 2>&1 | grep -m1 'E0659'
+# Kani's macro-override injection makes `assert!` ambiguous, so `cargo kani`
+# must fail with rustc's E0659 (GlobVsOuter). Capture the status explicitly:
+# the previous `cargo kani ... | grep E0659` pipeline reported grep's status,
+# so a change in the driver's exit behavior or a stray E0659 elsewhere could
+# have silently made the test pass for the wrong reason.
+status=0
+output=$(cargo kani 2>&1) || status=$?
+if [ "$status" -eq 0 ]; then
+    echo "unexpected success: cargo kani should have failed with an ambiguity error"
+    echo "$output"
+    exit 1
+fi
+# Match the specific ambiguity error rather than a bare `E0659`, so the
+# `.expected` check confirms the first run failed for the intended reason.
+if ! grep -m1 -F 'error[E0659]: `assert` is ambiguous' <<<"$output"; then
+    echo "expected E0659 ambiguity error not found in cargo kani output; got:"
+    echo "$output"
+    exit 1
+fi
+
 echo "[with flag]"
+# The macro-override injection is skipped, so the crate compiles. The
+# intentionally failing harness still fails verification, producing the
+# expected non-zero exit status (see config.yml: exit_code: 1).
 cargo kani --no-assert-overrides

--- a/tests/script-based-pre/cargo_no_assert_overrides/src/lib.rs
+++ b/tests/script-based-pre/cargo_no_assert_overrides/src/lib.rs
@@ -1,0 +1,47 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Reproduces the libc (>= 0.2.188) pattern: a macro-generated internal prelude that
+// re-exports `core::assert`, glob-imported by modules that call `assert!`. With Kani's
+// macro-override injection this is ambiguous (E0659, GlobVsOuter, a hard error);
+// `--no-assert-overrides` skips the injection so the crate compiles, at the cost of
+// assertion failures being reported as generic panics.
+
+macro_rules! make_prelude {
+    () => {
+        mod prelude {
+            #[allow(unused_imports)]
+            pub(crate) use core::assert;
+        }
+    };
+}
+
+make_prelude!();
+
+mod uses_assert {
+    use crate::prelude::*;
+
+    pub fn checked_add(x: u8, y: u8) -> u8 {
+        let sum = x.wrapping_add(y);
+        assert!(sum >= x || sum < x); // trivially true; exercises the ambiguous macro
+        sum
+    }
+}
+
+#[cfg(kani)]
+mod verify {
+    #[kani::proof]
+    fn check_add() {
+        let x: u8 = kani::any();
+        let y: u8 = kani::any();
+        let _ = crate::uses_assert::checked_add(x, y);
+    }
+
+    // Assertion failures still fail verification without the overrides,
+    // just with a generic panic message.
+    #[kani::proof]
+    fn check_assert_still_fails() {
+        let x: u8 = kani::any();
+        assert!(x < 255);
+    }
+}


### PR DESCRIPTION
### Description

Adds a `--no-assert-overrides` flag that skips injecting Kani's macro overrides (`assert!`, `panic!`, ...) into the crate under verification.

Kani injects `#[macro_use] extern crate std as _kani_std_macros;` so that its overrides shadow the prelude macros. rustc's restricted-shadowing rule makes a *glob import* of the same macro name ambiguous against the macro_use prelude — E0659 with kind `GlobVsOuter`, which is a hard error with no lint-level escape. Crates that glob-import a module re-exporting `core::assert` therefore cannot compile under Kani. #4666 already skips the injection for external dependencies, but the same pattern in the *crate under verification* still fails: verifying libc itself (whose `prelude!` macro re-exports `core::assert` into an internal prelude that its modules glob-import) fails with ``error[E0659]: `assert` is ambiguous`` (this is #1597 / the primary-crate remainder of #4665).

With the flag, verification remains sound — assertion failures are still detected, just reported as generic panics without the original condition/message, matching how external and `no_std` dependencies already behave since #4666. The flag is an escape hatch rather than a default change; the error-message-preserving behavior is untouched for everyone else.

Found while evaluating `kani autoharness` on the top-100 crates.io crates, where libc 0.2.189 fails to build. With this flag (plus #4682 for its `no_std`-ness), libc compiles cleanly under Kani.

### Testing

New script-based test `cargo_no_assert_overrides` reproducing the libc pattern (macro-generated prelude re-exporting `core::assert`, glob-imported by a module calling `assert!`): asserts E0659 without the flag, successful compilation with it, and that an intentionally failing assertion still fails verification (soundness of the degraded mode).

`kani-driver` unit tests and formatting pass; manually verified libc 0.2.189 compiles under `cargo kani --no-assert-overrides`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
