### PR TITLE
Implement Arbitrary for Rc<T> and Arc<T>

### DIFF
--- a/library/kani/src/arbitrary.rs
+++ b/library/kani/src/arbitrary.rs
@@ -15,6 +15,24 @@ where
     }
 }
 
+impl<T> Arbitrary for std::rc::Rc<T>
+where
+    T: Arbitrary,
+{
+    fn any() -> Self {
+        std::rc::Rc::new(T::any())
+    }
+}
+
+impl<T> Arbitrary for std::sync::Arc<T>
+where
+    T: Arbitrary,
+{
+    fn any() -> Self {
+        std::sync::Arc::new(T::any())
+    }
+}
+
 impl Arbitrary for std::time::Duration {
     fn any() -> Self {
         const NANOS_PER_SEC: u32 = 1_000_000_000;

--- a/tests/kani/Arbitrary/rc_arc.rs
+++ b/tests/kani/Arbitrary/rc_arc.rs
@@ -1,0 +1,33 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that Rc<T> and Arc<T> implement Arbitrary (like Box<T>), producing an
+// unconstrained value of the pointee type behind shared-ownership indirection.
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+#[derive(kani::Arbitrary)]
+struct Point {
+    x: u8,
+    y: u8,
+}
+
+#[kani::proof]
+fn check_rc() {
+    let p: Rc<Point> = kani::any();
+    kani::cover!(p.x == 255 && p.y == 0, "extreme values are generated");
+}
+
+#[kani::proof]
+fn check_arc() {
+    let v: Arc<i32> = kani::any();
+    kani::cover!(*v == i32::MIN, "extreme values are generated");
+    kani::cover!(*v == 42, "specific values are generated");
+}
+
+#[kani::proof]
+fn check_nested() {
+    let v: Rc<Arc<u8>> = kani::any();
+    kani::cover!(**v == 7, "nested smart pointers are generated");
+}


### PR DESCRIPTION
### Description

`Box<T>` implements `Arbitrary`, but `Rc<T>` and `Arc<T>` did not, so functions taking reference-counted arguments could not be verified against nondeterministic inputs — and were skipped by `kani autoharness` with "Missing Arbitrary implementation" (smart-pointer receivers are among the largest skip classes in the top-100 crates.io evaluation). This PR adds the analogous implementations.

Note that unlike slice/container arguments (#4691/#4693), these need no bound and no opt-in flag: a smart pointer to `T` covers exactly the values of `T`, so the generated values retain Kani's usual full-coverage guarantee.

A follow-up will extend autoharness to smart pointers around types that only *can-derive* `Arbitrary` (compiler-synthesized implementations); that requires compiler-side models that depend on `alloc` and hence some optional-model plumbing for the `no_core` flow.

### Testing

New test `tests/kani/Arbitrary/rc_arc.rs` with cover checks proving extreme values, specific values, and nested smart pointers (`Rc<Arc<u8>>`) are all generated (all SATISFIED). The `Arbitrary` suite and `kani` library unit/doc tests pass; verified via autoharness that `Rc<T>`/`Arc<T>`-taking functions are now selected and verified.

Towards #3832

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
