### PR TITLE
Upgrade Rust toolchain to nightly-2026-05-01

### DIFF
--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/place.rs
@@ -296,9 +296,17 @@ impl GotocCtx<'_, '_> {
                         )
                     }
                     TyKind::RigidTy(RigidTy::Pat(..)) => {
-                        // See https://github.com/rust-lang/types-team/issues/126
-                        // for what is currently supported.
-                        unreachable!("projection inside a pattern is not supported, only transmute")
+                        // Rust itself does not allow projecting inside a pattern type, only
+                        // transmuting it: see https://github.com/rust-lang/types-team/issues/126
+                        // for what is currently supported. Kani does synthesize such a projection to
+                        // see through the pattern type that `NonNull` wraps its address in, and
+                        // codegens a pattern type as a struct with a single tuple-like field
+                        // holding the constrained type, so read that field.
+                        assert_eq!(
+                            field_idx, 0,
+                            "a pattern type only has field 0, but found {field_idx}"
+                        );
+                        Ok(parent_expr.member(Self::tuple_fld_name(field_idx), &self.symbol_table))
                     }
                 }
             }

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -702,13 +702,11 @@ impl GotocCtx<'_, '_> {
                                     slice_fat_ptr(typ, data_cast, meta, &self.symbol_table)
                                 }
                                 RigidTy::Dynamic(..) => {
-                                    let vtable_expr = meta
-                                        .member("_vtable_ptr", &self.symbol_table)
-                                        .member("pointer", &self.symbol_table)
-                                        .cast_to(
-                                            typ.lookup_field_type("vtable", &self.symbol_table)
-                                                .unwrap(),
-                                        );
+                                    let vtable_expr = self.codegen_ptr_out_of_wrappers(
+                                        meta,
+                                        typ.lookup_field_type("vtable", &self.symbol_table)
+                                            .unwrap(),
+                                    );
                                     dynamic_fat_ptr(typ, data_cast, vtable_expr, &self.symbol_table)
                                 }
                                 _ => {
@@ -722,10 +720,10 @@ impl GotocCtx<'_, '_> {
                         let data_cast =
                             data.cast_to(Type::Pointer { typ: Box::new(pointee_goto_typ) });
                         let meta = self.codegen_operand_stable(&operands[1]);
-                        let vtable_expr = meta
-                            .member("_vtable_ptr", &self.symbol_table)
-                            .member("pointer", &self.symbol_table)
-                            .cast_to(typ.lookup_field_type("vtable", &self.symbol_table).unwrap());
+                        let vtable_expr = self.codegen_ptr_out_of_wrappers(
+                            meta,
+                            typ.lookup_field_type("vtable", &self.symbol_table).unwrap(),
+                        );
                         dynamic_fat_ptr(typ, data_cast, vtable_expr, &self.symbol_table)
                     }
                     _ => {
@@ -851,24 +849,17 @@ impl GotocCtx<'_, '_> {
                         assert!(dst_components[0].typ().is_struct_like());
                         assert_eq!(dst_components[1].name(), "_phantom");
                         self.assert_is_rust_phantom_data_like(&dst_components[1].typ());
-                        // accessing pointer type of _vtable_ptr, which is wrapped in NonNull
-                        let vtable_ptr_typ = dst_goto_typ
-                            .lookup_field_type("_vtable_ptr", &self.symbol_table)
-                            .unwrap()
-                            .lookup_components(&self.symbol_table)
-                            .unwrap()[0]
-                            .typ();
+                        // `_vtable_ptr` is a `NonNull`, which wraps the raw pointer in one or
+                        // more single-field structs, so rebuild those layers around the vtable
+                        // pointer rather than assuming a fixed nesting depth.
                         Expr::struct_expr(
                             dst_goto_typ.clone(),
                             btree_string_map![
                                 (
                                     "_vtable_ptr",
-                                    Expr::struct_expr_from_values(
-                                        dst_goto_typ
-                                            .lookup_field_type("_vtable_ptr", &self.symbol_table)
-                                            .unwrap(),
-                                        vec![vtable_expr.clone().cast_to(vtable_ptr_typ)],
-                                        &self.symbol_table
+                                    self.codegen_ptr_in_wrappers(
+                                        dst_components[0].typ(),
+                                        vtable_expr.clone()
                                     )
                                 ),
                                 (
@@ -1434,14 +1425,18 @@ impl GotocCtx<'_, '_> {
     /// source expression, except for the field being coerced.
     /// Coercion ignores phantom data structures, so do we.
     /// See <https://github.com/rust-lang/rust/issues/26905> for more details.
+    ///
+    /// Pattern types are accepted here as well: they are not ADTs, but they are codegen'd as a
+    /// struct with a single tuple-like field holding the type they constrain, so the field by
+    /// field assignment below applies unchanged.
     fn codegen_struct_unsized_coercion(
         &mut self,
         src_expr: Expr,
         info: CoerceUnsizedInfo,
         member_coercion: Expr,
     ) -> Expr {
-        assert!(info.src_ty.kind().is_adt(), "Expected struct. Found {:?}", info.src_ty);
-        assert!(info.dst_ty.kind().is_adt(), "Expected struct. Found {:?}", info.dst_ty);
+        assert!(is_struct_like(info.src_ty), "Expected struct. Found {:?}", info.src_ty);
+        assert!(is_struct_like(info.dst_ty), "Expected struct. Found {:?}", info.dst_ty);
         let dst_goto_type = self.codegen_ty_stable(info.dst_ty);
         let src_field_exprs = src_expr.struct_field_exprs(&self.symbol_table);
         let dst_field_exprs = src_field_exprs
@@ -1851,6 +1846,15 @@ fn wrapping_sub(expr: &Expr, constant: u64) -> Expr {
         let constant = Expr::int_constant(constant, unsigned_expr.typ().clone());
         unsigned_expr.sub(constant)
     }
+}
+
+/// Whether `ty` is codegen'd as a struct whose fields can be assigned one by one.
+///
+/// Besides ADTs, this covers pattern types (e.g. the `pattern_type!(*const T is !null)` inside
+/// `NonNull<T>`), which are codegen'd as a struct with a single tuple-like field holding the type
+/// they constrain.
+fn is_struct_like(ty: Ty) -> bool {
+    matches!(ty.kind(), TyKind::RigidTy(RigidTy::Adt(..)) | TyKind::RigidTy(RigidTy::Pat(..)))
 }
 
 /// Remove the equality from an operator. Translates `<=` to `<` and `>=` to `>`

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -11,6 +11,7 @@ use rustc_abi::{
 };
 use rustc_ast::ast::Mutability;
 use rustc_index::IndexVec;
+use rustc_middle::ty::Unnormalized;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::print::FmtPrinter;
 use rustc_middle::ty::print::with_no_trimmed_paths;
@@ -583,8 +584,9 @@ impl<'tcx, 'r> GotocCtx<'tcx, 'r> {
     ///      c.f. <https://rust-lang.github.io/unsafe-code-guidelines/introduction.html>
     pub fn codegen_ty(&mut self, ty: Ty<'tcx>) -> Type {
         // TODO: Remove all monomorphize calls
-        let normalized =
-            self.tcx.normalize_erasing_regions(ty::TypingEnv::fully_monomorphized(), ty);
+        let normalized = self
+            .tcx
+            .normalize_erasing_regions(ty::TypingEnv::fully_monomorphized(), Unnormalized::new(ty));
         let goto_typ = self.codegen_ty_inner(normalized);
         if let Some(tag) = goto_typ.tag() {
             self.type_map.entry(tag).or_insert_with(|| {
@@ -1046,8 +1048,10 @@ impl<'tcx, 'r> GotocCtx<'tcx, 'r> {
     pub fn codegen_ty_ref(&mut self, pointee_type: Ty<'tcx>) -> Type {
         // Normalize pointee_type to remove projection and opaque types
         trace!(?pointee_type, "codegen_ty_ref");
-        let pointee_type =
-            self.tcx.normalize_erasing_regions(ty::TypingEnv::fully_monomorphized(), pointee_type);
+        let pointee_type = self.tcx.normalize_erasing_regions(
+            ty::TypingEnv::fully_monomorphized(),
+            Unnormalized::new(pointee_type),
+        );
 
         if !self.use_thin_pointer(pointee_type) {
             return self.codegen_fat_ptr(pointee_type);
@@ -1656,6 +1660,15 @@ impl<'tcx, 'r> GotocCtx<'tcx, 'r> {
                     trace!(?data_path, ?curr, ?s_name, ?components, "codegen_trait_receiver");
                     components
                 })
+            } else if matches!(curr.kind(), ty::Pat(..)) {
+                // A pattern type is codegen'd as a struct with a single tuple-like field holding
+                // the type it constrains, so rebuild it with the thin data pointer in that field.
+                self.ensure_struct(new_name, new_pretty_name, |_, _| {
+                    vec![DatatypeComponent::Field {
+                        name: GotocCtx::tuple_fld_name(0).intern(),
+                        typ: last_type.clone(),
+                    }]
+                })
             } else {
                 unreachable!("Expected structs only {:?}", curr);
             }
@@ -1736,6 +1749,12 @@ impl<'tcx, 'r> GotocCtx<'tcx, 'r> {
                     self.curr = next;
                     assert!(non_zsts.next().is_none(), "Expected only one non-zst field.");
                     Some((name, self.curr))
+                } else if let ty::Pat(base_ty, _) = self.curr.kind() {
+                    // A pattern type is codegen'd as a struct with a single tuple-like field
+                    // holding the type it constrains. `NonNull` holds a
+                    // `pattern_type!(*const T is !null)`, so keep walking to reach the pointer.
+                    self.curr = *base_ty;
+                    Some((GotocCtx::tuple_fld_name(0), self.curr))
                 } else {
                     None
                 }

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/names.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/names.rs
@@ -6,7 +6,7 @@
 use crate::codegen_cprover_gotoc::GotocCtx;
 use cbmc::InternedString;
 use rustc_hir::def_id::LOCAL_CRATE;
-use rustc_middle::mir::mono::CodegenUnitNameBuilder;
+use rustc_middle::mono::CodegenUnitNameBuilder;
 use rustc_middle::ty::TyCtxt;
 use rustc_public::mir::Local;
 

--- a/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/utils/utils.rs
@@ -133,6 +133,48 @@ impl GotocCtx<'_, '_> {
         assert_eq!(components.len(), 0);
     }
 
+    /// Rebuild the chain of single-field struct wrappers described by `typ` around `ptr_expr`,
+    /// casting the pointer to the type found at the innermost level.
+    ///
+    /// A `NonNull<T>` holds a `pattern_type!(*const T is !null)`, and Kani codegens both the
+    /// `NonNull` and the pattern type as single-field structs, so the raw pointer sits two levels
+    /// deep. Recursing keeps this independent of how many wrappers the standard library uses.
+    pub fn codegen_ptr_in_wrappers(&self, typ: Type, ptr_expr: Expr) -> Expr {
+        if !typ.is_struct_like() {
+            return ptr_expr.cast_to(typ);
+        }
+        let components = typ.lookup_components(&self.symbol_table).unwrap();
+        let fields: Vec<_> = components.iter().filter(|c| !c.is_padding()).collect();
+        assert_eq!(
+            fields.len(),
+            1,
+            "Expected a single-field struct wrapping a pointer, but found {typ:?}"
+        );
+        let inner = self.codegen_ptr_in_wrappers(fields[0].typ(), ptr_expr);
+        Expr::struct_expr_from_values(typ, vec![inner], &self.symbol_table)
+    }
+
+    /// Extract the vtable pointer that `metadata_expr`, a `DynMetadata`, holds in its
+    /// `_vtable_ptr` field, and cast it to `vtable_typ`.
+    ///
+    /// This is the inverse of [`Self::codegen_ptr_in_wrappers`]: peel off the single-field struct
+    /// wrappers until the raw pointer is reached.
+    pub fn codegen_ptr_out_of_wrappers(&self, metadata_expr: Expr, vtable_typ: Type) -> Expr {
+        let mut expr = metadata_expr.member("_vtable_ptr", &self.symbol_table);
+        while expr.typ().is_struct_like() {
+            let components = expr.typ().lookup_components(&self.symbol_table).unwrap();
+            let fields: Vec<_> = components.iter().filter(|c| !c.is_padding()).collect();
+            assert_eq!(
+                fields.len(),
+                1,
+                "Expected a single-field struct wrapping a pointer, but found {:?}",
+                expr.typ()
+            );
+            expr = expr.member(fields[0].name(), &self.symbol_table);
+        }
+        expr.cast_to(vtable_typ)
+    }
+
     /// Best effort check if the struct represents a Rust `Box`. May return false positives.
     fn assert_is_rust_box_like(&self, t: &Type) {
         // struct std::boxed::Box<[u8; 8]>::15334369982748499855

--- a/kani-compiler/src/kani_middle/codegen_units.rs
+++ b/kani-compiler/src/kani_middle/codegen_units.rs
@@ -206,7 +206,7 @@ impl CodegenUnits {
 }
 
 fn stub_def(tcx: TyCtxt, def_id: DefId) -> FnDef {
-    let ty_internal = tcx.type_of(def_id).instantiate_identity();
+    let ty_internal = tcx.type_of(def_id).instantiate_identity().skip_normalization();
     let ty = rustc_internal::stable(ty_internal);
     if let TyKind::RigidTy(RigidTy::FnDef(def, _)) = ty.kind() {
         def
@@ -481,7 +481,8 @@ fn impl_derived_candidates(tcx: TyCtxt, def: FnDef) -> FxHashMap<usize, Vec<Ty>>
             let slot = candidates.entry(param_ty.index as usize).or_default();
             for impls in tcx.trait_impls_of(trait_pred.def_id()).non_blanket_impls().values() {
                 for &impl_def_id in impls {
-                    let self_ty = tcx.type_of(impl_def_id).instantiate_identity();
+                    let self_ty =
+                        tcx.type_of(impl_def_id).instantiate_identity().skip_normalization();
                     // Only fully concrete self types can be substituted directly.
                     if rustc_middle::ty::TypeVisitableExt::has_param(&self_ty) {
                         continue;
@@ -514,7 +515,12 @@ fn args_satisfy_predicates(tcx: TyCtxt, def: FnDef, args: &GenericArgs) -> bool 
     let args_internal = rustc_internal::internal(tcx, args);
     let predicates = tcx.predicates_of(def_id).instantiate(tcx, args_internal);
     for (predicate, _span) in predicates {
-        ocx.register_obligation(Obligation::new(tcx, cause.clone(), param_env, predicate));
+        ocx.register_obligation(Obligation::new(
+            tcx,
+            cause.clone(),
+            param_env,
+            predicate.skip_normalization(),
+        ));
     }
     ocx.evaluate_obligations_error_on_ambiguity().is_empty()
 }

--- a/kani-compiler/src/kani_middle/coercion.rs
+++ b/kani-compiler/src/kani_middle/coercion.rs
@@ -225,6 +225,19 @@ impl Iterator for CoerceUnsizedIterator<'_> {
                 self.dst_ty = Some(dst_fields[coerce_index].ty_with_args(dst_args));
                 Some(src_fields[coerce_index].name.clone())
             }
+            (
+                TyKind::RigidTy(RigidTy::Pat(src_base_ty, _)),
+                TyKind::RigidTy(RigidTy::Pat(dst_base_ty, _)),
+            ) => {
+                // A pattern type has the same layout as the type it constrains, and it is
+                // codegen'd as a struct with a single tuple-like field holding that base type.
+                // `NonNull<T>` wraps a `pattern_type!(*const T is !null)`, so the pointer that
+                // carries the metadata sits one field deeper. Traverse into it so that the base
+                // case below sees the underlying pointer.
+                self.src_ty = Some(src_base_ty);
+                self.dst_ty = Some(dst_base_ty);
+                Some("0".to_string())
+            }
             _ => {
                 // Base case is always a pointer (Box, raw_pointer or reference).
                 assert!(

--- a/kani-compiler/src/kani_middle/intrinsics.rs
+++ b/kani-compiler/src/kani_middle/intrinsics.rs
@@ -80,7 +80,7 @@ impl<'tcx> ModelIntrinsics<'tcx> {
             let Operand::Constant(fn_def) = func else { unreachable!() };
             fn_def.const_ = mirConst::from_value(
                 ConstValue::ZeroSized,
-                tcx.type_of(stub_id).instantiate(tcx, &*new_gen_args),
+                tcx.type_of(stub_id).instantiate(tcx, &*new_gen_args).skip_normalization(),
             );
         } else {
             debug!(?arg_ty, "replace_simd_bitmask failed");

--- a/kani-compiler/src/kani_middle/mod.rs
+++ b/kani-compiler/src/kani_middle/mod.rs
@@ -37,10 +37,12 @@ pub fn readable_name(instance: Instance) -> String {
 
 /// If `ty` is `NonNull<T>`, return `T`.
 ///
-/// `NonNull<T>` is `repr(transparent)` over `*const T`, so it holds exactly the same address. The
-/// Rust allocation shims (`__rust_dealloc`, `__rust_realloc`) took their pointer arguments as
-/// `*mut u8` until nightly-2026-03-21 and as `NonNull<u8>` afterwards, so code that reasons about
-/// those arguments as pointers has to see through the wrapper.
+/// `NonNull<T>` is `repr(transparent)` over a single field holding a `*const T`, so it holds
+/// exactly the same address. That field is a bare `*const T` up to nightly-2026-04-01 and a
+/// `pattern_type!(*const T is !null)` afterwards, so reaching the pointer can take more than one
+/// projection. The Rust allocation shims (`__rust_dealloc`, `__rust_realloc`) took their pointer
+/// arguments as `*mut u8` until nightly-2026-03-21 and as `NonNull<u8>` afterwards, so code that
+/// reasons about those arguments as pointers has to see through the wrapper.
 pub fn nonnull_pointee(ty: Ty) -> Option<Ty> {
     let TyKind::RigidTy(RigidTy::Adt(def, args)) = ty.kind() else { return None };
     if !matches!(def.name().as_str(), "core::ptr::NonNull" | "std::ptr::NonNull") {

--- a/kani-compiler/src/kani_middle/stubbing/mod.rs
+++ b/kani-compiler/src/kani_middle/stubbing/mod.rs
@@ -183,7 +183,8 @@ pub fn check_compatibility(tcx: TyCtxt, old_def: FnDef, new_def: FnDef) -> Resul
     let new_ret_ty = new_body.ret_local().ty;
     let old_ret_internal = rustc_internal::internal(tcx, old_ret_ty);
     let new_ret_internal = rustc_internal::internal(tcx, new_ret_ty);
-    let new_ret_renamed = EarlyBinder::bind(new_ret_internal).instantiate(tcx, rename_args);
+    let new_ret_renamed =
+        EarlyBinder::bind(new_ret_internal).instantiate(tcx, rename_args).skip_normalization();
 
     let mut diff = vec![];
     // Error messages show the user's original types (before renaming) for clarity.
@@ -195,7 +196,8 @@ pub fn check_compatibility(tcx: TyCtxt, old_def: FnDef, new_def: FnDef) -> Resul
     {
         let old_ty_internal = rustc_internal::internal(tcx, old_arg.ty);
         let new_ty_internal = rustc_internal::internal(tcx, new_arg.ty);
-        let new_renamed = EarlyBinder::bind(new_ty_internal).instantiate(tcx, rename_args);
+        let new_renamed =
+            EarlyBinder::bind(new_ty_internal).instantiate(tcx, rename_args).skip_normalization();
         if old_ty_internal != new_renamed {
             diff.push(format!(
                 "Expected type `{}` for parameter {}, but found `{}`",

--- a/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/mod.rs
+++ b/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/mod.rs
@@ -90,7 +90,9 @@ fn is_harness(instance: Instance, tcx: TyCtxt) -> bool {
         ],
     ];
     harness_identifiers.iter().any(|attr_path| {
-        tcx.has_attrs_with_path(rustc_internal::internal(tcx, instance.def.def_id()), attr_path)
+        tcx.get_attrs_by_path(rustc_internal::internal(tcx, instance.def.def_id()), attr_path)
+            .next()
+            .is_some()
     })
 }
 

--- a/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
+++ b/kani-compiler/src/kani_middle/transform/check_uninit/ptr_uninit/uninit_visitor.rs
@@ -17,8 +17,8 @@ use crate::{
 };
 use rustc_public::{
     mir::{
-        AggregateKind, CastKind, LocalDecl, MirVisitor, Mutability, NonDivergingIntrinsic, Operand,
-        Place, PointerCoercion, ProjectionElem, Rvalue, Statement, StatementKind, Terminator,
+        AggregateKind, CastKind, LocalDecl, MirVisitor, NonDivergingIntrinsic, Operand, Place,
+        PointerCoercion, ProjectionElem, Rvalue, Statement, StatementKind, Terminator,
         TerminatorKind,
         alloc::GlobalAlloc,
         mono::{Instance, InstanceKind},
@@ -714,17 +714,45 @@ fn try_resolve_instance(locals: &[LocalDecl], func: &Operand) -> Result<Instance
 /// The pointer argument of an allocation shim, as a raw pointer.
 ///
 /// These shims take `NonNull<u8>` as of nightly-2026-03-21, where they previously took `*mut u8`.
-/// `NonNull<T>` is `repr(transparent)` over a single `*const T` field, so projecting that field
-/// yields the same address with the pointer type the shadow-memory models expect. Operands that are
-/// already raw pointers, and any shape we cannot project, are passed through unchanged.
+/// `NonNull<T>` holds the address in a single field, which as of nightly-2026-05-01 is a
+/// `pattern_type!(*const T is !null)` rather than a bare `*const T`. Project through those
+/// single-field wrappers until the raw pointer is reached, so that the shadow-memory models see the
+/// same address with the pointer type they expect. Operands that are already raw pointers, and any
+/// shape we cannot project all the way down to a pointer, are passed through unchanged.
 fn raw_ptr_arg(arg: &Operand, locals: &[LocalDecl]) -> Operand {
     let Ok(arg_ty) = arg.ty(locals) else { return arg.clone() };
-    let Some(pointee) = nonnull_pointee(arg_ty) else { return arg.clone() };
+    if nonnull_pointee(arg_ty).is_none() {
+        return arg.clone();
+    }
     let place = match arg {
         Operand::Copy(place) | Operand::Move(place) => place,
         Operand::Constant(_) | Operand::RuntimeChecks(_) => return arg.clone(),
     };
     let mut projection = place.projection.clone();
-    projection.push(ProjectionElem::Field(0, Ty::new_ptr(pointee, Mutability::Not)));
+    let mut curr_ty = arg_ty;
+    while !curr_ty.kind().is_raw_ptr() {
+        let Some(field_ty) = single_field_ty(curr_ty) else { return arg.clone() };
+        projection.push(ProjectionElem::Field(0, field_ty));
+        curr_ty = field_ty;
+    }
     Operand::Copy(Place { local: place.local, projection })
+}
+
+/// The type held by `ty`'s only field, if `ty` is a single-field wrapper.
+///
+/// This sees through both structs with exactly one field (such as `NonNull`) and pattern types,
+/// which hold the type they constrain in a single tuple-like field.
+fn single_field_ty(ty: Ty) -> Option<Ty> {
+    match ty.kind() {
+        TyKind::RigidTy(RigidTy::Adt(def, args)) => {
+            let variant = def.variants_iter().next()?;
+            let fields = variant.fields();
+            if fields.len() != 1 {
+                return None;
+            }
+            Some(fields[0].ty_with_args(&args))
+        }
+        TyKind::RigidTy(RigidTy::Pat(base_ty, _)) => Some(base_ty),
+        _ => None,
+    }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2026-04-01"
+channel = "nightly-2026-05-01"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tools/compiletest/src/main.rs
+++ b/tools/compiletest/src/main.rs
@@ -263,6 +263,10 @@ pub fn run_tests(config: Config) {
         return;
     }
 
+    // `run_tests_console` now takes a tagged list. compiletest collects tests by walking
+    // directories, so the order is not by name and must be reported as `Unsorted`: the
+    // harness binary-searches a list tagged `Sorted`.
+    let tests = test::TestList::new(tests, test::TestListOrder::Unsorted);
     let res = test::run_tests_console(&opts, tests);
     match res {
         Ok(true) => {}

--- a/tools/scanner/src/analysis.rs
+++ b/tools/scanner/src/analysis.rs
@@ -140,7 +140,7 @@ impl OverallStats {
     }
 
     /// Iterate over all functions defined in this crate and log any unsafe operation.
-    pub fn unsafe_operations(&mut self, filename: PathBuf) {
+    pub fn unsafe_operations(&mut self, filename: PathBuf, tcx: &TyCtxt) {
         let all_items = rustc_public::all_local_items();
         let (has_unsafe, no_unsafe) = all_items
             .into_iter()
@@ -149,7 +149,8 @@ impl OverallStats {
                 if !kind.is_fn() {
                     return None;
                 };
-                let unsafe_ops = FnUnsafeOperations::new(item.name()).collect(&item.expect_body());
+                let unsafe_ops =
+                    FnUnsafeOperations::new(item.name()).collect(&item.expect_body(), tcx);
                 let fn_sig = kind.fn_sig().unwrap();
                 let is_unsafe = fn_sig.skip_binder().safety == Safety::Unsafe;
                 self.fn_stats.get_mut(&item).unwrap().has_unsafe_ops =
@@ -434,8 +435,8 @@ fn_props! {
 }
 
 impl FnUnsafeOperations {
-    pub fn collect(self, body: &Body) -> FnUnsafeOperations {
-        let mut visitor = BodyVisitor { props: self, body };
+    pub fn collect(self, body: &Body, tcx: &TyCtxt) -> FnUnsafeOperations {
+        let mut visitor = BodyVisitor { props: self, body, tcx };
         visitor.visit_body(body);
         visitor.props
     }
@@ -450,12 +451,13 @@ impl FnUnsafeOperations {
     }
 }
 
-struct BodyVisitor<'a> {
+struct BodyVisitor<'a, 'tcx> {
     props: FnUnsafeOperations,
     body: &'a Body,
+    tcx: &'a TyCtxt<'tcx>,
 }
 
-impl MirVisitor for BodyVisitor<'_> {
+impl MirVisitor for BodyVisitor<'_, '_> {
     fn visit_terminator(&mut self, term: &Terminator, location: Location) {
         match &term.kind {
             TerminatorKind::Call { func, .. } => {
@@ -522,7 +524,12 @@ impl MirVisitor for BodyVisitor<'_> {
                 }
             }
             ProjectionElem::Field(_, ty) => {
-                if ty.kind().is_union() {
+                // Check union-ness on the internal representation. The field type may be an
+                // un-normalized alias, and `rustc_public` cannot yet convert those to their stable
+                // representation, so calling the stable `Ty::kind()` on one panics. The internal
+                // representation is always safe to inspect, and reports an alias as not a union,
+                // which is what the stable `TyKind::Alias` did before it became unconvertible.
+                if rustc_internal::internal(*self.tcx, ty).is_union() {
                     self.props.unsafe_union_access += 1;
                 }
             }

--- a/tools/scanner/src/call_graph.rs
+++ b/tools/scanner/src/call_graph.rs
@@ -8,6 +8,7 @@
 //! the call-graph could be reused by different analysis.
 
 use crate::analysis::{FnCallVisitor, FnUnsafeOperations, OverallStats};
+use rustc_middle::ty::TyCtxt;
 use rustc_public::mir::{MirVisitor, Safety};
 use rustc_public::ty::{FnDef, RigidTy, Ty, TyKind};
 use rustc_public::{CrateDef, CrateDefType};
@@ -23,10 +24,12 @@ impl OverallStats {
     /// - 0 if this function contains unsafe code (including invoking unsafe fns).
     /// - 1 if this function calls a safe abstraction.
     /// - 2+ if this function calls other functions that call safe abstractions.
-    pub fn unsafe_distance(&mut self, filename: PathBuf) {
+    pub fn unsafe_distance(&mut self, filename: PathBuf, tcx: &TyCtxt) {
         let all_items = rustc_public::all_local_items();
-        let mut queue =
-            all_items.into_iter().filter_map(|item| Node::try_new(item.ty())).collect::<Vec<_>>();
+        let mut queue = all_items
+            .into_iter()
+            .filter_map(|item| Node::try_new(item.ty(), tcx))
+            .collect::<Vec<_>>();
         // Build call graph
         let mut call_graph = CallGraph::default();
         while let Some(node) = queue.pop() {
@@ -37,7 +40,7 @@ impl OverallStats {
                 };
                 let mut visitor = FnCallVisitor { body: &body, fns: vec![] };
                 visitor.visit_body(&body);
-                queue.extend(visitor.fns.iter().map(|def| Node::try_new(def.ty()).unwrap()));
+                queue.extend(visitor.fns.iter().map(|def| Node::try_new(def.ty(), tcx).unwrap()));
                 for callee in &visitor.fns {
                     call_graph.rev_edges.entry(*callee).or_default().push(node.def)
                 }
@@ -79,13 +82,13 @@ struct Node {
 }
 
 impl Node {
-    fn try_new(ty: Ty) -> Option<Node> {
+    fn try_new(ty: Ty, tcx: &TyCtxt) -> Option<Node> {
         let kind = ty.kind();
         let TyKind::RigidTy(RigidTy::FnDef(def, _)) = kind else {
             return None;
         };
         let has_unsafe = if let Some(body) = def.body() {
-            let unsafe_ops = FnUnsafeOperations::new(def.name()).collect(&body);
+            let unsafe_ops = FnUnsafeOperations::new(def.name()).collect(&body, tcx);
             unsafe_ops.has_unsafe()
         } else {
             true

--- a/tools/scanner/src/lib.rs
+++ b/tools/scanner/src/lib.rs
@@ -99,10 +99,10 @@ fn analyze_crate(tcx: TyCtxt, analyses: &[Analysis]) -> ControlFlow<()> {
                 crate_stats.safe_fns(out_path);
             }
             Analysis::InputTys => crate_stats.supported_inputs(out_path),
-            Analysis::UnsafeOps => crate_stats.unsafe_operations(out_path),
+            Analysis::UnsafeOps => crate_stats.unsafe_operations(out_path, &tcx),
             Analysis::FnLoops => crate_stats.loops(out_path),
             Analysis::Recursion => crate_stats.recursion(out_path),
-            Analysis::UnsafeDistance => crate_stats.unsafe_distance(out_path),
+            Analysis::UnsafeDistance => crate_stats.unsafe_distance(out_path, &tcx),
             Analysis::PublicFns => crate_stats.public_fns(&tcx),
         }
     }


### PR DESCRIPTION
### Description

Bumps `rust-toolchain.toml` from `nightly-2026-04-01` to `nightly-2026-05-01`.

#### What changed upstream, and what it required here

**1. `NonNull<T>` now holds a pattern type.** This is the root cause of most of the breakage:

```rust
// nightly-2026-04-01
pub struct NonNull<T: PointeeSized> { pointer: *const T }
// nightly-2026-05-01
pub struct NonNull<T: PointeeSized> { pointer: crate::pattern_type!(*const T is !null) }
```

Kani codegens a pattern type as a struct with a single tuple-like field holding the type it constrains, so the raw pointer behind `NonNull` moved one level deeper. Five places assumed a fixed nesting depth, and because `DynMetadata` holds a `NonNull<VTable>` this reached vtable/metadata codegen too:

| File | Change |
| --- | --- |
| `kani_middle/coercion.rs` | New `RigidTy::Pat` arm in `CoerceUnsizedIterator::next`, so the unsize-coercion path steps through the pattern type (field `"0"`) and the base case reaches the real pointer. |
| `codegen/rvalue.rs` | `codegen_struct_unsized_coercion` accepts pattern types via a new `is_struct_like` (ADT *or* `Pat`, both codegen'd as assignable structs). Both `DynMetadata` sites use the new recursive helpers instead of hardcoded `.member("pointer")` / one-level `lookup_components()[0]`. |
| `utils/utils.rs` | New `codegen_ptr_in_wrappers` (wrap a pointer in N single-field struct layers) and `codegen_ptr_out_of_wrappers` (peel them off). |
| `codegen/typ.rs` | `receiver_data_path` walks through pattern types; `codegen_trait_receiver`'s rebuild handles a `Pat` path element. |
| `codegen/place.rs` | `codegen_field` projects into a pattern type (reads field `"0"`) instead of `unreachable!`. Rust itself forbids this projection, but Kani synthesizes one in `raw_ptr_arg`, so it must be supported. |
| `check_uninit/.../uninit_visitor.rs` | `raw_ptr_arg` derives its projection chain from the actual field types via a new `single_field_ty`, looping until it reaches a raw pointer, instead of pushing one hardcoded `Field(0, *const T)`. |

All of these are written to be **depth-agnostic** rather than adding one more hop. `raw_ptr_arg` had already broken once on exactly this assumption (when the allocation shims switched from `*mut u8` to `NonNull<u8>` in nightly-2026-03-21), so hardcoding the new depth would only defer the next break.

**2. `rustc_public` lost the `ty::Alias` stable conversion.** The alias kind moved into `AliasTy` and the conversion was left as `todo!()`, so the stable `Ty::kind()` now panics on an un-normalized alias. `kani-compiler` normalizes before inspecting types and is unaffected; the `scanner` tool does not, so it ICE'd. `tools/scanner/src/{lib,analysis,call_graph}.rs` now thread `TyCtxt` down to `BodyVisitor`/`Node::try_new` so the union check uses `rustc_internal::internal(tcx, ty).is_union()`. The internal representation reports an alias as not-a-union, which is exactly what the stable `TyKind::Alias` did before it became unconvertible, so behaviour is preserved rather than just the crash avoided. **Worth reporting upstream.**

**3. Assorted API changes:**

| Change | Site |
| --- | --- |
| `rustc_middle::mir::mono::CodegenUnitNameBuilder` moved to `rustc_middle::mono` | `utils/names.rs` |
| `type_of(..).instantiate*()` and `predicates_of(..).instantiate(..)` now return an unnormalized wrapper; need `.skip_normalization()` | `codegen_units.rs`, `intrinsics.rs`, `stubbing/mod.rs`, `codegen/typ.rs` |
| `tcx.has_attrs_with_path` removed; use `get_attrs_by_path(..).next().is_some()` | `check_uninit/ptr_uninit/mod.rs` |
| `test::run_tests_console` now takes a `TestList` tagged with an ordering | `tools/compiletest/src/main.rs` |

On the compiletest change: the list must be tagged `Unsorted`. compiletest collects tests by walking directories, so it is not name-ordered, and the harness binary-searches a list tagged `Sorted`.

#### Note on a previously-suspected regression

An earlier pass on this upgrade flagged `tests/cargo-kani/mir-linker` as a genuine non-termination regression (`memchr_naive` unwinding 3400+ times against a 4.4s baseline on 04-01). **It is not a regression.** I reduced it to a standalone reproducer with the same harness and pinned dependency versions: `semver 1.0.22` hangs, `semver 1.0.28` verifies in seconds. That test's manifest requires only `semver = "1.0"`, and `tests/cargo-kani/.gitignore` ignores `Cargo.lock`, so no lockfile is tracked — the 1.0.22 pin was a stale local artifact. A fresh checkout resolves the newest `1.0.x` and the test passes; after refreshing the local lockfile it reports `VERIFICATION:- SUCCESSFUL` with 40 unwinding lines. No code change was needed, and the full `cargo-kani` suite is 71/71.

There is also an optional follow-up cleanup, deliberately left out to keep this diff focused: `PatternKind::NotNull` became convertible in 05-01, which makes the internal-representation workaround in `check_uninit/../check_values.rs` (`is_pattern_type`, added for nightly-2026-03-01) redundant. It is still correct.

### Testing

Local, macOS aarch64, CBMC 6.10.0 (`cbmc-6.9.0-214-g45436eea34`):

| Suite | Result |
| --- | --- |
| `kani` | **607 passed**, 0 failed, 23 ignored |
| `cargo-kani` | **71 passed**, 0 failed (previously 70/71, see above) |
| `script-based-pre` | **66 passed**, 0 failed, 1 ignored (includes `tool-scanner`, which covers the `ty::Alias` fix, and `verify_std_cmd`) |
| `std-checks` | **5 passed**, 0 failed (this suite was never run on the earlier pass) |
| `cargo-ui` | 30 passed, 0 failed |
| `coverage` | 20 passed, 0 failed |
| `expected` (targeted: `dynamic-trait`, `uninit`) | 28 passed, 0 failed |
| `kani` (targeted: `DynTrait`, `Uninit`) | 35 passed, 0 failed |

Other gates, all clean:

- `cargo build-dev`
- `cargo build-dev -- --features cprover --features llbc`
- `cargo clippy --workspace --tests`
- `./scripts/kani-fmt.sh --check`
- Unit tests: `cprover_bindings`, `kani-compiler`, `kani-driver`, `kani_metadata`

I ran targeted subsets rather than the full remaining suites (`expected`, `ui`, `firecracker`, `prusti`, `smack`, `kani-fixme`, `cargo-coverage`, `kani-docs`) locally, since CI covers those. Two caveats on local runs: this CBMC build has no `cadical`, so `ui/solver-{attribute,option}/cadical` fail locally on output text only, and `expected/shadow/slices/slice_split` is very slow under the MiniSat fallback. Both are expected to be clean on CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
