### PR TITLE
Fix ICE on non-literal `cover`/`assert`/`check` message expressions

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -79,7 +79,12 @@ fn extract_msg_or_err(gcx: &GotocCtx, msg_expr: &Expr, span: Span, construct: &s
     gcx.extract_const_message(msg_expr).unwrap_or_else(|| {
         utils::span_err(gcx.tcx, span, format!("`{construct}` message must be a string literal"));
         gcx.tcx.dcx().abort_if_errors();
-        unreachable!("Rustc should have aborted already")
+        // `span_err` above emits a hard error, which `abort_if_errors` is guaranteed to
+        // observe and turn into a fatal error, unwinding before we get here.
+        unreachable!(
+            "rustc should have aborted after the `{construct}` message error emitted above; \
+             reaching this point means that error was never counted by the diagnostic context"
+        )
     })
 }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -79,7 +79,7 @@ fn extract_msg_or_err(gcx: &GotocCtx, msg_expr: &Expr, span: Span, construct: &s
     gcx.extract_const_message(msg_expr).unwrap_or_else(|| {
         utils::span_err(gcx.tcx, span, format!("`{construct}` message must be a string literal"));
         gcx.tcx.dcx().abort_if_errors();
-        String::new()
+        unreachable!("Rustc should have aborted already")
     })
 }
 

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -62,6 +62,27 @@ struct Cover;
 
 const UNEXPECTED_CALL: &str = "Hooks from kani library handled as a map";
 
