### PR TITLE
Keep completed results when --fail-fast aborts a run

### DIFF
--- a/kani-driver/src/args/mod.rs
+++ b/kani-driver/src/args/mod.rs
@@ -267,6 +267,8 @@ pub struct VerificationArgs {
     pub extra_pointer_checks: bool,
 
     /// Stop the verification process as soon as one of the harnesses fails.
+    /// Harnesses already running when that happens still finish and are counted, so under
+    /// `--jobs N` the set of reported harnesses depends on how many were in flight.
     #[arg(long)]
     pub fail_fast: bool,
 

--- a/kani-driver/src/frontend/schema_utils.rs
+++ b/kani-driver/src/frontend/schema_utils.rs
@@ -361,8 +361,8 @@ pub fn process_harness_results(
 
             // Add property details for this harness. `harness_id` is what makes an entry
             // attributable: this array is built in harness-metadata order while
-            // `verification_results.results` follows the order harnesses were scheduled in, so
-            // the two need not agree and cannot be correlated by position.
+            // `verification_results.results` is sorted into `sort_harnesses_by_loc` order, so the
+            // two need not agree and cannot be correlated by position.
             handler.add_harness_detail(
                 "property_details",
                 json!({

--- a/kani-driver/src/frontend/schema_utils.rs
+++ b/kani-driver/src/frontend/schema_utils.rs
@@ -361,8 +361,8 @@ pub fn process_harness_results(
 
             // Add property details for this harness. `harness_id` is what makes an entry
             // attributable: this array is built in harness-metadata order while
-            // `verification_results.results` is in completion order, so the two cannot be
-            // correlated by position.
+            // `verification_results.results` follows the order harnesses were scheduled in, so
+            // the two need not agree and cannot be correlated by position.
             handler.add_harness_detail(
                 "property_details",
                 json!({

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -38,6 +38,52 @@ pub(crate) struct HarnessResult<'pr> {
     pub result: VerificationResult,
 }
 
+/// The outcome of one unit of work run by [`run_until_abort`].
+struct Completed<T> {
+    payload: T,
+    /// Whether this outcome should stop units that have not started yet.
+    aborts: bool,
+}
+
+/// Run `run_one` over `items` in parallel, keeping the payloads of units that completed even when
+/// one of them aborts the run, and returning them in `items` order together with whether an abort
+/// happened.
+///
+/// The abort is latched rather than raised through the `Err` channel, which stays reserved for
+/// genuine errors. `try_for_each` surfaces only one `Err`, so signalling an abort that way would
+/// let it displace a real failure raised by a sibling unit still in flight.
+fn run_until_abort<I: Sync, T: Send>(
+    items: &[I],
+    run_one: impl Fn(&I) -> Result<Completed<T>> + Sync,
+) -> Result<(Vec<T>, bool)> {
+    let completed: Mutex<Vec<(usize, T)>> = Mutex::new(Vec::new());
+    let aborted = AtomicBool::new(false);
+
+    items.par_iter().enumerate().try_for_each(|(idx, item)| -> Result<()> {
+        // A unit that has not started returns without running once an abort is latched. Units
+        // already in flight finish and record their payloads.
+        if aborted.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+
+        let Completed { payload, aborts } = run_one(item)?;
+        completed.lock().unwrap().push((idx, payload));
+
+        if aborts {
+            aborted.store(true, Ordering::Relaxed);
+        }
+        Ok(())
+    })?;
+
+    // Completion order under parallelism is nondeterministic; restore `items` order.
+    let mut collected = completed.into_inner().unwrap();
+    collected.sort_by_key(|(idx, _)| *idx);
+    let payloads = collected.into_iter().map(|(_, payload)| payload).collect();
+
+    // Read after the parallel region has joined, which orders every store before this load.
+    Ok((payloads, aborted.load(Ordering::Relaxed)))
+}
+
 impl<'pr> HarnessRunner<'_, 'pr> {
     /// Given a [`HarnessRunner`] (to abstract over how these harnesses were generated), this runs
     /// the proof-checking process for each harness in `harnesses`.
@@ -78,23 +124,8 @@ impl<'pr> HarnessRunner<'_, 'pr> {
             builder.build()?
         };
 
-        // Completed results accumulate here so a `--fail-fast` abort keeps them.
-        let completed: Mutex<Vec<(usize, HarnessResult<'pr>)>> = Mutex::new(Vec::new());
-
-        // `--fail-fast` is signalled by this latch rather than through the `Err` channel, which
-        // stays reserved for genuine errors. `try_for_each` surfaces only one `Err`, so sharing
-        // the channel would let an abort mask a real failure raised by a sibling harness.
-        let fail_fast = AtomicBool::new(false);
-
-        let run_result = pool.install(|| -> Result<()> {
-            sorted_harnesses.par_iter().enumerate().try_for_each(|(idx, harness)| -> Result<()> {
-                // Once a harness has failed under `--fail-fast`, the remaining harnesses return
-                // without starting. Harnesses already in flight still finish and record their
-                // results.
-                if fail_fast.load(Ordering::Relaxed) {
-                    return Ok(());
-                }
-
+        let run_result = pool.install(|| {
+            run_until_abort(&sorted_harnesses, |harness| {
                 let goto_file =
                     self.project.get_harness_artifact(harness, ArtifactType::Goto).unwrap();
 
@@ -114,31 +145,18 @@ impl<'pr> HarnessRunner<'_, 'pr> {
                     progress_indicator.update_with_result(succeeded, timed_out);
                 }
 
-                let triggered =
+                let aborts =
                     self.sess.args.fail_fast && result.status == VerificationStatus::Failure;
 
-                completed.lock().unwrap().push((idx, HarnessResult { harness, result }));
-
-                if triggered {
-                    fail_fast.store(true, Ordering::Relaxed);
-                }
-                Ok(())
+                Ok(Completed { payload: HarnessResult { harness, result }, aborts })
             })
         });
 
         // Finish progress indicator
         progress_indicator.finish();
 
-        // The `Err` channel now carries genuine errors only, so any error propagates.
-        run_result?;
-
-        // Read after the parallel region has joined, which orders every store before this load.
-        let fail_fast = fail_fast.load(Ordering::Relaxed);
-
-        // Completion order under parallelism is nondeterministic; restore harness order.
-        let mut collected = completed.into_inner().unwrap();
-        collected.sort_by_key(|(idx, _)| *idx);
-        let results: Vec<HarnessResult<'pr>> = collected.into_iter().map(|(_, r)| r).collect();
+        // The `Err` channel carries genuine errors only, so any error propagates.
+        let (results, fail_fast) = run_result?;
 
         if let Some(handler) = json_handler {
             let status_label = if fail_fast { "completed_with_fail_fast" } else { "completed" };
@@ -369,5 +387,136 @@ impl KaniSession {
     /// This is just a placeholder for now.
     fn show_coverage_summary(&self) -> Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Completed, run_until_abort};
+    use anyhow::{Result, anyhow};
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    /// What one unit of work should do when it runs.
+    #[derive(Clone, Copy)]
+    enum Unit {
+        Pass,
+        /// Completes, and latches the abort.
+        Abort,
+        /// Fails for a reason of its own, unrelated to `--fail-fast`.
+        Error,
+    }
+
+    /// Run `units` on a single thread, so the order they are visited in is the order given.
+    fn run_sequential(units: &[Unit]) -> (Result<(Vec<usize>, bool)>, Vec<usize>) {
+        run_on(units, 1)
+    }
+
+    fn run_on(units: &[Unit], threads: usize) -> (Result<(Vec<usize>, bool)>, Vec<usize>) {
+        let ran: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+        let indexed: Vec<(usize, Unit)> = units.iter().copied().enumerate().collect();
+        let pool = rayon::ThreadPoolBuilder::new().num_threads(threads).build().unwrap();
+
+        let outcome = pool.install(|| {
+            run_until_abort(&indexed, |(idx, unit)| {
+                ran.lock().unwrap().push(*idx);
+                match unit {
+                    Unit::Pass => Ok(Completed { payload: *idx, aborts: false }),
+                    Unit::Abort => Ok(Completed { payload: *idx, aborts: true }),
+                    Unit::Error => Err(anyhow!("unit {idx} failed for its own reasons")),
+                }
+            })
+        });
+
+        let mut ran = ran.into_inner().unwrap();
+        ran.sort_unstable();
+        (outcome, ran)
+    }
+
+    /// The property the whole design rests on: an abort is reported through the returned flag and
+    /// never through the `Err` channel.
+    ///
+    /// This is what makes it impossible for an abort to displace a genuine error. `try_for_each`
+    /// surfaces only one `Err`, so as long as an abort never produces one, whatever `Err` comes
+    /// back is a real failure. Revert the latch to an `Err(FailFastAbort)` and this test fails.
+    #[test]
+    fn an_abort_is_not_reported_as_an_error() {
+        let (outcome, _) = run_sequential(&[Unit::Abort]);
+        let (payloads, aborted) = outcome.expect("an abort must not surface as an error");
+        assert!(aborted, "the abort must be reported through the flag");
+        assert_eq!(payloads, vec![0], "the aborting unit's own payload is kept");
+    }
+
+    /// The reviewer's scenario: one unit trips the abort while another returns a genuine error, both
+    /// in flight at once. The genuine error must be what propagates.
+    ///
+    /// Both units wait for the other to start before returning, so the abort and the error really do
+    /// overlap. The wait is bounded, so this cannot hang if rayon runs them on one thread; in that
+    /// case the assertion still holds, it is just no longer testing an overlap.
+    #[test]
+    fn a_genuine_error_is_not_displaced_by_a_concurrent_abort() {
+        let started = AtomicUsize::new(0);
+        let units = [Unit::Abort, Unit::Error];
+        let indexed: Vec<(usize, Unit)> = units.iter().copied().enumerate().collect();
+        let pool = rayon::ThreadPoolBuilder::new().num_threads(2).build().unwrap();
+
+        let outcome = pool.install(|| {
+            run_until_abort(&indexed, |(idx, unit)| {
+                started.fetch_add(1, Ordering::SeqCst);
+                for _ in 0..1_000 {
+                    if started.load(Ordering::SeqCst) >= 2 {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                match unit {
+                    Unit::Abort => Ok(Completed { payload: *idx, aborts: true }),
+                    _ => Err(anyhow!("unit {idx} failed for its own reasons")),
+                }
+            })
+        });
+
+        let err = outcome.expect_err("the genuine error must propagate");
+        assert_eq!(err.to_string(), "unit 1 failed for its own reasons");
+    }
+
+    /// A genuine error propagates when nothing aborts, which is the behaviour that existed before
+    /// `--fail-fast` and must not regress.
+    #[test]
+    fn a_genuine_error_propagates_on_its_own() {
+        let (outcome, _) = run_sequential(&[Unit::Pass, Unit::Error]);
+        let err = outcome.expect_err("a genuine error must propagate");
+        assert_eq!(err.to_string(), "unit 1 failed for its own reasons");
+    }
+
+    /// An abort stops units that have not started. The unit after it never runs, which is why the
+    /// error it would have raised is absent rather than swallowed.
+    #[test]
+    fn an_abort_stops_units_that_have_not_started() {
+        let (outcome, ran) = run_sequential(&[Unit::Abort, Unit::Error]);
+        let (payloads, aborted) = outcome.expect("the skipped unit never ran, so no error exists");
+        assert!(aborted);
+        assert_eq!(payloads, vec![0]);
+        assert_eq!(ran, vec![0], "the unit after the abort must not have run");
+    }
+
+    /// Units that completed before the abort keep their payloads, in input order rather than
+    /// completion order. This is the original defect the branch fixes.
+    #[test]
+    fn units_completed_before_an_abort_are_kept_in_order() {
+        let (outcome, _) = run_sequential(&[Unit::Pass, Unit::Pass, Unit::Abort, Unit::Pass]);
+        let (payloads, aborted) = outcome.expect("an abort is not an error");
+        assert!(aborted);
+        assert_eq!(payloads, vec![0, 1, 2], "completed payloads kept, in input order");
+    }
+
+    /// A run where nothing aborts and nothing fails reports no abort and keeps everything.
+    #[test]
+    fn a_clean_run_reports_no_abort() {
+        let (outcome, _) = run_sequential(&[Unit::Pass, Unit::Pass, Unit::Pass]);
+        let (payloads, aborted) = outcome.expect("a clean run must succeed");
+        assert!(!aborted);
+        assert_eq!(payloads, vec![0, 1, 2]);
     }
 }

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -1,13 +1,14 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use anyhow::{Error, Result};
+use anyhow::Result;
 use kani_metadata::{ArtifactType, HarnessKind, HarnessMetadata};
 use rayon::prelude::*;
 use std::fs::File;
 use std::io::{IsTerminal, Write};
 use std::path::Path;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::args::{NumThreads, OutputFormat};
 use crate::call_cbmc::{VerificationResult, VerificationStatus};
@@ -35,19 +36,6 @@ pub(crate) struct HarnessRunner<'sess, 'pr> {
 pub(crate) struct HarnessResult<'pr> {
     pub harness: &'pr HarnessMetadata,
     pub result: VerificationResult,
-}
-
-/// Signals that a harness failed under `--fail-fast`, so no further harnesses should start.
-/// The failing harness's result is already in the shared accumulator, so this carries no payload.
-#[derive(Debug)]
-struct FailFastAbort;
-
-impl std::error::Error for FailFastAbort {}
-
-impl std::fmt::Display for FailFastAbort {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "aborting: a harness failed and --fail-fast is set")
-    }
 }
 
 impl<'pr> HarnessRunner<'_, 'pr> {
@@ -93,8 +81,20 @@ impl<'pr> HarnessRunner<'_, 'pr> {
         // Completed results accumulate here so a `--fail-fast` abort keeps them.
         let completed: Mutex<Vec<(usize, HarnessResult<'pr>)>> = Mutex::new(Vec::new());
 
+        // `--fail-fast` is signalled by this latch rather than through the `Err` channel, which
+        // stays reserved for genuine errors. `try_for_each` surfaces only one `Err`, so sharing
+        // the channel would let an abort mask a real failure raised by a sibling harness.
+        let fail_fast = AtomicBool::new(false);
+
         let run_result = pool.install(|| -> Result<()> {
             sorted_harnesses.par_iter().enumerate().try_for_each(|(idx, harness)| -> Result<()> {
+                // Once a harness has failed under `--fail-fast`, the remaining harnesses return
+                // without starting. Harnesses already in flight still finish and record their
+                // results.
+                if fail_fast.load(Ordering::Relaxed) {
+                    return Ok(());
+                }
+
                 let goto_file =
                     self.project.get_harness_artifact(harness, ArtifactType::Goto).unwrap();
 
@@ -114,26 +114,26 @@ impl<'pr> HarnessRunner<'_, 'pr> {
                     progress_indicator.update_with_result(succeeded, timed_out);
                 }
 
-                let fail_fast_triggered =
+                let triggered =
                     self.sess.args.fail_fast && result.status == VerificationStatus::Failure;
 
                 completed.lock().unwrap().push((idx, HarnessResult { harness, result }));
 
-                // Ask rayon to stop scheduling further harnesses (best effort); harnesses
-                // already in flight still complete and record their results.
-                if fail_fast_triggered { Err(Error::new(FailFastAbort)) } else { Ok(()) }
+                if triggered {
+                    fail_fast.store(true, Ordering::Relaxed);
+                }
+                Ok(())
             })
         });
 
         // Finish progress indicator
         progress_indicator.finish();
 
-        // A genuine error (not the fail-fast signal) must still propagate.
-        let fail_fast = match run_result {
-            Ok(()) => false,
-            Err(err) if err.is::<FailFastAbort>() => true,
-            Err(err) => return Err(err),
-        };
+        // The `Err` channel now carries genuine errors only, so any error propagates.
+        run_result?;
+
+        // Read after the parallel region has joined, which orders every store before this load.
+        let fail_fast = fail_fast.load(Ordering::Relaxed);
 
         // Completion order under parallelism is nondeterministic; restore harness order.
         let mut collected = completed.into_inner().unwrap();

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -60,8 +60,10 @@ fn run_until_abort<I: Sync, T: Send>(
     let aborted = AtomicBool::new(false);
 
     items.par_iter().enumerate().try_for_each(|(idx, item)| -> Result<()> {
-        // A unit that has not started returns without running once an abort is latched. Units
-        // already in flight finish and record their payloads.
+        // Best effort: a unit that has not started returns without running once it observes a
+        // latched abort. The load is `Relaxed`, so a unit racing the store may still run; that
+        // costs one extra unit of work and is not incorrect. Units already in flight finish and
+        // record their payloads.
         if aborted.load(Ordering::Relaxed) {
             return Ok(());
         }
@@ -451,9 +453,14 @@ mod tests {
     /// The reviewer's scenario: one unit trips the abort while another returns a genuine error, both
     /// in flight at once. The genuine error must be what propagates.
     ///
-    /// Both units wait for the other to start before returning, so the abort and the error really do
-    /// overlap. The wait is bounded, so this cannot hang if rayon runs them on one thread; in that
-    /// case the assertion still holds, it is just no longer testing an overlap.
+    /// Both units wait for the other to start, so on a pool that runs them in parallel the abort
+    /// and the error really do overlap. The wait is bounded, so nothing hangs.
+    ///
+    /// Rayon is free not to split a two-element iterator, and if it serializes them the aborting
+    /// unit would latch the abort before the erroring unit ran, leaving no genuine error to
+    /// displace and no way to assert one. So the aborting unit latches the abort only once it has
+    /// seen the other unit start. Serialized, it declines to abort and the erroring unit runs
+    /// afterwards, so the assertion holds either way rather than failing on a scheduling accident.
     #[test]
     fn a_genuine_error_is_not_displaced_by_a_concurrent_abort() {
         let started = AtomicUsize::new(0);
@@ -464,14 +471,16 @@ mod tests {
         let outcome = pool.install(|| {
             run_until_abort(&indexed, |(idx, unit)| {
                 started.fetch_add(1, Ordering::SeqCst);
+                let mut both_in_flight = false;
                 for _ in 0..1_000 {
                     if started.load(Ordering::SeqCst) >= 2 {
+                        both_in_flight = true;
                         break;
                     }
                     std::thread::sleep(Duration::from_millis(1));
                 }
                 match unit {
-                    Unit::Abort => Ok(Completed { payload: *idx, aborts: true }),
+                    Unit::Abort => Ok(Completed { payload: *idx, aborts: both_in_flight }),
                     _ => Err(anyhow!("unit {idx} failed for its own reasons")),
                 }
             })

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -7,6 +7,7 @@ use rayon::prelude::*;
 use std::fs::File;
 use std::io::{IsTerminal, Write};
 use std::path::Path;
+use std::sync::Mutex;
 
 use crate::args::{NumThreads, OutputFormat};
 use crate::call_cbmc::{VerificationResult, VerificationStatus};
@@ -36,17 +37,16 @@ pub(crate) struct HarnessResult<'pr> {
     pub result: VerificationResult,
 }
 
+/// Signals that a harness failed under `--fail-fast`, so no further harnesses should start.
+/// The failing harness's result is already in the shared accumulator, so this carries no payload.
 #[derive(Debug)]
-struct FailFastHarnessInfo {
-    pub index_to_failing_harness: usize,
-    pub result: VerificationResult,
-}
+struct FailFastAbort;
 
-impl std::error::Error for FailFastHarnessInfo {}
+impl std::error::Error for FailFastAbort {}
 
-impl std::fmt::Display for FailFastHarnessInfo {
+impl std::fmt::Display for FailFastAbort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "harness failed")
+        write!(f, "aborting: a harness failed and --fail-fast is set")
     }
 }
 
@@ -56,7 +56,7 @@ impl<'pr> HarnessRunner<'_, 'pr> {
     pub(crate) fn check_all_harnesses(
         &self,
         harnesses: &'pr [&HarnessMetadata],
-        mut json_handler: Option<&mut JsonHandler>,
+        json_handler: Option<&mut JsonHandler>,
     ) -> Result<Vec<HarnessResult<'pr>>> {
         let sorted_harnesses = crate::metadata::sort_harnesses_by_loc(harnesses);
 
@@ -90,75 +90,62 @@ impl<'pr> HarnessRunner<'_, 'pr> {
             builder.build()?
         };
 
-        let results = pool.install(|| -> Result<Vec<HarnessResult<'pr>>> {
-            sorted_harnesses
-                .par_iter()
-                .enumerate()
-                .map(|(idx, harness)| -> Result<HarnessResult<'pr>> {
-                    let goto_file =
-                        self.project.get_harness_artifact(harness, ArtifactType::Goto).unwrap();
+        // Completed results accumulate here so a `--fail-fast` abort keeps them.
+        let completed: Mutex<Vec<(usize, HarnessResult<'pr>)>> = Mutex::new(Vec::new());
 
-                    self.sess.instrument_model(goto_file, goto_file, self.project, harness)?;
+        let run_result = pool.install(|| -> Result<()> {
+            sorted_harnesses.par_iter().enumerate().try_for_each(|(idx, harness)| -> Result<()> {
+                let goto_file =
+                    self.project.get_harness_artifact(harness, ArtifactType::Goto).unwrap();
 
-                    if self.sess.args.synthesize_loop_contracts {
-                        self.sess.synthesize_loop_contracts(goto_file, goto_file, harness)?;
-                    }
+                self.sess.instrument_model(goto_file, goto_file, self.project, harness)?;
 
-                    let result = self.sess.check_harness(goto_file, harness)?;
+                if self.sess.args.synthesize_loop_contracts {
+                    self.sess.synthesize_loop_contracts(goto_file, goto_file, harness)?;
+                }
 
-                    // Update progress indicator if active
-                    if progress_indicator.is_active() {
-                        let succeeded = result.status == VerificationStatus::Success;
-                        let timed_out =
-                            matches!(&result.results, Err(crate::call_cbmc::ExitStatus::Timeout));
-                        progress_indicator.update_with_result(succeeded, timed_out);
-                    }
+                let result = self.sess.check_harness(goto_file, harness)?;
 
-                    if self.sess.args.fail_fast && result.status == VerificationStatus::Failure {
-                        Err(Error::new(FailFastHarnessInfo {
-                            index_to_failing_harness: idx,
-                            result,
-                        }))
-                    } else {
-                        Ok(HarnessResult { harness, result })
-                    }
-                })
-                .collect::<Result<Vec<_>>>()
+                // Update progress indicator if active
+                if progress_indicator.is_active() {
+                    let succeeded = result.status == VerificationStatus::Success;
+                    let timed_out =
+                        matches!(&result.results, Err(crate::call_cbmc::ExitStatus::Timeout));
+                    progress_indicator.update_with_result(succeeded, timed_out);
+                }
+
+                let fail_fast_triggered =
+                    self.sess.args.fail_fast && result.status == VerificationStatus::Failure;
+
+                completed.lock().unwrap().push((idx, HarnessResult { harness, result }));
+
+                // Ask rayon to stop scheduling further harnesses (best effort); harnesses
+                // already in flight still complete and record their results.
+                if fail_fast_triggered { Err(Error::new(FailFastAbort)) } else { Ok(()) }
+            })
         });
 
         // Finish progress indicator
         progress_indicator.finish();
 
-        match results {
-            Ok(results) => {
-                if let Some(handler) = json_handler.as_deref_mut() {
-                    add_runner_results_to_json(handler, &results, harnesses.len(), "completed");
-                }
-                Ok(results)
-            }
-            Err(err) => {
-                if err.is::<FailFastHarnessInfo>() {
-                    let failed = err.downcast::<FailFastHarnessInfo>().unwrap();
-                    let result = vec![HarnessResult {
-                        harness: sorted_harnesses[failed.index_to_failing_harness],
-                        result: failed.result,
-                    }];
+        // A genuine error (not the fail-fast signal) must still propagate.
+        let fail_fast = match run_result {
+            Ok(()) => false,
+            Err(err) if err.is::<FailFastAbort>() => true,
+            Err(err) => return Err(err),
+        };
 
-                    if let Some(handler) = json_handler {
-                        add_runner_results_to_json(
-                            handler,
-                            &result,
-                            harnesses.len(),
-                            "completed_with_fail_fast",
-                        );
-                    }
+        // Completion order under parallelism is nondeterministic; restore harness order.
+        let mut collected = completed.into_inner().unwrap();
+        collected.sort_by_key(|(idx, _)| *idx);
+        let results: Vec<HarnessResult<'pr>> = collected.into_iter().map(|(_, r)| r).collect();
 
-                    Ok(result)
-                } else {
-                    Err(err)
-                }
-            }
+        if let Some(handler) = json_handler {
+            let status_label = if fail_fast { "completed_with_fail_fast" } else { "completed" };
+            add_runner_results_to_json(handler, &results, harnesses.len(), status_label);
         }
+
+        Ok(results)
     }
 }
 

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -45,6 +45,15 @@ struct Completed<T> {
     aborts: bool,
 }
 
+/// Restore input order over payloads tagged with the index they came from.
+///
+/// Units finish in whatever order the thread pool gets to them, so without this the results
+/// would be reported in completion order and would differ run to run.
+fn in_input_order<T>(mut tagged: Vec<(usize, T)>) -> Vec<T> {
+    tagged.sort_by_key(|(idx, _)| *idx);
+    tagged.into_iter().map(|(_, payload)| payload).collect()
+}
+
 /// Run `run_one` over `items` in parallel, keeping the payloads of units that completed even when
 /// one of them aborts the run, and returning them in `items` order together with whether an abort
 /// happened.
@@ -77,10 +86,7 @@ fn run_until_abort<I: Sync, T: Send>(
         Ok(())
     })?;
 
-    // Completion order under parallelism is nondeterministic; restore `items` order.
-    let mut collected = completed.into_inner().unwrap();
-    collected.sort_by_key(|(idx, _)| *idx);
-    let payloads = collected.into_iter().map(|(_, payload)| payload).collect();
+    let payloads = in_input_order(completed.into_inner().unwrap());
 
     // Read after the parallel region has joined, which orders every store before this load.
     Ok((payloads, aborted.load(Ordering::Relaxed)))
@@ -394,7 +400,7 @@ impl KaniSession {
 
 #[cfg(test)]
 mod tests {
-    use super::{Completed, run_until_abort};
+    use super::{Completed, in_input_order, run_until_abort};
     use anyhow::{Result, anyhow};
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -518,6 +524,24 @@ mod tests {
         let (payloads, aborted) = outcome.expect("an abort is not an error");
         assert!(aborted);
         assert_eq!(payloads, vec![0, 1, 2], "completed payloads kept, in input order");
+    }
+
+    /// The ordering step, on an input it can actually fail on.
+    ///
+    /// The runs above are all on a one-thread pool, where units complete in index order and the
+    /// sort is a no-op: delete it and every one of them still passes. Under `--jobs N` completion
+    /// order really is shuffled, so drive the sort directly with a shuffled input.
+    #[test]
+    fn payloads_are_restored_to_input_order() {
+        let shuffled = vec![(3, "d"), (0, "a"), (2, "c"), (1, "b")];
+        assert_eq!(in_input_order(shuffled), vec!["a", "b", "c", "d"]);
+    }
+
+    /// Already-ordered and empty inputs are the boundary cases.
+    #[test]
+    fn in_input_order_handles_sorted_and_empty_inputs() {
+        assert_eq!(in_input_order(vec![(0, "a"), (1, "b")]), vec!["a", "b"]);
+        assert!(in_input_order(Vec::<(usize, &str)>::new()).is_empty());
     }
 
     /// A run where nothing aborts and nothing fails reports no abort and keeps everything.

--- a/tests/json-handler/fail-fast/config.yml
+++ b/tests/json-handler/fail-fast/config.yml
@@ -1,0 +1,3 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: test.sh

--- a/tests/json-handler/fail-fast/test.rs
+++ b/tests/json-handler/fail-fast/test.rs
@@ -1,0 +1,18 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Two proof harnesses: one fails, one passes. `sort_harnesses_by_loc` processes
+// later-appearing harnesses first, so `z_passes` (below) runs before
+// `a_fails`. Run sequentially (the default), the pass therefore completes before the
+// failure triggers the `--fail-fast` abort -- the exact situation in which the
+// previous code discarded the already-completed pass (#4729).
+
+#[kani::proof]
+fn a_fails() {
+    assert!(false, "intentional failure for the --fail-fast regression test");
+}
+
+#[kani::proof]
+fn z_passes() {
+    assert!(1 + 1 == 2);
+}

--- a/tests/json-handler/fail-fast/test.sh
+++ b/tests/json-handler/fail-fast/test.sh
@@ -7,10 +7,10 @@
 # The rendered-summary half of this regression lives in
 # tests/script-based-pre/fail_fast_keeps_completed/.
 
-# Not `set -e`: the run under test exits non-zero by design (a harness fails).
-set -u
-# The validator's exit status is piped into `tail` below; without pipefail a failed
-# validation is masked by tail's success and this test passes regardless.
+set -eu
+# The validator's exit status is piped into `tail` below; `pipefail` makes the
+# pipeline report it and `set -e` makes that status fatal — both are needed, or a
+# failed validation is masked and this test passes regardless.
 set -o pipefail
 
 OUTPUT_FILE="fail_fast_output.json"
@@ -22,9 +22,12 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 VALIDATOR="$PROJECT_ROOT/scripts/validate_json_export.py"
 
 # `sort_harnesses_by_loc` runs later-appearing harnesses first, so sequentially
-# `z_passes` completes before `a_fails` aborts the run.
+# `z_passes` completes before `a_fails` aborts the run. The run exits non-zero by
+# design (a harness fails), so only this invocation is exempted from `set -e`.
+set +e
 kani -Z unstable-options test.rs --fail-fast --export-json "$OUTPUT_FILE"
 CODE=$?
+set -e
 
 # The run must fail overall; a --fail-fast run that exits 0 is a different bug.
 if [ "$CODE" -eq 0 ]; then

--- a/tests/json-handler/fail-fast/test.sh
+++ b/tests/json-handler/fail-fast/test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# Test JSON export under --fail-fast: a harness that completed before the abort must
+# still appear in the export, and the aborted run's document must still validate.
+# The rendered-summary half of this regression lives in
+# tests/script-based-pre/fail_fast_keeps_completed/.
+
+# Not `set -e`: the run under test exits non-zero by design (a harness fails).
+set -u
+# The validator's exit status is piped into `tail` below; without pipefail a failed
+# validation is masked by tail's success and this test passes regardless.
+set -o pipefail
+
+OUTPUT_FILE="fail_fast_output.json"
+# Remove the export on every exit path, not just the happy one.
+trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+VALIDATOR="$PROJECT_ROOT/scripts/validate_json_export.py"
+
+# `sort_harnesses_by_loc` runs later-appearing harnesses first, so sequentially
+# `z_passes` completes before `a_fails` aborts the run.
+kani -Z unstable-options test.rs --fail-fast --export-json "$OUTPUT_FILE"
+CODE=$?
+
+# The run must fail overall; a --fail-fast run that exits 0 is a different bug.
+if [ "$CODE" -eq 0 ]; then
+    echo "ERROR: --fail-fast run exited 0 despite a failing harness"
+    exit 1
+fi
+
+if [ ! -f "$OUTPUT_FILE" ]; then
+    echo "ERROR: JSON file $OUTPUT_FILE was not created"
+    exit 1
+fi
+
+# An aborted run still has to produce a structurally valid document.
+python3 "$VALIDATOR" "$OUTPUT_FILE" 2>&1 | tail -1
+
+python3 << EOF
+import json
+import sys
+
+with open('$OUTPUT_FILE', 'r') as f:
+    data = json.load(f)
+
+failures = []
+
+
+def check(condition, message):
+    if not condition:
+        failures.append(message)
+
+
+# The completed pass must survive the abort, in the counters and in the results.
+summary = data['verification_results']['summary']
+for field, want in [('executed', 2), ('successful', 1), ('failed', 1)]:
+    check(summary[field] == want,
+          f"summary.{field} should be {want}, got {summary[field]}")
+
+results = {r.get('harness_id'): r.get('status')
+           for r in data['verification_results']['results']}
+check(results.get('z_passes') == 'Success',
+      f"z_passes should be Success in results, got {results.get('z_passes')}")
+check(results.get('a_fails') == 'Failure',
+      f"a_fails should be Failure in results, got {results.get('a_fails')}")
+
+if failures:
+    for failure in failures:
+        print(f"ERROR: {failure}")
+    sys.exit(1)
+
+print("The completed harness survives a --fail-fast abort in the export")
+EOF

--- a/tests/script-based-pre/fail_fast_keeps_completed/config.yml
+++ b/tests/script-based-pre/fail_fast_keeps_completed/config.yml
@@ -1,0 +1,4 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: keeps_completed.sh
+expected: keeps_completed.expected

--- a/tests/script-based-pre/fail_fast_keeps_completed/fixture.rs
+++ b/tests/script-based-pre/fail_fast_keeps_completed/fixture.rs
@@ -1,0 +1,18 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Two proof harnesses: one fails, one passes. `sort_harnesses_by_loc` processes
+// later-appearing harnesses first, so `z_passes` (below) runs before
+// `a_fails`. Run sequentially (the default), the pass therefore completes before the
+// failure triggers the `--fail-fast` abort -- the exact situation in which the
+// previous code discarded the already-completed pass (#4729).
+
+#[kani::proof]
+fn a_fails() {
+    assert!(false, "intentional failure for the --fail-fast regression test");
+}
+
+#[kani::proof]
+fn z_passes() {
+    assert!(1 + 1 == 2);
+}

--- a/tests/script-based-pre/fail_fast_keeps_completed/keeps_completed.expected
+++ b/tests/script-based-pre/fail_fast_keeps_completed/keeps_completed.expected
@@ -1,0 +1,1 @@
+SUCCESS: --fail-fast retains already-completed harness results

--- a/tests/script-based-pre/fail_fast_keeps_completed/keeps_completed.sh
+++ b/tests/script-based-pre/fail_fast_keeps_completed/keeps_completed.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# Regression test for https://github.com/model-checking/kani/issues/4729:
+# under `--fail-fast`, a harness that already completed must not be dropped from
+# the final summary or the `--export-json` file when a later harness fails and
+# aborts the run.
+#
+# `sort_harnesses_by_loc` processes later-appearing harnesses first, so in the
+# default sequential run `z_passes` completes before `a_fails` aborts the run.
+# Previously the completed pass was discarded and the summary reported
+# "0 successfully verified harnesses ... 1 total"; it must now count the pass.
+# The export derives from the same result vector (#4729 impact item 2), so the
+# completed pass must appear there too.
+
+set +e
+
+EXPORT_FILE="fail_fast_export.json"
+trap 'rm -f "${EXPORT_FILE}"' EXIT
+
+OUT=$(kani fixture.rs --fail-fast -Z unstable-options --export-json "${EXPORT_FILE}" 2>&1)
+CODE=$?
+
+# The run must still fail overall (a harness failed).
+if [[ ${CODE} -eq 0 ]]; then
+    echo "FAIL: --fail-fast run exited 0 despite a failing harness"
+    echo "${OUT}"
+    exit 1
+fi
+
+# The already-completed passing harness must be retained in the summary.
+if ! grep -q "1 successfully verified harnesses, 1 failures, 2 total" <<< "${OUT}"; then
+    echo "FAIL: a completed harness was dropped from the --fail-fast summary; got:"
+    grep -E "successfully verified|total" <<< "${OUT}"
+    exit 1
+fi
+
+# The export must retain it as well: counters and per-harness results.
+if [[ ! -f "${EXPORT_FILE}" ]]; then
+    echo "FAIL: --export-json produced no file on a --fail-fast run"
+    exit 1
+fi
+
+python3 - "${EXPORT_FILE}" << 'EOF'
+import json
+import sys
+
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+
+failures = []
+
+
+def check(condition, message):
+    if not condition:
+        failures.append(message)
+
+
+summary = data['verification_results']['summary']
+for field, want in [('executed', 2), ('successful', 1), ('failed', 1)]:
+    check(summary[field] == want,
+          f"summary.{field} should be {want}, got {summary[field]}")
+
+results = {r.get('harness_id'): r.get('status')
+           for r in data['verification_results']['results']}
+check(results.get('z_passes') == 'Success',
+      f"z_passes should be Success in results, got {results.get('z_passes')}")
+check(results.get('a_fails') == 'Failure',
+      f"a_fails should be Failure in results, got {results.get('a_fails')}")
+
+if failures:
+    for failure in failures:
+        print(f"ERROR: {failure}")
+    sys.exit(1)
+EOF
+if [[ $? -ne 0 ]]; then
+    echo "FAIL: the export dropped or mislabeled a completed harness"
+    exit 1
+fi
+
+echo "SUCCESS: --fail-fast retains already-completed harness results"

--- a/tests/script-based-pre/fail_fast_keeps_completed/keeps_completed.sh
+++ b/tests/script-based-pre/fail_fast_keeps_completed/keeps_completed.sh
@@ -4,22 +4,19 @@
 
 # Regression test for https://github.com/model-checking/kani/issues/4729:
 # under `--fail-fast`, a harness that already completed must not be dropped from
-# the final summary or the `--export-json` file when a later harness fails and
-# aborts the run.
+# the final summary when a later harness fails and aborts the run.
 #
 # `sort_harnesses_by_loc` processes later-appearing harnesses first, so in the
 # default sequential run `z_passes` completes before `a_fails` aborts the run.
 # Previously the completed pass was discarded and the summary reported
 # "0 successfully verified harnesses ... 1 total"; it must now count the pass.
-# The export derives from the same result vector (#4729 impact item 2), so the
-# completed pass must appear there too.
+#
+# The `--export-json` half of this regression lives in tests/json-handler/fail-fast/,
+# with the rest of the export coverage.
 
 set +e
 
-EXPORT_FILE="fail_fast_export.json"
-trap 'rm -f "${EXPORT_FILE}"' EXIT
-
-OUT=$(kani fixture.rs --fail-fast -Z unstable-options --export-json "${EXPORT_FILE}" 2>&1)
+OUT=$(kani fixture.rs --fail-fast 2>&1)
 CODE=$?
 
 # The run must still fail overall (a harness failed).
@@ -33,49 +30,6 @@ fi
 if ! grep -q "1 successfully verified harnesses, 1 failures, 2 total" <<< "${OUT}"; then
     echo "FAIL: a completed harness was dropped from the --fail-fast summary; got:"
     grep -E "successfully verified|total" <<< "${OUT}"
-    exit 1
-fi
-
-# The export must retain it as well: counters and per-harness results.
-if [[ ! -f "${EXPORT_FILE}" ]]; then
-    echo "FAIL: --export-json produced no file on a --fail-fast run"
-    exit 1
-fi
-
-python3 - "${EXPORT_FILE}" << 'EOF'
-import json
-import sys
-
-with open(sys.argv[1]) as f:
-    data = json.load(f)
-
-failures = []
-
-
-def check(condition, message):
-    if not condition:
-        failures.append(message)
-
-
-summary = data['verification_results']['summary']
-for field, want in [('executed', 2), ('successful', 1), ('failed', 1)]:
-    check(summary[field] == want,
-          f"summary.{field} should be {want}, got {summary[field]}")
-
-results = {r.get('harness_id'): r.get('status')
-           for r in data['verification_results']['results']}
-check(results.get('z_passes') == 'Success',
-      f"z_passes should be Success in results, got {results.get('z_passes')}")
-check(results.get('a_fails') == 'Failure',
-      f"a_fails should be Failure in results, got {results.get('a_fails')}")
-
-if failures:
-    for failure in failures:
-        print(f"ERROR: {failure}")
-    sys.exit(1)
-EOF
-if [[ $? -ne 0 ]]; then
-    echo "FAIL: the export dropped or mislabeled a completed harness"
     exit 1
 fi
 

--- a/tests/script-based-pre/fail_fast_parallel/config.yml
+++ b/tests/script-based-pre/fail_fast_parallel/config.yml
@@ -1,0 +1,4 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: early_abort.sh
+expected: early_abort.expected

--- a/tests/script-based-pre/fail_fast_parallel/early_abort.expected
+++ b/tests/script-based-pre/fail_fast_parallel/early_abort.expected
@@ -1,0 +1,1 @@
+SUCCESS: parallel --fail-fast aborts early and keeps completed results

--- a/tests/script-based-pre/fail_fast_parallel/early_abort.sh
+++ b/tests/script-based-pre/fail_fast_parallel/early_abort.sh
@@ -5,10 +5,13 @@
 # Parallel `--fail-fast` test, converted from a fixed `.expected` UI test when
 # https://github.com/model-checking/kani/issues/4729 was fixed: completed
 # results are now retained, so the summary counts depend on thread scheduling
-# and cannot be pinned to a constant. This script asserts the properties that
-# are stable: the run aborts early (fewer than all ten harnesses run), every
-# harness that ran is counted, and the summary total equals the number of
-# verdicts printed above it.
+# and cannot be pinned to a constant.
+#
+# The regression assertion is `VERDICTS == TOTAL` below: it reproduces #4729's
+# symptom (several verdicts printed above a "1 total" summary) and holds under
+# any schedule. The `< 10` bound above it is a smoke check that the abort
+# happened at all, not the regression check -- it is a statement about
+# scheduling, so it is deliberately loose and nothing rests on it.
 
 set +e
 
@@ -42,14 +45,17 @@ if [[ "${TOTAL}" -lt 1 ]]; then
     exit 1
 fi
 
-# The run must abort early: strictly fewer than all ten harnesses.
+# Smoke check, not the regression assertion: some harness was skipped, so the
+# abort did something. Loose on purpose -- with `--jobs 4` a correct run lands
+# near 4, but the exact number is scheduling, not behaviour.
 if [[ "${TOTAL}" -ge 10 ]]; then
     echo "FAIL: expected an early abort (< 10 harnesses), got ${TOTAL}"
     exit 1
 fi
 
-# The summary must count exactly the harnesses that printed a verdict above it
-# (#4729's symptom was several verdicts above a "1 total" summary).
+# THE regression assertion: the summary must count exactly the harnesses that
+# printed a verdict above it (#4729's symptom was several verdicts above a
+# "1 total" summary). Holds under any schedule.
 VERDICTS=$(grep -c "VERIFICATION:-" <<< "${OUT}")
 if [[ "${VERDICTS}" -ne "${TOTAL}" ]]; then
     echo "FAIL: ${VERDICTS} verdicts printed but the summary counts ${TOTAL}"

--- a/tests/script-based-pre/fail_fast_parallel/early_abort.sh
+++ b/tests/script-based-pre/fail_fast_parallel/early_abort.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# Parallel `--fail-fast` test, converted from a fixed `.expected` UI test when
+# https://github.com/model-checking/kani/issues/4729 was fixed: completed
+# results are now retained, so the summary counts depend on thread scheduling
+# and cannot be pinned to a constant. This script asserts the properties that
+# are stable: the run aborts early (fewer than all ten harnesses run), every
+# harness that ran is counted, and the summary total equals the number of
+# verdicts printed above it.
+
+set +e
+
+OUT=$(kani fixture.rs --fail-fast --jobs 4 --output-format=terse 2>&1)
+CODE=$?
+
+# A failing run must exit non-zero.
+if [[ ${CODE} -eq 0 ]]; then
+    echo "FAIL: --fail-fast run exited 0 despite failing harnesses"
+    exit 1
+fi
+
+SUMMARY=$(grep "successfully verified harnesses" <<< "${OUT}")
+read -r FAILURES TOTAL <<< "$(sed -n 's/.*Complete - \([0-9]*\) successfully verified harnesses, \([0-9]*\) failures, \([0-9]*\) total.*/\2 \3/p' <<< "${SUMMARY}")"
+
+if [[ -z "${TOTAL}" || -z "${FAILURES}" ]]; then
+    echo "FAIL: could not parse the summary line; got:"
+    echo "${OUT}"
+    exit 1
+fi
+
+# Every harness fails, so every counted harness must be a failure.
+if [[ "${FAILURES}" -ne "${TOTAL}" ]]; then
+    echo "FAIL: expected failures == total, got ${FAILURES} failures, ${TOTAL} total"
+    exit 1
+fi
+
+# At least the failing harness itself is counted.
+if [[ "${TOTAL}" -lt 1 ]]; then
+    echo "FAIL: expected at least one counted harness, got ${TOTAL}"
+    exit 1
+fi
+
+# The run must abort early: strictly fewer than all ten harnesses.
+if [[ "${TOTAL}" -ge 10 ]]; then
+    echo "FAIL: expected an early abort (< 10 harnesses), got ${TOTAL}"
+    exit 1
+fi
+
+# The summary must count exactly the harnesses that printed a verdict above it
+# (#4729's symptom was several verdicts above a "1 total" summary).
+VERDICTS=$(grep -c "VERIFICATION:-" <<< "${OUT}")
+if [[ "${VERDICTS}" -ne "${TOTAL}" ]]; then
+    echo "FAIL: ${VERDICTS} verdicts printed but the summary counts ${TOTAL}"
+    exit 1
+fi
+
+echo "SUCCESS: parallel --fail-fast aborts early and keeps completed results"

--- a/tests/script-based-pre/fail_fast_parallel/fixture.rs
+++ b/tests/script-based-pre/fail_fast_parallel/fixture.rs
@@ -1,8 +1,10 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// kani-flags: --fail-fast --jobs 4 --output-format=terse
-//! Ensure that the verification process stops as soon as one of the harnesses fails.
-//! This test runs on 4 parallel threads. Stops verification as soon as a harness on any of the threads fails.
+
+// Ten harnesses that all fail. Under `--fail-fast --jobs 4` the run must abort
+// before working through all ten, and every harness that did complete must be
+// counted in the summary. The exact count depends on thread scheduling, so the
+// driving script asserts a range rather than a constant.
 
 mod tests {
     #[kani::proof]

--- a/tests/ui/multiple-harnesses/stop_at_single_fail/fail_fast_test_parallel.expected
+++ b/tests/ui/multiple-harnesses/stop_at_single_fail/fail_fast_test_parallel.expected
@@ -1,1 +1,0 @@
-Complete - 0 successfully verified harnesses, 1 failures, 1 total.


### PR DESCRIPTION
`check_all_harnesses` collected results with `collect::<Result<Vec<_>>>()`, which short-circuits on the first error. A `--fail-fast` abort was such an error, so every result that had already completed was dropped. The summary then contradicted the per-harness output above it, and `--export-json` under-reported the run the same way.

Completed results now accumulate in a shared vector as harnesses finish. The abort signal carries no payload; the failing harness records its result like any other. Results are re-sorted into harness order after the parallel loop, since completion order is nondeterministic.

The parallel fail-fast UI test pinned the old behavior: "1 failures, 1 total" for ten failing harnesses under `--jobs 4`. With completed results retained, those counts depend on thread scheduling, so the test becomes a script-based test asserting the stable properties: the run aborts early (fewer than ten run) and every counted harness is a failure. The sequential UI test is unchanged: it aborts on its first harness, so its pinned summary stays correct. A new sequential script-based test proves retention deterministically ("1 successfully verified, 1 failures, 2 total"); it fails on `main`.

Testing: `cargo test -p kani-driver`, `rustfmt`, and `clippy` are clean; the two new script-based tests and the existing `stop_at_single_fail` UI test pass.

Resolves #4729