### PR TITLE
Derive the cargo output directory from cargo's reported artifacts

### DIFF
--- a/kani-driver/src/call_cargo.rs
+++ b/kani-driver/src/call_cargo.rs
@@ -28,8 +28,15 @@ use tracing::{debug, trace};
 
 /// The outputs of kani-compiler being invoked via cargo on a project.
 pub struct CargoOutputs {
-    /// The directory where compiler outputs should be directed.
-    /// Usually 'target/BUILD_TRIPLE/debug/deps/'
+    /// A directory holding compiler outputs for this build.
+    ///
+    /// Derived from the paths cargo reports for the artifacts it produced rather than assumed: the
+    /// layout under `target/` is cargo's to choose and has changed before. Up to cargo 1.98 every
+    /// artifact sat together in `target/kani/BUILD_TRIPLE/debug/deps/`; cargo 1.99 gives each
+    /// package its own `target/kani/BUILD_TRIPLE/debug/build/PKG/HASH/out/`.
+    ///
+    /// A multi-package build therefore no longer has a single output directory, so this names one
+    /// of them. To reach the artifacts themselves, use [`CargoOutputs::metadata`].
     pub outdir: PathBuf,
     /// The kani-metadata.json files written by kani-compiler.
     pub metadata: Vec<Artifact>,
@@ -142,7 +149,9 @@ crate-type = ["lib"]
             .unwrap_or(&metadata.target_directory.clone().into())
             .clone()
             .join("kani");
-        let outdir = target_dir.join(build_target).join("debug/deps");
+        // The directory to fall back on if the build turns out to produce no artifacts (see
+        // `CargoOutputs::outdir`). Computed here because `target_dir` is consumed below.
+        let profile_dir = target_dir.join(build_target).join("debug");
 
         if self.args.force_build && target_dir.exists() {
             fs::remove_dir_all(&target_dir)?;
@@ -254,6 +263,14 @@ crate-type = ["lib"]
         if !found_target {
             bail!("No supported targets were found.");
         }
+
+        // Report where cargo actually placed the artifacts rather than assuming a layout under
+        // `target/` (see `CargoOutputs::outdir`). With no artifacts there is no such directory to
+        // name, and the profile directory is the closest honest answer.
+        let outdir = artifacts
+            .first()
+            .and_then(|artifact| artifact.parent().map(Path::to_path_buf))
+            .unwrap_or(profile_dir);
 
         Ok(CargoOutputs { outdir, metadata: artifacts, cargo_metadata: metadata })
     }

--- a/kani-driver/src/frontend/schema_utils.rs
+++ b/kani-driver/src/frontend/schema_utils.rs
@@ -203,8 +203,9 @@ pub fn create_project_metadata_json(project: &Project) -> Value {
     .map(|m| m.crate_name.clone())
     .collect::<Vec<String>>(),
     // The real workspace root, which only exists for Cargo projects; null for a standalone run.
-    // `Project::outdir` is the compiler output directory -- for Cargo it sits under
-    // `target/<triple>/debug/deps` -- so reporting it as the workspace root was simply wrong.
+    // `Project::outdir` is the compiler output directory -- for Cargo it sits somewhere under
+    // `target/`, at a path of cargo's choosing -- so reporting it as the workspace root was
+    // simply wrong.
     "workspace_root": project.cargo_metadata.as_ref()
     .map(|metadata| metadata.workspace_root.clone()),
     "output_dir": project.outdir.clone(),

--- a/kani-driver/src/project.rs
+++ b/kani-driver/src/project.rs
@@ -33,8 +33,9 @@ use tracing::{debug, trace};
 pub struct Project {
     /// Each target crate metadata.
     pub metadata: Vec<KaniMetadata>,
-    /// The directory where all outputs should be directed to. This path represents the canonical
-    /// version of outdir.
+    /// The directory where all outputs should be directed to. This path is canonical whenever the
+    /// directory exists, since it is either canonicalized here or derived from an already-canonical
+    /// [`Artifact`] path.
     /// NOTE: This needs to be marked as dead_code even when it's clearly not
     #[allow(dead_code)]
     pub outdir: PathBuf,
@@ -221,7 +222,10 @@ pub fn cargo_project(session: &mut KaniSession, keep_going: bool) -> Result<Proj
         );
         return Ok(Project::default());
     }
-    let outdir = outputs.outdir.canonicalize()?;
+    // No `canonicalize` here: `CargoOutputs::outdir` is the parent of an artifact path, and
+    // `Artifact::try_new` canonicalizes, so it is already canonical. Canonicalizing would also turn
+    // the artifact-less fallback -- a directory cargo had no reason to create -- into a hard error.
+    let outdir = outputs.outdir;
     // For the MIR Linker we know there is only one metadata per crate. Use that in our favor.
     let metadata =
         outputs.metadata.iter().map(|md_file| from_json(md_file)).collect::<Result<Vec<_>>>()?;

--- a/tests/script-based-pre/cargo_playback_opts/playback_opts.expected
+++ b/tests/script-based-pre/cargo_playback_opts/playback_opts.expected
@@ -3,4 +3,4 @@
 [TEST] Only codegen test...
     Finished `test`
 [TEST] Executable
-debug/deps/sample_crate-
+/sample_crate-

--- a/tests/script-based-pre/cargo_playback_opts/playback_opts.sh
+++ b/tests/script-based-pre/cargo_playback_opts/playback_opts.sh
@@ -17,6 +17,8 @@ output=$(cargo kani playback -Z concrete-playback --only-codegen --message-forma
 executable=$(echo ${output} |
     jq 'select(.reason == "compiler-artifact") | select(.executable != null) | .executable')
 
+# Only the file name is asserted on: the directory cargo puts the executable in is cargo's to
+# choose, and it changed in cargo 1.99 (artifacts moved out of `debug/deps`).
 echo "[TEST] Executable"
 echo ${executable}
 

--- a/tests/script-based-pre/check-output/check-output.sh
+++ b/tests/script-based-pre/check-output/check-output.sh
@@ -10,21 +10,15 @@ echo
 
 # Test for platform
 PLATFORM=$(uname -sp)
-if [[ $PLATFORM == "Linux x86_64" ]]
-then
-  TARGET="x86_64-unknown-linux-gnu"
-elif [[ $PLATFORM == "Darwin i386" ]]
-then
-  TARGET="x86_64-apple-darwin"
-elif [[ $PLATFORM == "Darwin arm" ]]
-then
-  TARGET="aarch64-apple-darwin"
-else
-  echo
-  echo "Test only works on Linux or OSX platforms, skipping..."
-  echo
-  exit 0
-fi
+case "$PLATFORM" in
+  "Linux x86_64" | "Darwin i386" | "Darwin arm") ;;
+  *)
+    echo
+    echo "Test only works on Linux or OSX platforms, skipping..."
+    echo
+    exit 0
+    ;;
+esac
 
 export RUST_BACKTRACE=1
 cd $(dirname $0)
