### PR TITLE
Add kani-maintainers team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-*   @model-checking/kani-devs
+*   @model-checking/kani-devs @model-checking/kani-maintainers


### PR DESCRIPTION
Grant the new `@model-checking/kani-maintainers` team code-owner status alongside `@model-checking/kani-devs`, so an approval from either team satisfies the code-owner review requirement on `main`.

This is additive: `kani-maintainers` is a standalone team (no parent) with Write access on this repository only, so existing `kani-devs` members keep their approval rights.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
