### PR TITLE
Link independent harness models in parallel

### DIFF
--- a/kani-driver/src/args/mod.rs
+++ b/kani-driver/src/args/mod.rs
@@ -439,6 +439,25 @@ pub enum NumThreads {
 }
 
 impl NumThreads {
+    /// Build a Rayon thread pool with this job count.
+    pub(crate) fn build_thread_pool(
+        self,
+    ) -> Result<rayon::ThreadPool, rayon::ThreadPoolBuildError> {
+        let mut builder = rayon::ThreadPoolBuilder::new();
+        match self {
+            Self::UserSpecified(num_threads) => {
+                builder = builder.num_threads(num_threads);
+            }
+            Self::NoMultithreading => {
+                builder = builder.num_threads(1);
+            }
+            Self::ThreadPoolDefault => {
+                // Rayon uses its default number of threads.
+            }
+        }
+        builder.build()
+    }
+
     /// Checks if this will spawn multiple threads in the pool.
     pub fn will_multithread(&self) -> bool {
         match self {

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -8,7 +8,7 @@ use std::fs::File;
 use std::io::{IsTerminal, Write};
 use std::path::Path;
 
-use crate::args::{NumThreads, OutputFormat};
+use crate::args::OutputFormat;
 use crate::call_cbmc::{VerificationResult, VerificationStatus};
 use crate::frontend::{JsonHandler, schema_utils::add_runner_results_to_json};
 use crate::progress_indicator::ProgressIndicator;
@@ -75,20 +75,7 @@ impl<'pr> HarnessRunner<'_, 'pr> {
         // Create progress indicator
         let progress_indicator = ProgressIndicator::new(sorted_harnesses.len(), show_progress);
 
-        let pool = {
-            let mut builder = rayon::ThreadPoolBuilder::new();
-            match self.sess.args.jobs() {
-                NumThreads::UserSpecified(num_threads) => {
-                    builder = builder.num_threads(num_threads);
-                }
-                NumThreads::NoMultithreading => {
-                    builder = builder.num_threads(1);
-                }
-                NumThreads::ThreadPoolDefault => { /* rayon will automatically set num_threads to the default if not specified here */
-                }
-            }
-            builder.build()?
-        };
+        let pool = self.sess.args.jobs().build_thread_pool()?;
 
         let results = pool.install(|| -> Result<Vec<HarnessResult<'pr>>> {
             sorted_harnesses

--- a/kani-driver/src/project.rs
+++ b/kani-driver/src/project.rs
@@ -68,6 +68,7 @@ where
     let unique_destinations = link_jobs.iter().all(|job| destinations.insert(&job.output));
 
     if link_jobs.len() > 1 && jobs.will_multithread() && unique_destinations {
+        // Safe because each link only writes its own output; shared libraries are read-only.
         jobs.build_thread_pool()?.install(|| link_jobs.par_iter().map(execute).collect())
     } else {
         link_jobs.iter().map(execute).collect()
@@ -127,12 +128,10 @@ impl Project {
                 crate_metadata.test_harnesses.iter().chain(crate_metadata.proof_harnesses.iter())
             })
             .map(|harness| {
-                let input = harness
-                    .goto_file
-                    .as_ref()
-                    .expect("Expected a model file")
-                    .canonicalize()
-                    .context("Failed to canonicalize a harness model")?;
+                let model_path = harness.goto_file.as_ref().expect("Expected a model file");
+                let input = model_path.canonicalize().with_context(|| {
+                    format!("Failed to canonicalize harness model {}", model_path.display())
+                })?;
                 let output = convert_type(&input, SymTabGoto, Goto);
                 Ok(LinkJob { input, output })
             })

--- a/kani-driver/src/project.rs
+++ b/kani-driver/src/project.rs
@@ -4,6 +4,7 @@
 //! The goal is to provide one project view independent on the build system (cargo / standalone
 //! rustc) and its configuration (e.g.: linker type).
 
+use crate::args::NumThreads;
 use crate::metadata::from_json;
 use crate::session::KaniSession;
 use crate::util::{crate_name, info_operation};
@@ -11,6 +12,8 @@ use anyhow::{Context, Result};
 use kani_metadata::{
     ArtifactType, ArtifactType::*, HarnessMetadata, KaniMetadata, artifact::convert_type,
 };
+use rayon::prelude::*;
+use std::collections::HashSet;
 use std::env::current_dir;
 use std::fs;
 use std::ops::Deref;
@@ -42,6 +45,33 @@ pub struct Project {
     artifacts: Vec<Artifact>,
     /// Records the cargo metadata from the build, if there was any
     pub cargo_metadata: Option<cargo_metadata::Metadata>,
+}
+
+/// One model link whose input has been canonicalized before any work starts.
+#[derive(Debug)]
+struct LinkJob {
+    input: PathBuf,
+    output: PathBuf,
+}
+
+/// Execute independent model links with the configured verification job count.
+///
+/// The indexed parallel iterator preserves input order. If output paths are shared, or the user
+/// selected serial verification, use a regular iterator so two linkers can never write the same
+/// model concurrently.
+fn execute_link_jobs<T, F>(link_jobs: &[LinkJob], jobs: NumThreads, execute: F) -> Result<Vec<T>>
+where
+    T: Send,
+    F: Fn(&LinkJob) -> Result<T> + Send + Sync,
+{
+    let mut destinations = HashSet::with_capacity(link_jobs.len());
+    let unique_destinations = link_jobs.iter().all(|job| destinations.insert(&job.output));
+
+    if link_jobs.len() > 1 && jobs.will_multithread() && unique_destinations {
+        jobs.build_thread_pool()?.install(|| link_jobs.par_iter().map(execute).collect())
+    } else {
+        link_jobs.iter().map(execute).collect()
+    }
 }
 
 impl Project {
@@ -91,32 +121,43 @@ impl Project {
     ) -> Result<Self> {
         // For each harness (test or proof) from each metadata, read the path for the goto
         // SymTabGoto file. Use that path to find all the other artifacts.
-        let mut artifacts = vec![];
-        for crate_metadata in &metadata {
-            for harness_metadata in
+        let link_jobs = metadata
+            .iter()
+            .flat_map(|crate_metadata| {
                 crate_metadata.test_harnesses.iter().chain(crate_metadata.proof_harnesses.iter())
-            {
-                let symtab_out = Artifact::try_new(
-                    harness_metadata.goto_file.as_ref().expect("Expected a model file"),
-                    SymTabGoto,
-                )?;
-                let goto_path = convert_type(&symtab_out.path, symtab_out.typ, Goto);
+            })
+            .map(|harness| {
+                let input = harness
+                    .goto_file
+                    .as_ref()
+                    .expect("Expected a model file")
+                    .canonicalize()
+                    .context("Failed to canonicalize a harness model")?;
+                let output = convert_type(&input, SymTabGoto, Goto);
+                Ok(LinkJob { input, output })
+            })
+            .collect::<Result<Vec<_>>>()?;
 
-                // Link
-                session.link_goto_binary(&[symtab_out.to_path_buf()], &goto_path)?;
-                let goto = Artifact::try_new(&goto_path, Goto)?;
+        let build_artifacts = |link_job: &LinkJob| -> Result<Vec<Artifact>> {
+            let symtab_out = Artifact { path: link_job.input.clone(), typ: SymTabGoto };
 
-                // All other harness artifacts that may have been generated as part of the build.
-                artifacts.extend(
-                    [SymTab, TypeMap, VTableRestriction, PrettyNameMap].iter().filter_map(|typ| {
-                        let artifact = Artifact::try_from(&symtab_out, *typ).ok()?;
-                        Some(artifact)
-                    }),
-                );
-                artifacts.push(symtab_out);
-                artifacts.push(goto);
-            }
-        }
+            session.link_goto_binary(&[symtab_out.to_path_buf()], &link_job.output)?;
+            let goto = Artifact::try_new(&link_job.output, Goto)?;
+
+            // All other harness artifacts that may have been generated as part of the build.
+            let mut artifacts = [SymTab, TypeMap, VTableRestriction, PrettyNameMap]
+                .iter()
+                .filter_map(|typ| Artifact::try_from(&symtab_out, *typ).ok())
+                .collect::<Vec<_>>();
+            artifacts.push(symtab_out);
+            artifacts.push(goto);
+            Ok(artifacts)
+        };
+
+        let artifacts = execute_link_jobs(&link_jobs, session.args.jobs(), build_artifacts)?
+            .into_iter()
+            .flatten()
+            .collect();
 
         Ok(Project { outdir, input, metadata, artifacts, cargo_metadata })
     }
@@ -303,4 +344,103 @@ pub(crate) fn std_project(std_path: &Path, session: &KaniSession) -> Result<Proj
     // Get the metadata and return a Kani project.
     let metadata = outputs.iter().map(|md_file| from_json(md_file)).collect::<Result<Vec<_>>>()?;
     Project::try_new(session, outdir, None, metadata, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LinkJob, execute_link_jobs};
+    use crate::args::NumThreads;
+    use anyhow::Result;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    fn link_jobs(destinations: &[&str]) -> Vec<LinkJob> {
+        destinations
+            .iter()
+            .enumerate()
+            .map(|(index, destination)| LinkJob {
+                input: PathBuf::from(format!("{index}.symtab.out")),
+                output: PathBuf::from(destination),
+            })
+            .collect()
+    }
+
+    fn observe_concurrency(active: &AtomicUsize, peak: &AtomicUsize) {
+        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+        peak.fetch_max(current, Ordering::SeqCst);
+        thread::sleep(Duration::from_millis(25));
+        active.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn parallel_link_jobs_respect_job_limit_and_order() {
+        let link_jobs = link_jobs(&["0.out", "1.out", "2.out", "3.out"]);
+        let expected = execute_link_jobs(&link_jobs, NumThreads::UserSpecified(1), |job| {
+            Ok(job.input.clone())
+        })
+        .unwrap();
+        let active = AtomicUsize::new(0);
+        let peak = AtomicUsize::new(0);
+
+        let actual = execute_link_jobs(&link_jobs, NumThreads::UserSpecified(2), |job| {
+            observe_concurrency(&active, &peak);
+            Ok(job.input.clone())
+        })
+        .unwrap();
+
+        assert_eq!(actual, expected);
+        assert!(peak.load(Ordering::SeqCst) > 1);
+        assert!(peak.load(Ordering::SeqCst) <= 2);
+    }
+
+    #[test]
+    fn serial_job_settings_do_not_use_rayon_workers() {
+        let link_jobs = link_jobs(&["0.out", "1.out"]);
+        for jobs in [NumThreads::NoMultithreading, NumThreads::UserSpecified(1)] {
+            let used_rayon_worker = AtomicBool::new(false);
+            execute_link_jobs(&link_jobs, jobs, |_| {
+                used_rayon_worker
+                    .fetch_or(rayon::current_thread_index().is_some(), Ordering::SeqCst);
+                Ok(())
+            })
+            .unwrap();
+            assert!(!used_rayon_worker.load(Ordering::SeqCst));
+        }
+    }
+
+    #[test]
+    fn shared_destinations_are_linked_serially() {
+        let link_jobs = link_jobs(&["shared.out", "shared.out", "other.out"]);
+        let active = AtomicUsize::new(0);
+        let peak = AtomicUsize::new(0);
+        let used_rayon_worker = AtomicBool::new(false);
+
+        execute_link_jobs(&link_jobs, NumThreads::UserSpecified(2), |_| {
+            used_rayon_worker.fetch_or(rayon::current_thread_index().is_some(), Ordering::SeqCst);
+            observe_concurrency(&active, &peak);
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(peak.load(Ordering::SeqCst), 1);
+        assert!(!used_rayon_worker.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn parallel_link_failures_are_propagated() {
+        let link_jobs = link_jobs(&["0.out", "1.out", "2.out"]);
+
+        let error =
+            execute_link_jobs(&link_jobs, NumThreads::UserSpecified(2), |job| -> Result<()> {
+                if job.input == Path::new("1.symtab.out") {
+                    anyhow::bail!("synthetic link failure");
+                }
+                Ok(())
+            })
+            .unwrap_err();
+
+        assert_eq!(error.to_string(), "synthetic link failure");
+    }
 }

--- a/tests/script-based-pre/cargo_autoharness_parallel/parallel.expected
+++ b/tests/script-based-pre/cargo_autoharness_parallel/parallel.expected
@@ -1,5 +1,7 @@
 TERSE: yes
 PARALLEL: yes
+SERIAL: yes
+EQUIVALENT: yes
 | f1 | #[kani::proof] | Success
 | f2 | #[kani::proof] | Success
 | f3 | #[kani::proof] | Success

--- a/tests/script-based-pre/cargo_autoharness_parallel/parallel.sh
+++ b/tests/script-based-pre/cargo_autoharness_parallel/parallel.sh
@@ -5,31 +5,60 @@
 # Autoharness defaults to parallel verification (-j) with terse output. Harness results
 # arrive in nondeterministic order, so assert on order-independent evidence: the absence of
 # per-check detail, the thread prefixes, the (sorted) per-function summary lines, and the
-# totals line.
+# totals line. Then compare those structured summaries with an explicit --jobs=1 run.
 #
-# RAYON_NUM_THREADS pins the pool size, so the thread prefixes below appear regardless of how
-# much parallelism the machine (or its cgroup/CPU affinity) actually offers. This still checks
-# the default: rayon only consults the environment variable when the thread count is left
-# unset, which is exactly what the defaulted `--jobs` does -- sequential verification passes an
-# explicit `num_threads(1)` that overrides it.
-output=$(RAYON_NUM_THREADS=2 cargo kani autoharness -Z autoharness 2>&1)
+# RAYON_NUM_THREADS pins the default pool size, so the thread prefixes below appear regardless
+# of how much parallelism the machine (or its cgroup/CPU affinity) actually offers. Rayon only
+# consults the environment variable when the thread count is left unset; --jobs=1 must override
+# it and preserve the serial opt-out.
+if ! parallel_output=$(RAYON_NUM_THREADS=2 cargo kani autoharness -Z autoharness 2>&1); then
+    echo "$parallel_output"
+    exit 1
+fi
+if ! serial_output=$(RAYON_NUM_THREADS=2 cargo kani autoharness -Z autoharness --jobs=1 2>&1); then
+    echo "$serial_output"
+    exit 1
+fi
+
+normalized_results() {
+    local output=$1
+    {
+        echo "$output" | grep -oE '\| f[0-9] .*(Success|Failure)' | tr -s ' ' | sort
+        echo "$output" | grep "^Complete - "
+    }
+}
 
 # Terse output omits the per-check detail that `--output-format=regular` prints.
-if echo "$output" | grep -qE '^Check [0-9]+:'; then
+if echo "$parallel_output" | grep -qE '^Check [0-9]+:'; then
     echo "TERSE: no"
-    echo "$output"
+    echo "$parallel_output"
 else
     echo "TERSE: yes"
 fi
 
 # Harness results are prefixed with the thread that produced them when the pool has more than
 # one thread.
-if echo "$output" | grep -q "Thread [0-9]*:"; then
+if echo "$parallel_output" | grep -q "Thread [0-9]*:"; then
     echo "PARALLEL: yes"
 else
     echo "PARALLEL: no"
-    echo "$output"
+    echo "$parallel_output"
 fi
 
-echo "$output" | grep -oE '\| f[0-9] .*(Success|Failure)' | tr -s ' ' | sort
-echo "$output" | grep "^Complete - "
+if echo "$serial_output" | grep -q "Thread [0-9]*:"; then
+    echo "SERIAL: no"
+    echo "$serial_output"
+else
+    echo "SERIAL: yes"
+fi
+
+parallel_results=$(normalized_results "$parallel_output")
+serial_results=$(normalized_results "$serial_output")
+if [[ "$parallel_results" == "$serial_results" ]]; then
+    echo "EQUIVALENT: yes"
+else
+    echo "EQUIVALENT: no"
+    diff <(echo "$serial_results") <(echo "$parallel_results")
+fi
+
+echo "$parallel_results"


### PR DESCRIPTION
## Summary

Use Kani's existing verification job budget to link harness models concurrently only when every computed destination path is distinct. Shared or duplicate destinations, explicit serial settings, and single-link projects retain the existing serial path.

This also centralizes construction of the Rayon pool so linking and harness verification cannot interpret `--jobs` differently.

## Motivation

Autoharness can produce many independent symbol-table models. `Project::try_new` currently invokes `goto-cc` for each model serially before the already-parallel harness pipeline starts. Local process profiling identified that sequence as a measurable preparation boundary.

The change is intentionally conservative: it removes that boundary where independence can be established, without changing formulas, solver behavior, verification defaults, or the number of workers selected by Kani.

## Behavior and concurrency contract

- Canonicalize every model input and compute its final `.out` destination before starting any link.
- Use an indexed Rayon parallel iterator only when there is more than one link, the configured job setting permits parallelism, and all destination paths are unique.
- Fall back to a regular serial iterator if any destination is shared or uniqueness is otherwise not established.
- Preserve `NumThreads` exactly: omitted ordinary-Kani jobs remain serial, `--jobs=1` remains serial, `--jobs=N` uses exactly `N`, and Rayon's existing default remains the autoharness default.
- Collect artifact groups in metadata order even when links complete out of order.
- Propagate any link error and abort project construction.

The link and verification phases use separate stage-local pools, both built from the same existing `NumThreads` selection; this PR does not add workers to that selection.

## Correctness

Focused unit coverage exercises:

- a two-worker upper bound while proving indexed results match the serial order;
- both the ordinary serial setting and explicit `--jobs=1` without entering a Rayon worker;
- duplicate destinations forcing the complete link set down the serial path;
- a failure from a parallel link reaching the caller.

The existing autoharness script regression now also runs with explicit `--jobs=1` and compares normalized per-harness/final summaries with the parallel run.

Local validation on the current tree:

- `cargo build-dev`
- `cargo test -p kani-driver` (85 passed)
- `cargo clippy --workspace --tests -- -D warnings`
- `RUSTFLAGS="--cfg=kani_sysroot" cargo clippy --workspace -- -D warnings`
- `./scripts/kani-fmt.sh --check`
- `bash -n tests/script-based-pre/cargo_autoharness_parallel/parallel.sh`

The end-to-end script could not run to completion locally because this host does not currently have `goto-cc`/CBMC on `PATH`; the script now fails immediately rather than accepting an empty comparison. The normal Linux regression job supplies those dependencies.

## Benchmarks

These are end-to-end `cargo kani autoharness` measurements comparing current upstream behavior (`U`) with only independent linking added (`L`). Each cell is steady median seconds `[min–max]` / maximum aggregate process-tree RSS MiB. Control has seven retained steady samples; the other workloads have three. All samples were retained.

| Workload | U | L | Median change |
|---|---:|---:|---:|
| 24-proof control | 54.668 `[43.952–56.363]` / 346.5 | 51.633 `[42.812–55.823]` / 351.0 | **−5.6%** |
| Heterogeneous medium, 22 jobs | 20.419 `[18.610–22.240]` / 200.4 | 17.724 `[16.292–18.018]` / 184.5 | **−13.2%** |
| Memory-heavy formatting, 13 jobs | 19.880 `[18.098–21.500]` / 3,037.2 | 16.684 `[15.654–17.113]` / 3,050.5 | **−16.1%** |
| `num-traits` 0.2.19 constructor subset, 30 jobs | 6.854 `[5.999–7.164]` / 93.7 | 3.130 `[2.776–3.612]` / 110.7 | **−54.3%** |

Artifact-cold U→L samples were also directionally positive: control 53.296→46.162 s, medium 23.168→21.139 s, heavy 23.248→20.686 s, and the real subset 8.924→5.642 s. “Artifact-cold” means deleting the workload target, not flushing the macOS filesystem cache.

Common command (the real subset additionally used the shown include filter):

```bash
RAYON_NUM_THREADS=12 \
RUSTUP_TOOLCHAIN=nightly-2026-04-01-aarch64-apple-darwin \
PATH="<exact-state>/scripts:<cbmc-6.10.0-bin>:$PATH" \
cargo kani autoharness -Z autoharness -Z unstable-options \
  --solver cadical --output-format=terse --quiet \
  --harness-timeout 120s \
  [--include-pattern '::(zero|one)$'] \
  --export-json '<fresh-run-dir>/results.json'
```

The benchmark host was an Apple M3 Pro (`Mac15,7`), 12 cores (6 performance + 6 efficiency), 36 GiB RAM, macOS 26.5.2 arm64, CBMC 6.10.0/CaDiCaL, on battery and shared with other work. The new matrix interleaved states and used one cold plus three steady samples per state/workload.

All 60 new formal matrix runs exited successfully with fresh exports and equivalent structured output. No run timed out or hit its RSS stop, and no newly observed swapout or throttling occurred. The control exports covered 24/24 harnesses and 432/432 successful properties; medium covered 22/22 and 342/342; heavy covered 13/13 with all 29,003 property records identical; the real subset covered 30/30 constructors.

## Resource impact

The memory-heavy U→L maximum changed by +0.4% (+13.3 MiB), while medium decreased by 7.9%. The largest relative increase was the tiny real constructor subset (+18.1%), but that was +17.0 MiB absolute (93.7→110.7 MiB). Control increased by 4.5 MiB.

This does not increase Kani's configured worker budget. Concurrent linker processes can raise short-lived preparation RSS relative to serial linking, but measured heavy-workload memory remained dominated by solver processes.

## Non-goals

- No implicit worker oversubscription or default worker-count change.
- No fixed CPU-derived memory policy or memory-budget mechanism.
- No solver scheduling, solver selection, formula, unwind, or property change.
- No change to explicit `--jobs` semantics.

## Limitations

- Measurements are from one noisy, heterogeneous-core arm64 macOS host, not representative Linux x86_64 hardware. No non-emulated Linux x86_64 benchmark facility was available locally; I did not use architecture emulation. The PR CI is the available upstream-supported Linux x86_64 validation.
- The 5.6% control effect is modest and its ranges overlap substantially.
- The 54.3% `num-traits` result is a **limited 30-constructor, link-dominated subset**, not a full-crate result. Those constructors produced no property records. A full unfiltered `num-traits --list` attempt was stopped safely at 300.057 s and 909,392 KiB before a harness list appeared, so full-crate behavior remains unknown.
- No additional high-harness public crate was genuinely available within the bounded local setup.
- Medium/heavy/real series have three steady repetitions; RSS is sampled aggregate resident memory rather than proportional set size; swap counters are system-wide.
- The benchmark did not inject duplicate destinations or link failures; the new focused unit tests cover both paths.

## Reviewer question

Is the existing verification `--jobs` budget the right authority for linker concurrency, or should linking eventually have a separate explicit budget?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