@@ -73,19 +67,21 @@ rm -rf build
 cargo kani --target-dir build --gen-c -Z unstable-options >& kani.log || \
     { ret=$?; echo "== Failed to run Kani"; cat kani.log; rm kani.log; exit 1; }
 rm -f kani.log
-cd build/kani/${TARGET}/debug/deps/
 
-mangled=$(ls multifile*main.c)
-if ! [ -e "${mangled}" ]
+# The generated C sits next to the build artifacts, at a path under `--target-dir` that cargo
+# picks and has changed before (cargo 1.99 moved artifacts out of `debug/deps`), so search the
+# target directory rather than hardcoding the layout.
+mangled=$(find build -name 'multifile*main.c' -print -quit)
+if [ -z "${mangled}" ]
 then
-    echo "Error: no GotoC file found. Expected: build/kani/${TARGET}/debug/deps/multifile*main.c"
+    echo "Error: no GotoC file found under build/. Expected: multifile*main.c"
     exit 1
 fi
 
-demangled=$(ls multifile*main.demangled.c)
-if ! [ -e "${demangled}" ]
+demangled=$(find build -name 'multifile*main.demangled.c' -print -quit)
+if [ -z "${demangled}" ]
 then
-    echo "Error: no demangled GotoC file found. Expected build/kani/${TARGET}/debug/deps/multifile*main.demangled.c."
+    echo "Error: no demangled GotoC file found under build/. Expected: multifile*main.demangled.c"
     exit 1
 fi
 


