### PR TITLE
Fix exit code swallowed by --quiet on verification failure

### DIFF
--- a/kani-driver/src/harness_runner.rs
+++ b/kani-driver/src/harness_runner.rs
@@ -306,10 +306,6 @@ impl KaniSession {
     /// Note: Takes `self` "by ownership". This function wants to be able to drop before
     /// exiting with an error code, if needed.
     pub(crate) fn print_final_summary(self, results: &[HarnessResult<'_>]) -> Result<()> {
-        if self.args.common_args.quiet {
-            return Ok(());
-        }
-
         let (automatic, manual): (Vec<_>, Vec<_>) =
             results.iter().partition(|r| r.harness.is_automatically_generated);
 
@@ -319,6 +315,21 @@ impl KaniSession {
         let succeeding = successes.len();
         let failing = failures.len();
         let total = succeeding + failing;
+
+        // Failure count of automatically generated harnesses, computed without printing so the
+        // `--quiet` path below stays honest. Must match `print_autoharness_summary`'s partition.
+        let autoharness_failing_count =
+            automatic.iter().filter(|r| r.result.status != VerificationStatus::Success).count();
+
+        if self.args.common_args.quiet {
+            // `--quiet` suppresses all output, but never the exit status: a failing
+            // verification must exit nonzero even when nothing is printed.
+            if failing + autoharness_failing_count > 0 {
+                drop(self);
+                std::process::exit(1);
+            }
+            return Ok(());
+        }
 
         if self.args.concrete_playback.is_some() {
             if failures.is_empty() {

--- a/tests/script-based-pre/quiet-exit-code/config.yml
+++ b/tests/script-based-pre/quiet-exit-code/config.yml
@@ -1,0 +1,3 @@
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+script: quiet-exit-code.sh

--- a/tests/script-based-pre/quiet-exit-code/failing.rs
+++ b/tests/script-based-pre/quiet-exit-code/failing.rs
@@ -1,0 +1,7 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#[kani::proof]
+fn failing_harness() {
+    assert!(1 == 2);
+}

--- a/tests/script-based-pre/quiet-exit-code/passing.rs
+++ b/tests/script-based-pre/quiet-exit-code/passing.rs
@@ -1,0 +1,7 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#[kani::proof]
+fn passing_harness() {
+    assert!(1 == 1);
+}

--- a/tests/script-based-pre/quiet-exit-code/quiet-exit-code.sh
+++ b/tests/script-based-pre/quiet-exit-code/quiet-exit-code.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# Regression test for https://github.com/model-checking/kani/issues/4745:
+# `--quiet` must suppress output but never the exit status. A failing
+# verification under `--quiet` must exit nonzero; a passing one must exit 0;
+# both must produce no output.
+
+set -eu
+
+cd $(dirname $0)
+rm -f quiet-fail.out quiet-pass.out
+
+echo "Checking --quiet on a failing harness..."
+if kani --quiet failing.rs > quiet-fail.out 2>&1; then
+    echo "Error: kani --quiet on a failing harness exited 0 (failure masked as pass)."
+    exit 1
+fi
+if [ -s quiet-fail.out ]; then
+    echo "Error: kani --quiet produced output on the failing run:"
+    cat quiet-fail.out
+    exit 1
+fi
+
+echo "Checking --quiet on a passing harness..."
+if ! kani --quiet passing.rs > quiet-pass.out 2>&1; then
+    echo "Error: kani --quiet on a passing harness exited nonzero."
+    exit 1
+fi
+if [ -s quiet-pass.out ]; then
+    echo "Error: kani --quiet produced output on the passing run:"
+    cat quiet-pass.out
+    exit 1
+fi
+
+rm -f quiet-fail.out quiet-pass.out
+echo "Finished quiet exit-code check successfully."


### PR DESCRIPTION
## Description

`kani --quiet` (and `cargo kani --quiet`) always exits 0, even when verification fails. `print_final_summary` in `kani-driver/src/harness_runner.rs` returned `Ok(())` early under `--quiet`, skipping the `process::exit(1)` path used in non-quiet mode. This silently breaks CI pipelines that rely on the exit code while suppressing output.

The fix hoists the failure/success partitions (and the autoharness failing count) above the quiet gate so the exit status is computed the same way in both modes. The quiet-mode contract — no verification output on stdout — is preserved; only the exit code changes (0 → 1 on failure).

## Context

Reported by @ivmat in #4745: running `kani --quiet` on a failing harness prints nothing (correct) but returns exit status 0 (incorrect), so failures are invisible to scripts and CI.

## Manual testing

New script-based regression test `tests/script-based-pre/quiet-exit-code/`: runs `kani --quiet` on a failing and a passing harness and asserts (a) exit code 1 / 0 respectively, and (b) empty stdout/stderr in both cases. Verified RED without the fix (exit 0 on failure) and GREEN with it, on this branch. `cargo test -p kani-driver` passes (101/101).

Resolves #4745

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
