### PR TITLE
Upgrade Rust toolchain to nightly-2026-02-15

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/contract.rs
@@ -136,26 +136,36 @@ impl GotocCtx<'_, '_> {
             .typ
             .clone();
 
-        let shadow_memory_assign = self
-            .tcx
-            .all_diagnostic_items(())
-            .name_to_id
-            .get(&rustc_span::symbol::Symbol::intern("KaniMemoryInitializationState"))
-            .map(|attr_id| {
-                self.tcx
-                    .symbol_name(rustc_middle::ty::Instance::mono(self.tcx, *attr_id))
-                    .name
-                    .to_string()
-            })
-            .and_then(|shadow_memory_table| self.symbol_table.lookup(&shadow_memory_table).cloned())
-            .map(|shadow_memory_symbol| {
-                vec![Lambda::as_contract_for(
-                    &goto_annotated_fn_typ,
-                    None,
-                    shadow_memory_symbol.to_expr(),
-                )]
-            })
-            .unwrap_or_default();
+        // Find the memory-initialization shadow-memory static. It is tagged with the
+        // `KaniMemoryInitializationState` `fn_marker` (a `#[rustc_diagnostic_item]`
+        // can no longer be applied to statics). Its goto symbol is named after the
+        // static's mangled name, matching `codegen_static`.
+        let shadow_memory_assign = {
+            let mut crates = rustc_public::find_crates("kani");
+            if crates.is_empty() {
+                // In case we are using `kani_core`.
+                crates.extend(rustc_public::find_crates("core"));
+            }
+            crates
+                .into_iter()
+                .flat_map(|krate| krate.statics())
+                .find(|static_def| {
+                    crate::kani_middle::attributes::fn_marker(*static_def).as_deref()
+                        == Some("KaniMemoryInitializationState")
+                })
+                .map(|static_def| Instance::from(static_def).mangled_name())
+                .and_then(|shadow_memory_table| {
+                    self.symbol_table.lookup(&shadow_memory_table).cloned()
+                })
+                .map(|shadow_memory_symbol| {
+                    vec![Lambda::as_contract_for(
+                        &goto_annotated_fn_typ,
+                        None,
+                        shadow_memory_symbol.to_expr(),
+                    )]
+                })
+                .unwrap_or_default()
+        };
 
         // The last argument is a tuple with addresses that can be modified.
         let modifies_local = Local::from(modifies.fn_abi().unwrap().args.len());

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -955,7 +955,11 @@ impl GotocCtx<'_, '_> {
     pub fn codegen_get_discriminant(&mut self, e: Expr, ty: Ty, res_ty: Ty) -> Expr {
         let layout = self.layout_of_stable(ty);
         match &layout.variants {
-            Variants::Empty => unreachable!("Discriminant for uninhabited enum with no variants"),
+            // An uninhabited enum with no variants has no inhabitant, so reading its
+            // discriminant is unreachable at runtime. The rustc SSA backend returns a
+            // poison value for uninhabited layouts here; we mirror that with a nondet
+            // value of the target type (the surrounding code path is dead anyway).
+            Variants::Empty => Expr::nondet(self.codegen_ty_stable(res_ty)),
             Variants::Single { index } => {
                 let discr_val = layout
                     .ty

--- a/library/kani_core/src/mem_init.rs
+++ b/library/kani_core/src/mem_init.rs
@@ -12,7 +12,10 @@
 macro_rules! kani_mem_init {
     ($core:path) => {
         /// Global object for tracking memory initialization state.
-        #[rustc_diagnostic_item = "KaniMemoryInitializationState"]
+        // `#[rustc_diagnostic_item]` cannot be applied to statics (rust-lang/rust
+        // disallows it), so we identify this static via Kani's own `fn_marker` tool
+        // attribute instead; the compiler looks it up by that marker.
+        #[kanitool::fn_marker = "KaniMemoryInitializationState"]
         static mut MEM_INIT_STATE: MemoryInitializationState = MemoryInitializationState::new();
 
         /// Global object for tracking union initialization state across function boundaries.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2026-02-14"
+channel = "nightly-2026-02-15"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
Two rustc changes needed handling:

1. `#[rustc_diagnostic_item]` may no longer be applied to statics. Kani tagged the memory-initialization shadow-memory static (`MEM_INIT_STATE`) with one so the compiler could locate it for function-contract `assigns` clauses. Tag it with Kani's own `kanitool::fn_marker` attribute instead (which is allowed on statics), and locate it in `codegen_contract` by scanning the kani (or core) crate's statics for that marker, using the static's mangled name to look it up in the goto symbol table.

2. Some uninhabited enums are now given a `Variants::Empty` layout that reaches `codegen_get_discriminant`, which previously hit an `unreachable!`. Reading the discriminant of an uninhabited (variant-less) enum is dead code; mirror the rustc SSA backend (which returns a poison value) by returning a nondet value of the target type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
