### PR TITLE
Update Charon submodule to v0.1.88

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "charon"
-version = "0.1.87"
+version = "0.1.88"
 dependencies = [
  "annotate-snippets",
  "anstream 0.6.21",

--- a/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
@@ -441,6 +441,7 @@ fn get_translate_options(tcx: &TranslatedCrate, error_ctx: &mut ErrorCtx) -> Tra
         translate_all_methods: false,
         monomorphize: false,
         no_code_duplication: false,
+        no_ops_to_function_calls: false,
         hide_marker_traits: true,
         no_merge_goto_chains: false,
         item_opacities,

--- a/kani-compiler/src/codegen_aeneas_llbc/mir_to_ullbc/mod.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/mir_to_ullbc/mod.rs
@@ -1561,8 +1561,9 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
                     dest: self.translate_place(destination),
                 };
                 (
-                    Some(CharonRawStatement::Call(call)),
-                    CharonRawTerminator::Goto {
+                    None,
+                    CharonRawTerminator::Call {
+                        call,
                         target: CharonBlockId::from_usize(target.unwrap()),
                     },
                 )

--- a/scripts/charon-patch.diff
+++ b/scripts/charon-patch.diff
@@ -1,10 +1,10 @@
 diff --git a/charon/Cargo.toml b/charon/Cargo.toml
-index 71024f7c..615b9484 100644
+index 51a4b00d..25f528f2 100644
 --- a/charon/Cargo.toml
 +++ b/charon/Cargo.toml
 @@ -2,7 +2,7 @@
  name = "charon"
- version = "0.1.87"
+ version = "0.1.88"
  authors = ["Son Ho <hosonmarc@gmail.com>", "Guillaume Boisseau <nadrieril+git@gmail.com>"]
 -edition = "2021"
 +edition = "2024"
@@ -151,10 +151,10 @@ index d7e85c2e..5d6a0ac5 100644
      }
  
 diff --git a/charon/src/options.rs b/charon/src/options.rs
-index 84dd5bd0..fe5b8a96 100644
+index 692680d8..af052a50 100644
 --- a/charon/src/options.rs
 +++ b/charon/src/options.rs
-@@ -328,13 +328,13 @@ impl CliOpts {
+@@ -335,13 +335,13 @@ impl CliOpts {
  
          if self.mir_optimized {
              display_unspanned_error(
@@ -184,7 +184,7 @@ index cf4dad41..180adf08 100644
  
      /// For pretty error printing. This can print values that we encounter because we track binders
 diff --git a/charon/src/transform/expand_associated_types.rs b/charon/src/transform/expand_associated_types.rs
-index 418a1eb5..fd2e5e37 100644
+index 418a1eb5..23f78c0f 100644
 --- a/charon/src/transform/expand_associated_types.rs
 +++ b/charon/src/transform/expand_associated_types.rs
 @@ -794,7 +794,7 @@ impl<'a> ComputeItemModifications<'a> {
@@ -196,6 +196,15 @@ index 418a1eb5..fd2e5e37 100644
          let trait_id = clause.trait_.skip_binder.trait_id;
          let clause_path = clause_to_path(clause.clause_id);
          self.compute_extra_params_for_trait(trait_id)
+@@ -806,7 +806,7 @@ impl<'a> ComputeItemModifications<'a> {
+     fn compute_implied_constraints_for_predicate<'b>(
+         &'b mut self,
+         pred: &'b TraitDeclRef,
+-    ) -> impl Iterator<Item = (AssocTypePath, Ty)> + use<'b> {
++    ) -> impl Iterator<Item = (AssocTypePath, Ty)> + use<'a, 'b> {
+         let _ = self.compute_extra_params_for_trait(pred.trait_id);
+         self.trait_modifications[pred.trait_id]
+             .as_processed()
 diff --git a/charon/src/transform/simplify_constants.rs b/charon/src/transform/simplify_constants.rs
 index 9a44997c..77ccece2 100644
 --- a/charon/src/transform/simplify_constants.rs


### PR DESCRIPTION
Advance the Charon pin from v0.1.87 (c4af1eaf) to v0.1.88 (607f5683), continuing the incremental effort to catch the pinned Charon up with upstream (the endgame is dropping scripts/charon-patch.diff entirely).

Charon v0.1.88 turns calls from ULLBC statements into block terminators (`RawTerminator::Call` with an explicit `target` block), matching MIR's structure, and adds the `no_ops_to_function_calls` translation option (kept at the previous behavior).

Refresh scripts/charon-patch.diff so its hunks apply against the v0.1.88 sources (context-line drift only; the patch content is unchanged).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
