### PR TITLE
Upgrade Rust toolchain to nightly-2026-08-21

### DIFF
--- a/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_aeneas_llbc/compiler_interface.rs
@@ -38,9 +38,9 @@ use rustc_public::mir::mono::{Instance, MonoItem};
 use rustc_public::rustc_internal;
 use rustc_public::ty::FnDef;
 use rustc_public::{CrateDef, DefId};
-use rustc_session::Session;
 use rustc_session::config::{CrateType, OutputFilenames, OutputType};
 use rustc_session::output::out_filename;
+use rustc_session::{IncrCompSession, Session};
 use std::any::Any;
 use std::fs::File;
 use std::path::Path;
@@ -296,6 +296,7 @@ impl CodegenBackend for LlbcCodegenBackend {
         &self,
         ongoing_codegen: Box<dyn Any>,
         _sess: &Session,
+        _incr_comp_session: Option<&IncrCompSession>,
         _filenames: &OutputFilenames,
         _crate_info: &CrateInfo,
     ) -> (CompiledModules, UnordMap<WorkProductId, WorkProduct>) {

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/rvalue.rs
@@ -813,7 +813,15 @@ impl GotocCtx<'_, '_> {
             Rvalue::Cast(CastKind::PointerCoercion(k), e, t) => {
                 self.codegen_pointer_cast(k, e, *t, loc)
             }
-            Rvalue::Cast(CastKind::Transmute | CastKind::Subtype, operand, ty) => {
+            // `BoxDerefTransmute` is an elaborated `Box` deref turning the inner pointer into a
+            // raw one. Its docs describe it as a regular transmute that is additionally UB if the
+            // input is not valid as a `Box<T>`, and say backends may treat it as a plain
+            // transmute; Kani checks pointer validity separately at the deref itself.
+            Rvalue::Cast(
+                CastKind::Transmute | CastKind::BoxDerefTransmute | CastKind::Subtype,
+                operand,
+                ty,
+            ) => {
                 let src_ty = operand.ty(self.current_fn().locals()).unwrap();
                 // Transmute requires sized types.
                 let src_sz = LayoutOf::new(src_ty).size_of().unwrap();

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/statement.rs
@@ -745,6 +745,22 @@ impl GotocCtx<'_, '_> {
         debug!(?func, ?args, ?destination, ?span, "codegen_funcall");
         let instance_opt = self.get_instance(func);
         if let Some(instance) = instance_opt
+            && matches!(instance.kind, InstanceKind::LlvmIntrinsic)
+        {
+            // An LLVM intrinsic -- an `extern "unadjusted"` declaration whose symbol starts with
+            // `llvm.` -- has no Rust body, and rustc refuses to compute a `FnAbi` for one, so we
+            // cannot codegen the call or even its arguments. Kani has no model for these either,
+            // so report the call as unsupported. As of nightly-2026-08-21 these resolve to their
+            // own `InstanceKind`; before that they were foreign items, and this reports the same
+            // unsupported-construct check that the FFI shim did, so reaching one still fails
+            // verification rather than silently succeeding.
+            return self.codegen_unimplemented_stmt(
+                &format!("call to LLVM intrinsic `{}`", instance.mangled_name()),
+                self.codegen_span_stable(span),
+                "https://github.com/model-checking/kani/issues/4770",
+            );
+        }
+        if let Some(instance) = instance_opt
             && matches!(instance.kind, InstanceKind::Intrinsic)
         {
             let TyKind::RigidTy(RigidTy::FnDef(def, _)) = instance.ty().kind() else {
@@ -805,10 +821,12 @@ impl GotocCtx<'_, '_> {
                         self.codegen_virtual_funcall(self_ty, idx, destination, &mut fargs, loc)
                     }
                     // Normal, non-virtual function calls
-                    InstanceKind::Item
-                    | InstanceKind::Intrinsic
-                    | InstanceKind::LlvmIntrinsic
-                    | InstanceKind::Shim => {
+                    InstanceKind::LlvmIntrinsic => {
+                        unreachable!(
+                            "Kani reports LLVM intrinsic calls as unsupported before codegen"
+                        )
+                    }
+                    InstanceKind::Item | InstanceKind::Intrinsic | InstanceKind::Shim => {
                         // We need to handle FnDef items in a special way because `codegen_operand` compiles them to dummy structs.
                         // (cf. the function documentation)
                         let func_exp = self.codegen_func_expr(instance, loc);

--- a/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/codegen/typ.rs
@@ -1637,7 +1637,9 @@ impl<'tcx, 'r> GotocCtx<'tcx, 'r> {
         let rust_type = self.codegen_prim_typ(prim_type);
         let cbmc_type = self.codegen_ty(rust_type);
 
-        Type::vector(cbmc_type, *size)
+        // As of nightly-2026-08-21 the lane count is a `BackendLaneCount` (a `NonZero<u16>`)
+        // rather than a bare `u64`.
+        Type::vector(cbmc_type, size.as_u64())
     }
 
     /// the function type of the current instance

--- a/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/compiler_interface.rs
@@ -30,7 +30,7 @@ use rustc_codegen_ssa::back::link::link_binary;
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::{CompiledModules, CrateInfo, TargetConfig};
 use rustc_data_structures::fx::FxHashMap;
-use rustc_data_structures::unord::UnordMap;
+use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_hir::def_id::{DefId as InternalDefId, LOCAL_CRATE};
 use rustc_metadata::EncodedMetadata;
 use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
@@ -40,9 +40,9 @@ use rustc_public::CrateDef;
 use rustc_public::mir::mono::{Instance, MonoItem};
 use rustc_public::rustc_internal;
 use rustc_public::ty::FnDef;
-use rustc_session::Session;
 use rustc_session::config::{CrateType, OutputFilenames, OutputType};
 use rustc_session::output::out_filename;
+use rustc_session::{IncrCompSession, Session};
 use rustc_span::{Symbol, sym};
 use rustc_target::spec::{Arch, Os, PanicStrategy};
 use std::any::Any;
@@ -311,15 +311,13 @@ impl CodegenBackend for GotocCodegenBackend {
         } else {
             vec![]
         };
-        // FIXME do `unstable_target_features` properly
-        let unstable_target_features = target_features.clone();
-
         let has_reliable_f128 = true;
         let has_reliable_f16 = true;
 
         TargetConfig {
-            target_features,
-            unstable_target_features,
+            // As of nightly-2026-08-21 the separate stable/unstable `Vec<Symbol>` feature lists
+            // are a single `UnordSet`, so there is no longer an unstable list to populate.
+            internal_target_features: UnordSet::from_iter(target_features),
             has_reliable_f16,
             has_reliable_f16_math: has_reliable_f16,
             has_reliable_f128,
@@ -525,6 +523,7 @@ impl CodegenBackend for GotocCodegenBackend {
         &self,
         ongoing_codegen: Box<dyn Any>,
         _sess: &Session,
+        _incr_comp_session: Option<&IncrCompSession>,
         _filenames: &OutputFilenames,
         _crate_info: &CrateInfo,
     ) -> (CompiledModules, UnordMap<WorkProductId, WorkProduct>) {

--- a/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
+++ b/kani-compiler/src/codegen_cprover_gotoc/overrides/hooks.rs
@@ -17,7 +17,7 @@ use cbmc::goto_program::CIntType;
 use cbmc::goto_program::Symbol as GotoSymbol;
 use cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, StmtBody, SymbolValues, Type};
 use cbmc::{InternedString, goto_program::ExprValue};
-use rustc_hir::LangItem;
+use rustc_hir::attrs::lang_items::LangItem;
 use rustc_middle::ty::TyCtxt;
 use rustc_public::mir::mono::Instance;
 use rustc_public::mir::{BasicBlockIdx, Place};

--- a/kani-compiler/src/kani_middle/attributes.rs
+++ b/kani-compiler/src/kani_middle/attributes.rs
@@ -1338,7 +1338,10 @@ fn attr_kind(tcx: TyCtxt, attr: &Attribute) -> Option<KaniAttributeKind> {
 ///
 /// This provides a user-friendly interface to manipulate than the internal compiler AST.
 fn syn_attr(tcx: TyCtxt, attr: &Attribute) -> syn::Attribute {
-    let attr_str = rustc_hir_pretty::attribute_to_string(&tcx, attr);
+    // As of nightly-2026-08-21 `TyCtxt` no longer implements `PpAnn` directly; the impl is on
+    // `&dyn HirTyCtxt`, which `TyCtxt` does implement.
+    let hir_tcx: &dyn rustc_hir::intravisit::HirTyCtxt<'_> = &tcx;
+    let attr_str = rustc_hir_pretty::attribute_to_string(&hir_tcx, attr);
     let parser = syn::Attribute::parse_outer;
     parser.parse_str(&attr_str).unwrap().pop().unwrap()
 }

--- a/kani-compiler/src/kani_middle/codegen_units.rs
+++ b/kani-compiler/src/kani_middle/codegen_units.rs
@@ -547,7 +547,8 @@ fn args_satisfy_predicates(tcx: TyCtxt, def: FnDef, args: &GenericArgs) -> bool 
             predicate.skip_normalization(),
         ));
     }
-    ocx.evaluate_obligations_error_on_ambiguity().is_empty()
+    // As of nightly-2026-08-21 this returns a `TraitErrors` enum rather than a vector of errors.
+    ocx.evaluate_obligations_error_on_ambiguity().no_errors()
 }
 
 /// The nondet closure-model FnDefs, keyed by input shape. By-value models fix their

--- a/kani-compiler/src/kani_middle/coercion.rs
+++ b/kani-compiler/src/kani_middle/coercion.rs
@@ -13,7 +13,7 @@
 //! definition of custom coercions for smart pointers can be found in the
 //! [RFC 982 DST Coercion](https://rust-lang.github.io/rfcs/0982-dst-coercion.html).
 
-use rustc_hir::lang_items::LangItem;
+use rustc_hir::attrs::lang_items::LangItem;
 use rustc_middle::traits::{ImplSource, ImplSourceUserDefinedData};
 use rustc_middle::ty::TraitRef;
 use rustc_middle::ty::adjustment::CustomCoerceUnsized;

--- a/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
+++ b/kani-compiler/src/kani_middle/points_to/points_to_analysis.rs
@@ -35,8 +35,7 @@ use crate::{
 use rustc_middle::{
     mir::{
         BasicBlock, BinOp, Body, CallReturnPlaces, Location, NonDivergingIntrinsic, Operand, Place,
-        ProjectionElem, Rvalue, Statement, StatementKind, Terminator, TerminatorEdges,
-        TerminatorKind,
+        ProjectionElem, Rvalue, Statement, StatementKind, Terminator, TerminatorKind,
     },
     ty::{Instance, InstanceKind, List, TyCtxt, TyKind, TypingEnv},
 };
@@ -182,12 +181,12 @@ impl<'tcx> Analysis<'tcx> for PointsToAnalysis<'_, 'tcx> {
         }
     }
 
-    fn apply_primary_terminator_effect<'mir>(
+    fn apply_primary_terminator_effect(
         &self,
         state: &mut Self::Domain,
-        terminator: &'mir Terminator<'tcx>,
+        terminator: &Terminator<'tcx>,
         location: Location,
-    ) -> TerminatorEdges<'mir, 'tcx> {
+    ) {
         if let TerminatorKind::Call { func, args, destination, .. } = &terminator.kind {
             // Attempt to resolve callee. For now, we panic if the callee cannot be resolved (e.g.,
             // if a function pointer call is used), but we could leverage the call graph to resolve
@@ -331,7 +330,6 @@ impl<'tcx> Analysis<'tcx> for PointsToAnalysis<'_, 'tcx> {
                 }
             }
         };
-        terminator.edges()
     }
 
     /// We don't care about this and just need to implement this to implement the trait.

--- a/kani-compiler/src/kani_middle/transform/check_values.rs
+++ b/kani-compiler/src/kani_middle/transform/check_values.rs
@@ -629,7 +629,7 @@ impl MirVisitor for CheckValueVisitor<'_, '_> {
                         })
                     }
                 }
-                CastKind::Transmute | CastKind::Subtype => {
+                CastKind::Transmute | CastKind::BoxDerefTransmute | CastKind::Subtype => {
                     debug!(?dest_ty, "transmute");
                     // For transmute, we care about the destination type only.
                     // This could be optimized to only add a check if the requirements of the

--- a/kani-compiler/src/kani_middle/transform/internal_mir.rs
+++ b/kani-compiler/src/kani_middle/transform/internal_mir.rs
@@ -149,6 +149,7 @@ impl RustcInternalMir for CastKind {
             CastKind::PtrToPtr => rustc_middle::mir::CastKind::PtrToPtr,
             CastKind::FnPtrToPtr => rustc_middle::mir::CastKind::FnPtrToPtr,
             CastKind::Transmute => rustc_middle::mir::CastKind::Transmute,
+            CastKind::BoxDerefTransmute => rustc_middle::mir::CastKind::BoxDerefTransmute,
             CastKind::Subtype => rustc_middle::mir::CastKind::Subtype,
         }
     }

--- a/kani-compiler/src/kani_middle/transform/rustc_intrinsics.rs
+++ b/kani-compiler/src/kani_middle/transform/rustc_intrinsics.rs
@@ -13,7 +13,7 @@ use crate::kani_middle::transform::body::{
 };
 use crate::kani_middle::transform::{TransformPass, TransformationType};
 use crate::kani_queries::QueryDb;
-use rustc_hir::LangItem;
+use rustc_hir::attrs::lang_items::LangItem;
 use rustc_middle::ty::TyCtxt;
 use rustc_public::mir::mono::Instance;
 use rustc_public::mir::{

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2026-08-01"
+channel = "nightly-2026-08-21"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/expected/uninit/atomic/atomic.rs
+++ b/tests/expected/uninit/atomic/atomic.rs
@@ -18,10 +18,12 @@ fn local_atomic_uninit() {
     unsafe {
         match kani::any() {
             0 => {
-                atomic_store::<_, { AtomicOrdering::Relaxed }>(ptr, 1);
+                atomic_store::<_, { AtomicOrdering::Relaxed }, /* VOLATILE */ false>(ptr, 1);
             }
             1 => {
-                atomic_load::<_, { AtomicOrdering::Relaxed }>(ptr as *const u8);
+                atomic_load::<_, { AtomicOrdering::Relaxed }, /* VOLATILE */ false>(
+                    ptr as *const u8,
+                );
             }
             _ => {
                 atomic_cxchg::<_, { AtomicOrdering::Relaxed }, { AtomicOrdering::Relaxed }>(

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicLoad/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicLoad/main.rs
@@ -18,9 +18,9 @@ fn main() {
     let ptr_a3: *const u8 = &a3;
 
     unsafe {
-        let x1 = atomic_load::<_, { AtomicOrdering::SeqCst }>(ptr_a1);
-        let x2 = atomic_load::<_, { AtomicOrdering::Acquire }>(ptr_a2);
-        let x3 = atomic_load::<_, { AtomicOrdering::Relaxed }>(ptr_a3);
+        let x1 = atomic_load::<_, { AtomicOrdering::SeqCst }, /* VOLATILE */ false>(ptr_a1);
+        let x2 = atomic_load::<_, { AtomicOrdering::Acquire }, /* VOLATILE */ false>(ptr_a2);
+        let x3 = atomic_load::<_, { AtomicOrdering::Relaxed }, /* VOLATILE */ false>(ptr_a3);
 
         assert!(x1 == 1);
         assert!(x2 == 1);

--- a/tests/kani/Intrinsics/Atomic/Unstable/AtomicStore/main.rs
+++ b/tests/kani/Intrinsics/Atomic/Unstable/AtomicStore/main.rs
@@ -18,9 +18,9 @@ fn main() {
     let ptr_a3: *mut u8 = &mut a3;
 
     unsafe {
-        atomic_store::<_, { AtomicOrdering::SeqCst }>(ptr_a1, 0);
-        atomic_store::<_, { AtomicOrdering::Release }>(ptr_a2, 0);
-        atomic_store::<_, { AtomicOrdering::Relaxed }>(ptr_a3, 0);
+        atomic_store::<_, { AtomicOrdering::SeqCst }, /* VOLATILE */ false>(ptr_a1, 0);
+        atomic_store::<_, { AtomicOrdering::Release }, /* VOLATILE */ false>(ptr_a2, 0);
+        atomic_store::<_, { AtomicOrdering::Relaxed }, /* VOLATILE */ false>(ptr_a3, 0);
 
         assert!(*ptr_a1 == 0);
         assert!(*ptr_a2 == 0);

--- a/tools/build-kani/src/sysroot.rs
+++ b/tools/build-kani/src/sysroot.rs
@@ -148,6 +148,12 @@ fn build_kani_lib(
         "always-encode-mir",
         "-Z",
         "mir-enable-passes=-RemoveStorageMarkers",
+        // Kani copies these rlibs into its sysroot and later compiles against them on their own,
+        // so they must carry full metadata. Without this the rlib holds only a metadata stub and
+        // the full `.rmeta` is left behind in the build directory, which fails as
+        // "only metadata stub found for `rlib` dependency".
+        "-Z",
+        "embed-metadata=yes",
     ];
     rustc_args.extend_from_slice(extra_rustc_args);
     let mut cmd = Command::new("cargo")


### PR DESCRIPTION
All three dependencies — #4764 (`nightly-2026-07-01`), #4766 (cargo target layout) and #4767 (`nightly-2026-08-01`) — have merged, so this is now rebased onto `main` as a **single commit** and is ready for review.

### Description

`nightly-2026-08-21` is the first 1.100 nightly. Only 14 compile errors came with it — a much smaller upgrade than 08-01's 91 — but one *runtime* change broke the entire sysroot. That one first:

#### 1. The sysroot needs `-Zembed-metadata=yes`

Cargo builds Kani's `library/std` and `library/kani` with metadata embedding **off**, so the rlib holds only a metadata *stub* and the full `.rmeta` is left behind in the build directory. Kani copies just the rlib into its sysroot and later compiles against it standalone, so every verification failed:

```
error: only metadata stub found for `rlib` dependency `std`
       please provide path to the corresponding .rmeta file with full metadata
```

That took out **534 of 607** `kani` tests. The symptom was visible in the artifacts — the sysroot's `libstd.rlib` was 1024 bytes, and `ar t` showed nothing but a stub:

```
$ ar t target/kani/lib/libstd.rlib
__.SYMDEF
lib.rmeta          # 440 bytes -- the stub
lib.rmeta-link
```

Asking for full metadata in the sysroot build keeps those rlibs self-contained (they grow to 32 KB / 596 KB) and takes the failures from 534 to 2.

#### 2. Mechanical API adaptations

| Change | Adaptation |
|---|---|
| `LangItem` moved from `rustc_hir` to `rustc_hir::attrs::lang_items` | 3 imports, matching the path the compiler itself uses |
| `CodegenBackend::join_codegen` gained `Option<&IncrCompSession>` | added in both backends |
| `Analysis::apply_primary_terminator_effect` no longer returns `TerminatorEdges` | the framework computes them itself; drop the return value and the now-unused `'mir` lifetime |
| `BackendRepr::SimdVector`'s lane count is `BackendLaneCount` (a `NonZero<u16>`), not `u64` | `codegen_vector` calls `as_u64()` |
| `TargetConfig`'s `target_features` + `unstable_target_features` → one `internal_target_features: UnordSet<Symbol>` | also removes the `FIXME do unstable_target_features properly`, since there is no longer an unstable list |
| `TyCtxt` no longer implements `rustc_hir_pretty::PpAnn` | the impl is on `&dyn HirTyCtxt`, which `TyCtxt` does implement, so `syn_attr` coerces through it |
| `evaluate_obligations_error_on_ambiguity` returns a `TraitErrors` enum, not a vector | the emptiness check becomes `no_errors()` |
| `LocalModDefId` renamed `LocalModId` | rename |

#### 3. `fn_abi_of_instance` now refuses LLVM intrinsics

`fn_abi_adjust_for_abi` asserts that the ABI is not `Unadjusted`. `InstanceKind::LlvmIntrinsic` already existed on `nightly-2026-08-01` — where computing an ABI for one was still allowed, so codegen could treat it as an ordinary item — but on 1.100 that aborts the compiler:

```
assertion `left != right` failed: fn_abi_of_instance should not be called on LLVM intrinsics
```

There is no way to obtain a `FnAbi` for one: the assert sits in the shared `fn_abi_new_uncached`, so deriving it from the signature trips it too. Without an ABI Kani cannot codegen the call or even its arguments, and it has no model for LLVM intrinsics anyway, so `codegen_funcall` now reports the call as an unsupported construct (#4770) *before* touching the ABI:

```
call to LLVM intrinsic `llvm.aarch64.neon.uqadd.i64` is not currently supported by Kani.
Please post your example at https://github.com/model-checking/kani/issues/4770
```

**This preserves the earlier behaviour.** Before 1.100 these were foreign items (`DefKind::Fn` declarations in `stdarch`'s `extern "unadjusted"` blocks), so they went through Kani's FFI shim, which raised an equivalent unsupported-construct check. As then, reaching one fails verification and code that never reaches one still verifies.

#### 4. New `CastKind::BoxDerefTransmute`

An elaborated `Box` deref that turns the inner pointer into a raw one. Its documentation calls it a regular transmute that is *additionally* UB if the input is not valid as a `Box<T>`, and states that backends may treat it as a plain transmute. So codegen and the value checks group it with `Transmute` (as cranelift does) — Kani checks pointer validity separately at the deref itself. The stable-to-internal conversion maps it **faithfully** rather than collapsing it to `Transmute`, because MIR validation distinguishes the two (`Cannot BoxDerefTransmute to non-pointer type`).

Worth a reviewer's eye: the extra "input not valid as `Box<T>`" UB is not separately modelled. If we want a dedicated check there, that is a follow-up rather than part of a toolchain bump.

### Test changes (3 files)

`atomic_load` and `atomic_store` gained a `VOLATILE: bool` const parameter. Each call passes `false`, matching what the ordinary atomic types in `core` pass, and borrows their `/* VOLATILE */` annotation so the bare bool reads clearly:

```rust
atomic_store::<_, { AtomicOrdering::SeqCst }, /* VOLATILE */ false>(ptr_a1, 0);
```

I checked every atomic intrinsic signature rather than only the ones the suites happened to flag — **no other atomic intrinsic changed** (`cxchg`, `cxchgweak`, `xchg`, `xadd`, `xsub`, `and`, `nand`, `or`, `xor`, `max`, `min`, `umin`, `umax`, `fence`, `singlethreadfence` are all unchanged). This matters because 27 of the 29 `Intrinsics/Atomic` tests are `fixme`-ignored, so the compiler never type-checks them.

No verification behaviour changed.

### Testing

Local, macOS aarch64, CBMC 6.10.0 (`cbmc-6.9.0-214-g45436eea34`), on this branch rebased onto current `main` (`8fcd6d90e`):

| Suite | Result |
|---|---|
| `kani` | **607 passed, 0 failed** (matches the 08-01 baseline exactly) |
| `cargo-kani` | **71 passed, 0 failed** |
| `cargo-ui` | **30 passed, 0 failed** |
| `expected` | 472 passed, 0 real failures — see below |
| `ui` | 150 passed, 2 failed — environmental, see below |

Also clean: both the CPROVER and LLBC builds, `cargo clippy --workspace --tests -- -D warnings`, `RUSTFLAGS="--cfg=kani_sysroot" cargo clippy --workspace -- -D warnings`, and `./scripts/kani-fmt.sh --check`.

Re-verified after rebasing onto merged `main`: the cherry-pick was clean, and `main`'s squashed versions of the three dependencies matched what I had locally apart from one comment touch-up (`predicates_of` -> `clauses_of`) that `main` already carries.

The LLVM-intrinsic abort was caught by CI on `kani/SizeAndAlignOfDst/main_assert.rs`, which passes vacuously on macOS (its body is `#[cfg(not(target_os = "macos"))]`) and so could not reproduce on my machine. I reproduced the same abort locally with a targeted probe instead, confirmed the identical assertion, and confirmed the fix resolves it:

```rust
#[kani::proof]
fn check_scalar_saturating_add() {
    use std::arch::aarch64::vqaddd_u64;   // -> llvm.aarch64.neon.uqadd.i64
    let (x, y): (u64, u64) = (kani::any(), kani::any());
    let _ = unsafe { vqaddd_u64(x, y) };
}
```

Before the fix: `signal: 6 (SIGABRT)` with `fn_abi_of_instance should not be called on LLVM intrinsics`. After: the unsupported-construct check shown above.

Two caveats, stated rather than omitted:

- `expected/shadow/slices/slice_split` is **unverified locally**. It spends >20 minutes in CBMC's SAT solver and I interrupted it. It is **not** a regression from this upgrade or from 08-01: I timed it on the 07-01 branch as a control and it is equally slow there. CI covers it.
- The two `ui` failures are `solver-attribute/cadical` and `solver-option/cadical`, both expecting `Solving with CaDiCaL`. My local CBMC reports `The specified solver, 'cadical', is not available` — a missing solver in my environment, independent of the Rust toolchain, and failing identically on 08-01.

- Was this change tested? **Yes**
- Is this a breaking change? **No**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.