+/// Extracts a string message from a constant `Expr` produced by one of Kani's
+/// hooks (e.g. `kani::cover`, `kani::assert`, `kani::check`, ...).
+///
+/// The message argument to these functions is typed as `&'static str`, but
+/// nothing prevents a user from passing an expression that is not a string
+/// literal (e.g. a `const` computed via some indirection). In that case,
+/// `extract_const_message` cannot recover the string contents. Rather than
+/// panicking (which used to cause an internal compiler error), emit a clean,
+/// spanned, user-facing error and abort compilation.
+///
+/// `construct` should be the user-facing name of the Kani construct being
+/// codegen'd (e.g. `"cover"`, `"assert"`), and is only used for the error
+/// message.
+fn extract_msg_or_err(gcx: &GotocCtx, msg_expr: &Expr, span: Span, construct: &str) -> String {
+    gcx.extract_const_message(msg_expr).unwrap_or_else(|| {
+        utils::span_err(gcx.tcx, span, format!("`{construct}` message must be a string literal"));
+        gcx.tcx.dcx().abort_if_errors();
+        String::new()
+    })
+}
+
 impl GotocHook for Cover {
     fn hook_applies(
         &self,
@@ -85,7 +106,7 @@ impl GotocHook for Cover {
         assert_eq!(fargs.len(), 2);
         let cond = fargs.remove(0).cast_to(Type::bool());
         let msg = fargs.remove(0);
-        let msg = gcx.extract_const_message(&msg).unwrap();
+        let msg = extract_msg_or_err(gcx, &msg, span, "cover");
         let target = target.unwrap();
         let caller_loc = gcx.codegen_caller_span_stable(span);
 
@@ -156,7 +177,7 @@ impl GotocHook for Assert {
         assert_eq!(fargs.len(), 2);
         let cond = fargs.remove(0).cast_to(Type::bool());
         let msg = fargs.remove(0);
-        let msg = gcx.extract_const_message(&msg).unwrap();
+        let msg = extract_msg_or_err(gcx, &msg, span, "assert");
         let target = target.unwrap();
         let caller_loc = gcx.codegen_caller_span_stable(span);
 
@@ -196,7 +217,7 @@ impl GotocHook for UnsupportedCheck {
     ) -> Stmt {
         assert_eq!(fargs.len(), 1);
         let msg = fargs.pop().unwrap();
-        let msg = gcx.extract_const_message(&msg).unwrap();
+        let msg = extract_msg_or_err(gcx, &msg, span, "unsupported");
         let caller_loc = gcx.codegen_caller_span_stable(span);
         if let Some(target) = target {
             Stmt::block(
@@ -240,7 +261,7 @@ impl GotocHook for SafetyCheck {
         assert_eq!(fargs.len(), 2);
         let msg = fargs.pop().unwrap();
         let cond = fargs.pop().unwrap().cast_to(Type::bool());
-        let msg = gcx.extract_const_message(&msg).unwrap();
+        let msg = extract_msg_or_err(gcx, &msg, span, "safety_check");
         let target = target.unwrap();
         let caller_loc = gcx.codegen_caller_span_stable(span);
         Stmt::block(
@@ -277,7 +298,7 @@ impl GotocHook for SafetyCheckNoAssume {
         assert_eq!(fargs.len(), 2);
         let msg = fargs.pop().unwrap();
         let cond = fargs.pop().unwrap().cast_to(Type::bool());
-        let msg = gcx.extract_const_message(&msg).unwrap();
+        let msg = extract_msg_or_err(gcx, &msg, span, "safety_check_no_assume");
         let target = target.unwrap();
         let caller_loc = gcx.codegen_caller_span_stable(span);
         Stmt::block(
@@ -315,7 +336,7 @@ impl GotocHook for Check {
         assert_eq!(fargs.len(), 2);
         let cond = fargs.remove(0).cast_to(Type::bool());
         let msg = fargs.remove(0);
-        let msg = gcx.extract_const_message(&msg).unwrap();
+        let msg = extract_msg_or_err(gcx, &msg, span, "check");
         let target = target.unwrap();
         let caller_loc = gcx.codegen_caller_span_stable(span);
 

--- a/tests/ui/assert-non-literal-message/expected
+++ b/tests/ui/assert-non-literal-message/expected
@@ -1,0 +1,1 @@
+error: `assert` message must be a string literal

--- a/tests/ui/assert-non-literal-message/main.rs
+++ b/tests/ui/assert-non-literal-message/main.rs
@@ -1,0 +1,21 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test checks that `kani::assert` produces a clean, user-facing
+//! compiler error (instead of an internal compiler error / ICE) when its
+//! message argument is not a string literal.
+//!
+//! Previously, this triggered an ICE at
+//! kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs:158 via
+//! `gcx.extract_const_message(&msg).unwrap()`, because the message operand
+//! was not reducible to a string literal at codegen time (here, it is a
+//! function parameter rather than a literal expression at the call site).
+
+fn assert_with_msg(cond: bool, msg: &'static str) {
+    kani::assert(cond, msg);
+}
+
+#[kani::proof]
+fn main() {
+    assert_with_msg(true, "not actually a literal at the call site");
+}

--- a/tests/ui/assert-non-literal-message/main.rs
+++ b/tests/ui/assert-non-literal-message/main.rs
@@ -11,6 +11,10 @@
 //! was not reducible to a string literal at codegen time (here, it is a
 //! function parameter rather than a literal expression at the call site).
 
+// `#[inline(never)]` keeps `msg` a function parameter at the `kani::assert` call
+// site. If the helper were inlined, the message would fold back into a literal
+// and this test would stop exercising the non-literal path.
+#[inline(never)]
 fn assert_with_msg(cond: bool, msg: &'static str) {
     kani::assert(cond, msg);
 }

--- a/tests/ui/cover-non-literal-message/expected
+++ b/tests/ui/cover-non-literal-message/expected
@@ -1,0 +1,1 @@
+error: `cover` message must be a string literal

--- a/tests/ui/cover-non-literal-message/main.rs
+++ b/tests/ui/cover-non-literal-message/main.rs
@@ -1,0 +1,21 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This test checks that `kani::cover` produces a clean, user-facing
+//! compiler error (instead of an internal compiler error / ICE) when its
+//! message argument is not a string literal.
+//!
+//! Previously, this triggered an ICE at
+//! kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs:87 via
+//! `gcx.extract_const_message(&msg).unwrap()`, because the message operand
+//! was not reducible to a string literal at codegen time (here, it is a
+//! function parameter rather than a literal expression at the call site).
+
+fn cover_with_msg(cond: bool, msg: &'static str) {
+    kani::cover(cond, msg);
+}
+
+#[kani::proof]
+fn main() {
+    cover_with_msg(true, "not actually a literal at the call site");
+}

--- a/tests/ui/cover-non-literal-message/main.rs
+++ b/tests/ui/cover-non-literal-message/main.rs
@@ -11,6 +11,10 @@
 //! was not reducible to a string literal at codegen time (here, it is a
 //! function parameter rather than a literal expression at the call site).
 
+// `#[inline(never)]` keeps `msg` a function parameter at the `kani::cover` call
+// site. If the helper were inlined, the message would fold back into a literal
+// and this test would stop exercising the non-literal path.
+#[inline(never)]
 fn cover_with_msg(cond: bool, msg: &'static str) {
     kani::cover(cond, msg);
 }


### PR DESCRIPTION
## Problem

`kani-compiler`'s codegen hooks for `kani::cover`, `kani::assert`, `kani::check` and the internal
safety-check/unsupported-check hooks all call `gcx.extract_const_message(&msg).unwrap()` to recover the
message string.

`extract_const_message` returns `None` whenever the message operand does not codegen down to a
string-literal constant — for example when it is a function parameter — so the `.unwrap()` produces an
**internal compiler error** rather than a normal diagnostic.

Reproducer (`kani::cover` case):

```rust
#[kani::proof]
fn main() {
    let msg = "not a literal";
    kani::cover!(true, msg);
}
```

This still reproduces on `main`: all six `extract_const_message(&msg).unwrap()` call sites are present
in `kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs`.

## Fix

Add `extract_msg_or_err`, which mirrors the existing `utils::span_err` + `abort_if_errors` pattern
already used by neighbouring intrinsic codegen in the same file, and use it at all six call sites
(`Cover`, `Assert`, `UnsupportedCheck`, `SafetyCheck`, `SafetyCheckNoAssume`, `Check`).

Each now emits a spanned ``` `<construct>` message must be a string literal ``` error and aborts
compilation cleanly instead of panicking.

## Tests

UI regression tests modelled on the existing `tests/ui/ice-size-overflow` test (a prior
"ICE → clean error" regression test):

- `tests/ui/cover-non-literal-message/`
- `tests/ui/assert-non-literal-message/`

`kani::check` is `pub(crate)` in `library/kani_core/src/lib.rs` with no public re-export, so user code
cannot invoke it directly (it fails earlier with `E0425`). The remaining hooks
(`safety_check`, `safety_check_no_assume`, `unsupported_check`) are compiler-generated and not
reachable from user code either, so neither is given a UI test.

## Testing performed

- `cargo build -p kani-compiler` and `cargo check -p kani-compiler` on this branch — pass.
- Full local regression via compiletest (`--force-rerun`, all suites + unit tests): **1472 passed,
  3 failed — all 3 reproduce identically on a clean `main` checkout (`2b7972b7c`)**, so they are
  pre-existing environment issues (one requires z3, which is not installed here), not caused by this
  change.
- `cargo clippy` on the pinned nightly — clean.
- `scripts/kani-fmt.sh --check` and the copyright/format checks — clean.
- The two new UI tests fail as expected when the fix is reverted (negative control).

Happy to adjust the diagnostic wording or the test placement if you'd prefer something different.
