### PR TITLE
Report the failure exit code under `--quiet`

### DIFF
--- a/kani-driver/src/autoharness/mod.rs
+++ b/kani-driver/src/autoharness/mod.rs
@@ -213,6 +213,7 @@ impl KaniSession {
     pub fn print_autoharness_summary(
         &self,
         mut automatic: Vec<&HarnessResult<'_>>,
+        quiet: bool,
     ) -> Result<usize> {
         automatic.sort_by(|a, b| a.harness.pretty_name.cmp(&b.harness.pretty_name));
         let (successes, failures): (Vec<_>, Vec<_>) =
@@ -221,6 +222,12 @@ impl KaniSession {
         let succeeding = successes.len();
         let failing = failures.len();
         let total = succeeding + failing;
+
+        // Under --quiet we still need the failure count for the exit code, but the summary itself
+        // is suppressed.
+        if quiet {
+            return Ok(failing);
+        }
 
         println!("\nAutoharness Summary:");
 

--- a/kani-driver/src/autoharness/mod.rs
+++ b/kani-driver/src/autoharness/mod.rs
@@ -209,25 +209,27 @@ impl KaniSession {
         }
     }
 
-    /// Prints the results from running the `autoharness` subcommand.
-    pub fn print_autoharness_summary(
+    /// Computes the outcome of automatically-generated harnesses, if autoharness is enabled.
+    pub fn autoharness_result<'a, 'pr>(
         &self,
-        mut automatic: Vec<&HarnessResult<'_>>,
-        quiet: bool,
-    ) -> Result<usize> {
+        mut automatic: Vec<&'a HarnessResult<'pr>>,
+    ) -> Option<AutoharnessResult<'a, 'pr>> {
+        self.autoharness_compiler_flags.as_ref()?;
+
         automatic.sort_by(|a, b| a.harness.pretty_name.cmp(&b.harness.pretty_name));
-        let (successes, failures): (Vec<_>, Vec<_>) =
+        let (successes, failing) =
             automatic.into_iter().partition(|r| r.result.status == VerificationStatus::Success);
 
-        let succeeding = successes.len();
-        let failing = failures.len();
-        let total = succeeding + failing;
+        Some(AutoharnessResult { successes, failing })
+    }
 
-        // Under --quiet we still need the failure count for the exit code, but the summary itself
-        // is suppressed.
-        if quiet {
-            return Ok(failing);
-        }
+    /// Prints the results from running the `autoharness` subcommand.
+    pub fn print_autoharness_summary(&self, autoharness_result: AutoharnessResult<'_, '_>) {
+        let AutoharnessResult { successes, failing } = autoharness_result;
+
+        let succeeding = successes.len();
+        let failing_count = failing.len();
+        let total = succeeding + failing_count;
 
         println!("\nAutoharness Summary:");
 
@@ -263,7 +265,7 @@ impl KaniSession {
             ]);
         }
 
-        for failure in failures {
+        for failure in failing {
             any_bounded |= failure.harness.is_bounded;
             any_ctor |= failure.harness.is_ctor_based;
             verified_fns.add_row(vec![
@@ -291,7 +293,7 @@ impl KaniSession {
             );
         }
 
-        if failing > 0 {
+        if failing_count > 0 {
             println!(
                 "Note that `kani autoharness` sets default --harness-timeout of {AUTOHARNESS_TIMEOUT} and --default-unwind of {LOOP_UNWIND_DEFAULT}."
             );
@@ -302,12 +304,16 @@ impl KaniSession {
 
         if total > 0 {
             println!(
-                "Complete - {succeeding} successfully verified functions, {failing} failures, {total} total."
+                "Complete - {succeeding} successfully verified functions, {failing_count} failures, {total} total."
             );
         } else {
             println!("No functions were eligible for automatic verification.");
         }
-
-        Ok(failing)
     }
+}
+
+/// The outcome of computing results for automatically-generated harnesses.
+pub struct AutoharnessResult<'a, 'pr> {
+    successes: Vec<&'a HarnessResult<'pr>>,
+    pub(crate) failing: Vec<&'a HarnessResult<'pr>>,
 }

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -306,9 +306,13 @@ impl KaniSession {
     /// Note: Takes `self` "by ownership". This function wants to be able to drop before
     /// exiting with an error code, if needed.
     pub(crate) fn print_final_summary(self, results: &[HarnessResult<'_>]) -> Result<()> {
-        if self.args.common_args.quiet {
-            return Ok(());
-        }
+        // `--quiet` promises "no output, just an exit code and requested artifacts". It must
+        // suppress the summary output only -- the exit code and any error returns below have to be
+        // identical to a non-quiet run. So compute the counts unconditionally, gate the printing
+        // on `!quiet`, and keep the control flow (error return, `exit(1)`) quiet-independent.
+        // See issue #4745: previously an early `return Ok(())` here skipped the `exit(1)` below, so
+        // `--quiet` reported a failing run as exit 0.
+        let quiet = self.args.common_args.quiet;
 
         let (automatic, manual): (Vec<_>, Vec<_>) =
             results.iter().partition(|r| r.harness.is_automatically_generated);
@@ -320,50 +324,49 @@ impl KaniSession {
         let failing = failures.len();
         let total = succeeding + failing;
 
-        if self.args.concrete_playback.is_some() {
-            if failures.is_empty() {
+        if !quiet {
+            if self.args.concrete_playback.is_some() {
+                if failures.is_empty() {
+                    println!(
+                        "INFO: The concrete playback feature never generated unit tests because there were no failing harnesses."
+                    )
+                } else if failures.iter().all(|r| !r.result.generated_concrete_test) {
+                    eprintln!(
+                        "The concrete playback feature did not generate unit tests, but there were failing harnesses. Please file a bug report at {BUG_REPORT_URL}"
+                    )
+                }
+            }
+
+            println!("Manual Harness Summary:");
+
+            for failure in failures.iter() {
+                println!("Verification failed for - {}", failure.harness.pretty_name);
+            }
+
+            if total > 0 {
                 println!(
-                    "INFO: The concrete playback feature never generated unit tests because there were no failing harnesses."
-                )
-            } else if failures.iter().all(|r| !r.result.generated_concrete_test) {
-                eprintln!(
-                    "The concrete playback feature did not generate unit tests, but there were failing harnesses. Please file a bug report at {BUG_REPORT_URL}"
-                )
+                    "Complete - {succeeding} successfully verified harnesses, {failing} failures, {total} total."
+                );
+            } else if self.args.harnesses.is_empty() {
+                // TODO: This could use a better message, possibly with links to Kani documentation.
+                // New users may encounter this and could use a pointer to how to write proof harnesses.
+                println!("No proof harnesses (functions with #[kani::proof]) were found to verify.")
             }
         }
 
-        println!("Manual Harness Summary:");
-
-        for failure in failures.iter() {
-            println!("Verification failed for - {}", failure.harness.pretty_name);
+        // `determine_targets` fails a zero-match filter before codegen, so this only guards paths
+        // that skip harness filtering. Kept outside the `!quiet` block so the error (and its
+        // non-zero exit) is raised in both output modes.
+        if total == 0 && !self.args.harnesses.is_empty() {
+            return Err(crate::metadata::no_harness_match_error(&self.args.harnesses));
         }
 
-        if total > 0 {
-            println!(
-                "Complete - {succeeding} successfully verified harnesses, {failing} failures, {total} total."
-            );
-        } else {
-            match self.args.harnesses.as_slice() {
-                [] =>
-                // TODO: This could use a better message, possibly with links to Kani documentation.
-                // New users may encounter this and could use a pointer to how to write proof harnesses.
-                {
-                    println!(
-                        "No proof harnesses (functions with #[kani::proof]) were found to verify."
-                    )
-                }
-                // `determine_targets` fails a zero-match filter before codegen, so this arm
-                // only guards paths that skip harness filtering.
-                _ => return Err(crate::metadata::no_harness_match_error(&self.args.harnesses)),
-            };
-        }
-
-        if self.args.coverage {
+        if self.args.coverage && !quiet {
             self.show_coverage_summary()?;
         }
 
         let autoharness_failing = if self.autoharness_compiler_flags.is_some() {
-            self.print_autoharness_summary(automatic)?
+            self.print_autoharness_summary(automatic, quiet)?
         } else {
             0
         };

--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -306,12 +306,6 @@ impl KaniSession {
     /// Note: Takes `self` "by ownership". This function wants to be able to drop before
     /// exiting with an error code, if needed.
     pub(crate) fn print_final_summary(self, results: &[HarnessResult<'_>]) -> Result<()> {
-        // `--quiet` promises "no output, just an exit code and requested artifacts". It must
-        // suppress the summary output only -- the exit code and any error returns below have to be
-        // identical to a non-quiet run. So compute the counts unconditionally, gate the printing
-        // on `!quiet`, and keep the control flow (error return, `exit(1)`) quiet-independent.
-        // See issue #4745: previously an early `return Ok(())` here skipped the `exit(1)` below, so
-        // `--quiet` reported a failing run as exit 0.
         let quiet = self.args.common_args.quiet;
 
         let (automatic, manual): (Vec<_>, Vec<_>) =
@@ -365,11 +359,11 @@ impl KaniSession {
             self.show_coverage_summary()?;
         }
 
-        let autoharness_failing = if self.autoharness_compiler_flags.is_some() {
-            self.print_autoharness_summary(automatic, quiet)?
-        } else {
-            0
-        };
+        let autoharness_result = self.autoharness_result(automatic);
+        let autoharness_failing = autoharness_result.as_ref().map_or(0, |r| r.failing.len());
+        if !quiet && let Some(autoharness_result) = autoharness_result {
+            self.print_autoharness_summary(autoharness_result);
+        }
 
         if failing + autoharness_failing > 0 {
             // Failure exit code without additional error message

--- a/tests/script-based-pre/check-quiet/check-quiet.expected
+++ b/tests/script-based-pre/check-quiet/check-quiet.expected
@@ -1,1 +1,2 @@
-success: `--quiet` produced NO output
+success: passing run under `--quiet` produced no output and exited 0
+success: failing run under `--quiet` produced no output and exited non-zero

--- a/tests/script-based-pre/check-quiet/check-quiet.sh
+++ b/tests/script-based-pre/check-quiet/check-quiet.sh
@@ -2,15 +2,44 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-# Checks that no output is produced if `--quiet` is used
+# Checks the `--quiet` contract: it suppresses output but still reports the verdict through the
+# process exit code. A passing run exits 0 with no output; a failing run exits non-zero with no
+# output. The failing-run exit code is a regression test for issue #4745, where `--quiet` made a
+# failing verification run exit 0.
 
-set -eu
+# Note: no `set -e` -- we deliberately run a command expected to exit non-zero and inspect `$?`.
+set -u
 
-KANI_OUTPUT=`kani assume.rs --quiet | wc -l`
+# Runs `kani <file> --quiet`, capturing combined output in QUIET_OUT and the exit code in QUIET_RC
+# without aborting the script on a non-zero exit.
+run_quiet() {
+    QUIET_OUT=$(kani "$1" --quiet 2>&1) && QUIET_RC=0 || QUIET_RC=$?
+}
 
-if [[ ${KANI_OUTPUT} -ne 0 ]]; then
-    echo "error: \`--quiet\` produced some output"
+# 1. A passing run: no output, exit 0.
+run_quiet assume.rs
+if [[ -n "${QUIET_OUT}" ]]; then
+    echo "error: \`--quiet\` produced output for a passing run:"
+    echo "${QUIET_OUT}"
     exit 1
-else
-    echo "success: \`--quiet\` produced NO output"
 fi
+if [[ ${QUIET_RC} -ne 0 ]]; then
+    echo "error: passing run under \`--quiet\` exited ${QUIET_RC}, expected 0"
+    exit 1
+fi
+echo "success: passing run under \`--quiet\` produced no output and exited 0"
+
+# 2. A failing run: no output, exit non-zero (regression test for #4745).
+run_quiet fail.rs
+if [[ -n "${QUIET_OUT}" ]]; then
+    echo "error: \`--quiet\` produced output for a failing run:"
+    echo "${QUIET_OUT}"
+    exit 1
+fi
+if [[ ${QUIET_RC} -ne 1 ]]; then
+    # A verification failure exits with exactly 1; requiring 1 (not just non-zero) keeps a crash
+    # or signal death from passing this regression test. See #4745.
+    echo "error: failing run under \`--quiet\` exited ${QUIET_RC}, expected 1 (see #4745)"
+    exit 1
+fi
+echo "success: failing run under \`--quiet\` produced no output and exited non-zero"

--- a/tests/script-based-pre/check-quiet/fail.rs
+++ b/tests/script-based-pre/check-quiet/fail.rs
@@ -1,0 +1,10 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// A harness that always fails, used to check that `--quiet` still reports the failure through the
+// exit code (issue #4745).
+
+#[kani::proof]
+fn always_fails() {
+    assert!(false, "this harness must fail");
+}


### PR DESCRIPTION
Resolves #4745.

`--quiet`'s help text promises "Produces no output, just an exit code and requested artifacts", but `print_final_summary` returned early under `--quiet` before reaching the `exit(1)` that reports failures, so a failing verification run exited 0. Nothing else set the failure exit code.

This suppresses only the *summary output* under `--quiet`: the failure counts are computed unconditionally and the exit code and error returns are kept identical to a non-quiet run. `print_autoharness_summary` takes a `quiet` flag so it still reports its failure count without printing — so this also fixes the same swallowed-exit-code bug for `autoharness --quiet`.

### Behavior under `--quiet`, before → after
- Failing manual run: exit 0 → **exit 1** (the bug).
- Failing `autoharness` run: exit 0 → **exit 1** (same root cause).
- Passing run: exit 0 → exit 0 (unchanged), still no output.
- Zero-match `--harness` filter on a filter-skipping path: this now returns the `no_harness_match_error` (one line to stdout, exit non-zero) under `--quiet` as well, matching every other hard-error path — which already print and exit non-zero regardless of `--quiet`. Previously `--quiet` swallowed it into exit 0. (The common zero-match case is already handled earlier by `determine_targets` since #4743; this only affects the filter-skipping arm.)

### Test
Extends `tests/script-based-pre/check-quiet`: it now runs a failing harness under `--quiet` and asserts exit 1, plus a passing-run control asserting exit 0. The previous test only ran passing harnesses and never inspected the exit code. The check captures both stdout and stderr, since the `--quiet` contract covers all output, not just stdout.