### PR DESCRIPTION
## Description

`cargo_build` hardcoded the compiler output directory as `target/kani/<triple>/debug/deps`, and `cargo_project` then canonicalized it. That layout is cargo's to choose, and **cargo 1.99 changes it**: artifacts no longer share `debug/deps` — each package gets its own `debug/build/PKG/HASH/out/` — so `debug/deps` is never created and the canonicalize fails:

```
error: No such file or directory (os error 2)
```

Artifact *discovery* was already layout-agnostic: `map_kani_artifact` derives every path from the `filenames` that cargo reports. The hardcoded directory was the only thing tying the driver to the old layout.

This PR:

- Derives `CargoOutputs::outdir` from the discovered artifacts instead of assuming a path.
- Drops the `canonicalize` in `cargo_project`. An artifact path is canonical already (`Artifact::try_new` canonicalizes), and the no-artifacts fallback names a directory cargo had no reason to create — canonicalizing it turns a benign case into a hard error.
- Makes two tests layout-agnostic: `check-output` searches the target directory for its `--gen-c` output, and `cargo_playback_opts` asserts only the *file name* of the executable whose path cargo itself reports.

Note that with cargo 1.99 a multi-package build no longer has a single output directory. `outdir` names one of them; it feeds only the `output_dir` field of the `-Z unstable-options` JSON frontend, and previously named a directory that under 1.99 does not exist at all. The doc comment says so explicitly.

The layout change, confirmed locally on nightly-2026-08-01 (cargo 1.99.0-nightly):

```
# cargo 1.97
target/kani/<triple>/debug/deps/<pkg>-<hash>.kani-metadata.json

# cargo 1.99 -- one directory per package, no debug/deps at all
target/kani/<triple>/debug/build/<pkg>/<hash>/out/<pkg>-<hash>.kani-metadata.json
```

## Why this is a standalone PR

This unblocks the toolchain upgrade chain. It has no dependency on any toolchain bump and is behaviour-preserving on the current toolchain, so it can land on its own. The intended order is #4760 (2026-06-01) → #4764 (2026-07-01) → this PR → the 2026-08-01 bump, which is blocked on it.

## Testing

**On the current toolchain (nightly-2026-05-01, cargo 1.97 — old layout):**

- `cargo-kani`: 71 passed, 0 failed
- `script-based-pre`: 70 passed, 2 failed — both failures (`cargo_autoharness_filter`, `cargo_autoharness_slices`) reproduce on unmodified `main` and are unrelated to this change
- `cargo test -p kani-driver`: 93 passed
- `./scripts/kani-fmt.sh --check`, `cargo clippy --workspace --tests -- -D warnings`, `RUSTFLAGS="--cfg=kani_sysroot" cargo clippy --workspace -- -D warnings`: clean

**Cherry-picked onto the local 2026-08-01 branch (cargo 1.99 — new layout), which is where the bug bites:**

| Suite | Before | After |
|---|---|---|
| `cargo-kani` | 68 failed | **71 passed, 0 failed** |
| `script-based-pre` | 11 failed | **68 passed, 0 failed** |

- Was this change tested? **Yes**
- Is this a breaking change? **No**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
