### PR TITLE
Upgrade Rust toolchain to nightly-2026-02-18

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/foreign_function.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/foreign_function.rs
@@ -109,7 +109,20 @@ impl GotocCtx<'_, '_> {
             .unwrap()
             .iter()
             .zip(args)
-            .map(|(param, arg)| arg.cast_to(param.typ().clone()))
+            .map(|(param, arg)| {
+                let param_typ = param.typ().clone();
+                // `cast_to` only handles scalar conversions. When an aggregate is
+                // involved — e.g. `core::ptr::Alignment` (a struct) passed where the C
+                // shim in `kani_lib.c` declares `size_t` — reinterpret the bits with
+                // `transmute_to` instead (the two are ABI-identical).
+                if arg.typ().is_scalar() && param_typ.is_scalar() {
+                    arg.cast_to(param_typ)
+                } else if *arg.typ() == param_typ {
+                    arg
+                } else {
+                    arg.transmute_to(param_typ, &self.symbol_table)
+                }
+            })
             .collect::<Vec<_>>();
         let call_expr = fn_expr.call(expected_args);
 
@@ -155,7 +168,19 @@ impl GotocCtx<'_, '_> {
             .map(|(idx, arg)| {
                 let arg_name = format!("{fn_name}::param_{idx}");
                 let base_name = format!("param_{idx}");
-                let arg_type = self.codegen_ty_stable(arg.ty);
+                // `core::ptr::Alignment` is `repr(transparent)` over a `repr(usize)`
+                // enum (ABI-identical to `usize`). As of nightly-2026-02-16 the Rust
+                // allocation shims (`__rust_alloc` etc.) take their alignment argument
+                // as `Alignment` rather than `usize`. Its goto type is not `size_t`,
+                // which would mismatch the `size_t` parameters of the C definitions in
+                // `kani_lib.c` at link time, leaving the allocator body unlinked (so it
+                // havocs and may "fail", making the OOM path reachable). Represent it as
+                // `size_t` for FFI so the definitions link.
+                let arg_type = if is_ptr_alignment(arg.ty) {
+                    Type::size_t()
+                } else {
+                    self.codegen_ty_stable(arg.ty)
+                };
                 let sym = Symbol::variable(&arg_name, &base_name, arg_type.clone(), loc)
                     .with_is_parameter(true);
                 self.symbol_table.insert(sym);
@@ -197,4 +222,18 @@ impl GotocCtx<'_, '_> {
             loc,
         )
     }
+}
+
+/// Returns `true` if `ty` is `core::ptr::Alignment`.
+///
+/// That type is `repr(transparent)` over a `repr(usize)` enum and is therefore
+/// ABI-identical to `usize`, but its goto type is not `size_t`. We treat it as
+/// `size_t` in foreign (FFI) signatures so that Rust's allocation shims match the
+/// `size_t`-typed definitions in `kani_lib.c`.
+fn is_ptr_alignment(ty: rustc_public::ty::Ty) -> bool {
+    matches!(
+        ty.kind(),
+        TyKind::RigidTy(RigidTy::Adt(def, _))
+            if matches!(def.name().as_str(), "core::ptr::Alignment" | "std::ptr::Alignment")
+    )
 }

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -384,7 +384,7 @@ impl GotocHook for Panic {
         &self,
         tcx: TyCtxt,
         instance: Instance,
-        _instance_name: &str,
+        instance_name: &str,
         kani_tool_attr: Option<&String>,
     ) -> bool {
         let def_id = rustc_internal::internal(tcx, instance.def.def_id());
@@ -396,6 +396,13 @@ impl GotocHook for Panic {
             || tcx.is_lang_item(def_id, LangItem::PanicDisplay)
             || Some(def_id) == tcx.lang_items().panic_fmt()
             || Some(def_id) == tcx.lang_items().begin_panic_fn()
+            // The diverging error path of string slicing. It is not a lang
+            // item, and (since nightly-2026-02-16) its message formatting
+            // uses `floor_char_boundary`/`ceil_char_boundary`, whose loops
+            // get codegen'd into every slicing call site and blow up
+            // symbolic execution. Treating it as a panic (which Kani models
+            // as `assert false` anyway) skips that dead formatting code.
+            || instance_name == "core::str::slice_error_fail"
     }
 
     fn handle(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2026-02-15"
+channel = "nightly-2026-02-18"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/expected/shadow/unsupported_num_objects/test.rs
+++ b/tests/expected/shadow/unsupported_num_objects/test.rs
@@ -18,21 +18,23 @@ fn check_max_objects<const N: usize>() {
     // numbering, so the `N` thresholds below may need to be adjusted when
     // upgrading CBMC.
     let mut have_42 = false;
-    // Push the boxes into a leaked `Vec` so that they are real heap allocations
-    // (escaping the loop body prevents stack promotion, which would otherwise let the
-    // compiler elide them) while avoiding the cost of symbolically executing a
-    // per-iteration deallocation. This keeps the test well under the per-test timeout
-    // on slower CI runners.
-    let mut boxes: Vec<Box<usize>> = Vec::with_capacity(N);
+    // Allocate each object directly (leaked; never deallocated) so that it is
+    // a real heap allocation with the least possible surrounding code for
+    // symbolic execution: no `Box` place projections, no deallocation, and no
+    // container bookkeeping. This keeps the test well under the per-test
+    // timeout on slower CI runners.
+    let layout = std::alloc::Layout::new::<usize>();
     while i < N {
-        let x: Box<usize> = Box::new(kani::any());
-        if *x == 42 {
-            have_42 = true;
+        let x: *mut usize = unsafe { std::alloc::alloc(layout) as *mut usize };
+        unsafe {
+            x.write(kani::any());
+            if *x == 42 {
+                have_42 = true;
+            }
         }
-        boxes.push(x);
+        std::hint::black_box(x);
         i += 1;
     }
-    std::mem::forget(boxes);
 
     // create a new object whose ID is `N` + 3
     let x: i32 = have_42 as i32;
@@ -46,10 +48,10 @@ fn check_max_objects<const N: usize>() {
 
 #[kani::proof]
 fn check_max_objects_pass() {
-    check_max_objects::<1020>();
+    check_max_objects::<1021>();
 }
 
 #[kani::proof]
 fn check_max_objects_fail() {
-    check_max_objects::<1021>();
+    check_max_objects::<1022>();
 }


### PR DESCRIPTION
Advance from nightly-2026-02-15 to nightly-2026-02-18. One source change is required (first needed at nightly-2026-02-16); 02-17 and 02-18 then pass with no further changes.

nightly-2026-02-16 changed the Rust allocation shims (`__rust_alloc`, `__rust_alloc_zeroed`, `__rust_dealloc`, `__rust_realloc`) to take their alignment argument as `core::ptr::Alignment` instead of `usize`.

`Alignment` is `repr(transparent)` over a `repr(usize)` enum (ABI-identical to `usize`), but Kani codegens it as a struct, whose goto type does not match the `size_t` parameters of the C definitions in `kani_lib.c`. At link time goto-cc reported a parameter type mismatch on `__rust_alloc::align`, leaving the allocator bodies unlinked. The allocator then havocked and could "return null", making the out-of-memory path (`handle_alloc_error` -> `__rust_alloc_error_handler`, an unsupported foreign function, plus `caller_location`) reachable and failing verification for every harness that allocates.

Represent `core::ptr::Alignment` as `size_t` in foreign-function signatures so the extern declarations match `kani_lib.c`, and, since the argument is codegen'd as a struct, reinterpret it with `transmute_to` (rather than `cast_to`, which only supports scalars) when passing it to the C shim. The allocator bodies link again, so allocation is modeled as succeeding and the OOM path is unreachable.

## Additional change: hook `core::str::slice_error_fail` as a panic function

Beyond the toolchain compatibility fixes above, **this PR also changes how Kani codegens `core::str::slice_error_fail`**, the diverging function that produces the panic for out-of-bounds/non-boundary string slicing:

- **Why:** nightly-2026-02-16 rewrote this function's panic-message formatting to use `floor_char_boundary`/`ceil_char_boundary`, whose loops are bounded by the index *value* rather than UTF-8's 4-byte width. Kani codegens this (never-taken-in-verification-success) formatting code into every string-slicing call site, and CBMC then unwinds those loops at each of them. On perf/smol_str this exploded verification from 73s/2.3GB to out-of-memory on a 30GB machine — the cause of the perf CI job consistently OOM-killing its 16GB runner.
- **What:** `slice_error_fail` is added to Kani's panic hook, alongside the `panic`/`panic_fmt`/`begin_panic` lang items. It is not a lang item, so it is matched by its symbol name (precedent: the `exchange_malloc` hook). Kani already models every panic as a verification failure (`assert false`) and never renders panic messages at runtime, so slicing failures are still detected exactly as before — the only effect is that the dead message-formatting code is no longer analyzed.
- **Effect:** perf/smol_str verifies in 32s/0.8GB, faster than before the toolchain change. Any harness slicing strings gets the same improvement.

## Additional change: speed up the shadow/unsupported_num_objects test

The nightly's new MIR for `Vec::push` also makes CBMC's symbolic execution of this test several times slower, threatening the per-test timeout on slow CI runners. The test's object-creation loop now allocates directly via `std::alloc::alloc` (leaked, never deallocated, no container bookkeeping to execute symbolically). The object-count thresholds move to 1021/1022, still tightly bracketing Kani's 1024-object shadow-memory limit, and the test runs several times faster than the unmodified version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
